### PR TITLE
Fixed `else` statement

### DIFF
--- a/compel/arch/x86/src/lib/infect.c
+++ b/compel/arch/x86/src/lib/infect.c
@@ -213,7 +213,7 @@ int sigreturn_prep_fpu_frame_plain(struct rt_sigframe *sigframe,
 		}
 
 		sigframe->native.uc.uc_mcontext.fpstate = (void *)addr;
-	} else if (!sigframe->is_native) {
+	} else {
 		sigframe->compat.uc.uc_mcontext.fpstate =
 			(uint32_t)(unsigned long)(void *)&fpu_state->fpu_state_ia32;
 	}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
criu/compel/arch/x86/src/lib/infect.c       216     warn    V547 Expression '!sigframe->is_native' is always true.