### PR TITLE
images.py: remove shebang

### DIFF
--- a/lib/py/images/images.py
+++ b/lib/py/images/images.py
@@ -1,5 +1,3 @@
-#!/bin/env python2
-
 # This file contains methods to deal with criu images.
 #
 # According to http://criu.org/Images, criu images can be described


### PR DESCRIPTION
This file is not executable directly, so it should not have the shebang.