### PR TITLE
compel: add missing header required by musl on ARM

### DIFF
--- a/compel/arch/aarch64/src/lib/infect.c
+++ b/compel/arch/aarch64/src/lib/infect.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <sys/uio.h>

--- a/compel/arch/arm/src/lib/infect.c
+++ b/compel/arch/arm/src/lib/infect.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <compel/plugins/std/syscall-codes.h>


### PR DESCRIPTION
Hi,

When using the musl libc on ARM, the compilation fails with the following messages:
```
armv7a-hardfloat-linux-musleabi-gcc -c -O2 -pipe -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=hard -march=armv7-a -Wall -Wformat-security -DCONFIG_ARMV7 -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE  -iquote include/  -iquote images/ images/netdev.pb-c.c -o images/netdev.o
compel/arch/arm/src/lib/infect.c: In function ‘sigreturn_prep_regs_plain’:
compel/arch/arm/src/lib/infect.c:53:2: warning: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
  memcpy(&aux->vfp.ufp.fpregs, &fpregs->fpregs, sizeof(aux->vfp.ufp.fpregs));
  ^
compel/arch/arm/src/lib/infect.c:53:2: warning: incompatible implicit declaration of built-in function ‘memcpy’
compel/arch/arm/src/lib/infect.c:53:2: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
compel/arch/arm/src/lib/infect.c: In function ‘get_task_regs’:
compel/arch/arm/src/lib/infect.c:75:37: error: ‘NULL’ undeclared (first use in this function)
  if (ptrace(PTRACE_GETVFPREGS, pid, NULL, &vfp)) {
                                     ^
compel/arch/arm/src/lib/infect.c:75:37: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [/dev/shm/portage/sys-process/criu-3.6/work/criu-3.6/scripts/nmk/scripts/build.mk:209: compel/arch/arm/src/lib/infect.o] Error 1
make: *** [Makefile.compel:36: compel/libcompel.a] Error 2
```

The easiest way to solve this, is to apply this patch:
```diff
--- a/compel/arch/arm/src/lib/infect.c  2017-11-30 19:00:51.584264054 +0100
+++ b/compel/arch/arm/src/lib/infect.c  2017-11-30 19:00:47.104036743 +0100
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <compel/plugins/std/syscall-codes.h>
```

Indeed, `string.h` includes a definition for `NULL`, and this avoid warning.

But, I notice that the problem doesn't show up on x86+musl, and after investigating, I found that including `compel/plugins/std/syscall.h`, make the job. I think this is more future-proof than adding only `string.h`, but let me know if you prefer the minimal patch.

Perhaps code for ppc64 and s390 should also benefits from this patch, but I don't have such hardware to test.