### PR TITLE
criu: Don't fail if ghost file has no parent dirs.

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1476,10 +1476,8 @@ static int make_parent_dirs_if_need(int mntns_root, char *path)
 	struct stat st;
 
 	p = last_delim = strrchr(path, '/');
-	if (!p) {
-		pr_err("Path %s has no parent dir\n", path);
-		return -1;
-	}
+	if (!p)
+		return 0;
 	*p = '\0';
 
 	if (fstatat(mntns_root, path, &st, AT_EMPTY_PATH) == 0)


### PR DESCRIPTION
Due to way CRIU handles paths (as relative to workdir), there's a case,
where migration would fail. Simple example is a ghost file in filesystem
root (with root being cwd). For example, "/unlinked" becomes "unlinked".
And original code piece scans path for other slashes, which would be
missing in this case. But it's still a perfectly valid case, and there's
no need to fail. So if there's no parent dir - we just don't need to
create one and we can just return 0 here instead of failing.

Signed-off-by: Vitaly Ostrosablin <vostrosablin@virtuozzo.com>