### PR TITLE
inventory: save dump_uptime for criu dump if track_mem is set

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1472,10 +1472,14 @@ static int cr_pre_dump_finish(int ret)
 	 * Restore registers for tasks only. The threads have not been
 	 * infected. Therefore, the thread register sets have not been changed.
 	 */
-	if (arch_set_thread_regs(root_item, false) < 0)
+	ret = arch_set_thread_regs(root_item, false);
+	if (ret)
 		goto err;
 
-	prepare_inventory_pre_dump(&he);
+	ret = invertory_save_uptime(&he);
+	if (ret)
+		goto err;
+
 	pstree_switch_state(root_item, TASK_ALIVE);
 
 	timing_stop(TIME_FROZEN);
@@ -1879,6 +1883,10 @@ int cr_dump_tasks(pid_t pid)
 		goto err;
 
 	ret = tty_post_actions();
+	if (ret)
+		goto err;
+
+	ret = invertory_save_uptime(&he);
 	if (ret)
 		goto err;
 

--- a/criu/image.c
+++ b/criu/image.c
@@ -106,14 +106,20 @@ int write_img_inventory(InventoryEntry *he)
 	return 0;
 }
 
-void prepare_inventory_pre_dump(InventoryEntry *he)
+int invertory_save_uptime(InventoryEntry *he)
 {
-	pr_info("Perparing image inventory for pre-dump (version %u)\n", CRTOOLS_IMAGES_V1);
+	if (!opts.track_mem)
+		return 0;
 
-	he->img_version = CRTOOLS_IMAGES_V1_1;
+	/*
+	 * dump_uptime is used to detect whether a process was handled
+	 * before or it is a new process with the same pid.
+	 */
+	if (parse_uptime(&he->dump_uptime))
+		return -1;
 
-	if (!parse_uptime(&he->dump_uptime))
-		he->has_dump_uptime = true;
+	he->has_dump_uptime = true;
+	return 0;
 }
 
 InventoryEntry *get_parent_inventory(void)

--- a/criu/include/crtools.h
+++ b/criu/include/crtools.h
@@ -12,7 +12,7 @@
 
 extern int check_img_inventory(void);
 extern int write_img_inventory(InventoryEntry *he);
-extern void prepare_inventory_pre_dump(InventoryEntry *he);
+extern int invertory_save_uptime(InventoryEntry *he);
 extern InventoryEntry *get_parent_inventory(void);
 extern int prepare_inventory(InventoryEntry *he);
 struct pprep_head {

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -299,6 +299,12 @@ static int detect_pid_reuse(struct pstree_item *item,
 	unsigned long long tps; /* ticks per second */
 	int ret;
 
+	if (!parent_ie) {
+		pr_err("Pid-reuse detection failed: no parent inventory, " \
+		       "check warnings in get_parent_stats\n");
+		return -1;
+	}
+
 	tps = sysconf(_SC_CLK_TCK);
 	if (tps == -1) {
 		pr_perror("Failed to get clock ticks via sysconf");
@@ -310,12 +316,6 @@ static int detect_pid_reuse(struct pstree_item *item,
 		ret = parse_pid_stat(item->pid->real, pps);
 		if (ret < 0)
 			return -1;
-	}
-
-	if (!parent_ie) {
-		pr_err("Pid-reuse detection failed: no parent inventory, " \
-		       "check warnings in get_parent_stats\n");
-		return -1;
 	}
 
 	dump_ticks = parent_ie->dump_uptime/(USEC_PER_SEC/tps);


### PR DESCRIPTION
A set of images from criu dump can be used as a previous point, when we
are doing snapshots. In this case, each point contains a full set of
images.

https://github.com/checkpoint-restore/criu/issues/479

v2: return -1 if invertory_save_uptime failed

Cc: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>
Signed-off-by: Andrei Vagin <avagin@virtuozzo.com>
Reviewed-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>
Signed-off-by: Andrei Vagin <avagin@virtuozzo.com>