### PR TITLE
c-lib: added strdup-null checks, simplify the interface

### DIFF
--- a/lib/c/criu.c
+++ b/lib/c/criu.c
@@ -59,18 +59,23 @@ void criu_set_service_comm(enum criu_service_comm comm)
 	criu_local_set_service_comm(global_opts, comm);
 }
 
-void criu_local_set_service_address(criu_opts *opts, const char *path)
+int criu_local_set_service_address(criu_opts *opts, const char *path)
 {
 	criu_free_service(opts);
-	if (path)
+	if (path) {
 		opts->service_address = strdup(path);
-	else
+	} else {
 		opts->service_address = strdup(CR_DEFAULT_SERVICE_ADDRESS);
+	}
+	if(opts->service_address == NULL) {
+		return -ENOMEM;
+	}
+	return 0;
 }
 
-void criu_set_service_address(const char *path)
+int criu_set_service_address(const char *path)
 {
-	criu_local_set_service_address(global_opts, path);
+	return criu_local_set_service_address(global_opts, path);
 }
 
 void criu_local_set_service_fd(criu_opts *opts, int fd)
@@ -84,18 +89,23 @@ void criu_set_service_fd(int fd)
 	criu_local_set_service_fd(global_opts, fd);
 }
 
-void criu_local_set_service_binary(criu_opts *opts, const char *path)
+int criu_local_set_service_binary(criu_opts *opts, const char *path)
 {
 	criu_free_service(opts);
-	if (path)
+	if (path) {
 		opts->service_binary = strdup(path);
-	else
+	} else {
 		opts->service_binary = strdup(CR_DEFAULT_SERVICE_BIN);
+	}
+	if(opts->service_binary == NULL) {
+		return -ENOMEM;
+	}
+	return 0;
 }
 
-void criu_set_service_binary(const char *path)
+int criu_set_service_binary(const char *path)
 {
-	criu_local_set_service_binary(global_opts, path);
+	return criu_local_set_service_binary(global_opts, path);
 }
 
 void criu_local_free_opts(criu_opts *opts)
@@ -257,6 +267,12 @@ int criu_local_init_opts(criu_opts **o)
 	opts->service_comm	= CRIU_COMM_BIN;
 	opts->service_binary	= strdup(CR_DEFAULT_SERVICE_BIN);
 
+	if(opts->service_binary == NULL) {
+		perror("Can't allocate memory for criu service setting");
+		criu_local_free_opts(opts);
+		return -1;
+	}
+
 	*o = opts;
 
 	return 0;
@@ -311,14 +327,18 @@ void criu_set_images_dir_fd(int fd)
 	criu_local_set_images_dir_fd(global_opts, fd);
 }
 
-void criu_local_set_parent_images(criu_opts *opts, const char *path)
+int criu_local_set_parent_images(criu_opts *opts, const char *path)
 {
 	opts->rpc->parent_img = strdup(path);
+	if(opts->rpc->parent_img == NULL) {
+		return -ENOMEM;
+	}
+	return 0;
 }
 
-void criu_set_parent_images(const char *path)
+int criu_set_parent_images(const char *path)
 {
-	criu_local_set_parent_images(global_opts, path);
+	return criu_local_set_parent_images(global_opts, path);
 }
 
 void criu_local_set_track_mem(criu_opts *opts, bool track_mem)
@@ -533,14 +553,18 @@ void criu_set_log_level(int log_level)
 	criu_local_set_log_level(global_opts, log_level);
 }
 
-void criu_local_set_root(criu_opts *opts, const char *root)
+int criu_local_set_root(criu_opts *opts, const char *root)
 {
 	opts->rpc->root = strdup(root);
+	if(opts->rpc->root == NULL) {
+		return -ENOMEM;
+	}
+	return 0;
 }
 
-void criu_set_root(const char *root)
+int criu_set_root(const char *root)
 {
-	criu_local_set_root(global_opts, root);
+	return criu_local_set_root(global_opts, root);
 }
 
 void criu_local_set_manage_cgroups(criu_opts *opts, bool manage)
@@ -565,14 +589,18 @@ void criu_set_manage_cgroups_mode(enum criu_cg_mode mode)
 	criu_local_set_manage_cgroups_mode(global_opts, mode);
 }
 
-void criu_local_set_freeze_cgroup(criu_opts *opts, const char *name)
+int criu_local_set_freeze_cgroup(criu_opts *opts, const char *name)
 {
 	opts->rpc->freeze_cgroup = strdup(name);
+	if(opts->rpc->freeze_cgroup == NULL) {
+		return -ENOMEM;
+	}
+	return 0;
 }
 
-void criu_set_freeze_cgroup(const char *name)
+int criu_set_freeze_cgroup(const char *name)
 {
-	criu_local_set_freeze_cgroup(global_opts, name);
+	return criu_local_set_freeze_cgroup(global_opts, name);
 }
 
 void criu_local_set_timeout(criu_opts *opts, unsigned int timeout)
@@ -618,14 +646,18 @@ void criu_set_ext_masters(bool val)
 	criu_local_set_ext_masters(global_opts, val);
 }
 
-void criu_local_set_log_file(criu_opts *opts, const char *log_file)
+int criu_local_set_log_file(criu_opts *opts, const char *log_file)
 {
 	opts->rpc->log_file = strdup(log_file);
+	if(opts->rpc->log_file == NULL) {
+		return -ENOMEM;
+	}
+	return 0;
 }
 
-void criu_set_log_file(const char *log_file)
+int criu_set_log_file(const char *log_file)
 {
-	criu_local_set_log_file(global_opts, log_file);
+	return criu_local_set_log_file(global_opts, log_file);
 }
 
 void criu_local_set_cpu_cap(criu_opts *opts, unsigned int cap)

--- a/lib/c/criu.c
+++ b/lib/c/criu.c
@@ -49,19 +49,10 @@ void criu_free_service(criu_opts *opts)
 	}
 }
 
-void criu_local_set_service_comm(criu_opts *opts, enum criu_service_comm comm)
-{
-	opts->service_comm = comm;
-}
-
-void criu_set_service_comm(enum criu_service_comm comm)
-{
-	criu_local_set_service_comm(global_opts, comm);
-}
-
 int criu_local_set_service_address(criu_opts *opts, const char *path)
 {
 	criu_free_service(opts);
+	opts->service_comm = CRIU_COMM_SK;
 	if (path) {
 		opts->service_address = strdup(path);
 	} else {
@@ -81,6 +72,7 @@ int criu_set_service_address(const char *path)
 void criu_local_set_service_fd(criu_opts *opts, int fd)
 {
 	criu_free_service(opts);
+	opts->service_comm = CRIU_COMM_FD;
 	opts->service_fd = fd;
 }
 
@@ -92,6 +84,7 @@ void criu_set_service_fd(int fd)
 int criu_local_set_service_binary(criu_opts *opts, const char *path)
 {
 	criu_free_service(opts);
+	opts->service_comm = CRIU_COMM_BIN;
 	if (path) {
 		opts->service_binary = strdup(path);
 	} else {

--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -46,12 +46,6 @@ void criu_set_service_fd(int fd);
 int criu_set_service_binary(const char *path);
 
 /*
- * You can choose if you want libcriu to connect to service socket
- * by itself, use provided file descriptor or spawn swrk by itself
- */
-void criu_set_service_comm(enum criu_service_comm);
-
-/*
  * Set opts to defaults. _Must_ be called first before using any functions from
  * the list down below. 0 on success, -1 on fail.
  */
@@ -165,7 +159,6 @@ void criu_local_free_opts(criu_opts *opts);
 
 int criu_local_set_service_address(criu_opts *opts, const char *path);
 void criu_local_set_service_fd(criu_opts *opts, int fd);
-void criu_local_set_service_comm(criu_opts *opts, enum criu_service_comm);
 
 void criu_local_set_service_fd(criu_opts *opts, int fd);
 

--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -41,9 +41,9 @@ enum criu_cg_mode {
 	CRIU_CG_MODE_DEFAULT,
 };
 
-void criu_set_service_address(const char *path);
+int criu_set_service_address(const char *path);
 void criu_set_service_fd(int fd);
-void criu_set_service_binary(const char *path);
+int criu_set_service_binary(const char *path);
 
 /*
  * You can choose if you want libcriu to connect to service socket
@@ -60,7 +60,7 @@ void criu_free_opts(void);
 
 void criu_set_pid(int pid);
 void criu_set_images_dir_fd(int fd); /* must be set for dump/restore */
-void criu_set_parent_images(const char *path);
+int criu_set_parent_images(const char *path);
 void criu_set_work_dir_fd(int fd);
 void criu_set_leave_running(bool leave_running);
 void criu_set_ext_unix_sk(bool ext_unix_sk);
@@ -77,12 +77,12 @@ void criu_set_auto_dedup(bool auto_dedup);
 void criu_set_force_irmap(bool force_irmap);
 void criu_set_link_remap(bool link_remap);
 void criu_set_log_level(int log_level);
-void criu_set_log_file(const char *log_file);
+int criu_set_log_file(const char *log_file);
 void criu_set_cpu_cap(unsigned int cap);
-void criu_set_root(const char *root);
+int criu_set_root(const char *root);
 void criu_set_manage_cgroups(bool manage);
 void criu_set_manage_cgroups_mode(enum criu_cg_mode mode);
-void criu_set_freeze_cgroup(const char *name);
+int criu_set_freeze_cgroup(const char *name);
 void criu_set_timeout(unsigned int timeout);
 void criu_set_auto_ext_mnt(bool val);
 void criu_set_ext_sharing(bool val);
@@ -163,7 +163,7 @@ typedef struct criu_opts criu_opts;
 int criu_local_init_opts(criu_opts **opts);
 void criu_local_free_opts(criu_opts *opts);
 
-void criu_local_set_service_address(criu_opts *opts, const char *path);
+int criu_local_set_service_address(criu_opts *opts, const char *path);
 void criu_local_set_service_fd(criu_opts *opts, int fd);
 void criu_local_set_service_comm(criu_opts *opts, enum criu_service_comm);
 
@@ -171,8 +171,8 @@ void criu_local_set_service_fd(criu_opts *opts, int fd);
 
 void criu_local_set_pid(criu_opts *opts, int pid);
 void criu_local_set_images_dir_fd(criu_opts *opts, int fd); /* must be set for dump/restore */
-void criu_local_set_parent_images(criu_opts *opts, const char *path);
-void criu_local_set_service_binary(criu_opts *opts, const char *path);
+int criu_local_set_parent_images(criu_opts *opts, const char *path);
+int criu_local_set_service_binary(criu_opts *opts, const char *path);
 void criu_local_set_work_dir_fd(criu_opts *opts, int fd);
 void criu_local_set_leave_running(criu_opts *opts, bool leave_running);
 void criu_local_set_ext_unix_sk(criu_opts *opts, bool ext_unix_sk);
@@ -189,12 +189,12 @@ void criu_local_set_auto_dedup(criu_opts *opts, bool auto_dedup);
 void criu_local_set_force_irmap(criu_opts *opts, bool force_irmap);
 void criu_local_set_link_remap(criu_opts *opts, bool link_remap);
 void criu_local_set_log_level(criu_opts *opts, int log_level);
-void criu_local_set_log_file(criu_opts *opts, const char *log_file);
+int criu_local_set_log_file(criu_opts *opts, const char *log_file);
 void criu_local_set_cpu_cap(criu_opts *opts, unsigned int cap);
-void criu_local_set_root(criu_opts *opts, const char *root);
+int criu_local_set_root(criu_opts *opts, const char *root);
 void criu_local_set_manage_cgroups(criu_opts *opts, bool manage);
 void criu_local_set_manage_cgroups_mode(criu_opts *opts, enum criu_cg_mode mode);
-void criu_local_set_freeze_cgroup(criu_opts *opts, const char *name);
+int criu_local_set_freeze_cgroup(criu_opts *opts, const char *name);
 void criu_local_set_timeout(criu_opts *opts, unsigned int timeout);
 void criu_local_set_auto_ext_mnt(criu_opts *opts, bool val);
 void criu_local_set_ext_sharing(criu_opts *opts, bool val);


### PR DESCRIPTION
This pull request consists of two commits. The first one contains missing `strudp()` checks (as requested in #602)

The other commit is a proposal that simplifies the c-interface, as it does not require to call `*set_service_comm()` anymore.
I think it would be a good idea to omit these calls in favour of `*set_service_address()`, `*set_service_fd()` or `*set_service_binary()`. As these calls already set the intention of the library user.
And it can not happen that the user sets the wrong service_comm value to the `set_service_*()` calls.
E.g. If `*set_service_comm()` was set to socket, but a string to the binary was given
via `*set_service_binary()` it would probably cause to undefined behavior that can be prevented by a better library design.