### PR TITLE
cr-service: Don't log return value of parse_options()

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -277,7 +277,6 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 
 		rpc_cfg_file = req->config_file;
 		i = parse_options(0, NULL, &dummy, &dummy, PARSING_RPC_CONF);
-		pr_warn("parse_options returns %d\n", i);
 		if (i) {
 			xfree(tmp_output);
 			xfree(tmp_work);


### PR DESCRIPTION
The function parse_options() should return an integer 0, 1 or 2, where:

* 0 := Success
* 1 := Failure
* 2 := CRIU should display help text

The current behaviour always creates a warning message which shows the return value of that function. With this change only the values that are different than 0 (Success) will be logged.

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>