### PR TITLE
mount: realloc info->source when resolve ext mount

### DIFF
--- a/criu/mount.c
+++ b/criu/mount.c
@@ -491,14 +491,13 @@ static int try_resolve_ext_mount(struct mount_info *info)
 			int len;
 
 			len = strlen(val) + sizeof("dev[]");
-			source = xmalloc(len);
+			source = xrealloc(info->source, len);
 			if (source == NULL)
 				return -1;
 
 			snprintf(source, len, "dev[%s]", val);
 			info->fstype = fstype_auto();
 			BUG_ON(info->fstype->code != FSTYPE__AUTO);
-			xfree(info->source);
 			info->source = source;
 			return 1;
 		}


### PR DESCRIPTION
Use `realloc()` to change the size of the memory block pointed to by `info->source` instead of allocating new memory area and releasing the old one. If `info->source` is NULL then the call is equivalent to `malloc(size)`.

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>