### PR TITLE
remote: Ignore interupt signals

### DIFF
--- a/criu/img-remote.c
+++ b/criu/img-remote.c
@@ -832,7 +832,9 @@ void accept_image_connections() {
 		int n_events, i;
 
 		n_events = epoll_wait(epoll_fd, events, EPOLL_MAX_EVENTS, 250);
-		if (n_events < 0) {
+
+		/* epoll_wait isn't restarted after interrupted by a signal */
+		if (n_events < 0 && errno != EINTR) {
 			pr_perror("Failed to epoll wait");
 			goto end;
 		}


### PR DESCRIPTION
When an interrupt signal ([even `SIGWINCH` when `strace` is used](https://unix.stackexchange.com/a/465194)) is received while epoll_wait() sleeps, it will return a value of -1 and set errno to `EINTR`, which is not an error and should be ignored.