### PR TITLE
Fix -R option

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -436,7 +436,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 		{OPT_NAME, no_argument, SAVE_TO, true},\
 		{"no-" OPT_NAME, no_argument, SAVE_TO, false}
 
-	static const char short_opts[] = "dSsR:t:hD:o:v::x::Vr:jJ:lW:L:M:";
+	static const char short_opts[] = "dSsRt:hD:o:v::x::Vr:jJ:lW:L:M:";
 	static struct option long_opts[] = {
 		{ "tree",			required_argument,	0, 't'	},
 		{ "leave-stopped",		no_argument,		0, 's'	},

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -3,7 +3,6 @@
 #include <limits.h>
 #include <unistd.h>
 #include <errno.h>
-#include <getopt.h>
 #include <string.h>
 #include <ctype.h>
 #include <sched.h>


### PR DESCRIPTION
The `-R` is short for `--leave-running`, which is a boolean option and does not require an argument.

From getopt(3) man page:
> optstring is a string containing the legitimate option characters. If such a character is followed by a colon, the option requires an argument, ...