### PR TITLE
Fix pathname passed to access()

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1178,6 +1178,9 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms,
 		 */
 		if (pid != 0) {
 			bool is_dead = strip_deleted(link);
+			mntns_root = mntns_get_root_fd(nsid);
+			if (mntns_root < 0)
+				return -1;
 
 			/* /proc/<pid> will be "/proc/1 (deleted)" when it is
 			 * dead, but a path like /proc/1/mountinfo won't have
@@ -1189,7 +1192,7 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms,
 			 */
 			if (!is_dead) {
 				*end = 0;
-				is_dead = access(rpath, F_OK);
+				is_dead = faccessat(mntns_root, rpath, F_OK, 0);
 				*end = '/';
 			}
 

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -209,6 +209,7 @@ TST_NOFILE	:=				\
 		unlink_multiple_largefiles	\
 		config_inotify_irmap		\
 		thp_disable			\
+		pid_file			\
 #		jobctl00			\
 
 ifneq ($(SRCARCH),arm)

--- a/test/zdtm/static/pid_file.c
+++ b/test/zdtm/static/pid_file.c
@@ -1,0 +1,52 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc 	= "Check that environment didn't change";
+const char *test_author	= "Andrei Vagin <avagin@gmail.com>";
+
+int main(int argc, char **argv)
+{
+	int fd, fd2;
+	struct stat st, st2;
+
+	test_init(argc, argv);
+
+	fd = open("/proc/1/status", O_RDONLY);
+	if (fd < 0) {
+		pr_perror("Unable to open /proc/1/status");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	fd2 = open("/proc/1/status", O_RDONLY);
+	if (fd2 < 0) {
+		pr_perror("Unable to open /proc/1/status");
+		return 1;
+	}
+	if (fstat(fd, &st)) {
+		pr_perror("fstat");
+		return 1;
+	}
+	if (fstat(fd2, &st2)) {
+		pr_perror("fstat");
+		return 1;
+	}
+	close(fd);
+	close(fd2);
+
+	if (st.st_ino != st2.st_ino) {
+		fail("inode numbers mismatch");
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
The pathname passed to access() in check_path_remap() should
not include the "." prefix present in link names.

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>