### PR TITLE
crit: display help message when using python3

### DIFF
--- a/lib/py/cli.py
+++ b/lib/py/cli.py
@@ -331,6 +331,11 @@ def main():
 
 	opts = vars(parser.parse_args())
 
+	if not opts:
+		sys.stderr.write(parser.format_usage())
+		sys.stderr.write("crit: error: too few arguments\n")
+		sys.exit(1)
+
 	opts["func"](opts)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Running crit with python2 gives following minimal help message:

 $ crit/crit
 usage: crit [-h] {decode,encode,info,x,show} ...
 crit: error: too few arguments

Using a python3 only system crit shows the following error:

 $ crit/crit
 Traceback (most recent call last):
   File "crit/crit", line 6, in <module>
     cli.main()
   File "/home/criu/crit/pycriu/cli.py", line 334, in main
     opts["func"](opts)
 KeyError: 'func'

Using this patch the python3 output changes to:

 $ crit/crit
 usage: crit [-h] {decode,encode,info,x,show} ...
 crit: error: the following arguments are required: parser

The help message is not 100% the same but almost. Better than a
traceback in any way.

Signed-off-by: Adrian Reber <areber@redhat.com>