### PR TITLE
seek_pagemap: Use pagemap_len()

### DIFF
--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -155,8 +155,7 @@ static int seek_pagemap(struct page_read *pr, unsigned long vaddr)
 
 	do {
 		unsigned long start = pr->pe->vaddr;
-		unsigned long len = pr->pe->nr_pages * PAGE_SIZE;
-		unsigned long end = start + len;
+		unsigned long end = start + pagemap_len(pr->pe);
 
 		if (vaddr < pr->cvaddr)
 			break;


### PR DESCRIPTION
The variable `len` is used only to calculate the value of `end`. We already have the static inline function `pagemap_len()`, which can be used, instead.