### PR TITLE
util: Don't pass address/port as arguments

### DIFF
--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -244,7 +244,7 @@ int main(int argc, char *argv[], char *envp[])
 	if (!strcmp(argv[optind], "image-cache")) {
 		if (!opts.port)
 			goto opt_port_missing;
-		return image_cache(opts.daemon_mode, DEFAULT_CACHE_SOCKET, opts.port);
+		return image_cache(opts.daemon_mode, DEFAULT_CACHE_SOCKET);
 	}
 
 	if (!strcmp(argv[optind], "image-proxy")) {
@@ -254,7 +254,7 @@ int main(int argc, char *argv[], char *envp[])
 		}
 		if (!opts.port)
 			goto opt_port_missing;
-		return image_proxy(opts.daemon_mode, DEFAULT_PROXY_SOCKET, opts.addr, opts.port);
+		return image_proxy(opts.daemon_mode, DEFAULT_PROXY_SOCKET);
 	}
 
 	if (!strcmp(argv[optind], "service"))

--- a/criu/img-cache.c
+++ b/criu/img-cache.c
@@ -8,19 +8,19 @@
 #include "cr_options.h"
 #include "util.h"
 
-int image_cache(bool background, char *local_cache_path, unsigned short cache_write_port)
+int image_cache(bool background, char *local_cache_path)
 {
 	int tmp;
 
-	pr_info("Proxy to Cache Port %d, CRIU to Cache Path %s\n",
-			cache_write_port, local_cache_path);
+	pr_info("Proxy to Cache Port %u, CRIU to Cache Path %s\n",
+			opts.port, local_cache_path);
 	restoring = true;
 
 	if (opts.ps_socket != -1) {
 		proxy_to_cache_fd = opts.ps_socket;
 		pr_info("Re-using ps socket %d\n", proxy_to_cache_fd);
 	} else {
-		proxy_to_cache_fd = setup_tcp_server("image cache", NULL, &cache_write_port);
+		proxy_to_cache_fd = setup_tcp_server("image cache");
 		if (proxy_to_cache_fd < 0) {
 			pr_perror("Unable to open proxy to cache TCP socket");
 			return -1;

--- a/criu/img-proxy.c
+++ b/criu/img-proxy.c
@@ -7,10 +7,10 @@
 #include "cr_options.h"
 #include "util.h"
 
-int image_proxy(bool background, char *local_proxy_path, char *fwd_host, unsigned short fwd_port)
+int image_proxy(bool background, char *local_proxy_path)
 {
-	pr_info("CRIU to Proxy Path: %s, Cache Address %s:%hu\n",
-		local_proxy_path, fwd_host, fwd_port);
+	pr_info("CRIU to Proxy Path: %s, Cache Address %s:%u\n",
+		local_proxy_path, opts.addr, opts.port);
 	restoring = false;
 
 	local_req_fd = setup_UNIX_server_socket(local_proxy_path);
@@ -23,7 +23,7 @@ int image_proxy(bool background, char *local_proxy_path, char *fwd_host, unsigne
 		proxy_to_cache_fd = opts.ps_socket;
 		pr_info("Re-using ps socket %d\n", proxy_to_cache_fd);
 	} else {
-		proxy_to_cache_fd = setup_tcp_client(fwd_host, fwd_port);
+		proxy_to_cache_fd = setup_tcp_client();
 		if (proxy_to_cache_fd < 0) {
 			pr_perror("Unable to open proxy to cache TCP socket");
 			close(local_req_fd);

--- a/criu/include/img-remote.h
+++ b/criu/include/img-remote.h
@@ -96,13 +96,13 @@ int finish_remote_restore();
 /* Starts an image proxy daemon (dump side). It receives image files through
  * socket connections and forwards them to the image cache (restore side).
  */
-int image_proxy(bool background, char *local_proxy_path, char *cache_host, unsigned short cache_port);
+int image_proxy(bool background, char *local_proxy_path);
 
 /* Starts an image cache daemon (restore side). It receives image files through
  * socket connections and caches them until they are requested by the restore
  * process.
  */
-int image_cache(bool background, char *local_cache_path, unsigned short cache_port);
+int image_cache(bool background, char *local_cache_path);
 
 /* Reads (discards) 'len' bytes from fd. This is used to emulate the function
  * lseek, which is used to advance the file needle.

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -289,9 +289,9 @@ char *xsprintf(const char *fmt, ...)
 
 void print_data(unsigned long addr, unsigned char *data, size_t size);
 
-int setup_tcp_server(char *type, char *addr, unsigned short *port);
+int setup_tcp_server(char *type);
 int run_tcp_server(bool daemon_mode, int *ask, int cfd, int sk);
-int setup_tcp_client(char *hostname, unsigned short port);
+int setup_tcp_client(void);
 
 #define LAST_PID_PATH		"sys/kernel/ns_last_pid"
 #define PID_MAX_PATH		"sys/kernel/pid_max"

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -1013,7 +1013,7 @@ int cr_page_server(bool daemon_mode, bool lazy_dump, int cfd)
 		goto no_server;
 	}
 
-	sk = setup_tcp_server("page", opts.addr, &opts.port);
+	sk = setup_tcp_server("page");
 	if (sk == -1)
 		return -1;
 no_server:
@@ -1054,7 +1054,7 @@ static int connect_to_page_server(void)
 		goto out;
 	}
 
-	page_server_sk = setup_tcp_client(opts.addr, opts.port);
+	page_server_sk = setup_tcp_client();
 	if (page_server_sk == -1)
 		return -1;
 out:


### PR DESCRIPTION
There is no need to pass the values for address and port as arguments when creating a TCP server. The external `opts` object, which provides `opts.addr` and `opts.port`, is accessible in all components that require these values.