### PR TITLE
page-xfer: Don't log addr/port on disconnect

### DIFF
--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -1084,8 +1084,7 @@ int disconnect_from_page_server(void)
 	if (page_server_sk == -1)
 		return 0;
 
-	pr_info("Disconnect from the page server %s:%u\n",
-			opts.addr, opts.port);
+	pr_info("Disconnect from the page server\n");
 
 	if (opts.ps_socket != -1)
 		/*


### PR DESCRIPTION
When the `--ps-socket` option is used with page-server, instead of `--address` and `--port`, this message would appear as:

    (00.028440) Disconnect from the page server (null):0