### PR TITLE
util: Don't log errno on bad server address

### DIFF
--- a/criu/util.c
+++ b/criu/util.c
@@ -1273,7 +1273,8 @@ static int get_sockaddr_in(struct sockaddr_storage *addr, char *host,
 	} else if (inet_pton(AF_INET6, host, &((struct sockaddr_in6 *)addr)->sin6_addr)) {
 		addr->ss_family = AF_INET6;
 	} else {
-		pr_perror("Bad server address");
+		pr_err("Invalid server address \"%s\". "
+		"The address must be in IPv4 or IPv6 format.\n", host);
 		return -1;
 	}
 


### PR DESCRIPTION
From man inet_pton(3):

    inet_pton() returns 1 on success (network address was successfully
    converted). 0 is returned if src does not contain a character
    string representing a valid network address in the specified
    address family. If af does not contain a valid address family,
    -1 is returned and errno is set to EAFNOSUPPORT.

We can assume that the return value is 1 or 0 (because `af` is set to AF_INET4 or AF_INET6), therefore `errno` will not be set.

If a user attempts to bind a server using invalid network address the following error message will be shown:

    Bad server address: Success

Which is not very clear, with this change the error message will look like this:

    Invalid server address "localhost". The address must be in IPv4 or IPv6 format.