### PR TITLE
config: Add msg for obsolete use of port/address

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -843,6 +843,10 @@ int check_options()
 		return 1;
 	}
 
+	if (opts.ps_socket != -1 && (opts.addr || opts.port))
+		pr_warn("Using --address or --port in "
+			"combination with --ps-socket is obsolete\n");
+
 	if (check_namespace_opts()) {
 		pr_err("Error: namespace flags conflict\n");
 		return 1;


### PR DESCRIPTION
When the `--ps-socket` option is specified the provided file descriptor of a socket will be reused for incoming TCP connection. In such case the `--address` and `--port` options are ignored.