### PR TITLE
util: Fix addr casting for IPv4/IPv6 in autobind

### DIFF
--- a/criu/util.c
+++ b/criu/util.c
@@ -1330,9 +1330,9 @@ int setup_tcp_server(char *type)
 		}
 
 		if (saddr.ss_family == AF_INET6) {
-			opts.port = ntohs(((struct sockaddr_in *)&saddr)->sin_port);
-		} else if (saddr.ss_family == AF_INET) {
 			opts.port = ntohs(((struct sockaddr_in6 *)&saddr)->sin6_port);
+		} else if (saddr.ss_family == AF_INET) {
+			opts.port = ntohs(((struct sockaddr_in *)&saddr)->sin_port);
 		}
 
 		pr_info("Using %u port\n", opts.port);


### PR DESCRIPTION
When `saddr.ss_family` is `AF_INET6` we should cast `&saddr` to `(struct sockaddr_in6 *)`.