### PR TITLE
remote: Rename 'local_req_fd' and 'proxy_to_cache_fd'

### DIFF
--- a/criu/img-cache.c
+++ b/criu/img-cache.c
@@ -38,8 +38,8 @@ int image_cache(bool background, char *local_cache_path)
 
 	pr_info("Cache is connected to Proxy through fd %d\n", remote_sk);
 
-	local_req_fd = setup_UNIX_server_socket(local_cache_path);
-	if (local_req_fd < 0) {
+	local_sk = setup_UNIX_server_socket(local_cache_path);
+	if (local_sk < 0) {
 		pr_perror("Unable to open cache to proxy UNIX socket");
 		close(remote_sk);
 		return -1;

--- a/criu/img-cache.c
+++ b/criu/img-cache.c
@@ -17,31 +17,31 @@ int image_cache(bool background, char *local_cache_path)
 	restoring = true;
 
 	if (opts.ps_socket != -1) {
-		proxy_to_cache_fd = opts.ps_socket;
-		pr_info("Re-using ps socket %d\n", proxy_to_cache_fd);
+		remote_sk = opts.ps_socket;
+		pr_info("Re-using ps socket %d\n", remote_sk);
 	} else {
-		proxy_to_cache_fd = setup_tcp_server("image cache");
-		if (proxy_to_cache_fd < 0) {
+		remote_sk = setup_tcp_server("image cache");
+		if (remote_sk < 0) {
 			pr_perror("Unable to open proxy to cache TCP socket");
 			return -1;
 		}
 		// Wait to accept connection from proxy.
-		tmp = accept(proxy_to_cache_fd, NULL, 0);
+		tmp = accept(remote_sk, NULL, 0);
 		if (tmp < 0) {
 			pr_perror("Unable to accept remote image connection"
 				  " from image proxy");
-			close(proxy_to_cache_fd);
+			close(remote_sk);
 			return -1;
 		}
-		proxy_to_cache_fd = tmp;
+		remote_sk = tmp;
 	}
 
-	pr_info("Cache is connected to Proxy through fd %d\n", proxy_to_cache_fd);
+	pr_info("Cache is connected to Proxy through fd %d\n", remote_sk);
 
 	local_req_fd = setup_UNIX_server_socket(local_cache_path);
 	if (local_req_fd < 0) {
 		pr_perror("Unable to open cache to proxy UNIX socket");
-		close(proxy_to_cache_fd);
+		close(remote_sk);
 		return -1;
 
 	}

--- a/criu/img-proxy.c
+++ b/criu/img-proxy.c
@@ -13,8 +13,8 @@ int image_proxy(bool background, char *local_proxy_path)
 		local_proxy_path, opts.addr, opts.port);
 	restoring = false;
 
-	local_req_fd = setup_UNIX_server_socket(local_proxy_path);
-	if (local_req_fd < 0) {
+	local_sk = setup_UNIX_server_socket(local_proxy_path);
+	if (local_sk < 0) {
 		pr_perror("Unable to open CRIU to proxy UNIX socket");
 		return -1;
 	}
@@ -26,7 +26,7 @@ int image_proxy(bool background, char *local_proxy_path)
 		remote_sk = setup_tcp_client();
 		if (remote_sk < 0) {
 			pr_perror("Unable to open proxy to cache TCP socket");
-			close(local_req_fd);
+			close(local_sk);
 			return -1;
 		}
 	}
@@ -40,7 +40,7 @@ int image_proxy(bool background, char *local_proxy_path)
 		}
 	}
 
-	// TODO - local_req_fd and remote_sk send as args.
+	// TODO - local_sk and remote_sk send as args.
 	accept_image_connections();
 	pr_info("Finished image proxy.");
 	return 0;

--- a/criu/img-proxy.c
+++ b/criu/img-proxy.c
@@ -20,18 +20,18 @@ int image_proxy(bool background, char *local_proxy_path)
 	}
 
 	if (opts.ps_socket != -1) {
-		proxy_to_cache_fd = opts.ps_socket;
-		pr_info("Re-using ps socket %d\n", proxy_to_cache_fd);
+		remote_sk = opts.ps_socket;
+		pr_info("Re-using ps socket %d\n", remote_sk);
 	} else {
-		proxy_to_cache_fd = setup_tcp_client();
-		if (proxy_to_cache_fd < 0) {
+		remote_sk = setup_tcp_client();
+		if (remote_sk < 0) {
 			pr_perror("Unable to open proxy to cache TCP socket");
 			close(local_req_fd);
 			return -1;
 		}
 	}
 
-	pr_info("Proxy is connected to Cache through fd %d\n", proxy_to_cache_fd);
+	pr_info("Proxy is connected to Cache through fd %d\n", remote_sk);
 
 	if (background) {
 		if (daemon(1, 0) == -1) {
@@ -40,7 +40,7 @@ int image_proxy(bool background, char *local_proxy_path)
 		}
 	}
 
-	// TODO - local_req_fd and proxy_to_cache_fd send as args.
+	// TODO - local_req_fd and remote_sk send as args.
 	accept_image_connections();
 	pr_info("Finished image proxy.");
 	return 0;

--- a/criu/include/img-remote.h
+++ b/criu/include/img-remote.h
@@ -67,7 +67,7 @@ struct roperation {
 /* This is the proxy to cache TCP socket FD. */
 extern int remote_sk;
 /* This the unix socket used to fulfill local requests. */
-extern int local_req_fd;
+extern int local_sk;
 /* True if we are running the cache/restore, false if proxy/dump. */
 extern bool restoring;
 

--- a/criu/include/img-remote.h
+++ b/criu/include/img-remote.h
@@ -65,7 +65,7 @@ struct roperation {
 };
 
 /* This is the proxy to cache TCP socket FD. */
-extern int proxy_to_cache_fd;
+extern int remote_sk;
 /* This the unix socket used to fulfill local requests. */
 extern int local_req_fd;
 /* True if we are running the cache/restore, false if proxy/dump. */


### PR DESCRIPTION
Rename `local_req_fd` and `proxy_to_cache_fd` to `local_sk` and `remote_sk`, because they are shorter and more similar to the name `page_server_sk` which is used in `criu/page-xfer.c`.