### PR TITLE
util: Introduce fd_set_nonblocking()

### DIFF
--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -274,6 +274,7 @@ static inline int sk_wait_data(int sk)
 	return poll(&pfd, 1, -1);
 }
 
+void fd_set_nonblocking(int fd, bool on);
 void tcp_nodelay(int sk, bool on);
 void tcp_cork(int sk, bool on);
 

--- a/criu/util.c
+++ b/criu/util.c
@@ -1139,6 +1139,24 @@ int fd_has_data(int lfd)
 	return ret;
 }
 
+void fd_set_nonblocking(int fd, bool on)
+{
+	int flags = fcntl(fd, F_GETFL, NULL);
+
+	if (flags < 0) {
+		pr_perror("Failed to obtain flags from fd %d", fd);
+		return;
+	}
+
+	if (on)
+		flags |= O_NONBLOCK;
+	else
+		flags &= (~O_NONBLOCK);
+
+	if (fcntl(fd, F_SETFL, flags) < 0)
+		pr_perror("Failed to set flags for fd %d", fd);
+}
+
 int make_yard(char *path)
 {
 	if (mount("none", path, "tmpfs", 0, NULL)) {


### PR DESCRIPTION
Combine the functionality of `socket_set_non_blocking()` and `socket_set_blocking()` into a new function, called `fd_set_nonblocking()`, and move it in `criu/util.c` to enable reusability throughout the code base.