### PR TITLE
Rename version protobuf RPC members

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -969,8 +969,8 @@ static int handle_version(int sk, CriuReq * msg)
 	CriuVersion version = CRIU_VERSION__INIT;
 
 	/* This assumes we will always have a major and minor version */
-	version.major = CRIU_VERSION_MAJOR;
-	version.minor = CRIU_VERSION_MINOR;
+	version.major_number = CRIU_VERSION_MAJOR;
+	version.minor_number = CRIU_VERSION_MINOR;
 	if (strcmp(CRIU_GITID, "0")) {
 		version.gitid = CRIU_GITID;
 	}

--- a/images/rpc.proto
+++ b/images/rpc.proto
@@ -211,8 +211,8 @@ message criu_resp {
 
 /* Answer for criu_req_type.VERSION requests */
 message criu_version {
-	required int32			major		= 1;
-	required int32			minor		= 2;
+	required int32			major_number	= 1;
+	required int32			minor_number	= 2;
 	optional string			gitid		= 3;
 	optional int32			sublevel	= 4;
 	optional int32			extra		= 5;

--- a/test/others/rpc/test.py
+++ b/test/others/rpc/test.py
@@ -66,8 +66,8 @@ if resp.type != rpc.VERSION:
 else:
 	if resp.success:
 		print('RPC: Success')
-		print('CRIU major %d' % resp.version.major)
-		print('CRIU minor %d' % resp.version.minor)
+		print('CRIU major %d' % resp.version.major_number)
+		print('CRIU minor %d' % resp.version.minor_number)
 		if resp.version.HasField('gitid'):
 			print('CRIU gitid %s' % resp.version.gitid)
 		if resp.version.HasField('sublevel'):

--- a/test/others/rpc/version.py
+++ b/test/others/rpc/version.py
@@ -32,8 +32,8 @@ if resp.type != rpc.VERSION:
 else:
 	if resp.success:
 		print('RPC: Success')
-		print('CRIU major %d' % resp.version.major)
-		print('CRIU minor %d' % resp.version.minor)
+		print('CRIU major %d' % resp.version.major_number)
+		print('CRIU minor %d' % resp.version.minor_number)
 		if resp.version.HasField('gitid'):
 			print('CRIU gitid %s' % resp.version.gitid)
 		if resp.version.HasField('sublevel'):


### PR DESCRIPTION
In rpc.proto the interface to query the CRIU version number uses major
and minor as keywords. This creates errors when using the RPC
definitions with C++: https://github.com/checkpoint-restore/criu/issues/625

In this commit the fields are renamed from major to major_number and
from minor to minor_number.

For existing programs using the RPC protobuf definition this should be a
transparent change. Only for programs importing the latest rpc.proto it
will require code changes.

Signed-off-by: Adrian Reber <areber@redhat.com>