### PR TITLE
[WIP] util: Enable socket zero-copy transmission

### DIFF
--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -375,4 +375,6 @@ static inline void print_stack_trace(pid_t pid) {}
 		___ret;									\
 	})
 
+int do_read_notification(int fd);
+
 #endif /* __CR_UTIL_H__ */


### PR DESCRIPTION
The `MSG_ZEROCOPY` flag enables copy avoidance for socket send calls.

The kernel is permissive when applications pass undefined flags to the send system call. By default it simply ignores these.

https://www.kernel.org/doc/html/latest/networking/msg_zerocopy.html