### PR TITLE
Remove irrelevant comment

### DIFF
--- a/criu/files.c
+++ b/criu/files.c
@@ -1479,10 +1479,6 @@ struct inherit_fd {
 
 int inh_fd_max = -1;
 
-/*
- * We can't print diagnostics messages in this function because the
- * log file isn't initialized yet.
- */
 int inherit_fd_parse(char *optarg)
 {
 	char *cp = NULL;


### PR DESCRIPTION
Support for printing early log messages was recently added, which makes the
comment below no longer relevant.
```
We can't print diagnostics messages in this function because the
log file isn't initialized yet.
```