### PR TITLE
criu: fix gcc9 rawhide compilation errors

### DIFF
--- a/compel/arch/x86/src/lib/include/uapi/asm/fpu.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/fpu.h
@@ -12,7 +12,9 @@
 
 #define FP_XSTATE_MAGIC1		0x46505853U
 #define FP_XSTATE_MAGIC2		0x46505845U
+#ifndef FP_XSTATE_MAGIC2_SIZE
 #define FP_XSTATE_MAGIC2_SIZE		sizeof(FP_XSTATE_MAGIC2)
+#endif
 
 #define XSTATE_FP			0x1
 #define XSTATE_SSE			0x2
@@ -261,7 +263,7 @@ struct xsave_struct_ia32 {
 		struct ymmh_struct	ymmh;
 		uint8_t			extended_state_area[EXTENDED_STATE_AREA_SIZE];
 	};
-} __aligned(FXSAVE_ALIGN_BYTES) __packed;
+} __aligned(FXSAVE_ALIGN_BYTES);
 
 typedef struct {
 	/*
@@ -286,7 +288,7 @@ struct user_i387_ia32_struct {
 	uint32_t			foo;		/* FPU Operand Pointer Offset	*/
 	uint32_t			fos;		/* FPU Operand Pointer Selector	*/
 	uint32_t			st_space[20];   /* 8*10 bytes for each FP-reg = 80 bytes */
-} __packed;
+};
 
 typedef struct {
 	struct {
@@ -294,12 +296,12 @@ typedef struct {
 
 		/* Software status information [not touched by FSAVE]:		*/
 		uint32_t			status;
-	} __packed fregs_state;
+	} fregs_state;
 	union {
 		struct xsave_struct_ia32	xsave;
 		uint8_t				__pad[sizeof(struct xsave_struct) + FP_XSTATE_MAGIC2_SIZE];
-	} __aligned(FXSAVE_ALIGN_BYTES) __packed;
-} __aligned(FXSAVE_ALIGN_BYTES) __packed fpu_state_ia32_t;
+	} __aligned(FXSAVE_ALIGN_BYTES);
+} __aligned(FXSAVE_ALIGN_BYTES) fpu_state_ia32_t;
 
 /*
  * This one is used in restorer.

--- a/compel/arch/x86/src/lib/include/uapi/asm/sigframe.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/sigframe.h
@@ -95,7 +95,7 @@ struct ucontext_ia32 {
 	compat_stack_t		uc_stack;
 	struct rt_sigcontext_32	uc_mcontext;
 	k_rtsigset_t		uc_sigmask; /* mask last for extensibility */
-} __packed;
+};
 
 struct rt_sigframe_ia32 {
 	uint32_t		pretcode;

--- a/criu/arch/x86/include/asm/restore.h
+++ b/criu/arch/x86/include/asm/restore.h
@@ -17,7 +17,7 @@
 		     : "g"(new_sp),					\
 		       "g"(restore_task_exec_start),			\
 		       "g"(task_args)					\
-		     : "rsp", "rdi", "rsi", "rbx", "rax", "memory")
+		     : "rdi", "rsi", "rbx", "rax", "memory")
 
 static inline void core_get_tls(CoreEntry *pcore, tls_t *ptls)
 {

--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -437,8 +437,8 @@ static int dump_one_unix_fd(int lfd, uint32_t id, const struct fd_parms *p)
 		 */
 		if (peer->peer_ino != ue->ino) {
 			if (!peer->name) {
-				pr_err("Unix socket %d with unreachable peer %d (%d/%s)\n",
-				       ue->ino, ue->peer, peer->peer_ino, peer->name);
+				pr_err("Unix socket %d with unreachable peer %d (%d)\n",
+				       ue->ino, ue->peer, peer->peer_ino);
 				goto err;
 			}
 		}

--- a/test/zdtm/static/binfmt_misc.c
+++ b/test/zdtm/static/binfmt_misc.c
@@ -98,7 +98,7 @@ int dump_content(const char *path, char **dump)
 int main(int argc, char **argv)
 {
 	char buf[MAX_REG_STR + 1];
-	char path[PATH_MAX];
+	char path[PATH_MAX*2 + 1];
 	char *dump[2];
 	int i, fd, len;
 


### PR DESCRIPTION
This fixes errors on current Fedora rawhide with gcc 9.

Most of the changes is to remove `__packed` to remove errors like:
```
 error: taking address of packed member of ‘union <anonymous>’ may result in an unaligned pointer value [-Werror=address-of-packed-member]
```
CC: @cyrillos @0x7f454c46 

There have similar changes last year for gcc 8 but that was more adding alignments. Not sure if removing `__packed` is correct.

This also fixes:
```
  CC       criu/cr-restore.o
In file included from criu/include/restore.h:6,
                 from criu/cr-restore.c:91:
criu/cr-restore.c: In function ‘sigreturn_restore’:
criu/arch/x86/include/asm/restore.h:10:2: error: listing the stack pointer register ‘rsp’ in a clobber list is deprecated [-Werror=deprecated]
   10 |  asm volatile(       \
      |  ^~~
```
and:
```
  CC       criu/sk-unix.o
In file included from criu/include/imgset.h:5,
                 from criu/sk-unix.c:17:
criu/sk-unix.c: In function ‘dump_one_unix_fd’:
criu/include/log.h:51:2: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
   51 |  print_on_level(LOG_ERROR,     \
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   52 |          "Error (%s:%d): " LOG_PREFIX fmt,  \
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |          __FILE__, __LINE__, ##__VA_ARGS__)
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
criu/sk-unix.c:440:5: note: in expansion of macro ‘pr_err’
  440 |     pr_err("Unix socket %d with unreachable peer %d (%d/%s)\n",
      |     ^~~~~~
```