### PR TITLE
docker-test: Fix deprecated security-opt format

### DIFF
--- a/scripts/travis/docker-test.sh
+++ b/scripts/travis/docker-test.sh
@@ -39,7 +39,7 @@ docker info
 
 criu --version
 
-docker run --tmpfs /tmp --tmpfs /run --read-only --security-opt=seccomp:unconfined --name cr -d alpine /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
+docker run --tmpfs /tmp --tmpfs /run --read-only --security-opt seccomp=unconfined --name cr -d alpine /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
 
 sleep 1
 for i in `seq 50`; do


### PR DESCRIPTION
The flag `--security-opt` doesn't use the colon separator (:) anymore to divide keys and values, instead it uses the equal symbol (=) for consistency with other similar flags, like `--storage-opt`.

Deprecated in release: v1.11.0
Target for removal in release: v17.06

https://docs.docker.com/engine/deprecated/