### PR TITLE
util: Remove deprecated print_data() routine

### DIFF
--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -288,8 +288,6 @@ char *xstrcat(char *str, const char *fmt, ...)
 char *xsprintf(const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 1, 2)));
 
-void print_data(unsigned long addr, unsigned char *data, size_t size);
-
 int setup_tcp_server(char *type);
 int run_tcp_server(bool daemon_mode, int *ask, int cfd, int sk);
 int setup_tcp_client(void);

--- a/criu/util.c
+++ b/criu/util.c
@@ -27,7 +27,6 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sched.h>
-#include <ctype.h>
 
 #include "bitops.h"
 #include "page.h"
@@ -1204,78 +1203,6 @@ void tcp_nodelay(int sk, bool on)
 	int val = on ? 1 : 0;
 	if (setsockopt(sk, SOL_TCP, TCP_NODELAY, &val, sizeof(val)))
 		pr_perror("Unable to restore TCP_NODELAY (%d)", val);
-}
-
-static inline void pr_xsym(unsigned char *data, size_t len, int pos)
-{
-	char sym;
-
-	if (pos < len)
-		sym = data[pos];
-	else
-		sym = ' ';
-
-	pr_msg("%c", isprint(sym) ? sym : '.');
-}
-
-static inline void pr_xdigi(unsigned char *data, size_t len, int pos)
-{
-	if (pos < len)
-		pr_msg("%02x ", data[pos]);
-	else
-		pr_msg("   ");
-}
-
-static int nice_width_for(unsigned long addr)
-{
-	int ret = 3;
-
-	while (addr) {
-		addr >>= 4;
-		ret++;
-	}
-
-	return ret;
-}
-
-void print_data(unsigned long addr, unsigned char *data, size_t size)
-{
-	int i, j, addr_len;
-	unsigned zero_line = 0;
-
-	addr_len = nice_width_for(addr + size);
-
-	for (i = 0; i < size; i += 16) {
-		if (*(u64 *)(data + i) == 0 && *(u64 *)(data + i + 8) == 0) {
-			if (zero_line == 0)
-				zero_line = 1;
-			else {
-				if (zero_line == 1) {
-					pr_msg("*\n");
-					zero_line = 2;
-				}
-
-				continue;
-			}
-		} else
-			zero_line = 0;
-
-		pr_msg("%#0*lx: ", addr_len, addr + i);
-		for (j = 0; j < 8; j++)
-			pr_xdigi(data, size, i + j);
-		pr_msg(" ");
-		for (j = 8; j < 16; j++)
-			pr_xdigi(data, size, i + j);
-
-		pr_msg(" |");
-		for (j = 0; j < 8; j++)
-			pr_xsym(data, size, i + j);
-		pr_msg(" ");
-		for (j = 8; j < 16; j++)
-			pr_xsym(data, size, i + j);
-
-		pr_msg("|\n");
-	}
 }
 
 static int get_sockaddr_in(struct sockaddr_storage *addr, char *host)


### PR DESCRIPTION
The print_data() function was part of the deprecated (and removed)
'show' action, and it was moved in util.c with the following commit:

	a501b4804b3c95e1d83d64dd10ed95c37f0378bb
	The 'show' action has been deprecated since 1.6, let's finally drop it.

	The print_data() routine is kept for yet another (to be deprecated too)
	feature called 'criu exec'.

The criu exec feature was removed with:

	909590a3558560655c1ce5b72215efbb325999ca
	Remove criu exec code

	It's now obsoleted by compel library.
	Maybe-TODO: Add compel tool exec action?

Therefore, now we can drop print_data() as well.