### PR TITLE
restore: support restoring threads with SELinux

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3534,6 +3534,13 @@ static int sigreturn_restore(pid_t pid, struct task_restore_args *task_args, uns
 	task_args->auto_dedup		= opts.auto_dedup;
 
 	/*
+	 * In the restorer we need to know if it is SELinux or not. For SELinux
+	 * we must change the process context before creating threads. For
+	 * Apparmor we can change each thread after they have been created.
+	 */
+	task_args->lsm_type		= kdat.lsm;
+
+	/*
 	 * Make root and cwd restore _that_ late not to break any
 	 * attempts to open files by paths above (e.g. /proc).
 	 */

--- a/criu/include/restorer.h
+++ b/criu/include/restorer.h
@@ -216,6 +216,7 @@ struct task_restore_args {
 #ifdef ARCH_HAS_LONG_PAGES
 	unsigned			page_size;
 #endif
+	int				lsm_type;
 } __aligned(64);
 
 /*


### PR DESCRIPTION
Restoring a multi-threaded process with CRIU's SELinux support fails
because SELinux does not always support changing the process context of
a multi-threaded process.

Reading the man-page for setcon(), to change the context of a running
process, it states that changing the SELinux context of a multi-threaded
process can only work 'if the new security context is bounded by the old
security context'.

To be able to restore a process without the need to have 'the new
security context [] bounded by the old security context', this sets the
SELinux process context before creating the threads. Thus all threads
are created with the process context of the main process.

Signed-off-by: Adrian Reber <areber@redhat.com>