### PR TITLE
scripts/build: use the last stable release for s390

### DIFF
--- a/scripts/build/Dockerfile.s390x.hdr
+++ b/scripts/build/Dockerfile.s390x.hdr
@@ -1,4 +1,4 @@
-FROM s390x/debian:jessie-backports
+FROM s390x/debian:latest
 
 ENV QEMU_CPU z900
 COPY scripts/build/qemu-user-static/usr/bin/qemu-s390x-static /usr/bin/qemu-s390x-static

--- a/scripts/build/extract-deb-pkg
+++ b/scripts/build/extract-deb-pkg
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 MIRROR="https://mirrors.kernel.org/ubuntu"
-PKGS="$MIRROR/dists/xenial/universe/binary-amd64/Packages.gz"
+PKGS="$MIRROR/dists/bionic/universe/binary-amd64/Packages.gz"
 
 if [ $# -ne 1 ]; then
 	echo "Usage: $0 package-name" 1>&2


### PR DESCRIPTION
And get qemu-static from the 18.04 LTS Ubuntu repos.

https://github.com/checkpoint-restore/criu/issues/652
Signed-off-by: Andrei Vagin <avagin@gmail.com>