### PR TITLE
mount: check mounts after restoring

### DIFF
--- a/criu/include/namespaces.h
+++ b/criu/include/namespaces.h
@@ -166,7 +166,6 @@ extern int restore_ns(int rst, struct ns_desc *nd);
 
 extern int dump_task_ns_ids(struct pstree_item *);
 extern int predump_task_ns_ids(struct pstree_item *);
-extern struct ns_id *rst_new_ns_id(unsigned int id, pid_t pid, struct ns_desc *nd, enum ns_type t);
 extern int rst_add_ns_id(unsigned int id, struct pstree_item *, struct ns_desc *nd);
 extern struct ns_id *lookup_ns_by_id(unsigned int id, struct ns_desc *nd);
 

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -2989,6 +2989,11 @@ int read_mnt_ns_img(void)
 	struct mount_info *pms = NULL;
 	struct ns_id *nsid;
 
+	if (!(root_ns_mask & CLONE_NEWNS)) {
+		mntinfo = NULL;
+		return 0;
+	}
+
 	for (nsid = ns_ids; nsid != NULL; nsid = nsid->next) {
 		if (nsid->nd != &mnt_ns_desc)
 			continue;

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -3139,15 +3139,12 @@ static int populate_mnt_ns(void)
 	struct ns_id *nsid;
 	int ret;
 
-	if (mnt_roots) {
-		/* mnt_roots is a tmpfs mount and it's private */
-		root_yard_mp = mnt_entry_alloc();
-		if (!root_yard_mp)
-			return -1;
+	root_yard_mp = mnt_entry_alloc();
+	if (!root_yard_mp)
+		return -1;
 
-		root_yard_mp->mountpoint = mnt_roots;
-		root_yard_mp->mounted = true;
-	}
+	root_yard_mp->mountpoint = mnt_roots;
+	root_yard_mp->mounted = true;
 
 	pms = mnt_build_tree(mntinfo, root_yard_mp);
 	if (!pms)

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -290,7 +290,7 @@ static void nsid_add(struct ns_id *ns, struct ns_desc *nd, unsigned int id, pid_
 	pr_info("Add %s ns %d pid %d\n", nd->str, ns->id, ns->ns_pid);
 }
 
-struct ns_id *rst_new_ns_id(unsigned int id, pid_t pid,
+static struct ns_id *rst_new_ns_id(unsigned int id, pid_t pid,
 		struct ns_desc *nd, enum ns_type type)
 {
 	struct ns_id *nsid;

--- a/criu/net.c
+++ b/criu/net.c
@@ -2086,6 +2086,9 @@ int read_net_ns_img(void)
 {
 	struct ns_id *ns;
 
+	if (!(root_ns_mask & CLONE_NEWNET))
+		return 0;
+
 	for (ns = ns_ids; ns != NULL; ns = ns->next) {
 		struct cr_img *img;
 		int ret;


### PR DESCRIPTION
Patches 1-4 do a minor cleanup of mounts code.

Patch 5 brings in the option --check-mounts on restore to check that at
the end of restore we have properly restored tree of mounts in each
mount namespace of the container.

We've seen cases of container migration passing fine without error, but
actually some mounts changed their attributes or even some new mounts
appeared. Potentially these "inaccuracies" during restore can accumulate
over several migrations of the same container, and we will finally see
unexpected crap in mounts and won't be able to find out the initial
problem. With --check-mounts we will catch initial problem and fix it.