### PR TITLE
rpc: reserve number for --check-mounts feature

### DIFF
--- a/images/rpc.proto
+++ b/images/rpc.proto
@@ -114,6 +114,7 @@ message criu_opts {
 	optional string			config_file		= 51;
 	optional bool			tcp_close		= 52;
 	optional string			lsm_profile		= 53;
+/*	optional bool			check_mounts		= 128;	*/
 }
 
 message criu_dump_resp {


### PR DESCRIPTION
We want to commit --check-mounts feature to vz-criu. But to maintain
image level compatibility between ms-criu and vz-criu one shouldn't use
the same field id for different data. So add a comment that these id is
reserved.