### PR TITLE
crtools: Print error messages from check_options()

### DIFF
--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -110,8 +110,10 @@ int main(int argc, char *argv[], char *envp[])
 		return cr_service_work(atoi(argv[2]));
 	}
 
-	if (check_options())
+	if (check_options()) {
+		flush_early_log_buffer(STDERR_FILENO);
 		return 1;
+	}
 
 	if (opts.imgs_dir == NULL)
 		SET_CHAR_OPTS(imgs_dir, ".");

--- a/criu/include/log.h
+++ b/criu/include/log.h
@@ -30,6 +30,8 @@ extern void print_on_level(unsigned int loglevel, const char *format, ...)
 # define LOG_PREFIX
 #endif
 
+void flush_early_log_buffer(int fd);
+
 #define print_once(loglevel, fmt, ...)					\
 	do {								\
 		static bool __printed;					\

--- a/criu/log.c
+++ b/criu/log.c
@@ -170,7 +170,7 @@ struct early_log_hdr {
 	uint16_t len;
 };
 
-static void flush_early_log_buffer(int fd)
+void flush_early_log_buffer(int fd)
 {
 	unsigned int pos = 0;
 	int ret;


### PR DESCRIPTION
When `check_options()` exits with an error (return value != 0) the logging is not yet initialised, and therefore the error messages are not printed out.

Since this affects only command-line usage, and only when `check_options()` reports an error, flush the early log messages to standard error.

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>