### PR TITLE
sk-inet: restore SO_BROADCAST option

### DIFF
--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -742,6 +742,10 @@ static int post_open_inet_sk(struct file_desc *d, int sk)
 	if (!val && restore_opt(sk, SOL_SOCKET, SO_REUSEPORT, &val))
 		return -1;
 
+	val = ii->ie->opts->so_broadcast;
+	if (!val && restore_opt(sk, SOL_SOCKET, SO_BROADCAST, &val))
+		return -1;
+
 	return 0;
 }
 

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -566,6 +566,11 @@ int restore_socket_opts(int sk, SkOptsEntry *soe)
 		pr_debug("\tset no_check for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_NO_CHECK, &val);
 	}
+	if (soe->has_so_broadcast && soe->so_broadcast) {
+		val = 1;
+		pr_debug("\tset broadcast for socket\n");
+		ret |= restore_opt(sk, SOL_SOCKET, SO_BROADCAST, &val);
+	}
 
 	tv.tv_sec = soe->so_snd_tmo_sec;
 	tv.tv_usec = soe->so_snd_tmo_usec;
@@ -646,6 +651,10 @@ int dump_socket_opts(int sk, SkOptsEntry *soe)
 	ret |= dump_opt(sk, SOL_SOCKET, SO_NO_CHECK, &val);
 	soe->has_so_no_check = true;
 	soe->so_no_check = val ? true : false;
+
+	ret |= dump_opt(sk, SOL_SOCKET, SO_BROADCAST, &val);
+	soe->has_so_broadcast = true;
+	soe->so_broadcast = val ? true : false;
 
 	ret |= dump_bound_dev(sk, soe);
 	ret |= dump_socket_filter(sk, soe);

--- a/images/sk-opts.proto
+++ b/images/sk-opts.proto
@@ -22,6 +22,7 @@ message sk_opts_entry {
 
 	repeated fixed64	so_filter	= 16;
 	optional bool		so_reuseport	= 17;
+	optional bool		so_broadcast	= 18;
 }
 
 enum sk_shutdown {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -30,6 +30,7 @@ TST_NOFILE	:=				\
 		socket_listen6			\
 		socket_listen4v6		\
 		socket_udp			\
+		socket_udp-broadcast		\
 		socket_udp-corked		\
 		socket6_udp			\
 		socket_udp_shutdown		\

--- a/test/zdtm/static/socket_udp-broadcast.c
+++ b/test/zdtm/static/socket_udp-broadcast.c
@@ -1,0 +1,47 @@
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "test checkpoint/restore of SO_BROADCAST\n";
+const char *test_author = "Radostin Stoyanov <rstoyanov1@gmail.com>\n";
+
+/* Description:
+ * Create UDP socket, set SO_BROADCAST and verify its value after restore.
+ */
+
+int main(int argc, char **argv)
+{
+	int sockfd;
+	int val;
+	socklen_t len = sizeof(val);
+
+	test_init(argc, argv);
+
+	sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sockfd < 0) {
+		pr_perror("Can't create socket");
+		return 1;
+	}
+
+	if (setsockopt(sockfd, SOL_SOCKET, SO_BROADCAST, &(int){ 1 }, len)) {
+		pr_perror("setsockopt");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	if (getsockopt(sockfd, SOL_SOCKET, SO_BROADCAST, &val, &len)) {
+		pr_perror("getsockopt");
+		return 1;
+	}
+
+	if (len != sizeof(val) || val != 1) {
+		fail("SO_BROADCAST not set");
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
Inet sockets may have broadcasting capability enabled. The `SO_BROADCAST` option is used to enable this feature. It is a Boolean flag option, which is defined, fetched, and set with the int data type. During
checkpoint, CRIU should detect the state of this flag, and during restore, it should be set appropriately.

Fixes #673