### PR TITLE
util: cr_daemon: Drop keep_fd argument

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -845,9 +845,16 @@ int check_options()
 		return 1;
 	}
 
-	if (opts.ps_socket != -1 && (opts.addr || opts.port))
-		pr_warn("Using --address or --port in "
-			"combination with --ps-socket is obsolete\n");
+	if (opts.ps_socket != -1) {
+		if (opts.addr || opts.port)
+			pr_warn("Using --address or --port in "
+				"combination with --ps-socket is obsolete\n");
+		if (opts.ps_socket <= STDERR_FILENO && opts.daemon_mode) {
+			pr_err("Standard file descriptors will be closed"
+				" in daemon mode\n");
+			return 1;
+		}
+	}
 
 	if (check_namespace_opts()) {
 		pr_err("Error: namespace flags conflict\n");

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -176,7 +176,7 @@ extern int is_anon_link_type(char *link, char *type);
 extern int cr_system(int in, int out, int err, char *cmd, char *const argv[], unsigned flags);
 extern int cr_system_userns(int in, int out, int err, char *cmd,
 				char *const argv[], unsigned flags, int userns_pid);
-extern int cr_daemon(int nochdir, int noclose, int *keep_fd, int close_fd);
+extern int cr_daemon(int nochdir, int noclose, int close_fd);
 extern int close_status_fd(void);
 extern int is_root_user(void);
 

--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -1427,7 +1427,7 @@ int cr_lazy_pages(bool daemon)
 		return -1;
 
 	if (daemon) {
-		ret = cr_daemon(1, 0, &lazy_sk, -1);
+		ret = cr_daemon(1, 0, -1);
 		if (ret == -1) {
 			pr_err("Can't run in the background\n");
 			return -1;

--- a/criu/util.c
+++ b/criu/util.c
@@ -629,7 +629,7 @@ int close_status_fd(void)
 	return close_safe(&opts.status_fd);
 }
 
-int cr_daemon(int nochdir, int noclose, int *keep_fd, int close_fd)
+int cr_daemon(int nochdir, int noclose, int close_fd)
 {
 	int pid;
 
@@ -651,16 +651,6 @@ int cr_daemon(int nochdir, int noclose, int *keep_fd, int close_fd)
 
 		if (close_fd != -1)
 			close(close_fd);
-
-		if ((*keep_fd != -1) && (*keep_fd != 3)) {
-			fd = dup2(*keep_fd, 3);
-			if (fd < 0) {
-				pr_perror("Dup2 failed");
-				return -1;
-			}
-			close(*keep_fd);
-			*keep_fd = fd;
-		}
 
 		fd = open("/dev/null", O_RDWR);
 		if (fd < 0) {
@@ -1057,7 +1047,7 @@ int run_tcp_server(bool daemon_mode, int *ask, int cfd, int sk)
 	socklen_t clen = sizeof(caddr);
 
 	if (daemon_mode) {
-		ret = cr_daemon(1, 0, ask, cfd);
+		ret = cr_daemon(1, 0, cfd);
 		if (ret == -1) {
 			pr_err("Can't run in the background\n");
 			goto out;


### PR DESCRIPTION
When running lazy-pages in daemon mode, file descriptor 3 is reused after fork to keep the opened UNIX socket. However, fd 3 happens to correspond to the opened image directory, and therefore this causes the following error:

```sh
$ criu lazy-pages -D <PATH> --page-server --address <ADDR> --port <PORT> -d
...
(06.835596) Error (criu/image.c:470): Unable to open pagemap-1.img: Not a directory
(06.835855) Error (criu/uffd.c:773): uffd: 1-7: Failed to open pagemap
```