### PR TITLE
This also adds the correct labels to sockets during restore

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2997,6 +2997,8 @@ static void rst_reloc_creds(struct thread_restore_args *thread_args,
 
 	if (args->lsm_profile)
 		args->lsm_profile = rst_mem_remap_ptr(args->mem_lsm_profile_pos, RM_PRIVATE);
+	if (args->lsm_sockcreate)
+		args->lsm_sockcreate = rst_mem_remap_ptr(args->mem_lsm_sockcreate_pos, RM_PRIVATE);
 	if (args->groups)
 		args->groups = rst_mem_remap_ptr(args->mem_groups_pos, RM_PRIVATE);
 
@@ -3060,6 +3062,40 @@ rst_prep_creds_args(CredsEntry *ce, unsigned long *prev_pos)
 	} else {
 		args->lsm_profile = NULL;
 		args->mem_lsm_profile_pos = 0;
+	}
+
+	if (ce->lsm_sockcreate) {
+		char *rendered = NULL;
+		char *profile;
+
+		profile = ce->lsm_sockcreate;
+
+		if (validate_lsm(profile) < 0)
+			return ERR_PTR(-EINVAL);
+
+		if (profile && render_lsm_profile(profile, &rendered)) {
+			return ERR_PTR(-EINVAL);
+		}
+		if (rendered) {
+			size_t lsm_sockcreate_len;
+			char *lsm_sockcreate;
+
+			args->mem_lsm_sockcreate_pos = rst_mem_align_cpos(RM_PRIVATE);
+			lsm_sockcreate_len = strlen(rendered);
+			lsm_sockcreate = rst_mem_alloc(lsm_sockcreate_len + 1, RM_PRIVATE);
+			if (!lsm_sockcreate) {
+				xfree(rendered);
+				return ERR_PTR(-ENOMEM);
+			}
+
+			args = rst_mem_remap_ptr(this_pos, RM_PRIVATE);
+			args->lsm_sockcreate = lsm_sockcreate;
+			strncpy(args->lsm_sockcreate, rendered, lsm_sockcreate_len);
+			xfree(rendered);
+		}
+	} else {
+		args->lsm_sockcreate = NULL;
+		args->mem_lsm_sockcreate_pos = 0;
 	}
 
 	/*

--- a/criu/include/lsm.h
+++ b/criu/include/lsm.h
@@ -3,6 +3,7 @@
 
 #include "images/inventory.pb-c.h"
 #include "images/creds.pb-c.h"
+#include "images/fdinfo.pb-c.h"
 
 #define AA_SECURITYFS_PATH "/sys/kernel/security/apparmor"
 
@@ -34,4 +35,21 @@ int validate_lsm(char *profile);
 int render_lsm_profile(char *profile, char **val);
 
 extern int lsm_check_opts(void);
+
+#ifdef CONFIG_HAS_SELINUX
+int dump_xattr_security_selinux(int fd, FdinfoEntry *e);
+int run_setsockcreatecon(FdinfoEntry *e);
+int reset_setsockcreatecon();
+#else
+static inline int dump_xattr_security_selinux(int fd, FdinfoEntry *e) {
+	return 0;
+}
+static inline int run_setsockcreatecon(FdinfoEntry *e) {
+	return 0;
+}
+static inline int reset_setsockcreatecon() {
+	return 0;
+}
+#endif
+
 #endif /* __CR_LSM_H__ */

--- a/criu/include/restorer.h
+++ b/criu/include/restorer.h
@@ -69,8 +69,10 @@ struct thread_creds_args {
 	unsigned int			secbits;
 	char				*lsm_profile;
 	unsigned int			*groups;
+	char				*lsm_sockcreate;
 
 	unsigned long			mem_lsm_profile_pos;
+	unsigned long			mem_lsm_sockcreate_pos;
 	unsigned long			mem_groups_pos;
 
 	unsigned long			mem_pos_next;

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -22,6 +22,7 @@
 #include "util-pie.h"
 #include "sk-packet.h"
 #include "namespaces.h"
+#include "lsm.h"
 #include "net.h"
 #include "xmalloc.h"
 #include "fs-magic.h"
@@ -662,6 +663,9 @@ int dump_socket(struct fd_parms *p, int lfd, FdinfoEntry *e)
 {
 	int family;
 	const struct fdtype_ops *ops;
+
+	if (dump_xattr_security_selinux(lfd, e))
+		return -1;
 
 	if (dump_opt(lfd, SOL_SOCKET, SO_DOMAIN, &family))
 		return -1;

--- a/images/creds.proto
+++ b/images/creds.proto
@@ -20,4 +20,5 @@ message creds_entry {
 	repeated uint32	groups	= 14;
 
 	optional string lsm_profile = 15;
+	optional string lsm_sockcreate = 16;
 }

--- a/images/fdinfo.proto
+++ b/images/fdinfo.proto
@@ -47,6 +47,7 @@ message fdinfo_entry {
 	required uint32		flags	= 2;
 	required fd_types	type	= 3;
 	required uint32		fd	= 4;
+	optional string		xattr_security_selinux = 5;
 }
 
 message file_entry {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -211,6 +211,8 @@ TST_NOFILE	:=				\
 		thp_disable			\
 		pid_file			\
 		selinux00			\
+		selinux01			\
+		selinux02			\
 #		jobctl00			\
 
 ifneq ($(SRCARCH),arm)
@@ -513,6 +515,7 @@ unlink_fstat041:		CFLAGS += -DUNLINK_FSTAT041 -DUNLINK_FSTAT04
 ghost_holes01:		CFLAGS += -DTAIL_HOLE
 ghost_holes02:		CFLAGS += -DHEAD_HOLE
 sk-freebind-false:	CFLAGS += -DZDTM_FREEBIND_FALSE
+selinux02:		CFLAGS += -DUSING_SOCKCREATE
 stopped01:		CFLAGS += -DZDTM_STOPPED_KILL
 stopped02:		CFLAGS += -DZDTM_STOPPED_TKILL
 stopped12:		CFLAGS += -DZDTM_STOPPED_KILL -DZDTM_STOPPED_TKILL

--- a/test/zdtm/static/selinux00.c
+++ b/test/zdtm/static/selinux00.c
@@ -83,6 +83,31 @@ int checkprofile()
 	return 0;
 }
 
+int check_sockcreate()
+{
+	char *output = NULL;
+	FILE *f = fopen("/proc/self/attr/sockcreate", "r");
+	int ret = fscanf(f, "%ms", &output);
+	fclose(f);
+
+	if (ret >= 1) {
+		free(output);
+		/* sockcreate should be empty, if fscanf found something
+		 * it is wrong.*/
+		fail("sockcreate should be empty\n");
+		return -1;
+	}
+
+	if (output) {
+		free(output);
+		/* Same here, output should still be NULL. */
+		fail("sockcreate should be empty\n");
+		return -1;
+	}
+
+	return 0;
+}
+
 int main(int argc, char **argv)
 {
 	test_init(argc, argv);
@@ -95,11 +120,20 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
+	if (check_sockcreate())
+		return -1;
+
 	if (setprofile())
+		return -1;
+
+	if (check_sockcreate())
 		return -1;
 
 	test_daemon();
 	test_waitsig();
+
+	if (check_sockcreate())
+		return -1;
 
 	if (checkprofile() == 0)
 		pass();

--- a/test/zdtm/static/selinux01.c
+++ b/test/zdtm/static/selinux01.c
@@ -1,0 +1,200 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/mount.h>
+#include <sys/socket.h>
+#include <sys/xattr.h>
+#include <linux/limits.h>
+#include <signal.h>
+#include "zdtmtst.h"
+
+/* Enabling the right policy happens in selinux00.hook and selinx00.checkskip */
+
+const char *test_doc	= "Check that a SELinux socket context is restored";
+const char *test_author	= "Adrian Reber <areber@redhat.com>";
+
+/* This is all based on Tycho's apparmor code */
+
+#define CONTEXT "unconfined_u:unconfined_r:unconfined_dbusd_t:s0"
+
+/*
+ * This is used to store the state of SELinux. For this test
+ * SELinux is switched to permissive mode and later the previous
+ * SELinux state is restored.
+ */
+char state;
+
+int check_for_selinux()
+{
+	if (access("/sys/fs/selinux", F_OK) == 0)
+		return 0;
+	return 1;
+}
+
+int setprofile()
+{
+	int fd, len;
+
+	fd = open("/proc/self/attr/current", O_WRONLY);
+	if (fd < 0) {
+		fail("Could not open /proc/self/attr/current\n");
+		return -1;
+	}
+
+	len = write(fd, CONTEXT, strlen(CONTEXT));
+	close(fd);
+
+	if (len < 0) {
+		fail("Could not write context\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int set_sockcreate()
+{
+	int fd, len;
+
+	fd = open("/proc/self/attr/sockcreate", O_WRONLY);
+	if (fd < 0) {
+		fail("Could not open /proc/self/attr/sockcreate\n");
+		return -1;
+	}
+
+	len = write(fd, CONTEXT, strlen(CONTEXT));
+	close(fd);
+
+	if (len < 0) {
+		fail("Could not write context\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int check_sockcreate()
+{
+	int fd;
+	char context[1024];
+	int len;
+
+
+	fd = open("/proc/self/attr/sockcreate", O_RDONLY);
+	if (fd < 0) {
+		fail("Could not open /proc/self/attr/sockcreate\n");
+		return -1;
+	}
+
+	len = read(fd, context, strlen(CONTEXT));
+	close(fd);
+	if (len != strlen(CONTEXT)) {
+		fail("SELinux context has unexpected length %d, expected %zd\n",
+			len, strlen(CONTEXT));
+		return -1;
+	}
+
+	if (strncmp(context, CONTEXT, strlen(CONTEXT)) != 0) {
+		fail("Wrong SELinux context %s expected %s\n", context, CONTEXT);
+		return -1;
+	}
+
+	return 0;
+}
+
+int check_sockcreate_empty()
+{
+	char *output = NULL;
+	FILE *f = fopen("/proc/self/attr/sockcreate", "r");
+	int ret = fscanf(f, "%ms", &output);
+	fclose(f);
+
+	if (ret >= 1) {
+		free(output);
+		/* sockcreate should be empty, if fscanf found something
+		 * it is wrong.*/
+		fail("sockcreate should be empty\n");
+		return -1;
+	}
+
+	if (output) {
+		free(output);
+		/* Same here, output should still be NULL. */
+		fail("sockcreate should be empty\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	char ctx[1024];
+	test_init(argc, argv);
+
+	if (check_for_selinux()) {
+		skip("SELinux not found on this system.");
+		test_daemon();
+		test_waitsig();
+		pass();
+		return 0;
+	}
+
+#ifdef USING_SOCKCREATE
+	if (set_sockcreate())
+		return -1;
+#else
+	if (check_sockcreate_empty())
+		return -1;
+
+	if (setprofile())
+		return -1;
+
+	if (check_sockcreate_empty())
+		return -1;
+#endif
+
+	/* Open our test socket */
+	int sk = socket(AF_INET, SOCK_STREAM, 0);
+	memset(ctx, 0, 1024);
+	/* Read out the socket label */
+	if (fgetxattr(sk, "security.selinux", ctx, 1024) == -1) {
+		fail("Reading xattr 'security.selinux' failed.\n");
+		return -1;
+	}
+	if (strncmp(ctx, CONTEXT, strlen(CONTEXT)) != 0) {
+		fail("Wrong SELinux context %s expected %s\n", ctx, CONTEXT);
+		return -1;
+	}
+	memset(ctx, 0, 1024);
+
+	test_daemon();
+	test_waitsig();
+
+	/* Read out the socket label again */
+
+	if (fgetxattr(sk, "security.selinux", ctx, 1024) == -1) {
+		fail("Reading xattr 'security.selinux' failed.\n");
+		return -1;
+	}
+	if (strncmp(ctx, CONTEXT, strlen(CONTEXT)) != 0) {
+		fail("Wrong SELinux context %s expected %s\n", ctx, CONTEXT);
+		return -1;
+	}
+
+#ifdef USING_SOCKCREATE
+	if (check_sockcreate())
+		return -1;
+#else
+	if (check_sockcreate_empty())
+		return -1;
+#endif
+
+	pass();
+
+	return 0;
+}

--- a/test/zdtm/static/selinux01.checkskip
+++ b/test/zdtm/static/selinux01.checkskip
@@ -1,0 +1,1 @@
+selinux00.checkskip

--- a/test/zdtm/static/selinux01.desc
+++ b/test/zdtm/static/selinux01.desc
@@ -1,0 +1,1 @@
+selinux00.desc

--- a/test/zdtm/static/selinux01.hook
+++ b/test/zdtm/static/selinux01.hook
@@ -1,0 +1,1 @@
+selinux00.hook

--- a/test/zdtm/static/selinux02.c
+++ b/test/zdtm/static/selinux02.c
@@ -1,0 +1,1 @@
+selinux01.c

--- a/test/zdtm/static/selinux02.checkskip
+++ b/test/zdtm/static/selinux02.checkskip
@@ -1,0 +1,1 @@
+selinux01.checkskip

--- a/test/zdtm/static/selinux02.desc
+++ b/test/zdtm/static/selinux02.desc
@@ -1,0 +1,1 @@
+selinux01.desc

--- a/test/zdtm/static/selinux02.hook
+++ b/test/zdtm/static/selinux02.hook
@@ -1,0 +1,1 @@
+selinux01.hook


### PR DESCRIPTION
If restoring a process in a SELinux environment, sockets created during restore must also have the correct labels. This sets the label for all sockets to the label the process had during restore.

As with all SELinux related labels, this assumes that all processes and sockets restored are using the same label (that is what is currently done for SELinux containers with Podman).