### PR TITLE
lsm: fix compiler error 'unused-result'

### DIFF
--- a/criu/lsm.c
+++ b/criu/lsm.c
@@ -111,20 +111,22 @@ err:
 static int selinux_get_sockcreate_label(pid_t pid, char **output)
 {
 	FILE *f;
+	int ret;
 
 	f = fopen_proc(pid, "attr/sockcreate");
 	if (!f)
 		return -1;
 
-	fscanf(f, "%ms", output);
-	/*
-	 * No need to check the result of fscanf(). If there is something
-	 * in /proc/PID/attr/sockcreate it will be copied to *output. If
-	 * there is nothing it will stay NULL. So whatever fscanf() does
-	 * it should be correct.
-	 */
-
+	ret = fscanf(f, "%ms", output);
 	fclose(f);
+	if (ret == -1 && ferror(f))
+		/*
+		 * Only if the error indicator is set it is a real error.
+		 * -1 could also be EOF, which would mean that sockcreate
+		 * was just empty, which is the most common case.
+		 */
+		return -1;
+
 	return 0;
 }
 


### PR DESCRIPTION
Reading out the xattr 'security.selinux' of checkpointed sockets with
fscanf() works (at least in theory) without checking the result of
fscanf(). There are, however, multiple CI failures when ignoring the
return value of fscanf().

This adds some extra (unnecessary) return code checking to make CI
happy.

See CI errors in #685 