### PR TITLE
lsm: fix compiler error on Fedora 30

### DIFF
--- a/criu/lsm.c
+++ b/criu/lsm.c
@@ -163,7 +163,7 @@ int dump_xattr_security_selinux(int fd, FdinfoEntry *e)
 	/* Get the size of the xattr. */
 	len = fgetxattr(fd, "security.selinux", ctx, 0);
 	if (len == -1) {
-		pr_err("Reading xattr %s to FD %d failed\n", ctx, fd);
+		pr_err("Reading xattr security.selinux from FD %d failed\n", fd);
 		return -1;
 	}
 


### PR DESCRIPTION
This fixes following compiler error:
```
criu/lsm.c: In function ‘dump_xattr_security_selinux’:
criu/include/log.h:51:2: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
   51 |  print_on_level(LOG_ERROR,     \
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   52 |          "Error (%s:%d): " LOG_PREFIX fmt,  \
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |          __FILE__, __LINE__, ##__VA_ARGS__)
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
criu/lsm.c:166:3: note: in expansion of macro ‘pr_err’
  166 |   pr_err("Reading xattr %s to FD %d failed\n", ctx, fd);
      |   ^~~~~~
```