### PR TITLE
Preserve xattr when mounting cgroups

### DIFF
--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -1698,11 +1698,11 @@ static int prepare_cgroup_sfd(CgroupEntry *ce)
 			pr_debug("\tMaking controller dir %s (%s)\n", paux, opt);
 			if (mkdir(paux, 0700)) {
 				pr_perror("\tCan't make controller dir %s", paux);
-				return -1;
+				goto err;
 			}
 			if (mount("none", paux, "cgroup", 0, opt) < 0) {
 				pr_perror("\tCan't mount controller dir %s", paux);
-				return -1;
+				goto err;
 			}
 		}
 

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1819,6 +1819,12 @@ int cr_dump_tasks(pid_t pid)
 	if (parse_cg_info())
 		goto err;
 
+	if (opts.manage_cgroups) {
+		host_mountinfo = parse_mountinfo(1, NULL, 0);
+		if (!host_mountinfo)
+			goto err;
+	}
+
 	if (prepare_inventory(&he))
 		goto err;
 
@@ -1867,6 +1873,11 @@ int cr_dump_tasks(pid_t pid)
 	for_each_pstree_item(item) {
 		if (dump_one_task(item, parent_ie))
 			goto err;
+	}
+
+	if (host_mountinfo) {
+		free_mntinfo(host_mountinfo);
+		host_mountinfo = NULL;
 	}
 
 	if (parent_ie) {
@@ -1935,6 +1946,11 @@ int cr_dump_tasks(pid_t pid)
 	if (ret)
 		goto err;
 err:
+	if (host_mountinfo) {
+		free_mntinfo(host_mountinfo);
+		host_mountinfo = NULL;
+	}
+
 	if (parent_ie)
 		inventory_entry__free_unpacked(parent_ie, NULL);
 

--- a/criu/include/cgroup.h
+++ b/criu/include/cgroup.h
@@ -4,6 +4,7 @@
 #include "int.h"
 #include "images/core.pb-c.h"
 
+extern struct mount_info *host_mountinfo;
 struct pstree_item;
 struct parasite_dump_cgroup_args;
 extern u32 root_cg_set;

--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -138,6 +138,7 @@ extern void clean_cr_time_mounts(void);
 extern bool add_skip_mount(const char *mountpoint);
 struct ns_id;
 extern struct mount_info *parse_mountinfo(pid_t pid, struct ns_id *nsid, bool for_dump);
+extern void free_mntinfo(struct mount_info *pms);
 
 extern int check_mnt_id(void);
 

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -1669,7 +1669,7 @@ static int dump_one_mountpoint(struct mount_info *pm, struct cr_img *img)
 	return 0;
 }
 
-static void free_mntinfo(struct mount_info *pms)
+void free_mntinfo(struct mount_info *pms)
 {
 	while (pms) {
 		struct mount_info *pm;


### PR DESCRIPTION
1-st patch - fix error handling while on it.
2-nd patch - get xattr cgroup mount option from existing mount to suppress noisy kernel warnings.