### PR TITLE
Fixes for coverity and clang warnings

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -776,6 +776,7 @@ static struct collect_image_info remap_cinfo = {
 static int dump_ghost_file(int _fd, u32 id, const struct stat *st, dev_t phys_dev)
 {
 	struct cr_img *img;
+	int exit_code = -1;
 	GhostFileEntry gfe = GHOST_FILE_ENTRY__INIT;
 	Timeval atim = TIMEVAL__INIT, mtim = TIMEVAL__INIT;
 
@@ -812,7 +813,7 @@ static int dump_ghost_file(int _fd, u32 id, const struct stat *st, dev_t phys_de
 	}
 
 	if (pb_write_one(img, &gfe, PB_GHOST_FILE))
-		return -1;
+		goto err_out;
 
 	if (S_ISREG(st->st_mode)) {
 		int fd, ret;
@@ -826,7 +827,7 @@ static int dump_ghost_file(int _fd, u32 id, const struct stat *st, dev_t phys_de
 		fd = open(lpath, O_RDONLY);
 		if (fd < 0) {
 			pr_perror("Can't open ghost original file");
-			return -1;
+			goto err_out;
 		}
 
 		if (gfe.chunks)
@@ -835,11 +836,13 @@ static int dump_ghost_file(int _fd, u32 id, const struct stat *st, dev_t phys_de
 			ret = copy_file(fd, img_raw_fd(img), st->st_size);
 		close(fd);
 		if (ret)
-			return -1;
+			goto err_out;
 	}
 
+	exit_code = 0;
+err_out:
 	close_image(img);
-	return 0;
+	return exit_code;
 }
 
 struct file_remap *lookup_ghost_remap(u32 dev, u32 ino)

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -627,6 +627,7 @@ static int collect_threads(struct pstree_item *item)
 {
 	struct seccomp_entry *task_seccomp_entry;
 	struct pid *threads = NULL;
+	struct pid *tmp = NULL;
 	int nr_threads = 0, i = 0, ret, nr_inprogress, nr_stopped = 0;
 
 	task_seccomp_entry = seccomp_find_entry(item->pid->real);
@@ -643,9 +644,11 @@ static int collect_threads(struct pstree_item *item)
 	}
 
 	/* The number of threads can't be less than already frozen */
-	item->threads = xrealloc(item->threads, nr_threads * sizeof(struct pid));
-	if (item->threads == NULL)
-		return -1;
+	tmp = xrealloc(item->threads, nr_threads * sizeof(struct pid));
+	if (tmp == NULL)
+		goto err;
+
+	item->threads = tmp;
 
 	if (item->nr_threads == 0) {
 		item->threads[0].real = item->pid->real;

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -573,7 +573,7 @@ static int do_dump_one_inet_fd(int lfd, u32 id, const struct fd_parms *p, int fa
 		ie.ip_opts->raw = NULL;
 
 	if (pb_write_one(img_from_set(glob_imgset, CR_FD_FILES), &fe, PB_FILE))
-		goto err;
+		err = -1;
 err:
 	ip_raw_opts_free(&ipopts_raw);
 	release_skopts(&skopts);


### PR DESCRIPTION
I have been running some code analysis against criu 3.12 and this fixes a few of the reported errors.

All tests are still successful, but as this touches many different parts of criu I am not I did not break something.