### PR TITLE
make: Use asciidoctor by default

### DIFF
--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -36,7 +36,7 @@ RUN apk add \
 	bash \
 	go \
 	e2fsprogs \
-	asciidoc xmlto
+	asciidoctor
 
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 -D test

--- a/scripts/build/Dockerfile.centos
+++ b/scripts/build/Dockerfile.centos
@@ -32,7 +32,7 @@ RUN yum install -y \
 	which \
 	e2fsprogs \
 	python2-pip \
-	asciidoc xmlto
+	rubygem-asciidoctor
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -33,7 +33,7 @@ RUN dnf install -y \
 	tar \
 	which \
 	e2fsprogs \
-	asciidoc xmlto \
+	rubygem-asciidoctor \
 	kmod
 
 # Replace coreutils-single with "traditional" coreutils

--- a/scripts/nmk/scripts/tools.mk
+++ b/scripts/nmk/scripts/tools.mk
@@ -35,6 +35,8 @@ CTAGS		:= ctags
 export RM HOSTLD LD HOSTCC CC CPP AS AR STRIP OBJCOPY OBJDUMP
 export NM SH MAKE MKDIR AWK PERL PYTHON SH CSCOPE
 
+export USE_ASCIIDOCTOR ?= $(shell which asciidoctor 2>/dev/null)
+
 #
 # Footer.
 ____nmk_defined__tools = y

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -4,7 +4,7 @@ set -x -e
 TRAVIS_PKGS="protobuf-c-compiler libprotobuf-c0-dev libaio-dev
 		libprotobuf-dev protobuf-compiler libcap-dev
 		libnl-3-dev gcc-multilib gdb bash python-protobuf
-		libnet-dev util-linux asciidoc xmlto libnl-route-3-dev"
+		libnet-dev util-linux asciidoctor libnl-route-3-dev"
 
 travis_prep () {
 	[ -n "$SKIP_TRAVIS_PREP" ] && return


### PR DESCRIPTION
The final release of [asciidoc](https://github.com/asciidoc/asciidoc) was on Sep 29, 2017 and the development is continued under [asciidoctor](https://github.com/asciidoctor/asciidoctor).

In commit 0493724 was added support for this tool by introducing `USE_ASCIIDOCTOR`. However, using asciidoctor by default might be a better option.

With this change CRIU will use asciidoctor if installed. Otherwise, it will fallback to asciidoc.