### PR TITLE
python: Drop six dependency

### DIFF
--- a/lib/py/images/pb2dict.py
+++ b/lib/py/images/pb2dict.py
@@ -4,7 +4,7 @@ from ipaddress import IPv4Address, ip_address
 from ipaddress import IPv6Address
 import socket
 import collections
-import os, six
+import os
 
 # pb2dict and dict2pb are methods to convert pb to/from dict.
 # Inspired by:
@@ -216,7 +216,10 @@ def get_bytes_dec(field):
 		return decode_base64
 
 def is_string(value):
-	return isinstance(value, six.string_types)
+	# Python 3 compatibility
+	if not hasattr(__builtins__, "basestring"):
+		basestring = (str, bytes)
+	return isinstance(value, basestring)
 
 def _pb2dict_cast(field, value, pretty = False, is_hex = False):
 	if not is_hex:


### PR DESCRIPTION
From the python-six module is used only six.string_types in the is_string() function. An alternative solution is to use basestring with additional if statement for Python 3 compatibility.

This change avoids the dependency on the six module.

However, this module is required by junit_xml and it is not listed as a dependency in the CentOS 7 package python2-junit_xml.