### PR TITLE
aarch64: Remove stack pointer from clobber list

### DIFF
--- a/criu/arch/aarch64/include/asm/restore.h
+++ b/criu/arch/aarch64/include/asm/restore.h
@@ -15,7 +15,7 @@
 			: "r"(new_sp),				\
 			  "r"(restore_task_exec_start),		\
 			  "r"(task_args)			\
-			: "sp", "x0", "memory")
+			: "x0", "memory")
 
 static inline void core_get_tls(CoreEntry *pcore, tls_t *ptls)
 {


### PR DESCRIPTION
Since gcc version 9.1 was added the [restriction](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=9d1cdb749a1) that the clobber list of an inline assembly should not contain the stack pointer register.

In commit 901f5d4 have been fixed most of the build failures related to this gcc restriction. In this patch is resolved a build error that occurs only on aarch64.