### PR TITLE
files-reg: Fix return value of copy_file()

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -296,6 +296,58 @@ static int copy_file_from_chunks(struct cr_img *img, int fd, size_t file_size)
 	}
 }
 
+static int copy_file(int fd_in, int fd_out, size_t bytes)
+{
+	ssize_t written = 0;
+	size_t chunk = bytes ? bytes : 4096;
+	char *buffer;
+	ssize_t ret;
+
+	buffer = xmalloc(chunk);
+	if (buffer == NULL) {
+		pr_perror("failed to allocate buffer to copy file");
+		return -1;
+	}
+
+	while (1) {
+		if (opts.remote) {
+			ret = read(fd_in, buffer, chunk);
+			if (ret < 0) {
+				pr_perror("Can't read from fd_in\n");
+				ret = -1;
+				goto err;
+			}
+			if (write(fd_out, buffer, ret) != ret) {
+				pr_perror("Couldn't write all read bytes\n");
+				ret = -1;
+				goto err;
+			}
+		} else
+			ret = sendfile(fd_out, fd_in, NULL, chunk);
+
+		if (ret < 0) {
+			pr_perror("Can't send data to ghost file");
+			ret = -1;
+			goto err;
+		}
+
+		if (ret == 0) {
+			if (bytes && (written != bytes)) {
+				pr_err("Ghost file size mismatch %zu/%zu\n",
+						written, bytes);
+				ret = -1;
+				goto err;
+			}
+			break;
+		}
+
+		written += ret;
+	}
+err:
+	xfree(buffer);
+	return ret;
+}
+
 static int mkreg_ghost(char *path, GhostFileEntry *gfe, struct cr_img *img)
 {
 	int gfd, ret;

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -343,6 +343,7 @@ static int copy_file(int fd_in, int fd_out, size_t bytes)
 
 		written += ret;
 	}
+	ret = 0;
 err:
 	xfree(buffer);
 	return ret;

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -163,7 +163,6 @@ static inline dev_t kdev_to_odev(u32 kdev)
 	return makedev(major, minor);
 }
 
-extern int copy_file(int fd_in, int fd_out, size_t bytes);
 extern int is_anon_link_type(char *link, char *type);
 
 #define is_hex_digit(c)				\


### PR DESCRIPTION
https://lists.openvz.org/pipermail/criu/2019-May/044010.html

The function `copy_file()` is used only in the `files-reg.c` file. In this PR it is moved from the `util.c` to `files-reg.c` and its return value is set to 0 on success.