### PR TITLE
zdtm: Check stats file presence before reading

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1109,6 +1109,9 @@ class criu:
 		subprocess.Popen([self.__crit_bin, "show", self.__stats_file(action)]).wait()
 
 	def check_pages_counts(self):
+		if not os.access(self.__stats_file("dump"), os.R_OK):
+			return
+
 		stats_written = -1
 		with open(self.__stats_file("dump"), 'rb') as stfile:
 			stats = crpc.images.load(stfile)


### PR DESCRIPTION
In some cases the stats-dump file can be missing, so do not
crash the whole zdtm.py in this case.

https://ci.openvz.org/job/CRIU/job/criu-live-migration/job/criu-dev/2362/console

Signed-off-by: Pavel Emelyanov <xemul@virtuozzo.com>