### PR TITLE
zdtm: make grep_errors also grep warnings

### DIFF
--- a/criu/image.c
+++ b/criu/image.c
@@ -126,6 +126,18 @@ int inventory_save_uptime(InventoryEntry *he)
 	return 0;
 }
 
+/*
+ * This function is intended to get an inventory image from previous (parent)
+ * dump iteration. We use dump_uptime from the image in detect_pid_reuse().
+ *
+ * You see that these function never fails by itself, it only prints warnings
+ * to better understand reasons why we don't found a proper image, failing here
+ * is too early. We get to detect_pid_reuse() only if we have a parent pagemap
+ * and that's the proper place to fail: we know that there is a parent pagemap
+ * but we don't have (can't access, etc) parent inventory => can't detect
+ * pid-reuse => fail.
+ */
+
 InventoryEntry *get_parent_inventory(void)
 {
 	struct cr_img *img;
@@ -134,7 +146,15 @@ InventoryEntry *get_parent_inventory(void)
 
 	dir = openat(get_service_fd(IMG_FD_OFF), CR_PARENT_LINK, O_RDONLY);
 	if (dir == -1) {
-		pr_warn("Failed to open parent directory\n");
+		/*
+		 * We print the warning below to be notified that we had some
+		 * unexpected problem on open. For instance we have a parent
+		 * directory but have no access. Having no parent inventory
+		 * when also having no parent directory is an expected case of
+		 * first dump iteration.
+		 */
+		if (errno != ENOENT)
+			pr_warn("Failed to open parent directory\n");
 		return NULL;
 	}
 

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -318,7 +318,7 @@ static int detect_pid_reuse(struct pstree_item *item,
 
 	if (!parent_ie) {
 		pr_err("Pid-reuse detection failed: no parent inventory, " \
-		       "check warnings in get_parent_stats\n");
+		       "check warnings in get_parent_inventory\n");
 		return -1;
 	}
 

--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -87,11 +87,15 @@ int dedup_one_iovec(struct page_read *pr, unsigned long off, unsigned long len)
 
 		ret = pr->seek_pagemap(pr, off);
 		if (ret == 0) {
-			pr_warn("Missing %lx in parent pagemap\n", off);
-			if (off < pr->cvaddr && pr->cvaddr < iov_end)
+			if (off < pr->cvaddr && pr->cvaddr < iov_end) {
+				pr_debug("pr%lu-%u:No range %lx-%lx in pagemap\n",
+					 pr->img_id, pr->id, off, pr->cvaddr);
 				off = pr->cvaddr;
-			else
+			} else {
+				pr_debug("pr%lu-%u:No range %lx-%lx in pagemap\n",
+					 pr->img_id, pr->id, off, iov_end);
 				return 0;
+			}
 		}
 
 		if (!pr->pe)
@@ -106,7 +110,8 @@ int dedup_one_iovec(struct page_read *pr, unsigned long off, unsigned long len)
 		prp = pr->parent;
 		if (prp) {
 			/* recursively */
-			pr_debug("Go to next parent level\n");
+			pr_debug("pr%lu-%u:Go to next parent level\n",
+				 pr->img_id, pr->id);
 			len = min(piov_end, iov_end) - off;
 			ret = dedup_one_iovec(prp, off, len);
 			if (ret != 0)

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -2062,7 +2062,7 @@ def grep_errors(fname):
             before.append(l)
             if len(before) > 5:
                 before.pop(0)
-            if "Error" in l:
+            if "Error" in l or "Warn" in l:
                 if first:
                     print_fname(fname, 'log')
                     print_sep("grep Error", "-", 60)


### PR DESCRIPTION
It is inspired by the discussion about inotify fix:
https://github.com/checkpoint-restore/criu/pull/728#issuecomment-506929427

From one point of view, warnings might be important to understand why we
detect some visible change in the environment after c/r-ing the process,
and if this change is expected or not. So we should add "Warn" messages
to the output.

From over point, these warnings if they are expected, can spoil our
final logs with a lot of unnecessary details.

I see warnings from dedup when it tries to find region in parent hit the log limits:
```
From: https://api.travis-ci.org/v3/job/552665729/log.txt
The job exceeded the maximum log length, and has been terminated.
```
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>