### PR TITLE
make: Insert version macros in criu.h

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,6 @@
 CRIU_SO			:= libcriu.so
 CRIU_A			:= libcriu.a
-UAPI_HEADERS		:= lib/c/criu.h images/rpc.proto
+UAPI_HEADERS		:= lib/c/criu.h images/rpc.proto criu/include/version.h
 
 #
 # File to keep track of files installed by setup.py

--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -21,8 +21,10 @@
 
 #include <stdbool.h>
 
+#include "version.h"
+
 #ifdef __GNUG__
-       extern "C" {
+	extern "C" {
 #endif
 
 enum criu_service_comm {


### PR DESCRIPTION
Including the macros that provide information about the version of CRIU is required by projects that use libcriu to preserve backward compatibility.

Closes #738

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>