### PR TITLE
Replace libprotobuf-c0-dev with libprotobuf-c-dev

### DIFF
--- a/contrib/debian/dev-packages.lst
+++ b/contrib/debian/dev-packages.lst
@@ -1,7 +1,7 @@
 # Required packages for development in Debian
 build-essential
 libprotobuf-dev
-libprotobuf-c0-dev
+libprotobuf-c-dev
 protobuf-c-compiler
 protobuf-compiler
 python-protobuf

--- a/criu/Makefile.packages
+++ b/criu/Makefile.packages
@@ -11,7 +11,7 @@ REQ-RPM-PKG-NAMES	+= $(PYTHON)-future
 REQ-RPM-PKG-TEST-NAMES  += libaio-devel
 
 REQ-DEB-PKG-NAMES	+= libprotobuf-dev
-REQ-DEB-PKG-NAMES	+= libprotobuf-c0-dev
+REQ-DEB-PKG-NAMES	+= libprotobuf-c-dev
 REQ-DEB-PKG-NAMES	+= protobuf-c-compiler
 REQ-DEB-PKG-NAMES	+= protobuf-compiler
 REQ-DEB-PKG-NAMES	+= python-protobuf

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 	libgnutls28-dev \
 	libgnutls30 \
 	libnl-3-dev \
-	libprotobuf-c0-dev \
+	libprotobuf-c-dev \
 	libprotobuf-dev \
 	libselinux-dev \
 	pkg-config \

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -x -e
 
-TRAVIS_PKGS="protobuf-c-compiler libprotobuf-c0-dev libaio-dev
+TRAVIS_PKGS="protobuf-c-compiler libprotobuf-c-dev libaio-dev
 		libgnutls28-dev libgnutls30 libprotobuf-dev protobuf-compiler
 		libcap-dev libnl-3-dev gcc-multilib gdb bash python-protobuf
 		libnet-dev util-linux asciidoctor libnl-route-3-dev"


### PR DESCRIPTION
The `libprotobuf-c0-dev` virtual package is no longer available
in Debian Buster, but is provided by `libprotobuf-c-dev`, which
is available.

https://packages.debian.org/stretch/libprotobuf-c0-dev

> Virtual Package: libprotobuf-c0-dev
>
> This is a virtual package. See the Debian policy for a definition of virtual packages.
>
> Packages providing libprotobuf-c0-dev
> libprotobuf-c-dev
> Protocol Buffers C static library and headers (protobuf-c)
