### PR TITLE
Remove python2-future from Fedora Dockerfiles

### DIFF
--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -18,14 +18,9 @@ RUN dnf install -y \
 	procps-ng \
 	protobuf-c-devel \
 	protobuf-devel \
-	python2-protobuf \
-	python2 \
-	# Starting with Fedora 28 this is python2-ipaddress
 	python-ipaddress \
-	# Starting with Fedora 28 this is python2-pyyaml
 	python-yaml \
 	python3-pip \
-	python2-future \
 	python3-PyYAML \
 	python3-future \
 	python3-protobuf \

--- a/scripts/build/Makefile
+++ b/scripts/build/Makefile
@@ -2,6 +2,7 @@ QEMU_ARCHES := armv7hf aarch64 ppc64le s390x fedora-rawhide-aarch64 # require qe
 ARCHES := $(QEMU_ARCHES) x86_64 fedora-asan fedora-rawhide centos
 TARGETS := $(ARCHES) alpine
 TARGETS_CLANG := $(addsuffix $(TARGETS),-clang)
+CONTAINER_RUNTIME := docker
 
 all: $(TARGETS) $(TARGETS_CLANG)
 .PHONY: all
@@ -27,8 +28,8 @@ $(QEMU_ARCHES): qemu-user-static binfmt_misc
 $(TARGETS):
 	mkdir -p $(HOME)/.ccache
 	mv $(HOME)/.ccache ../../
-	docker build  -t criu-$@ -f Dockerfile.$@ $(DB_CC) $(DB_ENV) ../..
-	docker run criu-$@ tar c -C /tmp .ccache | tar x -C $(HOME)
+	$(CONTAINER_RUNTIME) build  -t criu-$@ -f Dockerfile.$@ $(DB_CC) $(DB_ENV) ../..
+	$(CONTAINER_RUNTIME) run criu-$@ tar c -C /tmp .ccache | tar x -C $(HOME)
 .PHONY: $(TARGETS)
 
 # Clang builds add some Docker build env


### PR DESCRIPTION
This removes python2 from Fedora based Dockerfiles as it is not needed and will be removed from future Fedora releases. This PR also adds an environment variable to use other container runtimes for testing.