### PR TITLE
vdso: Use gettimeofday() from vdso for timings

### DIFF
--- a/compel/plugins/include/uapi/std/log.h
+++ b/compel/plugins/include/uapi/std/log.h
@@ -1,10 +1,12 @@
 #ifndef COMPEL_PLUGIN_STD_LOG_H__
 #define COMPEL_PLUGIN_STD_LOG_H__
 
+#include "compel/loglevels.h"
+
 #define STD_LOG_SIMPLE_CHUNK	256
 
 extern void std_log_set_fd(int fd);
-extern void std_log_set_loglevel(unsigned int level);
+extern void std_log_set_loglevel(enum __compel_log_levels level);
 extern void std_log_set_start(struct timeval *tv);
 extern int std_vprint_num(char *buf, int blen, int num, char **ps);
 extern void std_sprintf(char output[STD_LOG_SIMPLE_CHUNK], const char *format, ...)

--- a/compel/plugins/include/uapi/std/log.h
+++ b/compel/plugins/include/uapi/std/log.h
@@ -8,6 +8,18 @@
 extern void std_log_set_fd(int fd);
 extern void std_log_set_loglevel(enum __compel_log_levels level);
 extern void std_log_set_start(struct timeval *tv);
+
+/*
+ * Provides a function to get time *in the infected task* for log timings.
+ * Expected use-case: address on the vdso page to get time.
+ * If not set or called with NULL - compel will use raw syscall,
+ * which requires enter in the kernel and as a result affects performance.
+ */
+typedef int (*gettimeofday_t)(struct timeval *tv, struct timezone *tz);
+extern void std_log_set_gettimeofday(gettimeofday_t gtod);
+/* std plugin helper to get time (hopefully, efficiently) */
+extern int std_gettimeofday(struct timeval *tv, struct timezone *tz);
+
 extern int std_vprint_num(char *buf, int blen, int num, char **ps);
 extern void std_sprintf(char output[STD_LOG_SIMPLE_CHUNK], const char *format, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)));

--- a/compel/plugins/std/log.c
+++ b/compel/plugins/std/log.c
@@ -16,6 +16,7 @@ struct simple_buf {
 static int logfd = -1;
 static int cur_loglevel = COMPEL_DEFAULT_LOGLEVEL;
 static struct timeval start;
+static gettimeofday_t __std_gettimeofday;
 
 static void sbuf_log_flush(struct simple_buf *b);
 
@@ -54,7 +55,7 @@ static void sbuf_log_init(struct simple_buf *b)
 	if (start.tv_sec != 0) {
 		struct timeval now;
 
-		sys_gettimeofday(&now, NULL);
+		std_gettimeofday(&now, NULL);
 		timediff(&start, &now);
 
 		/* Seconds */
@@ -128,6 +129,19 @@ void std_log_set_loglevel(enum __compel_log_levels level)
 void std_log_set_start(struct timeval *s)
 {
 	start = *s;
+}
+
+void std_log_set_gettimeofday(gettimeofday_t gtod)
+{
+	__std_gettimeofday = gtod;
+}
+
+int std_gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+	if (__std_gettimeofday != NULL)
+		return __std_gettimeofday(tv, tz);
+
+	return sys_gettimeofday(tv, tz);
 }
 
 static void print_string(const char *msg, struct simple_buf *b)

--- a/compel/plugins/std/log.c
+++ b/compel/plugins/std/log.c
@@ -120,7 +120,7 @@ void std_log_set_fd(int fd)
 	logfd = fd;
 }
 
-void std_log_set_loglevel(unsigned int level)
+void std_log_set_loglevel(enum __compel_log_levels level)
 {
 	cur_loglevel = level;
 }

--- a/criu/arch/aarch64/include/asm/vdso.h
+++ b/criu/arch/aarch64/include/asm/vdso.h
@@ -10,6 +10,7 @@
  * we should support at the moment.
  */
 #define VDSO_SYMBOL_MAX		4
+#define VDSO_SYMBOL_GTOD	2
 
 /*
  * Workaround for VDSO array symbol table's relocation.

--- a/criu/arch/arm/include/asm/vdso.h
+++ b/criu/arch/arm/include/asm/vdso.h
@@ -10,6 +10,7 @@
  * Poke from kernel file arch/arm/vdso/vdso.lds.S
  */
 #define VDSO_SYMBOL_MAX		2
+#define VDSO_SYMBOL_GTOD	1
 #define ARCH_VDSO_SYMBOLS			\
 	"__vdso_clock_gettime",		\
 	"__vdso_gettimeofday"

--- a/criu/arch/ppc64/include/asm/vdso.h
+++ b/criu/arch/ppc64/include/asm/vdso.h
@@ -13,6 +13,7 @@
  * inside the text page which should not be used as is from user space.
  */
 #define VDSO_SYMBOL_MAX		10
+#define VDSO_SYMBOL_GTOD	5
 #define ARCH_VDSO_SYMBOLS			\
 	"__kernel_clock_getres",		\
 	"__kernel_clock_gettime",		\

--- a/criu/arch/s390/include/asm/vdso.h
+++ b/criu/arch/s390/include/asm/vdso.h
@@ -8,7 +8,8 @@
  * This is a minimal amount of symbols
  * we should support at the moment.
  */
-#define VDSO_SYMBOL_MAX	4
+#define VDSO_SYMBOL_MAX		4
+#define VDSO_SYMBOL_GTOD	0
 
 /*
  * This definition is used in pie/util-vdso.c to initialize the vdso symbol

--- a/criu/arch/x86/include/asm/vdso.h
+++ b/criu/arch/x86/include/asm/vdso.h
@@ -12,7 +12,8 @@
  * This is a minimal amount of symbols
  * we should support at the moment.
  */
-#define VDSO_SYMBOL_MAX	6
+#define VDSO_SYMBOL_MAX		6
+#define VDSO_SYMBOL_GTOD	2
 
 /*
  * XXX: we don't patch __kernel_vsyscall as it's too small:

--- a/criu/include/parasite-vdso.h
+++ b/criu/include/parasite-vdso.h
@@ -81,6 +81,7 @@ static inline bool is_vdso_mark(void *addr)
 	return false;
 }
 
+extern void vdso_update_gtod_addr(struct vdso_maps *rt);
 extern int vdso_do_park(struct vdso_maps *rt, unsigned long park_at,
 			unsigned long park_size);
 extern int vdso_map_compat(unsigned long map_at);

--- a/criu/include/parasite-vdso.h
+++ b/criu/include/parasite-vdso.h
@@ -84,7 +84,7 @@ static inline bool is_vdso_mark(void *addr)
 extern int vdso_do_park(struct vdso_maps *rt, unsigned long park_at,
 			unsigned long park_size);
 extern int vdso_map_compat(unsigned long map_at);
-extern int vdso_proxify(struct vdso_symtable *sym_rt,
+extern int vdso_proxify(struct vdso_symtable *sym_rt, bool *added_proxy,
 			unsigned long vdso_rt_parked_at,
 			VmaEntry *vmas, size_t nr_vmas,
 			bool compat_vdso, bool force_trampolines);

--- a/criu/include/parasite-vdso.h
+++ b/criu/include/parasite-vdso.h
@@ -84,8 +84,7 @@ static inline bool is_vdso_mark(void *addr)
 extern int vdso_do_park(struct vdso_maps *rt, unsigned long park_at,
 			unsigned long park_size);
 extern int vdso_map_compat(unsigned long map_at);
-extern int vdso_proxify(struct vdso_symtable *sym_rt, bool *added_proxy,
-			unsigned long vdso_rt_parked_at,
+extern int vdso_proxify(struct vdso_maps *rt, bool *added_proxy,
 			VmaEntry *vmas, size_t nr_vmas,
 			bool compat_vdso, bool force_trampolines);
 extern int vdso_redirect_calls(unsigned long base_to, unsigned long base_from,

--- a/criu/include/util-vdso.h
+++ b/criu/include/util-vdso.h
@@ -38,6 +38,7 @@ struct vdso_maps {
 	unsigned long		vdso_start;
 	unsigned long		vvar_start;
 	struct vdso_symtable	sym;
+	bool			compatible;
 };
 
 #define VDSO_SYMBOL_INIT	{ .offset = VDSO_BAD_ADDR, }

--- a/criu/pie/parasite-vdso.c
+++ b/criu/pie/parasite-vdso.c
@@ -242,7 +242,8 @@ static int add_vdso_proxy(VmaEntry *vma_vdso, VmaEntry *vma_vvar,
 	return 0;
 }
 
-int vdso_proxify(struct vdso_symtable *sym_rt, unsigned long vdso_rt_parked_at,
+int vdso_proxify(struct vdso_symtable *sym_rt, bool *added_proxy,
+		 unsigned long vdso_rt_parked_at,
 		 VmaEntry *vmas, size_t nr_vmas,
 		 bool compat_vdso, bool force_trampolines)
 {
@@ -289,11 +290,13 @@ int vdso_proxify(struct vdso_symtable *sym_rt, unsigned long vdso_rt_parked_at,
 		 vma_vvar ? (unsigned long)vma_vvar->start : VVAR_BAD_ADDR,
 		 vma_vvar ? (unsigned long)vma_vvar->end : VVAR_BAD_ADDR);
 
+	*added_proxy = false;
 	if (blobs_matches(vma_vdso, vma_vvar, &s, sym_rt) && !force_trampolines) {
 		return remap_rt_vdso(vma_vdso, vma_vvar,
 				sym_rt, vdso_rt_parked_at);
 	}
 
+	*added_proxy = true;
 	return add_vdso_proxy(vma_vdso, vma_vvar, &s, sym_rt,
 			vdso_rt_parked_at, compat_vdso);
 }

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1402,6 +1402,8 @@ long __export_restore_task(struct task_restore_args *args)
 	if (args->can_map_vdso && (map_vdso(args, args->compatible_mode) < 0))
 		goto core_restore_end;
 
+	vdso_update_gtod_addr(&args->vdso_maps_rt);
+
 	/* Shift private vma-s to the left */
 	for (i = 0; i < args->vmas_n; i++) {
 		vma_entry = args->vmas + i;

--- a/criu/vdso.c
+++ b/criu/vdso.c
@@ -597,7 +597,8 @@ int vdso_init_restore(void)
 
 	vdso_maps.sym = kdat.vdso_sym;
 #ifdef CONFIG_COMPAT
-	vdso_maps_compat.sym = kdat.vdso_sym_compat;
+	vdso_maps_compat.sym		= kdat.vdso_sym_compat;
+	vdso_maps_compat.compatible	= true;
 #endif
 
 	return 0;
@@ -621,7 +622,8 @@ int kerndat_vdso_fill_symtable(void)
 		pr_err("Failed to fill compat vdso symtable\n");
 		return -1;
 	}
-	kdat.vdso_sym_compat = vdso_maps_compat.sym;
+	vdso_maps_compat.compatible	= true;
+	kdat.vdso_sym_compat		= vdso_maps_compat.sym;
 #endif
 
 	return 0;


### PR DESCRIPTION
Historically, PIE uses syscalls for printing timings.
The idea was written a while ago here:
https://github.com/checkpoint-restore/criu/issues/346

While at it, I've found that we print timings only in restorer blob, but
not in parasite. It may be intentional or just missed
std_log_set_start() call in parasite_init_daemon().
Anyway, I've decided to keep it as-is for now.

Also, adding support for timings from vdso in ia32 turned to be more
complex (see a comment in the last patch), so I decided to start from
native applications.

I've measured the gain on zdtm tests:
https://gist.github.com/0x7f454c46/7147b519e49f9ad01706c27ab1334fa7
It seems that criu is really voluble on restoring mappings :)

Anyway, the gain is not as huge as I've expected (I thought we print
much more), but still removes 50-100 syscalls per most of zdtm tests.
And it doesn't bring much complexity as we already have all information
about vdso mappings and symbol tables in restorer.
So, remove syscalls for free and keep being the same informative.

Cc: Cyrill Gorcunov <gorcunov@gmail.com>

Dmitry Safonov (8):
  compel/log: Use enum as parameter for std_log_set_loglevel()
  compel/std/uapi: Provide setter for gettimeofday()
  vdso/restorer: Try best to preserve vdso during restore
  vdso/restorer: Always track vdso/vvar positions in vdso_maps_rt
  restorer/parasite-vdso: Don't move vvar if failed to move vdso
  seccomp/restorer: Disable gtod from vdso in strict mode
  vdso: Add compatible property to vdso_maps
  restorer: Use gettimeofday() from rt-vdso for log timings

 compel/plugins/include/uapi/std/log.h |  16 ++-
 compel/plugins/std/log.c              |  18 ++-
 criu/arch/aarch64/include/asm/vdso.h  |   1 +
 criu/arch/arm/include/asm/vdso.h      |   1 +
 criu/arch/ppc64/include/asm/vdso.h    |   1 +
 criu/arch/s390/include/asm/vdso.h     |   3 +-
 criu/arch/x86/include/asm/vdso.h      |   3 +-
 criu/include/parasite-vdso.h          |   4 +-
 criu/include/util-vdso.h              |   1 +
 criu/pie/parasite-vdso.c              | 164 +++++++++++++++-----------
 criu/pie/restorer.c                   | 115 ++++++++++++++----
 criu/vdso.c                           |   6 +-
 12 files changed, 227 insertions(+), 106 deletions(-)