### PR TITLE
scripts: Remove Python 2 dependency for Fedora tests

### DIFF
--- a/lib/py/images/pb2dict.py
+++ b/lib/py/images/pb2dict.py
@@ -263,7 +263,7 @@ def get_bytes_dec(field):
 def is_string(value):
     # Python 3 compatibility
     if "basestring" in __builtins__:
-        string_types = basestring
+        string_types = basestring  # noqa: F821
     else:
         string_types = (str, bytes)
     return isinstance(value, string_types)

--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -18,7 +18,7 @@ RUN dnf install -y \
 	procps-ng \
 	protobuf-c-devel \
 	protobuf-devel \
-	python3-pip \
+	python3-flake8 \
 	python3-PyYAML \
 	python3-future \
 	python3-protobuf \

--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -18,8 +18,6 @@ RUN dnf install -y \
 	procps-ng \
 	protobuf-c-devel \
 	protobuf-devel \
-	python-ipaddress \
-	python-yaml \
 	python3-pip \
 	python3-PyYAML \
 	python3-future \

--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -37,6 +37,7 @@ RUN dnf install -y \
 RUN dnf install -y --allowerasing coreutils
 
 RUN ln -sf python3 /usr/bin/python
+ENV PYTHON=python3
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -163,7 +163,9 @@ ip net add test
 
 make -C test/others/shell-job
 
-pip install flake8
+if ! [ -x "$(command -v flake8)" ]; then
+	pip install flake8
+fi
 make lint
 
 # Check that help output fits into 80 columns

--- a/soccr/test/run.py
+++ b/soccr/test/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import sys, os
 import hashlib

--- a/test/check_actions.py
+++ b/test/check_actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import sys
 import os

--- a/test/others/ext-tty/run.py
+++ b/test/others/ext-tty/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import subprocess
 import os, sys, time, signal, pty
 

--- a/test/others/mounts/mounts.sh
+++ b/test/others/mounts/mounts.sh
@@ -20,7 +20,7 @@ for i in `cat /proc/self/mounts | awk '{ print $2 }'`; do
 	umount -l $i
 done
 
-python2 mounts.py
+python mounts.py
 kill $INMNTNS_PID
 while :; do
 	sleep 10

--- a/test/others/rpc/config_file.py
+++ b/test/others/rpc/config_file.py
@@ -1,29 +1,16 @@
 #!/usr/bin/python
 
 import os
-import socket
 import sys
 import rpc_pb2 as rpc
 import argparse
-import subprocess
 from tempfile import mkstemp
 import time
 
+from setup_swrk import setup_swrk
+
 log_file = 'config_file_test.log'
 does_not_exist = 'does-not.exist'
-
-
-def setup_swrk():
-    print('Connecting to CRIU in swrk mode.')
-    s1, s2 = socket.socketpair(socket.AF_UNIX, socket.SOCK_SEQPACKET)
-
-    kwargs = {}
-    if sys.version_info.major == 3:
-        kwargs["pass_fds"] = [s1.fileno()]
-
-    swrk = subprocess.Popen(['./criu', "swrk", "%d" % s1.fileno()], **kwargs)
-    s1.close()
-    return swrk, s2
 
 
 def setup_config_file(content):

--- a/test/others/rpc/config_file.py
+++ b/test/others/rpc/config_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python
 
 import os
 import socket
@@ -15,10 +15,15 @@ does_not_exist = 'does-not.exist'
 
 def setup_swrk():
     print('Connecting to CRIU in swrk mode.')
-    css = socket.socketpair(socket.AF_UNIX, socket.SOCK_SEQPACKET)
-    swrk = subprocess.Popen(['./criu', "swrk", "%d" % css[0].fileno()])
-    css[0].close()
-    return swrk, css[1]
+    s1, s2 = socket.socketpair(socket.AF_UNIX, socket.SOCK_SEQPACKET)
+
+    kwargs = {}
+    if sys.version_info.major == 3:
+        kwargs["pass_fds"] = [s1.fileno()]
+
+    swrk = subprocess.Popen(['./criu', "swrk", "%d" % s1.fileno()], **kwargs)
+    s1.close()
+    return swrk, s2
 
 
 def setup_config_file(content):

--- a/test/others/rpc/errno.py
+++ b/test/others/rpc/errno.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python
 # Test criu errno
 
 import socket, os, errno

--- a/test/others/rpc/ps_test.py
+++ b/test/others/rpc/ps_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python
 
 import socket, os, sys, errno
 import rpc_pb2 as rpc

--- a/test/others/rpc/restore-loop.py
+++ b/test/others/rpc/restore-loop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python
 
 import socket, os, sys
 import rpc_pb2 as rpc

--- a/test/others/rpc/setup_swrk.py
+++ b/test/others/rpc/setup_swrk.py
@@ -1,0 +1,16 @@
+import sys
+import socket
+import subprocess
+
+def setup_swrk():
+    print('Connecting to CRIU in swrk mode.')
+    s1, s2 = socket.socketpair(socket.AF_UNIX, socket.SOCK_SEQPACKET)
+
+    kwargs = {}
+    if sys.version_info.major == 3:
+        kwargs["pass_fds"] = [s1.fileno()]
+
+    swrk = subprocess.Popen(['./criu', "swrk", "%d" % s1.fileno()], **kwargs)
+    s1.close()
+    return swrk, s2
+

--- a/test/others/rpc/test.py
+++ b/test/others/rpc/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python
 
 import socket, os, sys
 import rpc_pb2 as rpc

--- a/test/others/rpc/version.py
+++ b/test/others/rpc/version.py
@@ -1,20 +1,13 @@
 #!/usr/bin/python
 
-import socket
 import sys
 import rpc_pb2 as rpc
-import subprocess
+
+from setup_swrk import setup_swrk
 
 print('Connecting to CRIU in swrk mode to check the version:')
 
-s1, s2 = socket.socketpair(socket.AF_UNIX, socket.SOCK_SEQPACKET)
-
-kwargs = {}
-if sys.version_info.major == 3:
-    kwargs["pass_fds"] = [s2.fileno()]
-
-swrk = subprocess.Popen(['./criu', "swrk", "%d" % s2.fileno()], **kwargs)
-s2.close()
+swrk, s1 = setup_swrk()
 
 # Create criu msg, set it's type to dump request
 # and set dump options. Checkout more options in protobuf/rpc.proto

--- a/test/others/shell-job/run.py
+++ b/test/others/shell-job/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import os, pty, sys, subprocess
 import termios, fcntl, time
 
@@ -9,11 +9,11 @@ os.chdir(os.getcwd())
 
 def create_pty():
     (fd1, fd2) = pty.openpty()
-    return (os.fdopen(fd1, "w+"), os.fdopen(fd2, "w+"))
+    return (os.fdopen(fd1, "wb"), os.fdopen(fd2, "wb"))
 
 
 if not os.access("work", os.X_OK):
-    os.mkdir("work", 0755)
+    os.mkdir("work", 0o755)
 
 open("running", "w").close()
 m, s = create_pty()


### PR DESCRIPTION
In https://github.com/checkpoint-restore/criu/pull/751 have been removed some of the Python 2 packages that are installed in Fedora Dockerfiles. There are a few necessary changes to allow the tests to work in environment with Python 3 only.

cc @adrianreber 