### PR TITLE
test: bring the lo interface up in each network namespace

### DIFF
--- a/test/zdtm/static/netns_sub.c
+++ b/test/zdtm/static/netns_sub.c
@@ -104,6 +104,8 @@ int main(int argc, char **argv)
 			pr_perror("unshare");
 			return 1;
 		}
+		if (system("ip link set up dev lo"))
+			return 1;
 		sk = create_socket(1);
 		if (sk < 0)
 			return 1;
@@ -166,6 +168,8 @@ int main(int argc, char **argv)
 			pr_perror("unshare");
 			return 1;
 		}
+		if (system("ip link set up dev lo"))
+			return 1;
 		sk = create_socket(2);
 		if (sk < 0)
 			return 1;

--- a/test/zdtm/static/netns_sub.desc
+++ b/test/zdtm/static/netns_sub.desc
@@ -1,1 +1,5 @@
-{'flavor': 'ns uns', 'flags': 'suid'}
+{
+    'deps': ['/bin/sh', '/sbin/ip|/bin/ip'],
+    'flavor': 'ns uns',
+    'flags': 'suid'
+}

--- a/test/zdtm/static/netns_sub_veth.c
+++ b/test/zdtm/static/netns_sub_veth.c
@@ -50,6 +50,8 @@ int main(int argc, char **argv)
 			if (unshare(CLONE_NEWNET))
 				return 1;
 
+			if (system("ip link set up dev lo"))
+				return 1;
 			task_waiter_complete(&lock, i);
 			test_waitsig();
 

--- a/test/zdtm/static/netns_sub_veth.desc
+++ b/test/zdtm/static/netns_sub_veth.desc
@@ -1,5 +1,5 @@
 {
-	'deps': ['/sbin/ip', '/bin/sh'],
+	'deps': ['/sbin/ip|/bin/ip', '/bin/sh'],
 	'flags': 'suid',
 	'flavor': 'ns uns',
 	'feature': 'link_nsid',


### PR DESCRIPTION
This is needed to workaround the problem with "ip route save":
(00.113153) 	Running ip route save
Error: ipv4: FIB table does not exist.

Signed-off-by: Andrei Vagin <avagin@gmail.com>