### PR TITLE
zdtm: make inotify04 require restore

### DIFF
--- a/test/zdtm/static/inotify04.desc
+++ b/test/zdtm/static/inotify04.desc
@@ -1,0 +1,1 @@
+{'flags': 'reqrst'}


### PR DESCRIPTION
After adding the test for fake inotify events cleanup on restore, we've
detected that we also have the same problem on dump/predump, criu
touches files that are watched and generates fake events:

  [root@snorch criu]# test/zdtm.py run -t zdtm/static/inotify04 --norst -k always
  === Run 1/1 ================ zdtm/static/inotify04
  ======================== Run zdtm/static/inotify04 in h ========================
  Start test
  ./inotify04 --pidfile=inotify04.pid --outfile=inotify04.out --dirname=inotify04.test
  Run criu dump
  =[log]=> dump/zdtm/static/inotify04/36/1/dump.log
  ------------------------ grep Error ------------------------
  (00.004050) fsnotify: 			openable (inode match) as home/snorch/devel/criu/test/zdtm/static/inotify04.test/inotify-testfile
  (00.004052) fsnotify: 	Dumping /home/snorch/devel/criu/test/zdtm/static/inotify04.test/inotify-testfile as path for handle
  (00.004055) fsnotify: id 0x000007 flags 0x000800
  (00.004071) 36 fdinfo 5: pos:                0 flags:             4000/0
  (00.004080) Warn  (criu/fsnotify.c:336): fsnotify: The 0x000008 inotify events will be dropped
  ------------------------ ERROR OVER ------------------------
  Send the 15 signal to  36
  Wait for zdtm/static/inotify04(36) to die for 0.100000
  ############### Test zdtm/static/inotify04 FAIL at result check ################
  Test output: ================================
  18:20:10.558:    36: Event       0x20
  18:20:10.558:    36: Event       0x10
  18:20:10.558:    36: Event       0x20
  18:20:10.558:    36: Event       0x10
  18:20:10.558:    36: Event       0x20
  18:20:10.558:    36: Event       0x10
  18:20:10.558:    36: Event       0x20
  18:20:10.558:    36: Event       0x10
  18:20:10.558:    36: Read 8 events
  18:20:10.558:    36: FAIL: inotify04.c:105: Found 8 unexpected inotify events (errno = 11 (Resource temporarily unavailable))

   <<< ================================
  ##################################### FAIL #####################################

To suppress fails in jenkins make the inotify04 test 'reqrst'. Still
need to cleanup (or do not create) these events on dump/predump.