### PR TITLE
Introduce new command line option: --cgroup-dump-only-below-criu

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -517,6 +517,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 		{ "tls-key",			required_argument,	0, 1095},
 		BOOL_OPT("tls", &opts.tls),
 		{"tls-no-cn-verify",		no_argument,		&opts.tls_no_cn_verify, true},
+		BOOL_OPT("cgroup-dump-only-below-criu", &opts.cgroup_dump_only_below_criu),
 		{ },
 	};
 

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -621,6 +621,9 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 	if (req->tls_no_cn_verify)
 		opts.tls_no_cn_verify = req->tls_no_cn_verify;
 
+	if (req->has_cgroup_dump_only_below_criu)
+		opts.cgroup_dump_only_below_criu = req->cgroup_dump_only_below_criu;
+
 	if (req->has_auto_ext_mnt)
 		opts.autodetect_ext_mounts = req->auto_ext_mnt;
 

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -106,6 +106,7 @@ struct cr_options {
 	char			*cgroup_props;
 	char			*cgroup_props_file;
 	struct list_head	new_cgroup_roots;
+	int			cgroup_dump_only_below_criu;
 	bool			autodetect_ext_mounts;
 	int			enable_external_sharing;
 	int			enable_external_masters;

--- a/images/rpc.proto
+++ b/images/rpc.proto
@@ -120,6 +120,9 @@ message criu_opts {
 	optional string			tls_key			= 57;
 	optional bool			tls			= 58;
 	optional bool			tls_no_cn_verify	= 59;
+
+	optional bool			cgroup_dump_only_below_criu	= 60;
+
 /*	optional bool			check_mounts		= 128;	*/
 }
 

--- a/lib/c/criu.c
+++ b/lib/c/criu.c
@@ -987,6 +987,12 @@ int criu_local_add_cg_dump_controller(criu_opts *opts, const char *name)
 	return 0;
 }
 
+void criu_local_set_cg_dump_only_below_criu(criu_opts *opts, bool val)
+{
+	opts->rpc->has_cgroup_dump_only_below_criu = true;
+	opts->rpc->cgroup_dump_only_below_criu = val;
+}
+
 int criu_add_skip_mnt(const char *mnt)
 {
 	return criu_local_add_skip_mnt(global_opts, mnt);

--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -207,6 +207,7 @@ int criu_local_add_irmap_path(criu_opts *opts, const char *path);
 int criu_local_add_cg_props(criu_opts *opts, const char *stream);
 int criu_local_add_cg_props_file(criu_opts *opts, const char *path);
 int criu_local_add_cg_dump_controller(criu_opts *opts, const char *name);
+void criu_local_set_cg_dump_only_below_criu(criu_opts *opts, bool val);
 int criu_local_add_inherit_fd(criu_opts *opts, int fd, const char *key);
 int criu_local_add_external(criu_opts *opts, const char *key);
 int criu_local_set_page_server_address_port(criu_opts *opts, const char *address, int port);


### PR DESCRIPTION
Currently CRIU will not migrate empty cgroups below the task's cgroup if CRIU runs in the same cgroup as the task ([proof](https://github.com/checkpoint-restore/criu/blob/criu-dev/criu/cgroup.c#L905)). This flag overrides that behaviour and causes CRIU to dump everything below the CRIU's cgroup.

This flag fixes another issue. Let's imagine we created cgroup A to contain some task. But the task created 2 sub-cgroups: A1 and A2. Then moved itself to A1. We start migration and put CRIU in cgroup A. In that situation only sub-cgroup A1 would be migrated since A2 doesn't contain any task and no task runs directly in A. But the expected behaviour is to migrate everything below cgroup A since everything there belongs to the task.