### PR TITLE
files-reg: Drop clear_ghost_files() prototype

### DIFF
--- a/criu/include/files-reg.h
+++ b/criu/include/files-reg.h
@@ -30,7 +30,6 @@ extern int open_reg_by_id(u32 id);
 extern int open_reg_fd(struct file_desc *);
 extern int open_path(struct file_desc *, int (*open_cb)(int ns_root_fd,
 			struct reg_file_info *, void *), void *arg);
-extern void clear_ghost_files(void);
 
 extern const struct fdtype_ops regfile_dump_ops;
 extern int do_open_reg_noseek_flags(int ns_root_fd, struct reg_file_info *rfi, void *arg);


### PR DESCRIPTION
The function `clear_ghost_files()` has been removed in commit b11eeea.