### PR TITLE
Display rlimits type and signal number

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -345,6 +345,8 @@ static int dump_task_rlimits(int pid, TaskRlimitsEntry *rls)
 
 		rls->rlimits[res]->cur = encode_rlim(lim.rlim_cur);
 		rls->rlimits[res]->max = encode_rlim(lim.rlim_max);
+		rls->rlimits[res]->has_rlimit_type = true;
+		rls->rlimits[res]->rlimit_type = res;
 	}
 
 	return 0;

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -246,6 +246,8 @@ int parasite_dump_sigacts_seized(struct parasite_ctl *ctl, struct pstree_item *i
 		memcpy(&sa->mask, args->sas[i].rt_sa_mask.sig, sizeof(sa->mask));
 		sa->has_compat_sigaction = true;
 		sa->compat_sigaction = !compel_mode_native(ctl);
+		sa->has_signal = true;
+		sa->signal = sig;
 
 		*(psa++) = sa++;
 	}

--- a/images/opts.proto
+++ b/images/opts.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 import "google/protobuf/descriptor.proto";
 
 message CRIU_Opts {
-	optional bool hex = 1; // Idicate that CRIT should treat this field as hex.
+	optional bool hex = 1; // Indicates that CRIT should treat this field as hex.
 	optional bool ipadd = 2; // The field is IPv4/v6 address
 	optional string flags = 3;
 	optional bool dev = 4; // Device major:minor packed

--- a/images/rlimit.proto
+++ b/images/rlimit.proto
@@ -1,6 +1,9 @@
 syntax = "proto2";
 
+import "opts.proto";
+
 message rlimit_entry {
 	required uint64		cur = 1;
 	required uint64		max = 2;
+	optional uint32		rlimit_type = 3 [(criu).dict = "rlimit"];
 }

--- a/images/sa.proto
+++ b/images/sa.proto
@@ -8,4 +8,5 @@ message sa_entry {
 	required uint64	restorer	= 3 [(criu).hex = true];
 	required uint64	mask		= 4 [(criu).hex = true];
 	optional bool compat_sigaction	= 5;
+	optional uint32 signal		= 6;
 }

--- a/lib/py/images/pb2dict.py
+++ b/lib/py/images/pb2dict.py
@@ -169,20 +169,40 @@ sk_maps = {
     },
 }
 
-gen_rmaps = {
-    k: {v2: k2
-        for k2, v2 in list(v.items())}
-    for k, v in list(gen_maps.items())
-}
-sk_rmaps = {
-    k: {v2: k2
-        for k2, v2 in list(v.items())}
-    for k, v in list(sk_maps.items())
+rlimits_map = {
+    'rlimit_type': {
+        0: 'RLIMIT_CPU',
+        1: 'RLIMIT_FSIZE',
+        2: 'RLIMIT_DATA',
+        3: 'RLIMIT_STACK',
+        4: 'RLIMIT_CORE',
+        5: 'RLIMIT_RSS',
+        6: 'RLIMIT_NPROC',
+        7: 'RLIMIT_NOFILE',
+        8: 'RLIMIT_MEMLOCK',
+        9: 'RLIMIT_AS',
+        10: 'RLIMIT_LOCKS',
+        11: 'RLIMIT_SIGPENDING',
+        12: 'RLIMIT_MSGQUEUE',
+        13: 'RLIMIT_NICE',
+        14: 'RLIMIT_RTPRIO',
+        15: 'RLIMIT_RTTIME',
+    },
 }
 
+
+def reverse_map(orig_map):
+    return {
+        k: {v2: k2
+            for k2, v2 in list(v.items())}
+        for k, v in list(orig_map.items())
+    }
+
+
 dict_maps = {
-    'gen': (gen_maps, gen_rmaps),
-    'sk': (sk_maps, sk_rmaps),
+    'gen': (gen_maps, reverse_map(gen_maps)),
+    'sk': (sk_maps, reverse_map(sk_maps)),
+    'rlimit': (rlimits_map, reverse_map(rlimits_map)),
 }
 
 


### PR DESCRIPTION
Display rlimits type and signal number when decoding
core-<pid>.img file using crit

Fixes #774 
Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>