### PR TITLE
scripts: Drop Fedora 28/rawhide fix

### DIFF
--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -30,12 +30,6 @@ RUN dnf install -y \
 	rubygem-asciidoctor \
 	kmod
 
-# Replace coreutils-single with "traditional" coreutils
-# to fix the following error on Fedora 28/rawhide while
-# running under QEMU:
-# > sh: /usr/bin/sort: /usr/bin/coreutils: bad interpreter: No such file or directory
-RUN dnf install -y --allowerasing coreutils
-
 RUN ln -sf python3 /usr/bin/python
 ENV PYTHON=python3
 


### PR DESCRIPTION
This change was introduced with c75cb2b and it is no longer necessary.