### PR TITLE
Couple of fixes to build and run libcriu tests

### DIFF
--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -161,6 +161,9 @@ ip net add test
 ./test/zdtm.py run -t zdtm/static/env00 -k always
 ./test/crit-recode.py
 
+# libcriu testing
+make -C test/others/libcriu run
+
 make -C test/others/shell-job
 
 if ! [ -x "$(command -v flake8)" ]; then

--- a/test/others/libcriu/Makefile
+++ b/test/others/libcriu/Makefile
@@ -1,3 +1,5 @@
+include ../../../../criu/Makefile.versions
+
 TESTS += test_sub 
 TESTS += test_self
 TESTS += test_notify
@@ -19,8 +21,16 @@ endef
 $(foreach t, $(TESTS), $(eval $(call genb, $(t))))
 
 %.o: %.c
-	gcc -c $^ -I../../../../criu/lib/c/ -I../../../../criu/images/ -o $@ -Werror
+	gcc -c $^ -iquote ../../../../criu/criu/include -I../../../../criu/lib/c/ -I../../../../criu/images/ -o $@ -Werror
 
-clean:
+clean: libcriu_clean
 	rm -rf $(TESTS) $(TESTS:%=%.o) lib.o
 .PHONY: clean
+
+libcriu_clean:
+	rm -f libcriu.so.${CRIU_SO_VERSION_MAJOR}
+.PHONY: libcriu_clean
+
+libcriu:
+	ln -s ../../../../criu/lib/c/libcriu.so libcriu.so.${CRIU_SO_VERSION_MAJOR}
+.PHONY: libcriu

--- a/test/others/libcriu/run.sh
+++ b/test/others/libcriu/run.sh
@@ -5,14 +5,13 @@ source ../env.sh || exit 1
 
 echo "== Clean"
 make clean
+make libcriu
 rm -rf wdir
-rm -f ./libcriu.so.1
 
 echo "== Prepare"
 mkdir -p wdir/i/
 
 echo "== Run tests"
-ln -s ../../../../criu/lib/c/libcriu.so libcriu.so.1
 export LD_LIBRARY_PATH=.
 export PATH="`dirname ${BASH_SOURCE[0]}`/../../:$PATH"
 
@@ -40,6 +39,6 @@ run_test test_iters
 run_test test_errno
 
 echo "== Tests done"
-unlink libcriu.so.1
+make libcriu_clean
 [ $RESULT -eq 0 ] && echo "Success" || echo "FAIL"
 exit $RESULT

--- a/test/others/libcriu/run.sh
+++ b/test/others/libcriu/run.sh
@@ -13,7 +13,7 @@ mkdir -p wdir/i/
 
 echo "== Run tests"
 export LD_LIBRARY_PATH=.
-export PATH="`dirname ${BASH_SOURCE[0]}`/../../:$PATH"
+export PATH="`dirname ${BASH_SOURCE[0]}`/../../../criu:$PATH"
 
 RESULT=0
 
@@ -21,6 +21,19 @@ function run_test {
 	echo "== Build $1"
 	if ! make $1; then
 		echo "FAIL build $1"
+		echo "** Output of $1/test.log"
+		cat wdir/i/$1/test.log
+		echo "---------------"
+		if [ -f wdir/i/$1/dump.log ]; then
+			echo "** Contents of dump.log"
+			cat wdir/i/$1/dump.log
+			echo "---------------"
+		fi
+		if [ -f wdir/i/$1/restore.log ]; then
+			echo "** Contents of restore.log"
+			cat wdir/i/$1/restore.log
+			echo "---------------"
+		fi
 		RESULT=1;
 	else
 		echo "== Test $1"


### PR DESCRIPTION
libcriu tests are currently broken. This patch fixes couple of
issues to allow the building and running libcriu tests.

1. lib/c/criu.h got updated to include version.h which is present
at "criu/include", but the command to compile libcriu tests is not
specifying "criu/include" in the path to be searched for header
files. This resulted in compilation error.
This can be fixed by adding "-I ../../../../../criu/criu/include"
however it causes more problems as "criu/include/fcntl.h" would now
hide system defined fcntl.h
Solution is to use "-iquote ../../../../../criu/criu/include"
which applies only to the quote form of include directive.

2. Secondly, libcriu.so major version got updated to 2 but
libcriu/run.sh still assumes verion 1. Instead of just updating the
version in libcriu/run.sh to 2, this patch updates the libcriu/Makefile
to use "CRIU_SO_VERSION_MAJOR" so that future changes to major version
of libcriu won't cause same problem again.

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>