### PR TITLE
GSoC 19: Optimizing the Pre-dump Algorithm

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -156,6 +156,12 @@ In addition, *page-server* options may be specified.
     Turn on memory changes tracker in the kernel. If the option is
     not passed the memory tracker get turned on implicitly.
 
+*--pre-dump-mode*='mode'::
+    There are two 'mode' to operate pre-dump algorithm. The 'splice' mode
+    is parasite based, whereas 'read' mode is based on process_vm_readv
+    syscall. The 'read' mode incurs reduced frozen time and reduced
+    memory pressure as compared to 'splice' mode. Default is 'splice' mode.
+
 *dump*
 ~~~~~~
 Performs a checkpoint procedure.

--- a/criu/config.c
+++ b/criu/config.c
@@ -276,6 +276,7 @@ void init_opts(void)
 	opts.empty_ns = 0;
 	opts.status_fd = -1;
 	opts.log_level = DEFAULT_LOGLEVEL;
+	opts.pre_dump_mode = PRE_DUMP_SPLICE;
 }
 
 bool deprecated_ok(char *what)
@@ -517,6 +518,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 		{ "tls-key",			required_argument,	0, 1095},
 		BOOL_OPT("tls", &opts.tls),
 		{"tls-no-cn-verify",		no_argument,		&opts.tls_no_cn_verify, true},
+		{ "pre-dump-mode",		required_argument,	0, 1097},
 		{ },
 	};
 
@@ -814,6 +816,14 @@ int parse_options(int argc, char **argv, bool *usage_error,
 			break;
 		case 1095:
 			SET_CHAR_OPTS(tls_key, optarg);
+			break;
+		case 1097:
+			if (!strcmp("read", optarg)) {
+				opts.pre_dump_mode = PRE_DUMP_READ;
+			} else if (strcmp("splice", optarg)) {
+				pr_err("Unable to parse value of --pre-dump-mode\n");
+				return 1;
+			}
 			break;
 		case 'V':
 			pr_msg("Version: %s\n", CRIU_VERSION);

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1515,7 +1515,8 @@ static int cr_pre_dump_finish(int status)
 		mem_pp = dmpi(item)->mem_pp;
 
 		if (opts.pre_dump_mode == PRE_DUMP_READ)
-			ret = 0;  /* Call optimized pre-dump here */
+			ret = page_xfer_predump_pages(item->pid->real,
+                                                      &xfer, mem_pp);
 		else
 			ret = page_xfer_dump_pages(&xfer, mem_pp);
 

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1514,11 +1514,13 @@ static int cr_pre_dump_finish(int status)
 
 		mem_pp = dmpi(item)->mem_pp;
 
-		if (opts.pre_dump_mode == PRE_DUMP_READ)
+		if (opts.pre_dump_mode == PRE_DUMP_READ) {
+			timing_stop(TIME_MEMWRITE);
 			ret = page_xfer_predump_pages(item->pid->real,
                                                       &xfer, mem_pp);
-		else
+		} else {
 			ret = page_xfer_dump_pages(&xfer, mem_pp);
+		}
 
 		xfer.close(&xfer);
 

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1513,7 +1513,11 @@ static int cr_pre_dump_finish(int status)
 			goto err;
 
 		mem_pp = dmpi(item)->mem_pp;
-		ret = page_xfer_dump_pages(&xfer, mem_pp);
+
+		if (opts.pre_dump_mode == PRE_DUMP_READ)
+			ret = 0;  /* Call optimized pre-dump here */
+		else
+			ret = page_xfer_dump_pages(&xfer, mem_pp);
 
 		xfer.close(&xfer);
 

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -442,6 +442,8 @@ usage:
 "                        pages images of previous dump\n"
 "                        when used on restore, as soon as page is restored, it\n"
 "                        will be punched from the image\n"
+"  --pre-dump-mode       splice - parasite based pre-dumping (default)\n"
+"                        read   - process_vm_readv syscall based pre-dumping\n"
 "\n"
 "Page/Service server options:\n"
 "  --address ADDR        address of server or service\n"

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -39,6 +39,12 @@ struct cg_root_opt {
 };
 
 /*
+ * Pre-dump variants
+ */
+#define PRE_DUMP_SPLICE		1		/* Pre-dump using parasite */
+#define PRE_DUMP_READ			2		/* Pre-dump using process_vm_readv syscall */
+
+/*
  * Cgroup management options.
  */
 #define CG_MODE_IGNORE		(0u << 0)	/* Zero is important here */
@@ -81,6 +87,7 @@ struct cr_options {
 	int			evasive_devices;
 	int			link_remap_ok;
 	int			log_file_per_pid;
+	int			pre_dump_mode;
 	bool			swrk_restore;
 	char			*output;
 	char			*root;

--- a/criu/include/page-xfer.h
+++ b/criu/include/page-xfer.h
@@ -9,6 +9,9 @@ struct ps_info {
 
 extern int cr_page_server(bool daemon_mode, bool lazy_dump, int cfd);
 
+/* Process not available in "read" mode pre-dump*/
+#define PR_UNAVIL -2
+
 /*
  * page_xfer -- transfer pages into image file.
  * Two images backends are implemented -- local image file
@@ -48,6 +51,7 @@ struct page_xfer {
 extern int open_page_xfer(struct page_xfer *xfer, int fd_type, unsigned long id);
 struct page_pipe;
 extern int page_xfer_dump_pages(struct page_xfer *, struct page_pipe *);
+extern int page_xfer_predump_pages(int pid, struct page_xfer *, struct page_pipe *);
 extern int connect_to_page_server_to_send(void);
 extern int connect_to_page_server_to_recv(int epfd);
 extern int disconnect_from_page_server(void);

--- a/criu/include/stats.h
+++ b/criu/include/stats.h
@@ -45,6 +45,7 @@ enum {
 };
 
 extern void cnt_add(int c, unsigned long val);
+extern void cnt_sub(int c, unsigned long val);
 
 #define DUMP_STATS	1
 #define RESTORE_STATS	2

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -482,7 +482,18 @@ static int __parasite_dump_pages_seized(struct pstree_item *item,
 	if (mdc->lazy)
 		memcpy(pargs_iovs(args), pp->iovs,
 		       sizeof(struct iovec) * pp->nr_iovs);
-	ret = drain_pages(pp, ctl, args);
+
+	/*
+	 * Faking drain_pages for pre-dump here. Actual drain_pages for pre-dump
+	 * will happen after task unfreezing in cr_pre_dump_finish(). This is
+	 * actual optimization which reduces time for which process was frozen
+	 * during pre-dump.
+	 */
+	if (mdc->pre_dump && opts.pre_dump_mode == PRE_DUMP_READ)
+		ret = 0;
+	else
+		ret = drain_pages(pp, ctl, args);
+
 	if (!ret && !mdc->pre_dump)
 		ret = xfer_pages(pp, &xfer);
 	if (ret)

--- a/criu/page-pipe.c
+++ b/criu/page-pipe.c
@@ -40,6 +40,16 @@ static int __ppb_resize_pipe(struct page_pipe_buf *ppb, unsigned long new_size)
 	ret /= PAGE_SIZE;
 	BUG_ON(ret < ppb->pipe_size);
 
+	/*
+	 * Sometimes vmsplice fails to splice N pages(where N=2^k)
+	 * from user buffer to pipe, so restricting page-pipe
+	 * capacity to accommodate N-1 pages.
+	 * e.g. Pipe size can be 512 pages, but it's filled till
+	 * 511 pages.
+	 */
+	if (opts.pre_dump_mode == PRE_DUMP_READ)
+		ret -= 1;
+
 	pr_debug("Grow pipe %x -> %x\n", ppb->pipe_size, ret);
 	ppb->pipe_size = ret;
 

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -827,6 +827,8 @@ int page_xfer_predump_pages(int pid, struct page_xfer *xfer,
 
 	list_for_each_entry(ppb, &pp->bufs, l) {
 
+		timing_start(TIME_MEMDUMP);
+
 		aux_len = 0;
 		bufvec.iov_len = sizeof(userbuf);
 		bufvec.iov_base = userbuf;
@@ -844,6 +846,9 @@ int page_xfer_predump_pages(int pid, struct page_xfer *xfer,
 			pr_err("vmsplice: Failed to splice user buffer to pipe %ld\n", ret);
 			return -1;
 		}
+
+		timing_stop(TIME_MEMDUMP);
+		timing_start(TIME_MEMWRITE);
 
 		/* generating pagemap */
 		for (i = 0; i < aux_len; i++) {
@@ -867,8 +872,11 @@ int page_xfer_predump_pages(int pid, struct page_xfer *xfer,
 			if (xfer->write_pages(xfer, ppb->p[0], iov.iov_len))
 				return -1;
 		}
+
+		timing_stop(TIME_MEMWRITE);
         }
 
+	timing_start(TIME_MEMWRITE);
 	return dump_holes(xfer, pp, &cur_hole, NULL);
 }
 

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -499,6 +499,380 @@ static inline u32 ppb_xfer_flags(struct page_xfer *xfer, struct page_pipe_buf *p
 		return PE_PRESENT;
 }
 
+
+/*
+ * Optimized pre-dump algorithm
+ * ==============================
+ *
+ * Note: Please refer man(2) page of process_vm_readv syscall.
+ *
+ * The following discussion covers the possibly faulty-iov
+ * locations in an iovec, which hinders process_vm_readv from
+ * dumping the entire iovec in a single invocation.
+ *
+ * Memory layout of target process:
+ *
+ * Pages: A        B        C
+ * 	  +--------+--------+--------+--------+--------+--------+
+ * 	  |||||||||||||||||||||||||||||||||||||||||||||||||||||||
+ * 	  +--------+--------+--------+--------+--------+--------+
+ *
+ * Single "iov" representation: {starting_address, length_in_bytes}
+ * An iovec is array of iov-s.
+ *
+ * NOTE: For easy representation and discussion purpose, we carry
+ *       out further discussion at "page granularity".
+ *       length_in_bytes will represent page count in iov instead
+ *       of byte count. Same assumption applies for the syscall's
+ *       return value. Instead of returning the number of bytes
+ *       read, it returns a page count.
+ *
+ * For above memory mapping, generated iovec: {A,1}{B,1}{C,4}
+ *
+ * This iovec remains unmodified once generated. At the same
+ * time some of memory regions listed in iovec may get modified
+ * (unmap/change protection) by the target process while syscall
+ * is trying to dump iovec regions.
+ *
+ * Case 1:
+ *	A is unmapped, {A,1} become faulty iov
+ *
+ *	A        B        C
+ * 	+--------+--------+--------+--------+--------+--------+
+ * 	|        ||||||||||||||||||||||||||||||||||||||||||||||
+ * 	+--------+--------+--------+--------+--------+--------+
+ * 	^        ^
+ * 	|        |
+ * 	start    |
+ *      (1)	 |
+ *               start
+ *               (2)
+ *
+ *      process_vm_readv will return -1. Increment start pointer(2),
+ *      syscall will process {B,1}{C,4} in one go and copy 5 pages
+ *      to userbuf from iov-B and iov-C.
+ *
+ * Case 2:
+ *      B is unmapped, {B,1} become faulty iov
+ *
+ *	A        B        C
+ * 	+--------+--------+--------+--------+--------+--------+
+ * 	|||||||||         |||||||||||||||||||||||||||||||||||||
+ * 	+--------+--------+--------+--------+--------+--------+
+ * 	^                 ^
+ * 	|                 |
+ * 	start             |
+ *      (1)               |
+ *                        start
+ *                        (2)
+ *
+ *      process_vm_readv will return 1, i.e. page A copied to
+ *      userbuf successfully and syscall stopped, since B got
+ *      unmapped.
+ *
+ *      Increment the start pointer to C(2) and invoke syscall.
+ *      Userbuf contains 5 pages overall from iov-A and iov-C.
+ *
+ *
+ * Case 3:
+ *	This case deals with partial unmapping of iov representing
+ *	more than one pagesize region.
+ *
+ *	Syscall can't process such faulty iov as whole. So we
+ *	process such regions part-by-part and form new sub-iovs
+ *	in aux_iov from successfully processed pages.
+ *
+ *
+ *	Part 3.1:
+ *		First page of C is unmapped
+ *
+ *	A        B        C
+ * 	+--------+--------+--------+--------+--------+--------+
+ * 	||||||||||||||||||         ||||||||||||||||||||||||||||
+ * 	+--------+--------+--------+--------+--------+--------+
+ * 	^                          ^
+ * 	|                          |
+ * 	start                      |
+ *      (1)	                   |
+ *				   dummy
+ *				   (2)
+ *
+ *	process_vm_readv will return 2, i.e. pages A and B copied.
+ *	We identify length of iov-C is more than 1 page, that is
+ *	where this case differs from Case 2.
+ *
+ *	dummy-iov is introduced(2) as: {C+1,3}. dummy-iov can be
+ *      directly placed at next page to failing page. This will copy
+ *	remaining 3 pages from iov-C to userbuf. Finally create
+ *	modified iov entry in aux_iov. Complete aux_iov look like:
+ *
+ *	aux_iov: {A,1}{B,1}{C+1,3}*
+ *
+ *
+ *	Part 3.2:
+ *		In between page of C is unmapped, let's say third
+ *
+ *
+ *	A        B        C
+ * 	+--------+--------+--------+--------+--------+--------+
+ * 	||||||||||||||||||||||||||||||||||||         ||||||||||
+ * 	+--------+--------+--------+--------+--------+--------+
+ * 	^                 			     ^
+ * 	|                 |-----------------|        |
+ * 	start              partial_read_bytes        |
+ *      (1)	                                     |
+ *			                             dummy
+ *			                             (2)
+ *
+ *	process_vm_readv will return 4, i.e. pages A and B copied
+ *      completely and first two pages of C are also copied.
+ *
+ *	Since, iov-C is not processed completely, we need to find
+ *	"partial_read_byte" count to place out dummy-iov for
+ *	remainig processing of iov-C. This function is performed by
+ *	analyze_iov function.
+ *
+ *	dummy-iov will be(2): {C+3,1}. dummy-iov will be placed
+ *      next to first failing address to process remaining iov-C.
+ *	New entries in aux_iov will look like:
+ *
+ *	aux_iov: {A,1}{B,1}{C,2}*{C+3,1}*
+ */
+
+static char userbuf[PIPE_MAX_SIZE << 12];
+
+unsigned long handle_faulty_iov(int pid, struct iovec* riov,
+                                unsigned long faulty_index,
+                                struct iovec *bufvec, struct iovec* aux_iov,
+                                unsigned long* aux_len,
+                                unsigned long partial_read_bytes)
+{
+	/* Handling Case 2*/
+	if (riov[faulty_index].iov_len == PAGE_SIZE) {
+		cnt_sub(CNT_PAGES_WRITTEN, 1);
+		return 0;
+	}
+
+	struct iovec dummy;
+	ssize_t bytes_read;
+	unsigned long offset = 0;
+	unsigned long final_read_cnt = 0;
+
+	/* Handling Case 3-Part 3.2*/
+	offset = (partial_read_bytes)? partial_read_bytes : PAGE_SIZE;
+
+	dummy.iov_base = riov[faulty_index].iov_base + offset;
+	dummy.iov_len = riov[faulty_index].iov_len - offset;
+
+	if (!partial_read_bytes)
+		cnt_sub(CNT_PAGES_WRITTEN, 1);
+
+	while (dummy.iov_len) {
+
+		bytes_read = process_vm_readv(pid, bufvec, 1, &dummy, 1, 0);
+
+		if(bytes_read == -1) {
+			/* Handling faulty page read in faulty iov */
+			cnt_sub(CNT_PAGES_WRITTEN, 1);
+			dummy.iov_base += PAGE_SIZE;
+			dummy.iov_len -= PAGE_SIZE;
+			continue;
+		}
+
+		/* If aux-iov can merge and expand or new entry required */
+		if (aux_iov[(*aux_len)-1].iov_base +
+			aux_iov[(*aux_len)-1].iov_len == dummy.iov_base)
+			aux_iov[(*aux_len)-1].iov_len += bytes_read;
+		else {
+			aux_iov[*aux_len].iov_base = dummy.iov_base;
+			aux_iov[*aux_len].iov_len = bytes_read;
+			(*aux_len) += 1;
+		}
+
+		dummy.iov_base += bytes_read;
+		dummy.iov_len -= bytes_read;
+		bufvec->iov_base += bytes_read;
+		bufvec->iov_len -= bytes_read;
+		final_read_cnt += bytes_read;
+	}
+
+	return final_read_cnt;
+}
+
+/*
+ * This function will position start pointer to the latest
+ * successfully read iov in iovec. In case of partial read it
+ * returns partial_read_bytes, otherwise 0.
+ */
+static unsigned long analyze_iov(ssize_t bytes_read, struct iovec* riov,
+                                 unsigned long *index, struct iovec *aux_iov,
+                                 unsigned long *aux_len)
+{
+	ssize_t processed_bytes = 0;
+	unsigned long partial_read_bytes = 0;
+
+	/* correlating iovs with read bytes */
+	while (processed_bytes < bytes_read) {
+
+		processed_bytes += riov[*index].iov_len;
+		aux_iov[*aux_len].iov_base = riov[*index].iov_base;
+		aux_iov[*aux_len].iov_len = riov[*index].iov_len;
+
+		(*aux_len) += 1;
+		(*index) += 1;
+	}
+
+	/* handling partially processed faulty iov*/
+	if (processed_bytes - bytes_read) {
+
+		(*index) -= 1;
+
+		partial_read_bytes = riov[*index].iov_len
+					- (processed_bytes - bytes_read);
+		aux_iov[*aux_len-1].iov_len = partial_read_bytes;
+	}
+
+	return partial_read_bytes;
+}
+
+/*
+ * This function iterates over complete ppb->iov entries and pass
+ * them to process_vm_readv syscall.
+ *
+ * Since process_vm_readv returns count of successfully read bytes.
+ * It does not point to iovec entry associated to last successful
+ * byte read. The correlation between bytes read and corresponding
+ * iovec is setup through analyze_iov function.
+ *
+ * If all iovecs are not processed in one go, it means there exists
+ * some faulty iov entry(memory mapping modified after it was grabbed)
+ * in iovec. process_vm_readv syscall stops at such faulty iov and
+ * skip processing further any entry in iovec. This is handled by
+ * handle_faulty_iov function.
+ */
+static long fill_userbuf(int pid, struct page_pipe_buf *ppb,
+                                  struct iovec *bufvec,
+                                  struct iovec* aux_iov,
+                                  unsigned long *aux_len)
+{
+	struct iovec *riov = ppb->iov;
+	ssize_t bytes_read;
+	unsigned long total_read = 0;
+	unsigned long start = 0;
+	unsigned long partial_read_bytes = 0;
+
+	while (start < ppb->nr_segs) {
+
+		bytes_read = process_vm_readv(pid, bufvec, 1, &riov[start],
+					           ppb->nr_segs - start, 0);
+
+		if (bytes_read == -1) {
+			/* Handling Case 1*/
+			if (riov[start].iov_len == PAGE_SIZE) {
+				cnt_sub(CNT_PAGES_WRITTEN, 1);
+				start += 1;
+				continue;
+			} else if (errno == ESRCH) {
+				pr_debug("Target process PID:%d not found\n", pid);
+				return PR_UNAVIL;
+			}
+		}
+
+		partial_read_bytes = 0;
+
+		if (bytes_read > 0) {
+			partial_read_bytes = analyze_iov(bytes_read, riov,
+							 &start, aux_iov,
+							 aux_len);
+			bufvec->iov_base += bytes_read;
+			bufvec->iov_len -= bytes_read;
+			total_read += bytes_read;
+		}
+
+		/*
+		 * If all iovs not processed in one go,
+		 * it means some iov in between has failed.
+		 */
+		if (start < ppb->nr_segs)
+			total_read += handle_faulty_iov(pid, riov, start, bufvec,
+							aux_iov, aux_len,
+							partial_read_bytes);
+		start += 1;
+
+	}
+
+	return total_read;
+}
+
+/*
+ * This function is similar to page_xfer_dump_pages, instead it uses
+ * auxiliary_iov array for pagemap generation.
+ *
+ * The entries of ppb->iov may mismatch with actual process mappings
+ * present at time of pre-dump. Such entries need to be adjusted as per
+ * the pages read by process_vm_readv syscall. These adjusted entries
+ * along with unmodified entries are present in aux_iov array.
+ */
+
+int page_xfer_predump_pages(int pid, struct page_xfer *xfer,
+                                     struct page_pipe *pp)
+{
+	struct page_pipe_buf *ppb;
+	unsigned int cur_hole = 0, i;
+	unsigned long ret, bytes_read;
+	struct iovec bufvec;
+
+	struct iovec aux_iov[PIPE_MAX_SIZE];
+	unsigned long aux_len;
+
+	list_for_each_entry(ppb, &pp->bufs, l) {
+
+		aux_len = 0;
+		bufvec.iov_len = sizeof(userbuf);
+		bufvec.iov_base = userbuf;
+
+		bytes_read = fill_userbuf(pid, ppb, &bufvec, aux_iov, &aux_len);
+
+		if (bytes_read == PR_UNAVIL)
+			return -1;
+
+		bufvec.iov_base = userbuf;
+		bufvec.iov_len = bytes_read;
+		ret = vmsplice(ppb->p[1], &bufvec, 1, SPLICE_F_NONBLOCK);
+
+		if (ret == -1 || ret != bytes_read) {
+			pr_err("vmsplice: Failed to splice user buffer to pipe %ld\n", ret);
+			return -1;
+		}
+
+		/* generating pagemap */
+		for (i = 0; i < aux_len; i++) {
+
+			struct iovec iov = aux_iov[i];
+			u32 flags;
+
+			ret = dump_holes(xfer, pp, &cur_hole, iov.iov_base);
+			if (ret)
+				return ret;
+
+			BUG_ON(iov.iov_base < (void *)xfer->offset);
+			iov.iov_base -= xfer->offset;
+			pr_debug("\t p %p [%u]\n", iov.iov_base,
+				(unsigned int)(iov.iov_len / PAGE_SIZE));
+
+			flags = ppb_xfer_flags(xfer, ppb);
+
+			if (xfer->write_pagemap(xfer, &iov, flags))
+				return -1;
+			if (xfer->write_pages(xfer, ppb->p[0], iov.iov_len))
+				return -1;
+		}
+        }
+
+	return dump_holes(xfer, pp, &cur_hole, NULL);
+}
+
+
 int page_xfer_dump_pages(struct page_xfer *xfer, struct page_pipe *pp)
 {
 	struct page_pipe_buf *ppb;

--- a/criu/stats.c
+++ b/criu/stats.c
@@ -41,6 +41,18 @@ void cnt_add(int c, unsigned long val)
 		BUG();
 }
 
+void cnt_sub(int c, unsigned long val)
+{
+	if (dstats != NULL) {
+		BUG_ON(c >= DUMP_CNT_NR_STATS);
+		dstats->counts[c] -= val;
+	} else if (rstats != NULL) {
+		BUG_ON(c >= RESTORE_CNT_NR_STATS);
+		atomic_sub(val, &rstats->counts[c]);
+	} else
+		BUG();
+}
+
 static void timeval_accumulate(const struct timeval *from, const struct timeval *to,
 		struct timeval *res)
 {

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1020,6 +1020,7 @@ class criu:
         self.__tls = self.__tls_options() if opts['tls'] else []
         self.__criu_bin = opts['criu_bin']
         self.__crit_bin = opts['crit_bin']
+        self.__pre_dump_mode = opts['pre_dump_mode']
 
     def fini(self):
         if self.__lazy_migrate:
@@ -1276,6 +1277,8 @@ class criu:
             a_opts += ['--leave-stopped']
         if self.__empty_ns:
             a_opts += ['--empty-ns', 'net']
+        if self.__pre_dump_mode:
+            a_opts += ["--pre-dump-mode", "%s" % self.__pre_dump_mode]
 
         nowait = False
         if self.__lazy_migrate and action == "dump":
@@ -1865,7 +1868,7 @@ class Launcher:
               'sat', 'script', 'rpc', 'lazy_pages', 'join_ns', 'dedup', 'sbs',
               'freezecg', 'user', 'dry_run', 'noauto_dedup',
               'remote_lazy_pages', 'show_stats', 'lazy_migrate', 'remote',
-              'tls', 'criu_bin', 'crit_bin')
+              'tls', 'criu_bin', 'crit_bin', 'pre_dump_mode')
         arg = repr((name, desc, flavor, {d: self.__opts[d] for d in nd}))
 
         if self.__use_log:
@@ -2512,6 +2515,10 @@ rp.add_argument("--criu-bin",
 rp.add_argument("--crit-bin",
                 help="Path to crit binary",
                 default='../crit/crit')
+rp.add_argument("--pre-dump-mode",
+                help="Use splice or read mode of pre-dumping",
+                choices=['splice', 'read'],
+                default='splice')
 
 lp = sp.add_parser("list", help="List tests")
 lp.set_defaults(action=list_tests)


### PR DESCRIPTION

This patch series implements optimization of pre-dumping algorithm
as part of GSoC 2019 project.

In current pre-dumping, the target process needs to be frozen
till all the memory pages are drained into pipes. Then the target
process gets unfrozen and pages collected into pipes are written
into image files at the end of pre-dump. This approach has two
problems. First, target process remains frozen for longer duration.
Second, pipes induce memory pressure in the system. If memory
utilization during pre-dump is nearly equal to system's memory,
then this risks running into out-of-memory failures as the pipe
pages are not reclaimable.

The new implementation of pre-dump solves above mentioned two
issues. In this, the target process is frozen untill memory
mappings are collected. Then the process will unfreeze and
continue. The pages of target process are copied while process
is running. We use process_vm_readv syscall to copy pages from
process memory to user-space buffer, by using collected mappings.
Since page copying and process execution are happening
simultaneously, there is possibility that process might have
modified some mappings after they have been collected. This
results in race over memory mappings.

This patch series handles the race over mappings, utilizes
user-space buffer through process_vm_readv syscall to copy pages
and reduces the frozen time for target process by allowing it to
run as soon as memory mappings are collected. We call this new
approach of pre-dumping as "read mode pre-dump". New CLI option
--pre-dump-mode is added for it, which takes "splice" or "read"
as input. "splice" mode is traditional parasite way of pre-dumping
and is set by default.

Evaluation of new approach:
---------------------------

Performance:
------------
$ ./test/zdtm.py run --pre 5 -t zdtm/static/maps04 -f h

Splice mode -
pre-dump: 0.59
pre-dump: 0.06
pre-dump: 0.07
pre-dump: 0.06
pre-dump: 0.06
dump: 0.12

$ ./test/zdtm.py run --pre 5 -t zdtm/static/maps04 --pre-dump-mode=read -f h

Read mode -
pre-dump: 0.66
pre-dump: 0.06
pre-dump: 0.06
pre-dump: 0.06
pre-dump: 0.06
dump: 0.12

Average drop : ~ 7%
Maximum drop : ~ 13%

Freeze time:
------------
$ ./test/zdtm.py run --pre 5 -t zdtm/static/maps04 --show-stats -f h

Splice mode -
pre-dump: 122235
pre-dump: 77514
pre-dump: 77912
pre-dump: 74940
pre-dump: 71977
dump: 131208

$ ./test/zdtm.py run --pre 5 -t zdtm/static/maps04 --pre-dump-mode=read --show-stats -f h

Read mode -
pre-dump: 82365
pre-dump: 67521
pre-dump: 68385
pre-dump: 68706
pre-dump: 67144
dump: 160998

Average reduction : ~18%
Maximum reduction : ~35%

Abhishek Dubey (7):
  Adding --pre-dump-mode option
  Skip generating iov for non-PROT_READ memory
  Skip adding PROT_READ to non-PROT_READ mappings
  Adding cnt_sub for stats manipulation
  Handle vmsplice failure for read mode pre-dump
  read mode pre-dump implementation
  Refactor time accounting macros

 Documentation/criu.txt    |   6 +
 criu/config.c             |  10 ++
 criu/cr-dump.c            |   9 +-
 criu/crtools.c            |   2 +
 criu/include/cr_options.h |   7 +
 criu/include/page-xfer.h  |   4 +
 criu/include/stats.h      |   1 +
 criu/mem.c                |  88 +++++++++--
 criu/page-pipe.c          |  10 ++
 criu/page-xfer.c          | 382 ++++++++++++++++++++++++++++++++++++++++++++++
 criu/stats.c              |  12 ++
 test/zdtm.py              |   9 +-
 12 files changed, 524 insertions(+), 16 deletions(-)
  