### PR TITLE
travis: Install missing diffutils dependency

### DIFF
--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -3,6 +3,7 @@ ARG ENV1=FOOBAR
 
 RUN dnf install -y \
 	ccache \
+	diffutils \
 	findutils \
 	gcc \
 	git \


### PR DESCRIPTION
The following tests fail in Fedora rawhide because `/usr/bin/diff` is not installed.
    
     * zdtm/static/bridge(ns)
     * zdtm/static/cr_veth(uns)
     * zdtm/static/macvlan(ns)
     * zdtm/static/netns(uns)
     * zdtm/static/netns-nf(ns)
     * zdtm/static/sit(ns)
