### PR TITLE
page-pipe: Resize up to PIPE_MAX_SIZE

### DIFF
--- a/criu/page-pipe.c
+++ b/criu/page-pipe.c
@@ -54,8 +54,12 @@ static inline int ppb_resize_pipe(struct page_pipe_buf *ppb)
 	if (ppb->pages_in + ppb->pipe_off < ppb->pipe_size)
 		return 0;
 
-	if (new_size > PIPE_MAX_SIZE)
-		return 1;
+	if (new_size > PIPE_MAX_SIZE) {
+		if (ppb->pipe_size < PIPE_MAX_SIZE)
+			ppb->pipe_size = PIPE_MAX_SIZE;
+		else
+			return 1;
+	}
 
 	ret = __ppb_resize_pipe(ppb, new_size);
 	if (ret < 0)


### PR DESCRIPTION
When performing pre-dump we continuously increase the page-pipe size to
fit the max amount memory pages in the pipe's buffer. However, we never
actually set the pipe's buffer size to max. By doing so, we can reduce
the number of pipe-s necessary for pre-dump and improve the performance
as shown in the example below.

For example, let's consider the following process:

	#include <stdio.h>
	#include <stdlib.h>
	#include <unistd.h>

	void main(void)
	{
		int i = 0;
		void *cache = calloc(1, 1024 * 1024 * 1024);
		while(1) {
			printf("%d\n", i++);
			sleep(1);
		}
	}

stats-dump before this change:

	frozen_time: 123538
	memdump_time: 95344
	pages_scanned: 262721
	pages_written: 262169
	page_pipes: 513
	page_pipe_bufs: 519

stats-dump after this change:

	frozen_time: 83287
	memdump_time: 54587
	pages_scanned: 262721
	pages_written: 262169
	page_pipes: 257
	page_pipe_bufs: 263