### PR TITLE
service: Use space on stack for msg buffer

### DIFF
--- a/criu/include/protobuf.h
+++ b/criu/include/protobuf.h
@@ -52,4 +52,11 @@ static inline int collect_images(struct collect_image_info **array, unsigned siz
 	return 0;
 }
 
+/*
+ * To speed up reading of packed objects
+ * by providing space on stack, this should
+ * be more than enough for most objects.
+ */
+#define PB_PKOBJ_LOCAL_SIZE	1024
+
 #endif /* __CR_PROTOBUF_H__ */

--- a/criu/protobuf.c
+++ b/criu/protobuf.c
@@ -20,13 +20,6 @@
 #include "protobuf.h"
 #include "util.h"
 
-/*
- * To speed up reading of packed objects
- * by providing space on stack, this should
- * be more than enough for most objects.
- */
-#define PB_PKOBJ_LOCAL_SIZE	1024
-
 static char *image_name(struct cr_img *img)
 {
 	int fd = img->_x.fd;


### PR DESCRIPTION
RPC messages are have fairly small size and using space on the stack might be a better option. This change follows the pattern used with do_pb_read_one() and pb_write_one().