### PR TITLE
security: change CR_FD_PERM from rw-r--r-- to rw-------

### DIFF
--- a/criu/include/crtools.h
+++ b/criu/include/crtools.h
@@ -8,7 +8,7 @@
 
 #include "images/inventory.pb-c.h"
 
-#define CR_FD_PERM		(S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
+#define CR_FD_PERM		(S_IRUSR | S_IWUSR)
 
 extern int check_img_inventory(void);
 extern int write_img_inventory(InventoryEntry *he);

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -1282,7 +1282,7 @@ static int usernsd(int sk)
 		else
 			fd = -1;
 
-		unsc_msg_init(&um, &call, &ret, NULL, 0, fd);
+		unsc_msg_init(&um, &call, &ret, msg, sizeof(msg), fd);
 		if (sendmsg(sk, &um.h, 0) <= 0) {
 			pr_perror("uns: send resp error");
 			return -1;
@@ -1345,7 +1345,7 @@ int __userns_call(const char *func_name, uns_call_t call, int flags,
 
 	/* Get the response back */
 
-	unsc_msg_init(&um, &call, &res, NULL, 0, 0);
+	unsc_msg_init(&um, &call, &res, arg, arg_size, 0);
 	ret = recvmsg(sk, &um.h, 0);
 	if (ret <= 0) {
 		pr_perror("uns: recv resp error");


### PR DESCRIPTION
When creating a container snapshot (e.g. using runc) all image files are by default as world-readable.

Therefore, unprivileged users on the system may be able to read data stored in container or process checkpoint.

For example, most of the files stored in the following paths have `-rw-r--r--` permissions:

(Podman) `/var/lib/containers/storage/overlay-containers/*/userdata/checkpoint/`
(LXD) `/var/snap/lxd/common/lxd/snapshots/*/*/state`

However, it should be noted that, an unprivileged user would be able to read the image files only if the parent directory has `o+x` permissions.

This patch also modifies `do_open_image()` to always use `userns_call()`. When user namespace is not being restored, this is equivalent to directly calling `openat()`.

`userns_call` has been updated (fixed) to send back the value of `errno`. This is necessary to properly handle (skip) missing image files.