### PR TITLE
Add Java-based CRIU Tests.

### DIFF
--- a/test/javaTests/README.md
+++ b/test/javaTests/README.md
@@ -1,0 +1,33 @@
+# JavaTests
+
+Java Functional tests checks the Java File based APIs and Memory mapping APIs by placing the process in various states before checkpointing and validates if these resources are still accessible after restore. It also validates if the file contents are in expected states.
+
+Tests are to be run by a user having following capabilities:  
+CAP_DAC_OVERRIDE  
+CAP_CHOWN  
+CAP_SETPCAP  
+CAP_SETGID  
+CAP_AUDIT_CONTROL  
+CAP_DAC_READ_SEARCH  
+CAP_NET_ADMIN  
+CAP_SYS_ADMIN  
+CAP_SYS_CHROOT  
+CAP_SYS_PTRACE  
+CAP_FOWNER  
+CAP_KILL  
+CAP_FSETID  
+CAP_SYS_RESOURCE  
+CAP_SETUID
+
+## File-based Java APIs
+
+Here we test the File-Based Java APIs by checkpointing the application in the following scenarios and verifying the contents of the file after restore:
+- Reading and writing in the same file. (FileRead.java)
+
+### Prerequisites for running the tests:
+- Maven
+
+### To run the tests:
+- In the javaTests folder run the command ```sudo mvn test```
+- To keep the img files and logs from previous failures, between different runs of the test, use the ```-DneverCleanFailures=true ``` option in the maven command
+as ```sudo mvn -DneverCleanFailures=true test```

--- a/test/javaTests/pom.xml
+++ b/test/javaTests/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>criu</groupId>
+	<artifactId>criu-javaTests</artifactId>
+	<version>1</version>
+	<name>criu-javaTests</name>
+	<build>
+		<!-- Source directory configuration -->
+		<sourceDirectory>src</sourceDirectory>
+		<plugins>
+			<!-- Following plugin executes the testng tests -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.14.1</version>
+				<configuration>
+					<!-- Suite testng xml file to consider for test execution -->
+					<suiteXmlFiles>
+						<suiteXmlFile>test.xml</suiteXmlFile>
+					</suiteXmlFiles>
+				</configuration>
+			</plugin>
+			<!-- Compiler plugin configures the java version to be used for compiling
+				the code -->
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<dependencies>
+		<!-- Dependency libraries to include for compilation -->
+		<dependency>
+			<groupId>org.testng</groupId>
+			<artifactId>testng</artifactId>
+			<version>6.3.1</version>
+		</dependency>
+	</dependencies>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+</project>

--- a/test/javaTests/src/org/criu/java/tests/CheckpointRestore.java
+++ b/test/javaTests/src/org/criu/java/tests/CheckpointRestore.java
@@ -1,0 +1,450 @@
+package org.criu.java.tests;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.io.*;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class CheckpointRestore {
+	private MappedByteBuffer mappedByteBuffer = null;
+	private String testName = "";
+	private String logFolder = Helper.LOG_FOLDER + "/";
+	private String outputFolder = Helper.OUTPUT_FOLDER_NAME + "/";
+
+	/**
+	 * Create CRlog and output directory if they don't exist.
+	 * Delete directories containing .img files from failed Checkpoint-Restore if 'neverCleanFailures' property is not set to true.
+	 *
+	 * @throws IOException
+	 */
+	@BeforeSuite
+	void suiteSetup() throws IOException {
+		System.out.println("Tests are to be run as a privileged user having capabilities mentioned in ReadMe");
+		boolean neverCleanFailures = Boolean.getBoolean("neverCleanFailures");
+		Path logDir = Paths.get(logFolder);
+		Path outputDir = Paths.get(outputFolder);
+		if (!Files.exists(logDir)) {
+			System.out.println("Logs directory does not exist, creating it");
+			Files.createDirectory(logDir);
+		}
+		if (!Files.exists(outputDir)) {
+			System.out.println("Output directory does not exist, creating it");
+			Files.createDirectory(outputDir);
+		}
+		/*
+		 * Delete the directories containing the img files from failed Checkpoint-Restore.
+		 */
+		if (!neverCleanFailures) {
+			File output = new File(outputFolder);
+			String[] name = output.list();
+			for (int i = 0; null != name && i < name.length; i++) {
+				File testFolder = new File(outputFolder + name[i]);
+				if (testFolder.isDirectory()) {
+					String[] list = testFolder.list();
+					File file;
+					if (null != list) {
+						for (int j = 0; j < list.length; j++) {
+							file = new File(outputFolder + name[i] + "/" + list[j]);
+							if (!file.isDirectory()) {
+								Files.delete(file.toPath());
+							}
+						}
+					}
+				}
+				Files.delete(testFolder.toPath());
+			}
+		}
+	}
+
+	/**
+	 * Create the output folder for the test in case it does not exist
+	 *
+	 * @param testName Name of the java test
+	 * @throws IOException
+	 */
+	private void testSetup(String testName) throws IOException {
+		Path testFolderPath = Paths.get(outputFolder + testName + "/");
+		if (!Files.exists(testFolderPath)) {
+			System.out.println("Test Folder does not exist creating it");
+			Files.createDirectory(testFolderPath);
+		}
+	}
+
+	/**
+	 * Read the pid of process from the pid file of test
+	 *
+	 * @param name Name of the java test
+	 * @return pid Process id of the java test process
+	 * @throws IOException
+	 */
+	private String getPid(String name) throws IOException {
+		name = outputFolder + testName + "/" + name + Helper.PID_APPEND;
+		File pidfile = new File(name);
+		BufferedReader pidReader = new BufferedReader(new FileReader(pidfile));
+		String pid = pidReader.readLine();
+		pidReader.close();
+		return pid;
+	}
+
+	/**
+	 * @param testName      Name of the java test
+	 * @param checkpointOpt Additional options for checkpoint
+	 * @param restoreOpt    Additional options for restore
+	 * @throws Exception
+	 */
+	@Test
+	@Parameters({"testname", "checkpointOpt", "restoreOpt"})
+	public void runtest(String testName, String checkpointOpt, String restoreOpt) throws Exception {
+		this.testName = testName;
+		String name = Helper.PACKAGE_NAME + "." + testName;
+		String pid;
+		int exitCode;
+
+		System.out.println("======= Testing " + testName + " ========");
+
+		testSetup(testName);
+
+		File f = new File(Helper.MEMORY_MAPPED_FILE_NAME);
+		if (f.exists()) {
+			f.delete();
+		}
+
+		/*
+		 * Create a new file that will be mapped to memory and used to communicate between
+		 * this process and the java test process.
+		 */
+		boolean newFile = f.createNewFile();
+		Assert.assertTrue(newFile, "Unable to create a new file to be mapped");
+
+		/*
+		 * MappedByteBuffer communicates between this process and java process called.
+		 */
+		FileChannel channel = FileChannel.open(f.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+		mappedByteBuffer = channel.map(MapMode.READ_WRITE, 0, Helper.MAPPED_REGION_SIZE);
+		mappedByteBuffer.clear();
+		channel.close();
+
+		/*
+		 * Put MappedByteBuffer in Init state
+		 */
+		mappedByteBuffer.putChar(Helper.MAPPED_INDEX, Helper.STATE_INIT);
+
+		/*
+		 * Run the test as a separate process
+		 */
+		System.out.println("Starting the java Test");
+		ProcessBuilder builder = new ProcessBuilder("java", "-cp", "target/classes", name);
+		Process process = builder.start();
+
+		char currentState = mappedByteBuffer.getChar(Helper.MAPPED_INDEX);
+		/*
+		 * Loop until the test process changes the state of MappedByteBuffer from init state
+		 */
+		while (Helper.STATE_INIT == currentState) {
+			currentState = mappedByteBuffer.getChar(Helper.MAPPED_INDEX);
+		}
+
+		/*
+		 * If Mapped Buffer is in Helper.STATE_FAIL state before checkpointing then an exception must
+		 * have occurred in the test.
+		 */
+		while (Helper.STATE_FAIL == currentState) {
+			try {
+				/*
+				 * We exit the test process with exit code 5 in case of an exception
+				 */
+				exitCode = process.exitValue();
+				/*
+				 * Reaching here implies that .exitValue() has not thrown an exception, so the process has
+				 * exited, We now check the exitCode.
+				 */
+				if (5 == exitCode) {
+					Assert.fail(testName + ": Exception occurred while running the test: check the log file for details.");
+				} else {
+					Assert.fail(testName + ": ERROR: Unexpected value of exit code: " + exitCode + ", expected: 5");
+				}
+			} catch (IllegalThreadStateException e) {
+				/*
+				 * Do nothing, as an Exception is expected if the process has not exited
+				 * and we try to get its exitValue.
+				 */
+			}
+
+			currentState = mappedByteBuffer.getChar(Helper.MAPPED_INDEX);
+		}
+
+		/*
+		 * Mapped Buffer state should be Helper.STATE_CHECKPOINT for checkpointing or Helper.STATE_END if some error occurs in test
+		 */
+		if (Helper.STATE_END != currentState) {
+			Assert.assertEquals(currentState, Helper.STATE_CHECKPOINT, testName + ": ERROR: Error occurred while running the test: test is not in the excepted 'waiting to be checkpointed state': " + currentState);
+		} else {
+			Assert.fail(testName + ": ERROR: Error took place in the test check the log file for more details");
+		}
+		/*
+		 * Reaching here implies that MappedByteBuffer is in To Be Checkpointed state.
+		 * Get the pid of the test process
+		 */
+
+		pid = getPid(testName);
+		try {
+			/*
+			 * Checkpoint the process
+			 */
+			checkpoint(pid, checkpointOpt);
+
+		} catch (Exception e) {
+			/*
+			 * If exception occurs put the MappedByteBuffer to Helper.STATE_TERMINATE-Terminate state.
+			 * On reading the terminate state, the test process terminates, else it
+			 * may go on looping.
+			 */
+			mappedByteBuffer.putChar(Helper.MAPPED_INDEX, Helper.STATE_TERMINATE);
+			Assert.fail(testName + ": Exception occurred while during checkpointing" + e, e);
+		}
+
+		/*
+		 * The process has been checkpointed successfully, now restoring the process.
+		 */
+		try {
+			/*
+			 * Restore the process
+			 */
+			restore(restoreOpt);
+		} catch (Exception e) {
+			mappedByteBuffer.putChar(Helper.MAPPED_INDEX, Helper.STATE_TERMINATE);
+			Assert.fail(testName + ": Exception occurred while restoring the test" + e, e);
+		}
+
+		/*
+		 * Wait for test process to finish
+		 */
+		currentState = mappedByteBuffer.getChar(Helper.MAPPED_INDEX);
+		while (Helper.STATE_RESTORE == currentState) {
+			currentState = mappedByteBuffer.getChar(Helper.MAPPED_INDEX);
+		}
+
+		/*
+		 * If a test passes it puts the MappedByteBuffer to Helper.STATE_PASS-Pass state,
+		 * On failing to Helper.STATE_FAIL-Fail state, and if our Buffer is in Helper.STATE_TERMINATE state
+		 * its because the checkpoint-restore of test process failed.
+		 */
+
+		Assert.assertNotEquals(currentState, Helper.STATE_TERMINATE, testName + ": ERROR: Checkpoint-Restore failed");
+		Assert.assertNotEquals(currentState, Helper.STATE_FAIL, testName + ": ERROR: Test Failed, Check Log for details");
+		Assert.assertEquals(currentState, Helper.STATE_PASS, testName + " ERROR: Unexpected State of Mapped Buffer");
+		System.out.println("-----" + "PASS" + "-----");
+
+	}
+
+	/**
+	 * Remove .img files, dump.log, restore.log, stats-dump and stats-restore files from Log Directory
+	 *
+	 * @throws IOException
+	 */
+	@AfterTest
+	void cleanup() throws IOException {
+		int i;
+		String currentPath = System.getProperty("user.dir");
+		currentPath = currentPath + "/" + logFolder;
+		File deleteFile;
+		File dir = new File(currentPath);
+		String[] imgFiles = dir.list(new ImgFilter());
+		if (null != imgFiles) {
+			for (i = 0; i < imgFiles.length; i++) {
+				deleteFile = new File(currentPath + imgFiles[i]);
+				Files.delete(deleteFile.toPath());
+			}
+		}
+
+		boolean exists = Files.exists(Paths.get(currentPath + "dump.log"));
+		if (exists) {
+			Files.delete(Paths.get(currentPath + "dump.log"));
+		}
+
+		exists = Files.exists(Paths.get(currentPath + "restore.log"));
+		if (exists) {
+			Files.delete(Paths.get(currentPath + "restore.log"));
+		}
+
+		exists = Files.exists(Paths.get(currentPath + "stats-dump"));
+		if (exists) {
+			Files.delete(Paths.get(currentPath + "stats-dump"));
+		}
+
+		exists = Files.exists(Paths.get(currentPath + "stats-restore"));
+		if (exists) {
+			Files.delete(Paths.get(currentPath + "stats-restore"));
+		}
+	}
+
+	/**
+	 * Copy .img files, dump.log, restore.log, stats-dump and stats-restore files from Log Directory if they exist
+	 * to another folder.
+	 *
+	 * @throws IOException
+	 */
+	String copyFiles() throws IOException {
+		String currentPath = System.getProperty("user.dir");
+		String folderSuffix = new SimpleDateFormat("yyMMddHHmmss").format(new Date());
+		String fromPath = currentPath + "/" + logFolder;
+		File fromDir = new File(fromPath);
+		Path fromFile, toFile;
+		boolean exists;
+		String toPath = currentPath + "/" + outputFolder + testName + folderSuffix + "/";
+		Path dirPath = Paths.get(toPath);
+		Files.createDirectory(dirPath);
+
+		String[] imgFiles = fromDir.list(new ImgFilter());
+		if (null != imgFiles) {
+			for (int i = 0; i < imgFiles.length; i++) {
+				fromFile = Paths.get(fromPath + imgFiles[i]);
+				toFile = Paths.get(toPath + imgFiles[i]);
+				Files.copy(fromFile, toFile);
+			}
+		}
+
+		fromFile = Paths.get(fromPath + "dump.log");
+		exists = Files.exists(fromFile);
+		if (exists) {
+			toFile = Paths.get(toPath + "dump.log");
+			Files.copy(fromFile, toFile);
+		}
+
+		fromFile = Paths.get(fromPath + "restore.log");
+		exists = Files.exists(fromFile);
+		if (exists) {
+			toFile = Paths.get(toPath + "restore.log");
+			Files.copy(fromFile, toFile);
+		}
+
+		fromFile = Paths.get(fromPath + "stats-dump");
+		exists = Files.exists(fromFile);
+		if (exists) {
+			toFile = Paths.get(toPath + "stats-dump");
+			Files.copy(fromFile, toFile);
+		}
+
+		fromFile = Paths.get(fromPath + "stats-restore");
+		exists = Files.exists(fromFile);
+		if (exists) {
+			toFile = Paths.get(toPath + "stats-restore");
+			Files.copy(fromFile, toFile);
+		}
+
+		return folderSuffix;
+	}
+
+	/**
+	 * Checkpoint the process, if process has not been checkpointed correctly
+	 * copy the .img, log and stats files, puts MappedBuffer to 'terminate' state and mark
+	 * test as failed
+	 *
+	 * @param pid           Pid of process to be checkpointed
+	 * @param checkpointOpt Additional options for checkpoint
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	private void checkpoint(String pid, String checkpointOpt) throws IOException, InterruptedException {
+		ProcessBuilder builder;
+		System.out.println("Checkpointing process " + pid);
+		String command = "../../criu/criu dump --shell-job -t " + pid + " -vvv -D " + logFolder + " -o dump.log";
+		if (0 == checkpointOpt.length()) {
+			String[] cmd = command.split(" ");
+			builder = new ProcessBuilder(cmd);
+		} else {
+			command = command + " " + checkpointOpt;
+			String[] cmd = command.split(" ");
+			builder = new ProcessBuilder(cmd);
+		}
+		Process process = builder.start();
+		BufferedReader stdError = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+		int exitCode = process.waitFor();
+
+		if (0 != exitCode) {
+			/*
+			 * Print the error stream
+			 */
+			String line = stdError.readLine();
+			while (null != line) {
+				System.out.println(line);
+				line = stdError.readLine();
+			}
+
+			mappedByteBuffer.putChar(Helper.MAPPED_INDEX, Helper.STATE_TERMINATE);
+			/*
+			 * If checkpoint fails copy the img files, dump.log, stats-dump, stats-restore
+			 */
+			String folderSuffix = copyFiles();
+
+			Assert.fail(testName + ": ERROR: Error during checkpoint: exitCode of checkpoint process was not zero.\nFor more details check dump.log in " + outputFolder + testName + folderSuffix);
+			return;
+		}
+
+		System.out.println("Checkpoint success");
+		process.destroy();
+
+	}
+
+	/**
+	 * Restore the process, if process has been restored correctly put Mapped Buffer to
+	 * 'restored' state, else copy the .img, log and stats files and put MappedBuffer to 'terminate'
+	 * state and mark test as failed
+	 *
+	 * @param restoreOpt Additional options for restore
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	private void restore(String restoreOpt) throws IOException, InterruptedException {
+		ProcessBuilder builder;
+		System.out.println("Restoring process");
+		String command = "../../criu/criu restore -d -vvv --shell-job -D " + logFolder + " -o restore.log";
+		if (0 == restoreOpt.length()) {
+			String[] cmd = command.split(" ");
+			builder = new ProcessBuilder(cmd);
+		} else {
+			command = command + " " + restoreOpt;
+			String[] cmd = command.split(" ");
+			builder = new ProcessBuilder(cmd);
+		}
+
+		Process process = builder.start();
+		BufferedReader stdError = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+		int exitCode = process.waitFor();
+
+		if (0 != exitCode) {
+			/*
+			 * Print the error stream
+			 */
+			String line = stdError.readLine();
+			while (null != line) {
+				System.out.println(line);
+				line = stdError.readLine();
+			}
+			mappedByteBuffer.putChar(Helper.MAPPED_INDEX, Helper.STATE_TERMINATE);
+			/*
+			 * If restore fails copy img files, dump.log, restore.log, stats-dump, stats-restore
+			 */
+			String folderSuffix = copyFiles();
+			Assert.fail(testName + ": ERROR: Error during restore: exitCode of restore process was not zero.\nFor more details check restore.log in " + outputFolder + testName + folderSuffix);
+
+			return;
+		} else {
+			System.out.println("Restore success");
+			mappedByteBuffer.putChar(Helper.MAPPED_INDEX, Helper.STATE_RESTORE);
+		}
+		process.destroy();
+	}
+}

--- a/test/javaTests/src/org/criu/java/tests/FileRead.java
+++ b/test/javaTests/src/org/criu/java/tests/FileRead.java
@@ -1,0 +1,175 @@
+package org.criu.java.tests;
+
+import java.io.*;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.StandardOpenOption;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class FileRead {
+	private static String TESTNAME = "FileRead";
+
+	/**
+	 * @param i int value denoting the line number.
+	 * @return The line as a string.
+	 */
+	private static String getLine(int i) {
+		return "Line No: " + i + "\n";
+	}
+
+	/**
+	 * Write in a file, line by line, and read it, checkpoint and restore
+	 * and then continue to read and write the file.
+	 *
+	 * @param args Not used
+	 */
+	public static void main(String[] args) {
+		MappedByteBuffer b = null;
+		Logger logger = null;
+		int wi, ri = 0;
+		try {
+			File file = new File(Helper.OUTPUT_FOLDER_NAME + "/" + TESTNAME + "/FileRead_write.txt");
+			File f = new File(Helper.MEMORY_MAPPED_FILE_NAME);
+			logger = Logger.getLogger(Helper.PACKAGE_NAME + "." + TESTNAME);
+			RuntimeMXBean bean = ManagementFactory.getRuntimeMXBean();
+			String pid = bean.getName();
+			int val = Helper.init(TESTNAME, pid, logger);
+			if (0 != val) {
+				logger.log(Level.SEVERE, "Helper.init returned a non-zero code.");
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_END);
+				System.exit(1);
+			}
+			logger.log(Level.INFO, "Test init done; pid written to pid file; beginning with test");
+			FileChannel channel = FileChannel.open(f.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+			b = channel.map(MapMode.READ_WRITE, 0, Helper.MAPPED_REGION_SIZE);
+			channel.close();
+			/*
+			 * Mapped Byte Buffer should be in init state at the beginning of test
+			 */
+			if ('I' != b.getChar(Helper.MAPPED_INDEX)) {
+				logger.log(Level.SEVERE, "Error: Error in memory mapping, test is not in init state");
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_END);
+				System.exit(1);
+			}
+
+			logger.log(Level.INFO, "Checking existence of file to be read and written to.");
+			if (file.exists()) {
+				file.delete();
+			}
+			boolean newFile = file.createNewFile();
+			if (!newFile) {
+				logger.log(Level.SEVERE, "Cannot create a new file to read and write to.");
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_END);
+				System.exit(1);
+			}
+
+			BufferedWriter brw = new BufferedWriter(new FileWriter(file));
+			BufferedReader brr = new BufferedReader(new FileReader(file));
+
+			logger.log(Level.INFO, "Start writing the lines in file");
+
+			for (wi = 1; wi <= 5; wi++) {
+				brw.write(getLine(wi));
+			}
+
+			brw.flush();
+			String s = "Line No: 0";
+			int i;
+
+			for (i = 0; i < 50; i++) {
+				brw.write(getLine(wi));
+				brw.flush();
+				wi++;
+				s = brr.readLine();
+				ri = Integer.parseInt(s.replaceAll("[\\D]", ""));
+			}
+
+			wi--;
+			logger.log(Level.INFO, "Going to checkpoint");
+
+			/*
+			 * Checkpoint and wait for restore
+			 */
+			Helper.checkpointAndWait(b, logger);
+			logger.log(Level.INFO, "Test has been restored!");
+
+			brw.flush();
+
+			try {
+				s = brr.readLine();
+
+			} catch (Exception e) {
+				logger.log(Level.SEVERE, "Error: Buffered Reader is not reading file");
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_FAIL);
+				System.exit(1);
+			}
+
+			if (null == s || s.isEmpty()) {
+				logger.log(Level.SEVERE, "Error: Error while reading lines after restore: Line read is null");
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_FAIL);
+				System.exit(1);
+			}
+			int readLineNo = Integer.parseInt(s.replaceAll("[\\D]", ""));
+			if (ri + 1 != readLineNo) {
+				logger.log(Level.SEVERE, "Error: Not reading at correct line");
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_FAIL);
+				System.exit(1);
+			}
+			String ch = brr.readLine();
+			while (null != ch && !ch.isEmpty()) {
+				s = ch;
+				ch = brr.readLine();
+			}
+
+			readLineNo = Integer.parseInt(s.replaceAll("[\\D]", ""));
+
+			if (readLineNo != wi) {
+				logger.log(Level.SEVERE, "Error: Data written has been lost");
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_FAIL);
+				System.exit(1);
+			}
+
+			try {
+				brw.write(getLine(wi + 1));
+				brw.flush();
+			} catch (IOException e) {
+				logger.log(Level.SEVERE, "Error: cannot write file after restore");
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_FAIL);
+				System.exit(1);
+			}
+
+			s = brr.readLine();
+			readLineNo = Integer.parseInt(s.replaceAll("[\\D]", ""));
+
+			if (readLineNo != wi + 1) {
+				logger.log(Level.SEVERE, "Error: Data not written correctly");
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_FAIL);
+				System.exit(1);
+			}
+			logger.log(Level.INFO, "File is being read and written to correctly after restore!");
+			logger.log(Level.INFO, Helper.PASS_MESSAGE);
+			brw.close();
+			brr.close();
+			b.putChar(Helper.MAPPED_INDEX, Helper.STATE_PASS);
+			System.exit(0);
+		} catch (Exception e) {
+			if (null != logger) {
+				StringWriter writer = new StringWriter();
+				PrintWriter printWriter = new PrintWriter(writer);
+				e.printStackTrace(printWriter);
+				logger.log(Level.SEVERE, "Exception occurred:" + e);
+				logger.log(Level.FINE, writer.toString());
+			}
+
+			if (null != b) {
+				b.putChar(Helper.MAPPED_INDEX, Helper.STATE_FAIL);
+			}
+
+			System.exit(5);
+		}
+	}
+}

--- a/test/javaTests/src/org/criu/java/tests/Helper.java
+++ b/test/javaTests/src/org/criu/java/tests/Helper.java
@@ -1,0 +1,99 @@
+package org.criu.java.tests;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+class Helper {
+	static String MEMORY_MAPPED_FILE_NAME = "output/file";
+	static String PASS_MESSAGE = "Test was a Success!!!";
+	static String OUTPUT_FOLDER_NAME = "output";
+	static String PACKAGE_NAME = "org.criu.java.tests";
+	static String PID_APPEND = ".pid";
+	static String SOURCE_FOLDER = "src/org/criu/java/tests";
+	static String LOG_FOLDER = "CRlogs";
+	static int MAPPED_REGION_SIZE = 100;
+	static int MAPPED_INDEX = 1;
+	static char STATE_RESTORE = 'R';
+	static char STATE_CHECKPOINT = 'C';
+	static char STATE_INIT = 'I';
+	static char STATE_TERMINATE = 'T';
+	static char STATE_END = 'E';
+	static char STATE_FAIL = 'F';
+	static char STATE_PASS = 'P';
+
+	/**
+	 * Create a new log file and pidfile and write
+	 * the pid to the pidFile.
+	 *
+	 * @param testName Name of the java test
+	 * @param pid Pid of the java test process
+	 * @param logger
+	 * @return 0 or 1 denoting whether the function was successful or not.
+	 * @throws IOException
+	 */
+	static int init(String testName, String pid, Logger logger) throws IOException {
+		File pidfile = new File(OUTPUT_FOLDER_NAME + "/" + testName + "/" + testName + PID_APPEND);
+
+		FileHandler handler = new FileHandler(Helper.OUTPUT_FOLDER_NAME + "/" + testName + "/" + testName + ".log", false);
+		handler.setFormatter(new SimpleFormatter());
+		handler.setLevel(Level.FINE);
+		logger.addHandler(handler);
+		logger.setLevel(Level.FINE);
+
+		/*
+		 * Create a pid file and write the process's pid into it.
+		 */
+		if (pidfile.exists()) {
+			pidfile.delete();
+		}
+		boolean newFile = pidfile.createNewFile();
+		if (!newFile) {
+			logger.log(Level.SEVERE, "Cannot create new pid file.");
+			return 1;
+		}
+		BufferedWriter pidWriter = new BufferedWriter(new FileWriter(pidfile));
+		pidWriter.write(pid + "\n");
+		pidWriter.close();
+		return 0;
+	}
+
+	/**
+	 * Put the Mapped Buffer to 'Ready to be checkpointed' state and wait for restore.
+	 *
+	 * @param b      The MappedByteBuffer from the calling process.
+	 * @param logger The Logger from the calling process.
+	 */
+	static void checkpointAndWait(MappedByteBuffer b, Logger logger) {
+		b.putChar(Helper.MAPPED_INDEX, Helper.STATE_CHECKPOINT);
+		char c = b.getChar(Helper.MAPPED_INDEX);
+		/*
+		 * Loop while MappedByteBuffer is in 'To be checkpointed' state
+		 */
+		while (Helper.STATE_CHECKPOINT == c) {
+			c = b.getChar(Helper.MAPPED_INDEX);
+		}
+		/*
+		 * Test is in 'T' state if some error or exception occurs during checkpoint or restore.
+		 */
+		if (Helper.STATE_TERMINATE == c) {
+			logger.log(Level.SEVERE, "Error during checkpoint-restore, Test terminated");
+			b.putChar(Helper.MAPPED_INDEX, Helper.STATE_FAIL);
+			System.exit(1);
+		}
+		/*
+		 * The expected state of MappedByteBuffer is Helper.STATE_RESTORE-restored state.
+		 */
+		if (Helper.STATE_RESTORE != c) {
+			logger.log(Level.INFO, "Error: Test state is not the expected Restored state");
+			b.putChar(Helper.MAPPED_INDEX, Helper.STATE_FAIL);
+			System.exit(1);
+		}
+	}
+}

--- a/test/javaTests/src/org/criu/java/tests/ImgFilter.java
+++ b/test/javaTests/src/org/criu/java/tests/ImgFilter.java
@@ -1,0 +1,11 @@
+package org.criu.java.tests;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+class ImgFilter implements FilenameFilter {
+	@Override
+	public boolean accept(File dir, String fileName) {
+		return (fileName.endsWith(".img"));
+	}
+}

--- a/test/javaTests/test.xml
+++ b/test/javaTests/test.xml
@@ -1,0 +1,13 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name = "Suite1">
+	<parameter name="checkpointOpt" value=""/>
+	<parameter name="restoreOpt" value=""/>
+	<test name = "test1-FileRead">
+		<parameter name="testname" value="FileRead"/>
+		<classes>
+			<class name = "org.criu.java.tests.CheckpointRestore"/>
+		</classes>
+	</test>
+</suite>


### PR DESCRIPTION
As noted in issue #820, we are adding sample Java tests to check CRIU APIs. Currently this only checks File-based CRIU APIs. Based on feedback we can add the remaining Java tests that we have been working on.

These tests take 1.5 minutes when run the first time as maven needs to build its repo. Subsequent runs on the same machine will take about 6 seconds as the required files will be cached locally.