### PR TITLE
travis: start to use aarch64 hardware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,9 @@ env:
   - TR_ARCH=x86_64
   - TR_ARCH=x86_64      CLANG=1
   - TR_ARCH=armv7hf
-  - TR_ARCH=aarch64
   - TR_ARCH=ppc64le
   - TR_ARCH=s390x
   - TR_ARCH=armv7hf     CLANG=1
-  - TR_ARCH=aarch64     CLANG=1
   - TR_ARCH=ppc64le     CLANG=1
   - TR_ARCH=alpine      CLANG=1
   - TR_ARCH=docker-test
@@ -27,6 +25,15 @@ env:
   - TR_ARCH=centos
   - TR_ARCH=podman-test
 matrix:
+  include:
+    - os: linux
+      arch: arm64
+      env: TR_ARCH=local
+      dist: bionic
+    - os: linux
+      arch: arm64
+      env: TR_ARCH=local CLANG=1
+      dist: bionic
   allow_failures:
     - env: TR_ARCH=docker-test
     - env: TR_ARCH=fedora-rawhide

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -42,5 +42,5 @@ RUN apk add \
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 -D test
 
-RUN pip install protobuf ipaddress junit_xml
+RUN pip install protobuf ipaddress junit_xml flake8
 RUN make -C test/zdtm

--- a/scripts/build/Dockerfile.centos
+++ b/scripts/build/Dockerfile.centos
@@ -23,6 +23,7 @@ RUN yum install -y \
 	protobuf-devel \
 	protobuf-python \
 	python \
+	python-flake8 \
 	python-ipaddress \
 	python2-future \
 	python2-junit_xml \

--- a/scripts/build/Makefile
+++ b/scripts/build/Makefile
@@ -1,5 +1,5 @@
-QEMU_ARCHES := armv7hf aarch64 ppc64le s390x fedora-rawhide-aarch64 # require qemu
-ARCHES := $(QEMU_ARCHES) x86_64 fedora-asan fedora-rawhide centos
+QEMU_ARCHES := armv7hf ppc64le s390x fedora-rawhide-aarch64 # require qemu
+ARCHES := $(QEMU_ARCHES) aarch64 x86_64 fedora-asan fedora-rawhide centos
 TARGETS := $(ARCHES) alpine
 TARGETS_CLANG := $(addsuffix $(TARGETS),-clang)
 CONTAINER_RUNTIME := docker

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -1,17 +1,31 @@
 #!/bin/sh
 set -x -e
 
-TRAVIS_PKGS="protobuf-c-compiler libprotobuf-c-dev libaio-dev
+TRAVIS_PKGS="protobuf-c-compiler libprotobuf-c-dev libaio-dev python-future
 		libgnutls28-dev libgnutls30 libprotobuf-dev protobuf-compiler
-		libcap-dev libnl-3-dev gcc-multilib gdb bash python-protobuf
-		libnet-dev util-linux asciidoctor libnl-route-3-dev"
+		libcap-dev libnl-3-dev gdb bash python-protobuf python-yaml
+		libnet-dev util-linux asciidoctor libnl-route-3-dev
+		python-junit.xml python-ipaddress time ccache flake8
+		libbsd-dev"
+
+X86_64_PKGS="gcc-multilib"
+
+UNAME_M=`uname -m`
+
+if [ "$UNAME_M" != "x86_64" ]; then
+	# For Travis only x86_64 seems to be baremetal. Other
+	# architectures are running in unprivileged LXD containers.
+	# That seems to block most of CRIU's interfaces.
+	SKIP_TRAVIS_TEST=1
+fi
 
 travis_prep () {
 	[ -n "$SKIP_TRAVIS_PREP" ] && return
 
 	cd ../../
 
-	service apport stop
+	# This can fail on aarch64 travis
+	service apport stop || :
 
 	CC=gcc
 	# clang support
@@ -43,23 +57,40 @@ travis_prep () {
 		sed -i '/security/ d' /etc/apt/sources.list
 	fi
 
+
+	# Do not install x86_64 specific packages on other architectures
+	if [ "$UNAME_M" = "x86_64" ]; then
+		TRAVIS_PKGS="$TRAVIS_PKGS $X86_64_PKGS"
+	fi
+
 	apt-get update -qq
 	apt-get install -qq --no-install-recommends $TRAVIS_PKGS
-	# travis is based on 14.04 and that does not have python
-	# packages for future and ipaddress (16.04 has those packages)
-	pip install junit-xml future ipaddress
 	chmod a+x $HOME
 }
 
 travis_prep
 
-ulimit -c unlimited
-echo "|`pwd`/test/abrt.sh %P %p %s %e" > /proc/sys/kernel/core_pattern
-
 export GCOV
+$CC --version
 time make CC="$CC" -j4
 
+./criu/criu -v4 cpuinfo dump || :
+./criu/criu -v4 cpuinfo check || :
+
+make lint
+
+# Check that help output fits into 80 columns
+WIDTH=$(./criu/criu --help | wc --max-line-length)
+if [ "$WIDTH" -gt 80 ]; then
+	echo "criu --help output does not obey 80 characters line width!"
+	exit 1
+fi
+
 [ -n "$SKIP_TRAVIS_TEST" ] && return
+
+ulimit -c unlimited
+
+echo "|`pwd`/test/abrt.sh %P %p %s %e" > /proc/sys/kernel/core_pattern
 
 if [ "${COMPAT_TEST}x" = "yx" ] ; then
 	# Dirty hack to keep both ia32 & x86_64 shared libs on a machine:
@@ -165,15 +196,3 @@ ip net add test
 make -C test/others/libcriu run
 
 make -C test/others/shell-job
-
-if ! [ -x "$(command -v flake8)" ]; then
-	pip install flake8
-fi
-make lint
-
-# Check that help output fits into 80 columns
-WIDTH=$(./criu/criu --help | wc --max-line-length)
-if [ "$WIDTH" -gt 80 ]; then
-	echo "criu --help output does not obey 80 characters line width!"
-	exit 1
-fi


### PR DESCRIPTION
With the newly introduced aarch64 at Travis it is possible for the CRIU test-cases to switch to aarch64.

Travis uses unprivileged LXD containers on aarch64 which blocks many of the kernel interfaces CRIU needs. So for now this only tests building CRIU natively on aarch64 instead of using the Docker+QEMU combination.

All tests based on Docker are not working on aarch64 is there currently seems to be a problem with Docker on aarch64. Maybe because of the nesting of Docker in LXD.

The problem with Docker on LXD was reported here: https://travis-ci.community/t/docker-container-download-fails/5674/2

Once this is fixed I will try to move all other arm32/arm64 related tests to native hardware.