### PR TITLE
Checkpoint only specified controllers

### DIFF
--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -2498,6 +2498,12 @@ int collect_controllers(struct list_head *cgroups, unsigned int *n_cgroups)
 			goto err;
 		}
 		*off = '\0';
+
+		if (cgp_should_skip_controller(controllers)) {
+			pr_debug("cg-prop: Skipping controller %s\n", controllers);
+			continue;
+		}
+
 		while (1) {
 			off = strchr(controllers, ',');
 			if (off)


### PR DESCRIPTION
Before this change CRIU would checkpoint all controllers, even the ones not specified in --cgroup-dump-controller. That becomes a problem if there's a cgroup controller on the checkpointing machine that doesn't exist on the restoring machine even if CRIU is instructed not to dump that controller. After that change everything works as expected.