### PR TITLE
restorer/inotify: reorder inotify cleanup after waiting helpers and z…

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1839,9 +1839,6 @@ long __export_restore_task(struct task_restore_args *args)
 
 	restore_finish_stage(task_entries_local, CR_STATE_RESTORE);
 
-	if (cleanup_current_inotify_events(args))
-		goto core_restore_end;
-
 	if (wait_helpers(args) < 0)
 		goto core_restore_end;
 	if (wait_zombies(args) < 0)
@@ -1853,6 +1850,9 @@ long __export_restore_task(struct task_restore_args *args)
 		pr_err("Unable to block signals %ld\n", ret);
 		goto core_restore_end;
 	}
+
+	if (cleanup_current_inotify_events(args))
+		goto core_restore_end;
 
 	if (!args->compatible_mode) {
 		ret = sys_sigaction(SIGCHLD, &args->sigchld_act,


### PR DESCRIPTION
…ombies

We've seen ppoll interrupted with signal in VZ7 CT migration tests, that
is because in the beggining of CR_STATE_RESTORE_SIGCHLD zombies and
helpers die, and that can trigger SIGCHILDs sent to their parents.

Adding additional debug (printing "Task..." for zombies and helpers) in
sigchld_handler I see:

  (15.644339) pie: 1: Task 10718 exited, status= 0
  (15.644349) pie: 1: Cleaning inotify events from 29
  (15.644359) pie: 1: Cleaning inotify events from 19
  (15.644367) pie: 1: Cleaning inotify events from 10

And previousely we had:

  (05.718449) pie: 104: Cleaning inotify events from 5
  (05.718835) pie: 330: Cleaning inotify events from 3
  (05.719046) pie: 1: Cleaning inotify events from 23
  (05.719164) pie: 80: Cleaning inotify events from 7
  (05.719185) pie: 1: Error (criu/pie/restorer.c:1287): Failed to poll from inotify fd: -4
  (05.719202) pie: 95: Cleaning inotify events from 6
  (05.719269) pie: 1: Error (criu/pie/restorer.c:1890): Restorer fail 1

So reordering cleanup and wait should fix it.

Previous discussion was in https://github.com/checkpoint-restore/criu/pull/803.