### PR TITLE
unix sysctl max-dgram-qlen preserve

### DIFF
--- a/images/netdev.proto
+++ b/images/netdev.proto
@@ -71,4 +71,5 @@ message netns_entry {
 
 	repeated netns_id nsids		= 7;
 	optional string	ext_key		= 8;
+	repeated sysctl_entry unix_conf	= 9;
 }

--- a/test/zdtm/lib/Makefile
+++ b/test/zdtm/lib/Makefile
@@ -4,7 +4,7 @@ CFLAGS	+= $(USERCFLAGS)
 
 LIB	:= libzdtmtst.a
 
-LIBSRC	:= datagen.c msg.c parseargs.c test.c streamutil.c lock.c ns.c tcp.c fs.c
+LIBSRC	:= datagen.c msg.c parseargs.c test.c streamutil.c lock.c ns.c tcp.c fs.c sysctl.c
 LIBOBJ	:= $(LIBSRC:%.c=%.o)
 
 BIN	:= groups

--- a/test/zdtm/lib/sysctl.c
+++ b/test/zdtm/lib/sysctl.c
@@ -1,0 +1,59 @@
+#include <fcntl.h>
+
+#include "zdtmtst.h"
+#include "sysctl.h"
+
+int sysctl_read_int(const char *name, int *data)
+{
+	int fd;
+	int ret;
+	char buf[16];
+
+	fd = open(name, O_RDONLY);
+	if (fd < 0) {
+		pr_perror("Can't open %s", name);
+		return fd;
+	}
+
+	ret = read(fd, buf, sizeof(buf) - 1);
+	if (ret < 0) {
+		pr_perror("Can't read %s", name);
+		ret = -errno;
+		goto err;
+	}
+
+	buf[ret] = '\0';
+
+	*data = (int)strtoul(buf, NULL, 10);
+	ret = 0;
+err:
+	close(fd);
+	return ret;
+}
+
+int sysctl_write_int(const char *name, int val)
+{
+	int fd;
+	int ret;
+	char buf[16];
+
+	fd = open(name, O_WRONLY);
+	if (fd < 0) {
+		pr_perror("Can't open %s", name);
+		return fd;
+	}
+
+	sprintf(buf, "%d\n", val);
+
+	ret = write(fd, buf, strlen(buf));
+	if (ret < 0) {
+		pr_perror("Can't write %d into %s", val, name);
+		ret = -errno;
+		goto err;
+	}
+
+	ret = 0;
+err:
+	close(fd);
+	return ret;
+}

--- a/test/zdtm/lib/sysctl.h
+++ b/test/zdtm/lib/sysctl.h
@@ -1,0 +1,7 @@
+#ifndef __ZDTM_SYSCTL__
+#define __ZDTM_SYSCTL__
+
+extern int sysctl_read_int(const char *name, int *data);
+extern int sysctl_write_int(const char *name, int val);
+
+#endif

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -207,6 +207,7 @@ TST_NOFILE	:=				\
 		pipe03				\
 		netns_sub			\
 		netns_sub_veth			\
+		netns_sub_sysctl	\
 		unlink_multiple_largefiles	\
 		config_inotify_irmap		\
 		thp_disable			\

--- a/test/zdtm/static/netns_sub_sysctl.c
+++ b/test/zdtm/static/netns_sub_sysctl.c
@@ -1,0 +1,56 @@
+#include <sched.h>
+
+#include "zdtmtst.h"
+#include "sysctl.h"
+
+const char *test_doc	= "Check dump and restore a net.unix.max_dgram_qlen sysctl parameter in subns";
+const char *test_author	= "Alexander Mikhalitsyn <alexander@mihalicyn.com>";
+
+typedef struct {
+	const char *path;
+	int old;
+	int new;
+} sysctl_opt_t;
+
+#define CONF_UNIX_BASE	"/proc/sys/net/unix"
+
+static sysctl_opt_t net_unix_params[] = {
+	{CONF_UNIX_BASE"/max_dgram_qlen", 0, 0},
+	{NULL, 0, 0}
+};
+
+int main(int argc, char **argv)
+{
+	int ret = 0;
+	sysctl_opt_t *p;
+	test_init(argc, argv);
+
+	for (p = net_unix_params; p->path != NULL; p++) {
+		p->old = (((unsigned)lrand48()) % 1023) + 1;
+		if (sysctl_write_int(p->path, p->old)) {
+			pr_perror("Can't change %s", p->path);
+			return -1;
+		}
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	for (p = net_unix_params; p->path != NULL; p++) {
+		if (sysctl_read_int(p->path, &p->new))
+			ret = 1;
+
+		if (p->old != p->new) {
+			errno = EINVAL;
+			pr_perror("%s changed: %d ---> %d", p->path, p->old, p->new);
+			ret = 1;
+		}
+	}
+
+	if (ret)
+		fail();
+	else
+		pass();
+
+	return ret;
+}

--- a/test/zdtm/static/netns_sub_sysctl.desc
+++ b/test/zdtm/static/netns_sub_sysctl.desc
@@ -1,0 +1,4 @@
+{
+    'flavor': 'ns',
+    'flags': 'suid'
+}


### PR DESCRIPTION
This patch set resolves problem of changing sysctl net.unix.max_dgram_qlen value after C/R