### PR TITLE
mount: Bind-mount root via userns_call

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -414,6 +414,8 @@ usually need to be escaped from shell.
 
 *-r*, *--root* 'path'::
     Change the root filesystem to 'path' (when run in a mount namespace).
+    This option is required to restore a mount namespace. The directory
+    'path' must be a mount point and its parent must not be overmounted.
 
 *--external* 'type'*[*'id'*]:*'value'::
     Restore an instance of an external resource. The generic syntax is

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1589,7 +1589,7 @@ static void restore_pgid(void)
 static int mount_proc(void)
 {
 	int fd, ret;
-	char proc_mountpoint[] = "crtools-proc.XXXXXX";
+	char proc_mountpoint[] = "/tmp/crtools-proc.XXXXXX";
 
 	if (root_ns_mask == 0)
 		fd = ret = open("/proc", O_DIRECTORY);

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -2020,25 +2020,35 @@ static char *mnt_fsname(struct mount_info *mi)
 	return mi->fstype->name;
 }
 
-static int apply_sb_flags(void *args, int fd, pid_t pid)
+static int userns_mount(char *src, void *args, int fd, pid_t pid)
 {
 	unsigned long flags = *(unsigned long *) args;
 	int rst = -1, err = -1;
-	char path[PSFDS];
+	char target[PSFDS];
 
-	snprintf(path, sizeof(path), "/proc/self/fd/%d", fd);
+	snprintf(target, sizeof(target), "/proc/self/fd/%d", fd);
 
 	if (pid != getpid() && switch_ns(pid, &mnt_ns_desc, &rst))
 		return -1;
 
-	err = mount(NULL, path, NULL, MS_REMOUNT | flags, NULL);
+	err = mount(src, target, NULL, flags, NULL);
 	if (err)
-		pr_perror("Unable to remount %s", path);
+		pr_perror("Unable to mount %s", target);
 
 	if (rst >= 0 &&	restore_ns(rst, &mnt_ns_desc))
 		return -1;
 
 	return err;
+}
+
+static int apply_sb_flags(void *args, int fd, pid_t pid)
+{
+	return userns_mount(NULL, args, fd, pid);
+}
+
+static int mount_root(void *args, int fd, pid_t pid)
+{
+	return userns_mount(opts.root, args, fd, pid);
 }
 
 static int do_new_mount(struct mount_info *mi)
@@ -2088,10 +2098,9 @@ static int do_new_mount(struct mount_info *mi)
 			pr_perror("Unable to open %s", mi->mountpoint);
 			return -1;
 		}
-		sflags |= MS_RDONLY;
-		if (userns_call(apply_sb_flags, 0,
-				&sflags, sizeof(sflags), fd)) {
-			pr_perror("Unable to apply mount flags %d for %s",
+		sflags |= MS_RDONLY | MS_REMOUNT;
+		if (userns_call(apply_sb_flags, 0, &sflags, sizeof(sflags), fd)) {
+			pr_err("Unable to apply mount flags %d for %s",
 						mi->sb_flags, mi->mountpoint);
 			close(fd);
 			return -1;
@@ -2491,15 +2500,33 @@ static int do_mount_one(struct mount_info *mi)
 	pr_debug("\tMounting %s @%s (%d)\n", mi->fstype->name, mi->mountpoint, mi->need_plugin);
 
 	if (rst_mnt_is_root(mi)) {
+		int fd;
+		unsigned long flags = MS_BIND | MS_REC;
+
 		if (opts.root == NULL) {
 			pr_err("The --root option is required to restore a mount namespace\n");
 			return -1;
 		}
 
 		/* do_mount_root() is called from populate_mnt_ns() */
-		if (mount(opts.root, mi->mountpoint, NULL, MS_BIND | MS_REC, NULL)) {
-			pr_perror("Unable to mount %s %s (id=%d)", opts.root, mi->mountpoint, mi->mnt_id);
-			return -1;
+		if (root_ns_mask & CLONE_NEWUSER) {
+			fd = open(mi->mountpoint, O_PATH);
+			if (fd < 0) {
+				pr_perror("Unable to open %s", mi->mountpoint);
+				return -1;
+			}
+
+			if (userns_call(mount_root, 0, &flags, sizeof(flags), fd)) {
+				pr_err("Unable to mount %s\n", mi->mountpoint);
+				close(fd);
+				return -1;
+			}
+			close(fd);
+		} else {
+			if (mount(opts.root, mi->mountpoint, NULL, flags, NULL)) {
+				pr_perror("Unable to mount %s %s (id=%d)", opts.root, mi->mountpoint, mi->mnt_id);
+				return -1;
+			}
 		}
 
 		if (do_mount_root(mi))

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -1325,8 +1325,10 @@ int ns_open_mountpoint(void *arg)
 	}
 
 	/* Remount all mounts as private to disable propagation */
-	if (mount("none", "/", NULL, MS_REC|MS_PRIVATE, NULL))
+	if (mount("none", "/", NULL, MS_REC|MS_PRIVATE, NULL)) {
+		pr_perror("Unable to remount");
 		goto err;
+	}
 
 	if (umount_overmounts(mi))
 		goto err;
@@ -1536,6 +1538,7 @@ static __maybe_unused int mount_cr_time_mount(struct ns_id *ns, unsigned int *s_
 
 	ret = mount(source, target, type, 0, NULL);
 	if (ret < 0) {
+		pr_perror("Unable to mount %s %s", source, target);
 		exit_code = -errno;
 		goto restore_ns;
 	} else {
@@ -2004,7 +2007,10 @@ static int fetch_rt_stat(struct mount_info *m, const char *where)
 static int do_simple_mount(struct mount_info *mi, const char *src, const
 			   char *fstype, unsigned long mountflags)
 {
-	return mount(src, mi->mountpoint, fstype, mountflags, mi->options);
+	int ret = mount(src, mi->mountpoint, fstype, mountflags, mi->options);
+	if (ret)
+		pr_perror("Unable to mount %s %s (id=%d)", src, mi->mountpoint, mi->mnt_id);
+	return ret;
 }
 
 static char *mnt_fsname(struct mount_info *mi)
@@ -2491,8 +2497,11 @@ static int do_mount_one(struct mount_info *mi)
 		}
 
 		/* do_mount_root() is called from populate_mnt_ns() */
-		if (mount(opts.root, mi->mountpoint, NULL, MS_BIND | MS_REC, NULL))
+		if (mount(opts.root, mi->mountpoint, NULL, MS_BIND | MS_REC, NULL)) {
+			pr_perror("Unable to mount %s %s (id=%d)", opts.root, mi->mountpoint, mi->mnt_id);
 			return -1;
+		}
+
 		if (do_mount_root(mi))
 			return -1;
 		mi->mounted = true;

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -62,6 +62,7 @@ tests_root = None
 def clean_tests_root():
     global tests_root
     if tests_root and tests_root[0] == os.getpid():
+        os.rmdir(os.path.join(tests_root[1], "root"))
         os.rmdir(tests_root[1])
 
 
@@ -70,7 +71,9 @@ def make_tests_root():
     if not tests_root:
         tests_root = (os.getpid(), tempfile.mkdtemp("", "criu-root-", "/tmp"))
         atexit.register(clean_tests_root)
-    return tests_root[1]
+        os.mkdir(os.path.join(tests_root[1], "root"))
+    os.chmod(tests_root[1], 0o777)
+    return os.path.join(tests_root[1], "root")
 
 
 # Report generation
@@ -480,6 +483,13 @@ class zdtm_test:
             # Wait less than a second to give the test chance to
             # move into some semi-random state
             time.sleep(random.random())
+
+        if self.__flavor.ns:
+            # In the case of runc the path specified with the opts.root
+            # option is created in /run/runc/ which is inaccessible to
+            # unprivileged users. The permissions here are set to test
+            # this use case.
+            os.chmod(os.path.dirname(self.__flavor.root), 0o700)
 
     def kill(self, sig=signal.SIGKILL):
         self.__freezer.thaw()

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -229,13 +229,11 @@ class ns_flavor:
                 rdev = os.stat(name).st_rdev
 
         name = self.root + name
-        os.mknod(name, stat.S_IFCHR, rdev)
-        os.chmod(name, 0o666)
+        os.mknod(name, stat.S_IFCHR | 0o666, rdev)
 
     def __construct_root(self):
         for dir in self.__root_dirs:
-            os.mkdir(self.root + dir)
-            os.chmod(self.root + dir, 0o777)
+            os.mkdir(self.root + dir, 0o777)
 
         for ldir in ["/bin", "/sbin", "/lib", "/lib64"]:
             os.symlink(".." + ldir, self.root + "/usr" + ldir)
@@ -1157,8 +1155,7 @@ class criu:
                 if action == "dump":
                     # create a clean directory for images
                     os.rename(__ddir, __ddir + ".fail")
-                    os.mkdir(__ddir)
-                    os.chmod(__ddir, 0o777)
+                    os.mkdir(__ddir, 0o777)
                 else:
                     # on restore we move only a log file, because we need images
                     os.rename(os.path.join(__ddir, log),
@@ -1217,8 +1214,7 @@ class criu:
 
     def dump(self, action, opts=[]):
         self.__iter += 1
-        os.mkdir(self.__ddir())
-        os.chmod(self.__ddir(), 0o777)
+        os.mkdir(self.__ddir(), 0o777)
 
         a_opts = ["-t", self.__test.getpid()]
         if self.__prev_dump_iter:

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -865,76 +865,57 @@ class criu_rpc:
     def __set_opts(criu, args, ctx):
         while len(args) != 0:
             arg = args.pop(0)
-            if arg == '-v4':
+            if "-v4" == arg:
                 criu.opts.log_level = 4
-                continue
-            if arg == '-o':
+            elif "-o" == arg:
                 criu.opts.log_file = args.pop(0)
-                continue
-            if arg == '-D':
+            elif "-D" == arg:
                 criu.opts.images_dir_fd = os.open(args.pop(0), os.O_DIRECTORY)
                 ctx['imgd'] = criu.opts.images_dir_fd
-                continue
-            if arg == '-t':
+            elif "-t" == arg:
                 criu.opts.pid = int(args.pop(0))
-                continue
-            if arg == '--pidfile':
+            elif "--pidfile" == arg:
                 ctx['pidf'] = args.pop(0)
-                continue
-            if arg == '--timeout':
+            elif "--timeout" == arg:
                 criu.opts.timeout = int(args.pop(0))
-                continue
-            if arg == '--restore-detached':
-                # Set by service by default
-                ctx['rd'] = True
-                continue
-            if arg == '--root':
+            elif "--restore-detached" == arg:
+                ctx['rd'] = True  # Set by service by default
+            elif "--root" == arg:
                 criu.opts.root = args.pop(0)
-                continue
-            if arg == '--external':
+            elif "--external" == arg:
                 criu.opts.external.append(args.pop(0))
-                continue
-            if arg == '--status-fd':
+            elif "--status-fd" == arg:
                 fd = int(args.pop(0))
                 os.write(fd, b"\0")
                 fcntl.fcntl(fd, fcntl.F_SETFD, fcntl.FD_CLOEXEC)
-                continue
-            if arg == '--port':
+            elif "--port" == arg:
                 criu.opts.ps.port = int(args.pop(0))
-                continue
-            if arg == '--address':
+            elif "--address" == arg:
                 criu.opts.ps.address = args.pop(0)
+            elif "--page-server" == arg:
                 continue
-            if arg == '--page-server':
-                continue
-            if arg == '--prev-images-dir':
+            elif "--prev-images-dir" == arg:
                 criu.opts.parent_img = args.pop(0)
-                continue
-            if arg == '--pre-dump-mode':
+            elif "--pre-dump-mode" == arg:
                 key = args.pop(0)
                 mode = crpc.rpc.VM_READ
                 if key == "splice":
                     mode = crpc.rpc.SPLICE
                 criu.opts.pre_dump_mode = mode
-                continue
-            if arg == '--track-mem':
+            elif "--track-mem" == arg:
                 criu.opts.track_mem = True
-                continue
-            if arg == '--tcp-established':
+            elif "--tcp-established" == arg:
                 criu.opts.tcp_established = True
-                continue
-            if arg == '--restore-sibling':
+            elif "--restore-sibling" == arg:
                 criu.opts.rst_sibling = True
-                continue
-            if arg == "--inherit-fd":
+            elif "--inherit-fd" == arg:
                 inhfd = criu.opts.inherit_fd.add()
                 key = args.pop(0)
                 fd, key = key.split(":", 1)
                 inhfd.fd = int(fd[3:-1])
                 inhfd.key = key
-                continue
-
-            raise test_fail_exc('RPC for %s(%s) required' % (arg, args.pop(0)))
+            else:
+                raise test_fail_exc('RPC for %s(%s) required' % (arg, args.pop(0)))
 
     @staticmethod
     def run(action,


### PR DESCRIPTION
When restoring a runc container with enabled user namespace CRIU fails to mount the specified root directory because the path is under `/run/runc` which is inaccessible to unprivileged users.