### PR TITLE
travis: exclude uns tests for lazy-pages on newer kernels 

### DIFF
--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -145,8 +145,15 @@ else
 fi
 LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps04"
 
+# Starting with 5.4 kernel requires SYS_CAP_PTRACE to use uffd events; as such
+# we cannot run lazy-pages tests in uns
+LAZY_FLAVORS=""
+if [ $KERN_MAJ -ge "5" ] && [ $KERN_MIN -ge "4" ]; then
+    LAZY_FLAVORS = "-f h,ns"
+fi
+
 LAZY_TESTS=.*\(maps0\|uffd-events\|lazy-thp\|futex\|fork\).*
-LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $ZDTM_OPTS"
+LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $LAZY_FLAVORS $ZDTM_OPTS"
 
 ./test/zdtm.py run $LAZY_OPTS --lazy-pages
 ./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -146,10 +146,11 @@ fi
 LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps04"
 
 LAZY_TESTS=.*\(maps0\|uffd-events\|lazy-thp\|futex\|fork\).*
+LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $ZDTM_OPTS"
 
-./test/zdtm.py run -p 2 -T $LAZY_TESTS --lazy-pages $LAZY_EXCLUDE $ZDTM_OPTS
-./test/zdtm.py run -p 2 -T $LAZY_TESTS --remote-lazy-pages $LAZY_EXCLUDE $ZDTM_OPTS
-./test/zdtm.py run -p 2 -T $LAZY_TESTS --remote-lazy-pages --tls $LAZY_EXCLUDE $ZDTM_OPTS
+./test/zdtm.py run $LAZY_OPTS --lazy-pages
+./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages
+./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls
 
 bash ./test/jenkins/criu-fault.sh
 bash ./test/jenkins/criu-fcg.sh


### PR DESCRIPTION
Kernels 5.4 and higher will restrict availability of UFFD_EVENT_FORK only
for users with SYS_CAP_PTRACE. This prevents running --lazy-pages tests
with 'uns' flavor.

Disable 'uns' for lazy pages testing in travis for newer kernels.
