### PR TITLE
Add checkpoint/restore support for TCP keepalive

### DIFF
--- a/criu/include/sk-inet.h
+++ b/criu/include/sk-inet.h
@@ -83,7 +83,7 @@ extern void tcp_locked_conn_add(struct inet_sk_info *);
 extern void rst_unlock_tcp_connections(void);
 extern void cpt_unlock_tcp_connections(void);
 
-extern int dump_one_tcp(int sk, struct inet_sk_desc *sd);
+extern int dump_one_tcp(int sk, struct inet_sk_desc *sd, SkOptsEntry *soe);
 extern int restore_one_tcp(int sk, struct inet_sk_info *si);
 
 #define SK_EST_PARAM	"tcp-established"

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -551,7 +551,7 @@ static int do_dump_one_inet_fd(int lfd, u32 id, const struct fd_parms *p, int fa
 
 	switch (proto) {
 	case IPPROTO_TCP:
-		err = (type != SOCK_RAW) ? dump_one_tcp(lfd, sk) : 0;
+		err = (type != SOCK_RAW) ? dump_one_tcp(lfd, sk, &skopts) : 0;
 		break;
 	case IPPROTO_UDP:
 	case IPPROTO_UDPLITE:
@@ -745,6 +745,10 @@ static int post_open_inet_sk(struct file_desc *d, int sk)
 
 	val = ii->ie->opts->so_broadcast;
 	if (!val && restore_opt(sk, SOL_SOCKET, SO_BROADCAST, &val))
+		return -1;
+
+	val = ii->ie->opts->so_keepalive;
+	if (!val && restore_opt(sk, SOL_SOCKET, SO_KEEPALIVE, &val))
 		return -1;
 
 	return 0;

--- a/criu/sk-tcp.c
+++ b/criu/sk-tcp.c
@@ -218,8 +218,26 @@ err_r:
 	return ret;
 }
 
-int dump_one_tcp(int fd, struct inet_sk_desc *sk)
+int dump_one_tcp(int fd, struct inet_sk_desc *sk, SkOptsEntry *soe)
 {
+	soe->has_tcp_keepcnt = true;
+	if (dump_opt(fd, SOL_TCP, TCP_KEEPCNT, &soe->tcp_keepcnt)) {
+		pr_perror("Can't read TCP_KEEPCNT");
+		return -1;
+	}
+
+	soe->has_tcp_keepidle = true;
+	if (dump_opt(fd, SOL_TCP, TCP_KEEPIDLE, &soe->tcp_keepidle)) {
+		pr_perror("Can't read TCP_KEEPIDLE");
+		return -1;
+	}
+
+	soe->has_tcp_keepintvl = true;
+	if (dump_opt(fd, SOL_TCP, TCP_KEEPINTVL, &soe->tcp_keepintvl)) {
+		pr_perror("Can't read TCP_KEEPINTVL");
+		return -1;
+	}
+
 	if (sk->dst_port == 0)
 		return 0;
 

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -566,6 +566,22 @@ int restore_socket_opts(int sk, SkOptsEntry *soe)
 		pr_debug("\tset broadcast for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_BROADCAST, &val);
 	}
+	if (soe->has_so_keepalive && soe->so_keepalive) {
+		pr_debug("\tset keepalive for socket\n");
+		ret |= restore_opt(sk, SOL_SOCKET, SO_KEEPALIVE, &val);
+	}
+	if (soe->has_tcp_keepcnt) {
+		pr_debug("\tset keepcnt for socket\n");
+		ret |= restore_opt(sk, SOL_TCP, TCP_KEEPCNT, &soe->tcp_keepcnt);
+	}
+	if (soe->has_tcp_keepidle) {
+		pr_debug("\tset keepidle for socket\n");
+		ret |= restore_opt(sk, SOL_TCP, TCP_KEEPIDLE, &soe->tcp_keepidle);
+	}
+	if (soe->has_tcp_keepintvl) {
+		pr_debug("\tset keepintvl for socket\n");
+		ret |= restore_opt(sk, SOL_TCP, TCP_KEEPINTVL, &soe->tcp_keepintvl);
+	}
 
 	tv.tv_sec = soe->so_snd_tmo_sec;
 	tv.tv_usec = soe->so_snd_tmo_usec;
@@ -650,6 +666,10 @@ int dump_socket_opts(int sk, SkOptsEntry *soe)
 	ret |= dump_opt(sk, SOL_SOCKET, SO_BROADCAST, &val);
 	soe->has_so_broadcast = true;
 	soe->so_broadcast = val ? true : false;
+
+	ret |= dump_opt(sk, SOL_SOCKET, SO_KEEPALIVE, &val);
+	soe->has_so_keepalive = true;
+	soe->so_keepalive = val ? true : false;
 
 	ret |= dump_bound_dev(sk, soe);
 	ret |= dump_socket_filter(sk, soe);

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -524,7 +524,7 @@ int restore_prepare_socket(int sk)
 
 int restore_socket_opts(int sk, SkOptsEntry *soe)
 {
-	int ret = 0, val;
+	int ret = 0, val = 1;
 	struct timeval tv;
 	/* In kernel a bufsize value is doubled. */
 	u32 bufs[2] = { soe->so_sndbuf / 2, soe->so_rcvbuf / 2};
@@ -547,27 +547,22 @@ int restore_socket_opts(int sk, SkOptsEntry *soe)
 		ret |= restore_opt(sk, SOL_SOCKET, SO_MARK, &soe->so_mark);
 	}
 	if (soe->has_so_passcred && soe->so_passcred) {
-		val = 1;
 		pr_debug("\tset passcred for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_PASSCRED, &val);
 	}
 	if (soe->has_so_passsec && soe->so_passsec) {
-		val = 1;
 		pr_debug("\tset passsec for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_PASSSEC, &val);
 	}
 	if (soe->has_so_dontroute && soe->so_dontroute) {
-		val = 1;
 		pr_debug("\tset dontroute for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_DONTROUTE, &val);
 	}
 	if (soe->has_so_no_check && soe->so_no_check) {
-		val = 1;
 		pr_debug("\tset no_check for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_NO_CHECK, &val);
 	}
 	if (soe->has_so_broadcast && soe->so_broadcast) {
-		val = 1;
 		pr_debug("\tset broadcast for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_BROADCAST, &val);
 	}

--- a/images/sk-opts.proto
+++ b/images/sk-opts.proto
@@ -23,6 +23,10 @@ message sk_opts_entry {
 	repeated fixed64	so_filter	= 16;
 	optional bool		so_reuseport	= 17;
 	optional bool		so_broadcast	= 18;
+	optional bool		so_keepalive	= 19;
+	optional uint32		tcp_keepcnt	= 20;
+	optional uint32		tcp_keepidle	= 21;
+	optional uint32		tcp_keepintvl	= 22;
 }
 
 enum sk_shutdown {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -105,7 +105,8 @@ TST_NOFILE	:=				\
 		socket-tcp-unconn		\
 		socket-tcp6-unconn		\
 		socket-tcp-syn-sent		\
-		socket-tcp-skip-in-flight       \
+		socket-tcp-skip-in-flight	\
+		socket-tcp-keepalive		\
 		sock_opts00			\
 		sock_opts01			\
 		sk-unix-unconn			\

--- a/test/zdtm/static/socket-tcp-keepalive.c
+++ b/test/zdtm/static/socket-tcp-keepalive.c
@@ -1,0 +1,97 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "test checkpoint/restore of SO_KEEPALIVE\n";
+const char *test_author = "Radostin Stoyanov <rstoyanov1@gmail.com>\n";
+
+int main(int argc, char **argv)
+{
+	int sk;
+	int alive = 1;
+	int cnt = 5;
+	int idle = 10;
+	int intvl = 15;
+	int optval;
+	socklen_t optlen;
+
+	test_init(argc, argv);
+
+	sk = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (sk < 0) {
+		pr_perror("Can't create socket");
+		return 1;
+	}
+
+	/* Set the option active */
+	if (setsockopt(sk, SOL_SOCKET, SO_KEEPALIVE, &alive, sizeof(alive)) < 0) {
+		pr_perror("setsockopt SO_KEEPALIVE");
+		return 1;
+	}
+
+	if (setsockopt(sk, SOL_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt)) < 0) {
+		pr_perror("setsockopt TCP_KEEPCNT");
+		return 1;
+	}
+
+	if (setsockopt(sk, SOL_TCP, TCP_KEEPIDLE, &idle, sizeof(idle)) < 0) {
+		pr_perror("setsockopt TCP_KEEPIDLE");
+		return 1;
+	}
+
+	optval = 5;
+	optlen = sizeof(optval);
+	if (setsockopt(sk, SOL_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl)) < 0) {
+		pr_perror("setsockopt TCP_KEEPINTVL");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	if (getsockopt(sk, SOL_SOCKET, SO_KEEPALIVE, &optval, &optlen)) {
+		pr_perror("getsockopt SO_KEEPALIVE");
+		return 1;
+	}
+
+	if (optlen != sizeof(optval) || optval != alive) {
+		fail("SO_KEEPALIVE not set");
+		return 1;
+	}
+
+	if (getsockopt(sk, SOL_TCP, TCP_KEEPCNT, &optval, &optlen) < 0) {
+		pr_perror("getsockopt TCP_KEEPCNT");
+		return 1;
+	}
+
+	if (optval != cnt) {
+		fail("TCP_KEEPCNT has incorrect value (%d != %d)", cnt, optval);
+		return 1;
+	}
+
+	if (getsockopt(sk, SOL_TCP, TCP_KEEPIDLE, &optval, &optlen) < 0) {
+		pr_perror("getsockopt TCP_KEEPIDLE");
+		return 1;
+	}
+
+	if (optval != idle) {
+		fail("TCP_KEEPIDLE has incorrect value (%d != %d)", idle, optval);
+		return 1;
+	}
+
+	if (getsockopt(sk, SOL_TCP, TCP_KEEPINTVL, &optval, &optlen) < 0) {
+		pr_perror("getsockopt TCP_KEEPINTVL");
+		return 1;
+	}
+
+	if (optval != intvl) {
+		fail("TCP_KEEPINTVL has incorrect value (%d != %d)", intvl, optval);
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
This PR implements checkpoint/restore support for `SO_KEEPALIVE`, `TCP_KEEPIDLE`, `TCP_KEEPINTVL` and `TCP_KEEPCNT` socket options.