### PR TITLE
Restore processes using clone3() with set_tid

### DIFF
--- a/compel/arch/arm/plugins/std/syscalls/syscall.def
+++ b/compel/arch/arm/plugins/std/syscalls/syscall.def
@@ -115,3 +115,4 @@ ppoll				73	336	(struct pollfd *fds, unsigned int nfds, const struct timespec *t
 fsopen				430	430	(char *fsname, unsigned int flags)
 fsconfig			431	431	(int fd, unsigned int cmd, const char *key, const char *value, int aux)
 fsmount				432	432	(int fd, unsigned int flags, unsigned int attr_flags)
+clone3				435	435	(struct clone_args *uargs, size_t size)

--- a/compel/arch/ppc64/plugins/std/syscalls/syscall-ppc64.tbl
+++ b/compel/arch/ppc64/plugins/std/syscalls/syscall-ppc64.tbl
@@ -111,3 +111,4 @@ __NR_ppoll		281		sys_ppoll		(struct pollfd *fds, unsigned int nfds, const struct
 __NR_fsopen		430		sys_fsopen		(char *fsname, unsigned int flags)
 __NR_fsconfig		431		sys_fsconfig		(int fd, unsigned int cmd, const char *key, const char *value, int aux)
 __NR_fsmount		432		sys_fsmount		(int fd, unsigned int flags, unsigned int attr_flags)
+__NR_clone3		435		sys_clone3		(struct clone_args *uargs, size_t size)

--- a/compel/arch/s390/plugins/std/syscalls/syscall-s390.tbl
+++ b/compel/arch/s390/plugins/std/syscalls/syscall-s390.tbl
@@ -111,3 +111,4 @@ __NR_ppoll		302		sys_ppoll		(struct pollfd *fds, unsigned int nfds, const struct
 __NR_fsopen		430		sys_fsopen		(char *fsname, unsigned int flags)
 __NR_fsconfig		431		sys_fsconfig		(int fd, unsigned int cmd, const char *key, const char *value, int aux)
 __NR_fsmount		432		sys_fsmount		(int fd, unsigned int flags, unsigned int attr_flags)
+__NR_clone3		435		sys_clone3		(struct clone_args *uargs, size_t size)

--- a/compel/arch/x86/plugins/std/syscalls/syscall_32.tbl
+++ b/compel/arch/x86/plugins/std/syscalls/syscall_32.tbl
@@ -99,3 +99,4 @@ __NR_ppoll		309		sys_ppoll		(struct pollfd *fds, unsigned int nfds, const struct
 __NR_fsopen		430		sys_fsopen		(char *fsname, unsigned int flags)
 __NR_fsconfig		431		sys_fsconfig		(int fd, unsigned int cmd, const char *key, const char *value, int aux)
 __NR_fsmount		432		sys_fsmount		(int fd, unsigned int flags, unsigned int attr_flags)
+__NR_clone3		435		sys_clone3		(struct clone_args *uargs, size_t size)

--- a/compel/arch/x86/plugins/std/syscalls/syscall_64.tbl
+++ b/compel/arch/x86/plugins/std/syscalls/syscall_64.tbl
@@ -110,3 +110,4 @@ __NR_ppoll			271		sys_ppoll		(struct pollfd *fds, unsigned int nfds, const struc
 __NR_fsopen			430		sys_fsopen		(char *fsname, unsigned int flags)
 __NR_fsconfig			431		sys_fsconfig		(int fd, unsigned int cmd, const char *key, const char *value, int aux)
 __NR_fsmount			432		sys_fsmount		(int fd, unsigned int flags, unsigned int attr_flags)
+__NR_clone3			435		sys_clone3		(struct clone_args *uargs, size_t size)

--- a/compel/plugins/include/uapi/std/syscall-types.h
+++ b/compel/plugins/include/uapi/std/syscall-types.h
@@ -39,6 +39,7 @@ struct msghdr;
 struct rusage;
 struct iocb;
 struct pollfd;
+struct clone_args;
 
 typedef unsigned long aio_context_t;
 

--- a/criu/arch/aarch64/include/asm/restorer.h
+++ b/criu/arch/aarch64/include/asm/restorer.h
@@ -42,6 +42,13 @@
 			  "r"(&thread_args[i])					\
 			: "x0", "x1", "x2", "x3", "x8", "memory")
 
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
+			      clone_restore_fn)	do { \
+	pr_err("This architecture does not support clone3() with set_tid, yet!\n"); \
+	pr_err("Not creating a process with PID: %d\n", ((pid_t *)u64_to_ptr(clone_args.set_tid))[0]); \
+	ret = -1; \
+} while (0)
+
 #define ARCH_FAIL_CORE_RESTORE					\
 	asm volatile(						\
 			"mov sp, %0			\n"	\

--- a/criu/arch/arm/include/asm/restorer.h
+++ b/criu/arch/arm/include/asm/restorer.h
@@ -43,6 +43,13 @@
 		       "r"(&thread_args[i])				\
 		     : "r0", "r1", "r2", "r3", "r7", "memory")
 
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
+			      clone_restore_fn)	do { \
+	pr_err("This architecture does not support clone3() with set_tid, yet!\n"); \
+	pr_err("Not creating a process with PID: %d\n", ((pid_t *)u64_to_ptr(clone_args.set_tid))[0]); \
+	ret = -1; \
+} while (0)
+
 #define ARCH_FAIL_CORE_RESTORE					\
 	asm volatile(						\
 		     "mov sp, %0			\n"	\

--- a/criu/arch/ppc64/include/asm/restorer.h
+++ b/criu/arch/ppc64/include/asm/restorer.h
@@ -48,6 +48,13 @@
 		  "r"(&thread_args[i])		/* %6 */		\
 		: "memory","0","3","4","5","6","7","14","15")
 
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
+			      clone_restore_fn)	do { \
+	pr_err("This architecture does not support clone3() with set_tid, yet!\n"); \
+	pr_err("Not creating a process with PID: %d\n", ((pid_t *)u64_to_ptr(clone_args.set_tid))[0]); \
+	ret = -1; \
+} while (0)
+
 #define arch_map_vdso(map, compat)		-1
 
 int restore_gpregs(struct rt_sigframe *f, UserPpc64RegsEntry *r);

--- a/criu/arch/s390/include/asm/restorer.h
+++ b/criu/arch/s390/include/asm/restorer.h
@@ -39,6 +39,13 @@
 	  "d"(&thread_args[i])						\
 	: "0", "1", "2", "3", "4", "5", "6", "cc", "memory")
 
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
+			      clone_restore_fn)	do { \
+	pr_err("This architecture does not support clone3() with set_tid, yet!\n"); \
+	pr_err("Not creating a process with PID: %d\n", ((pid_t *)u64_to_ptr(clone_args.set_tid))[0]); \
+	ret = -1; \
+} while (0)
+
 #define arch_map_vdso(map, compat)		-1
 
 int restore_gpregs(struct rt_sigframe *f, UserS390RegsEntry *r);

--- a/criu/arch/x86/include/asm/restorer.h
+++ b/criu/arch/x86/include/asm/restorer.h
@@ -25,6 +25,21 @@ static inline int set_compat_robust_list(uint32_t head_ptr, uint32_t len)
 }
 #endif /* !CONFIG_COMPAT */
 
+/*
+ * Documentation copied from glibc sysdeps/unix/sysv/linux/x86_64/clone.S
+ * The kernel expects:
+ * rax: system call number
+ * rdi: flags
+ * rsi: child_stack
+ * rdx: TID field in parent
+ * r10: TID field in child
+ * r8:	thread pointer
+ *
+ * int clone(unsigned long clone_flags, unsigned long newsp,
+ *           int *parent_tidptr, int *child_tidptr,
+ *           unsigned long tls);
+ */
+
 #define RUN_CLONE_RESTORE_FN(ret, clone_flags, new_sp, parent_tid,	\
 			     thread_args, clone_restore_fn)		\
 	asm volatile(							\
@@ -61,6 +76,83 @@ static inline int set_compat_robust_list(uint32_t head_ptr, uint32_t len)
 		       "g"(&thread_args[i].pid),			\
 		       "g"(clone_restore_fn),				\
 		       "g"(&thread_args[i])				\
+		     : "rax", "rcx", "rdi", "rsi", "rdx", "r10", "r11", "memory")
+
+/* int clone3(struct clone_args *args, size_t size) */
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args,		\
+			      clone_restore_fn)				\
+	asm volatile(							\
+		     "clone3_emul:				\n"	\
+	/*
+	 * Prepare stack pointer for child process. The kernel does
+	 * stack + stack_size before passing the stack pointer to the
+	 * child process. As we have to put the function and the
+	 * arguments for the new process on that stack we have handle
+	 * the kernel's implicit stack + stack_size.
+	 */								\
+		     "movq (%3), %%rsi	/* new stack pointer */	\n"	\
+	/* Move the stack_size to %rax to use later as the offset */	\
+		     "movq %4, %%rax				\n"	\
+	/* 16 bytes are needed on the stack for function and args */	\
+		     "subq $16, (%%rsi, %%rax)			\n"	\
+		     "movq %6, %%rdi	/* thread args */	\n"	\
+		     "movq %%rdi, 8(%%rsi, %%rax)		\n"	\
+		     "movq %5, %%rdi	/* thread function */	\n"	\
+		     "movq %%rdi, 0(%%rsi, %%rax)		\n"	\
+	/*
+	 * The stack address has been modified for the two
+	 * elements above (child function, child arguments).
+	 * This modified stack needs to be stored back into the
+	 * clone_args structure.
+	 */								\
+		     "movq (%%rsi), %3				\n"	\
+	/*
+	 * Do the actual clone3() syscall. First argument (%rdi) is
+	 * the clone_args structure, second argument is the size
+	 * of clone_args.
+	 */								\
+		     "movq %1, %%rdi	/* clone_args */	\n"	\
+		     "movq %2, %%rsi	/* size */		\n"	\
+		     "movl $"__stringify(__NR_clone3)", %%eax	\n"	\
+		     "syscall					\n"	\
+	/*
+	 * If clone3() was successful and if we are in the child
+	 * '0' is returned. Jump to the child function handler.
+	 */								\
+		     "testq %%rax,%%rax				\n"	\
+		     "jz thread3_run				\n"	\
+	/* Return the PID to the parent process. */			\
+		     "movq %%rax, %0				\n"	\
+		     "jmp clone3_end				\n"	\
+									\
+		     "thread3_run:	/* Child process */	\n"	\
+	/* Clear the frame pointer */					\
+		     "xorq %%rbp, %%rbp				\n"	\
+	/* Pop the child function from the stack */			\
+		     "popq %%rax				\n"	\
+	/* Pop the child function arguments from the stack */		\
+		     "popq %%rdi				\n"	\
+	/* Run the child function */					\
+		     "callq *%%rax				\n"	\
+	/*
+	 * If the child function is expected to return, this
+	 * would be the place to handle the return code. In CRIU's
+	 * case the child function is expected to not return
+	 * and do exit() itself.
+	 */								\
+									\
+		     "clone3_end:				\n"	\
+		     : "=r"(ret)		 			\
+	/*
+	 * This uses the "r" modifier for all parameters
+	 * as clang complained if using "g".
+	 */								\
+		     : "r"(&clone_args),				\
+		       "r"(size),					\
+		       "r"(&clone_args.stack),				\
+		       "r"(clone_args.stack_size),			\
+		       "r"(clone_restore_fn),				\
+		       "r"(args)					\
 		     : "rax", "rcx", "rdi", "rsi", "rdx", "r10", "r11", "memory")
 
 #define ARCH_FAIL_CORE_RESTORE					\

--- a/criu/clone-noasan.c
+++ b/criu/clone-noasan.c
@@ -1,4 +1,10 @@
+#include <stdlib.h>
 #include <sched.h>
+#include <unistd.h>
+
+#include <compel/plugins/std/syscall-codes.h>
+
+#include "sched.h"
 #include "common/compiler.h"
 #include "log.h"
 #include "common/bug.h"
@@ -31,10 +37,36 @@
 int clone_noasan(int (*fn)(void *), int flags, void *arg)
 {
 	void *stack_ptr = (void *)round_down((unsigned long)&stack_ptr - 1024, 16);
+
 	BUG_ON((flags & CLONE_VM) && !(flags & CLONE_VFORK));
 	/*
 	 * Reserve some bytes for clone() internal needs
 	 * and use as stack the address above this area.
 	 */
 	return clone(fn, stack_ptr, flags, arg);
+}
+
+int clone3_with_pid_noasan(int (*fn)(void *), void *arg, int flags,
+			   int exit_signal, pid_t pid)
+{
+	struct _clone_args c_args = {};
+
+	BUG_ON(flags & CLONE_VM);
+
+	/*
+	 * Make sure no child signals are requested. clone3() uses
+	 * exit_signal for that.
+	 */
+	BUG_ON(flags & 0xff);
+
+	pr_debug("Creating process using clone3()\n");
+
+	c_args.exit_signal = exit_signal;
+	c_args.flags = flags;
+	c_args.set_tid = ptr_to_u64(&pid);
+	c_args.set_tid_size = 1;
+	pid = syscall(__NR_clone3, &c_args, sizeof(c_args));
+	if (pid == 0)
+		exit(fn(arg));
+	return pid;
 }

--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1224,6 +1224,16 @@ static int check_uffd_noncoop(void)
 	return 0;
 }
 
+static int check_clone3_set_tid(void)
+{
+	if (!kdat.has_clone3_set_tid) {
+		pr_warn("clone3() with set_tid not supported\n");
+		return -1;
+	}
+
+	return 0;
+}
+
 static int check_can_map_vdso(void)
 {
 	if (kdat_can_map_vdso() == 1)
@@ -1373,6 +1383,7 @@ int cr_check(void)
 		ret |= check_sk_netns();
 		ret |= check_kcmp_epoll();
 		ret |= check_net_diag_raw();
+		ret |= check_clone3_set_tid();
 	}
 
 	/*
@@ -1476,6 +1487,7 @@ static struct feature_list feature_list[] = {
 	{ "link_nsid", check_link_nsid},
 	{ "kcmp_epoll", check_kcmp_epoll},
 	{ "external_net_ns", check_external_net_ns},
+	{ "clone3_set_tid", check_clone3_set_tid},
 	{ NULL, NULL },
 };
 

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1375,40 +1375,55 @@ static inline int fork_with_pid(struct pstree_item *item)
 	if (!(ca.clone_flags & CLONE_NEWPID)) {
 		char buf[32];
 		int len;
-		int fd;
+		int fd = -1;
 
-		fd = open_proc_rw(PROC_GEN, LAST_PID_PATH);
-		if (fd < 0)
-			goto err;
+		if (!kdat.has_clone3_set_tid) {
+			fd = open_proc_rw(PROC_GEN, LAST_PID_PATH);
+			if (fd < 0)
+				goto err;
+		}
 
 		lock_last_pid();
 
-		len = snprintf(buf, sizeof(buf), "%d", pid - 1);
-		if (write(fd, buf, len) != len) {
-			pr_perror("%d: Write %s to %s", pid, buf, LAST_PID_PATH);
+		if (!kdat.has_clone3_set_tid) {
+			len = snprintf(buf, sizeof(buf), "%d", pid - 1);
+			if (write(fd, buf, len) != len) {
+				pr_perror("%d: Write %s to %s", pid, buf,
+					LAST_PID_PATH);
+				close(fd);
+				goto err_unlock;
+			}
 			close(fd);
-			goto err_unlock;
 		}
-		close(fd);
 	} else {
 		BUG_ON(pid != INIT_PID);
 	}
 
-	/*
-	 * Some kernel modules, such as network packet generator
-	 * run kernel thread upon net-namespace creattion taking
-	 * the @pid we've been requeting via LAST_PID_PATH interface
-	 * so that we can't restore a take with pid needed.
-	 *
-	 * Here is an idea -- unhare net namespace in callee instead.
-	 */
-	/*
-	 * The cgroup namespace is also unshared explicitly in the
-	 * move_in_cgroup(), so drop this flag here as well.
-	 */
-	close_pid_proc();
-	ret = clone_noasan(restore_task_with_children,
-			(ca.clone_flags & ~(CLONE_NEWNET | CLONE_NEWCGROUP)) | SIGCHLD, &ca);
+	if (kdat.has_clone3_set_tid) {
+		ret = clone3_with_pid_noasan(restore_task_with_children,
+				&ca, (ca.clone_flags &
+					~(CLONE_NEWNET | CLONE_NEWCGROUP)),
+				SIGCHLD, pid);
+	} else {
+		/*
+		 * Some kernel modules, such as network packet generator
+		 * run kernel thread upon net-namespace creation taking
+		 * the @pid we've been requesting via LAST_PID_PATH interface
+		 * so that we can't restore a take with pid needed.
+		 *
+		 * Here is an idea -- unshare net namespace in callee instead.
+		 */
+		/*
+		 * The cgroup namespace is also unshared explicitly in the
+		 * move_in_cgroup(), so drop this flag here as well.
+		 */
+		close_pid_proc();
+		ret = clone_noasan(restore_task_with_children,
+				(ca.clone_flags &
+				 ~(CLONE_NEWNET | CLONE_NEWCGROUP)) | SIGCHLD,
+				&ca);
+	}
+
 	if (ret < 0) {
 		pr_perror("Can't fork for %d", pid);
 		goto err_unlock;
@@ -3594,6 +3609,7 @@ static int sigreturn_restore(pid_t pid, struct task_restore_args *task_args, uns
 	task_args->vdso_maps_rt = vdso_maps_rt;
 	task_args->vdso_rt_size = vdso_rt_size;
 	task_args->can_map_vdso = kdat.can_map_vdso;
+	task_args->has_clone3_set_tid = kdat.has_clone3_set_tid;
 
 	new_sp = restorer_stack(task_args->t->mz);
 

--- a/criu/include/clone-noasan.h
+++ b/criu/include/clone-noasan.h
@@ -2,5 +2,7 @@
 #define __CR_CLONE_NOASAN_H__
 
 int clone_noasan(int (*fn)(void *), int flags, void *arg);
+int clone3_with_pid_noasan(int (*fn)(void *), void *arg, int flags,
+			   int exit_signal, pid_t pid);
 
 #endif /* __CR_CLONE_NOASAN_H__ */

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -66,6 +66,7 @@ struct kerndat_s {
 	bool has_inotify_setnextwd;
 	bool has_kcmp_epoll_tfd;
 	bool has_fsopen;
+	bool has_clone3_set_tid;
 };
 
 extern struct kerndat_s kdat;

--- a/criu/include/restorer.h
+++ b/criu/include/restorer.h
@@ -221,6 +221,7 @@ struct task_restore_args {
 #endif
 	int				lsm_type;
 	int				child_subreaper;
+	bool				has_clone3_set_tid;
 } __aligned(64);
 
 /*

--- a/criu/include/rst_info.h
+++ b/criu/include/rst_info.h
@@ -4,6 +4,7 @@
 #include "common/lock.h"
 #include "common/list.h"
 #include "vma.h"
+#include "kerndat.h"
 
 struct task_entries {
 	int nr_threads, nr_tasks, nr_helpers;

--- a/criu/include/sched.h
+++ b/criu/include/sched.h
@@ -1,0 +1,33 @@
+#ifndef __CR_SCHED_H__
+#define __CR_SCHED_H__
+
+#include <linux/types.h>
+
+#ifndef ptr_to_u64
+#define ptr_to_u64(ptr)	((__u64)((uintptr_t)(ptr)))
+#endif
+#ifndef u64_to_ptr
+#define u64_to_ptr(x)	((void *)(uintptr_t)x)
+#endif
+
+/*
+ * This structure is needed by clone3(). The kernel
+ * calls it 'struct clone_args'. As CRIU will always
+ * need at least this part of the structure (VER1)
+ * to be able to test if clone3() with set_tid works,
+ * the structure is defined here as 'struct _clone_args'.
+ */
+
+struct _clone_args {
+	__aligned_u64 flags;
+	__aligned_u64 pidfd;
+	__aligned_u64 child_tid;
+	__aligned_u64 parent_tid;
+	__aligned_u64 exit_signal;
+	__aligned_u64 stack;
+	__aligned_u64 stack_size;
+	__aligned_u64 tls;
+	__aligned_u64 set_tid;
+	__aligned_u64 set_tid_size;
+};
+#endif /* __CR_SCHED_H__ */

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -35,6 +35,7 @@
 #include "sk-inet.h"
 #include "vma.h"
 #include "uffd.h"
+#include "sched.h"
 
 #include "common/lock.h"
 #include "common/page.h"
@@ -1771,16 +1772,19 @@ long __export_restore_task(struct task_restore_args *args)
 		long clone_flags = CLONE_VM | CLONE_FILES | CLONE_SIGHAND	|
 				   CLONE_THREAD | CLONE_SYSVSEM | CLONE_FS;
 		long last_pid_len;
+		pid_t thread_pid;
 		long parent_tid;
 		int i, fd = -1;
 
-		/* One level pid ns hierarhy */
-		fd = sys_openat(args->proc_fd, LAST_PID_PATH, O_RDWR, 0);
-		if (fd < 0) {
-			pr_err("can't open last pid fd %d\n", fd);
-			goto core_restore_end;
-		}
+		if (!args->has_clone3_set_tid) {
+			/* One level pid ns hierarhy */
+			fd = sys_openat(args->proc_fd, LAST_PID_PATH, O_RDWR, 0);
+			if (fd < 0) {
+				pr_err("can't open last pid fd %d\n", fd);
+				goto core_restore_end;
+			}
 
+		}
 		mutex_lock(&task_entries_local->last_pid_mutex);
 
 		for (i = 0; i < args->nr_threads; i++) {
@@ -1791,24 +1795,38 @@ long __export_restore_task(struct task_restore_args *args)
 				continue;
 
 			new_sp = restorer_stack(thread_args[i].mz);
-			last_pid_len = std_vprint_num(last_pid_buf, sizeof(last_pid_buf), thread_args[i].pid - 1, &s);
-			sys_lseek(fd, 0, SEEK_SET);
-			ret = sys_write(fd, s, last_pid_len);
-			if (ret < 0) {
-				pr_err("Can't set last_pid %ld/%s\n", ret, last_pid_buf);
-				sys_close(fd);
-				mutex_unlock(&task_entries_local->last_pid_mutex);
-				goto core_restore_end;
+			if (args->has_clone3_set_tid) {
+				struct _clone_args c_args = {};
+				thread_pid = thread_args[i].pid;
+				c_args.set_tid = ptr_to_u64(&thread_pid);
+				c_args.flags = clone_flags;
+				c_args.set_tid_size = 1;
+				/* The kernel does stack + stack_size. */
+				c_args.stack = new_sp - RESTORE_STACK_SIZE;
+				c_args.stack_size = RESTORE_STACK_SIZE;
+				c_args.child_tid = ptr_to_u64(&thread_args[i].pid);
+				c_args.parent_tid = ptr_to_u64(&parent_tid);
+				pr_debug("Using clone3 to restore the process\n");
+				RUN_CLONE3_RESTORE_FN(ret, c_args, sizeof(c_args), &thread_args[i], args->clone_restore_fn);
+			} else {
+				last_pid_len = std_vprint_num(last_pid_buf, sizeof(last_pid_buf), thread_args[i].pid - 1, &s);
+				sys_lseek(fd, 0, SEEK_SET);
+				ret = sys_write(fd, s, last_pid_len);
+				if (ret < 0) {
+					pr_err("Can't set last_pid %ld/%s\n", ret, last_pid_buf);
+					sys_close(fd);
+					mutex_unlock(&task_entries_local->last_pid_mutex);
+					goto core_restore_end;
+				}
+
+				/*
+				 * To achieve functionality like libc's clone()
+				 * we need a pure assembly here, because clone()'ed
+				 * thread will run with own stack and we must not
+				 * have any additional instructions... oh, dear...
+				 */
+				RUN_CLONE_RESTORE_FN(ret, clone_flags, new_sp, parent_tid, thread_args, args->clone_restore_fn);
 			}
-
-			/*
-			 * To achieve functionality like libc's clone()
-			 * we need a pure assembly here, because clone()'ed
-			 * thread will run with own stack and we must not
-			 * have any additional instructions... oh, dear...
-			 */
-
-			RUN_CLONE_RESTORE_FN(ret, clone_flags, new_sp, parent_tid, thread_args, args->clone_restore_fn);
 			if (ret != thread_args[i].pid) {
 				pr_err("Unable to create a thread: %ld\n", ret);
 				mutex_unlock(&task_entries_local->last_pid_mutex);


### PR DESCRIPTION
This is my first attempt to use the newly introduced clone3() with set_tid to replace CRIU's use of ns_last_pid.

My current test case is a simple threaded process which can be restored using the changes in this PR.

This is still work in progress and a request for comments. I am not sure if I did the whole child handling correct so please have close look at these changes. I am especially unsure about the child stack setup.

This is currently still x86_64 only and once this is working I would start looking at the other architectures.

One very nice result of clone3() with set_tid is that by no longer using ns_last_pid, newly created processes after running CRIU are using different PIDs and PID collisions during testing by restoring the same process again and again does not happen any more.