### PR TITLE
Rework mnt_is_external

### DIFF
--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -73,6 +73,7 @@ struct mount_info {
 	struct list_head	siblings;
 
 	struct list_head	mnt_bind;	/* circular list of derivatives of one real mount */
+	bool			mnt_no_bind;	/* no bind-mounts has been found for us */
 	struct list_head	mnt_share;	/* circular list of shared mounts */
 	struct list_head	mnt_slave_list;	/* list of slave mounts */
 	struct list_head	mnt_slave;	/* slave list entry */

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -299,9 +299,6 @@ static bool mounts_sb_equal(struct mount_info *a, struct mount_info *b)
 	if (a->s_dev != b->s_dev)
 		return false;
 
-	if (strcmp(a->source, b->source) != 0)
-		return false;
-
 	if (a->fstype->sb_equal) /* :) */
 		return b->fstype->sb_equal(a, b);
 


### PR DESCRIPTION
These basicly does three steps:

1) rework mounts_sb_equal so that mnt_bind list for mnt_is_external will be right;
2) fix order of mnt_bind list setup and mnt_is_external and add BUG_ON to prevent these in future;
3) simplify mnt_is_external and split separate can_receive_master_from_external to use in resolve_shared_mounts.