### PR TITLE
scripts: alpine: Install py2 packages with pip

### DIFF
--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -27,9 +27,7 @@ RUN mv .ccache /tmp && make mrproper && ccache -sz && \
 	date && make -j $(nproc) CC="$CC" && date && ccache -s
 
 RUN apk add \
-	py-yaml \
 	py-pip	\
-	py2-future \
 	ip6tables \
 	iptables \
 	iproute2 \
@@ -42,5 +40,5 @@ RUN apk add \
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 -D test
 
-RUN pip install protobuf ipaddress junit_xml flake8
+RUN pip install PyYAML future protobuf ipaddress junit_xml flake8
 RUN make -C test/zdtm

--- a/scripts/build/Dockerfile.openj9-alpine
+++ b/scripts/build/Dockerfile.openj9-alpine
@@ -17,9 +17,6 @@ RUN apk update && apk add \
 	python \
 	sudo \
 	maven \
-	py-yaml \
-	py-pip \
-	py2-future \
 	ip6tables \
 	iptables \
 	bash


### PR DESCRIPTION
The py-future package [has been renamed to py3-future](https://git.alpinelinux.org/aports/commit/main?id=316d44abaed13964e97eb43c095cd1b64e3943ad) and py2 package for yaml [has been dropped](https://git.alpinelinux.org/aports/commit/main?id=e369c1fd7707a73f2c3e2b11b613198d9a4106de).