### PR TITLE
Enforce kernel style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ export PROTOUFIX DEFINES
 DEFINES			+= -D_FILE_OFFSET_BITS=64
 DEFINES			+= -D_GNU_SOURCE
 
-WARNINGS		:= -Wall -Wformat-security -Wdeclaration-after-statement
+WARNINGS		:= -Wall -Wformat-security -Wdeclaration-after-statement -Wstrict-prototypes
 
 CFLAGS-GCOV		:= --coverage -fno-exceptions -fno-inline -fprofile-update=atomic
 export CFLAGS-GCOV

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ export PROTOUFIX DEFINES
 DEFINES			+= -D_FILE_OFFSET_BITS=64
 DEFINES			+= -D_GNU_SOURCE
 
-WARNINGS		:= -Wall -Wformat-security
+WARNINGS		:= -Wall -Wformat-security -Wdeclaration-after-statement
 
 CFLAGS-GCOV		:= --coverage -fno-exceptions -fno-inline -fprofile-update=atomic
 export CFLAGS-GCOV

--- a/criu/config.c
+++ b/criu/config.c
@@ -854,7 +854,7 @@ bad_arg:
 	return 1;
 }
 
-int check_options()
+int check_options(void)
 {
 	if (opts.tcp_established_ok)
 		pr_info("Will dump/restore TCP connections\n");

--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -51,7 +51,7 @@
 #include "restorer.h"
 #include "uffd.h"
 
-static char *feature_name(int (*func)());
+static char *feature_name(int (*func)(void));
 
 static int check_tty(void)
 {
@@ -513,7 +513,7 @@ static int check_ipc(void)
 	return -1;
 }
 
-static int check_sigqueuinfo()
+static int check_sigqueuinfo(void)
 {
 	siginfo_t info = { .si_code = 1 };
 
@@ -960,7 +960,7 @@ static int clone_cb(void *_arg) {
 	exit(0);
 }
 
-static int check_clone_parent_vs_pid()
+static int check_clone_parent_vs_pid(void)
 {
 	struct clone_arg ca;
 	pid_t pid;
@@ -1447,7 +1447,7 @@ static int check_external_net_ns(void)
 
 struct feature_list {
 	char *name;
-	int (*func)();
+	int (*func)(void);
 };
 
 static struct feature_list feature_list[] = {
@@ -1517,7 +1517,7 @@ int check_add_feature(char *feat)
 	return -1;
 }
 
-static char *feature_name(int (*func)())
+static char *feature_name(int (*func)(void))
 {
 	struct feature_list *fl;
 

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1440,7 +1440,7 @@ err_cure_imgset:
 
 static int alarm_attempts = 0;
 
-bool alarm_timeouted() {
+bool alarm_timeouted(void) {
 	return alarm_attempts > 0;
 }
 
@@ -1457,7 +1457,7 @@ static void alarm_handler(int signo)
 	BUG();
 }
 
-static int setup_alarm_handler()
+static int setup_alarm_handler(void)
 {
 	struct sigaction sa = {
 		.sa_handler	= alarm_handler,

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -183,13 +183,13 @@ static int __restore_wait_inprogress_tasks(int participants)
 	return 0;
 }
 
-static int restore_wait_inprogress_tasks()
+static int restore_wait_inprogress_tasks(void)
 {
 	return __restore_wait_inprogress_tasks(0);
 }
 
 /* Wait all tasks except the current one */
-static int restore_wait_other_tasks()
+static int restore_wait_other_tasks(void)
 {
 	int participants, stage;
 
@@ -1588,7 +1588,7 @@ static void restore_pgid(void)
 		futex_set_and_wake(&rsti(current)->pgrp_set, 1);
 }
 
-static int __legacy_mount_proc()
+static int __legacy_mount_proc(void)
 {
 	char proc_mountpoint[] = "/tmp/crtools-proc.XXXXXX";
 	int fd;
@@ -1942,7 +1942,7 @@ static int catch_tasks(bool root_seized, enum trace_flags *flag)
 	return 0;
 }
 
-static int clear_breakpoints()
+static int clear_breakpoints(void)
 {
 	struct pstree_item *item;
 	int ret = 0, i;

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -1278,7 +1278,7 @@ static void reap_worker(int signo)
 	}
 }
 
-static int setup_sigchld_handler()
+static int setup_sigchld_handler(void)
 {
 	struct sigaction action;
 
@@ -1295,7 +1295,7 @@ static int setup_sigchld_handler()
 	return 0;
 }
 
-static int restore_sigchld_handler()
+static int restore_sigchld_handler(void)
 {
 	struct sigaction action;
 

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -48,7 +48,7 @@
 #include "sysctl.h"
 #include "img-remote.h"
 
-void flush_early_log_to_stderr() __attribute__((destructor));
+void flush_early_log_to_stderr(void) __attribute__((destructor));
 
 void flush_early_log_to_stderr(void)
 {

--- a/criu/fault-injection.c
+++ b/criu/fault-injection.c
@@ -3,7 +3,7 @@
 
 enum faults fi_strategy;
 
-int fault_injection_init()
+int fault_injection_init(void)
 {
 	char *val;
 	int start;

--- a/criu/img-remote.c
+++ b/criu/img-remote.c
@@ -979,9 +979,10 @@ int write_remote_image_connection(char *snapshot_id, char *path, int flags)
 
 int finish_remote_dump(void)
 {
+	int fd;
 	pr_info("Dump side is calling finish\n");
-	int fd = write_remote_image_connection(NULL_SNAPSHOT_ID, FINISH, O_WRONLY);
 
+	fd = write_remote_image_connection(NULL_SNAPSHOT_ID, FINISH, O_WRONLY);
 	if (fd == -1) {
 		pr_err("Unable to open finish dump connection");
 		return -1;
@@ -993,9 +994,10 @@ int finish_remote_dump(void)
 
 int finish_remote_restore(void)
 {
+	int fd;
 	pr_info("Restore side is calling finish\n");
-	int fd = read_remote_image_connection(NULL_SNAPSHOT_ID, FINISH);
 
+	fd = read_remote_image_connection(NULL_SNAPSHOT_ID, FINISH);
 	if (fd == -1) {
 		pr_err("Unable to open finish restore connection\n");
 		return -1;
@@ -1078,10 +1080,12 @@ static int pull_snapshot_ids(void)
 int push_snapshot_id(void)
 {
 	int n;
-	restoring = false;
 	SnapshotIdEntry rn = SNAPSHOT_ID_ENTRY__INIT;
-	int sockfd = write_remote_image_connection(NULL_SNAPSHOT_ID, PARENT_IMG, O_APPEND);
+	int sockfd;
 
+	restoring = false;
+
+	sockfd = write_remote_image_connection(NULL_SNAPSHOT_ID, PARENT_IMG, O_APPEND);
 	if (sockfd < 0) {
 		pr_err("Unable to open snapshot id push connection\n");
 		return -1;

--- a/criu/img-remote.c
+++ b/criu/img-remote.c
@@ -432,7 +432,7 @@ err:
 	return NULL;
 }
 
-static inline void finish_local()
+static inline void finish_local(void)
 {
 	int ret;
 	finished_local = true;
@@ -726,7 +726,7 @@ err:
 	xfree(rop);
 }
 
-static void check_pending()
+static void check_pending(void)
 {
 	struct roperation *rop = NULL;
 	struct rimage *rimg = NULL;
@@ -745,7 +745,7 @@ static void check_pending()
 	}
 }
 
-void accept_image_connections() {
+void accept_image_connections(void) {
 	int ret;
 
 	epoll_fd = epoll_create(EPOLL_MAX_EVENTS);

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -159,7 +159,7 @@ extern struct cr_options opts;
 char *rpc_cfg_file;
 
 extern int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, int state);
-extern int check_options();
-extern void init_opts();
+extern int check_options(void);
+extern void init_opts(void);
 
 #endif /* __CR_OPTIONS_H__ */

--- a/criu/include/img-remote.h
+++ b/criu/include/img-remote.h
@@ -72,7 +72,7 @@ extern int local_sk;
 /* True if we are running the cache/restore, false if proxy/dump. */
 extern bool restoring;
 
-void accept_image_connections();
+void accept_image_connections(void);
 struct rimage *get_rimg_by_name(const char *snapshot_id, const char *path);
 
 int setup_UNIX_server_socket(char *path);
@@ -91,8 +91,8 @@ int write_remote_image_connection(char *snapshot_id, char *path, int flags);
  * creates a new connection with a special control name. The receiver side uses
  * it to ack that no more files are coming.
  */
-int finish_remote_dump();
-int finish_remote_restore();
+int finish_remote_dump(void);
+int finish_remote_restore(void);
 
 /* Starts an image proxy daemon (dump side). It receives image files through
  * socket connections and forwards them to the image cache (restore side).
@@ -123,14 +123,14 @@ int skip_remote_bytes(int fd, unsigned long len);
 void init_snapshot_id(char *ns);
 
 /* Returns the current snapshot_id. */
-char *get_curr_snapshot_id();
+char *get_curr_snapshot_id(void);
 
 /* Returns the snapshot_id index representing the current snapshot_id. This
  * index represents the hierarchy position. For example: images tagged with
  * the snapshot_id with index 1 are more recent than the images tagged with
  * the snapshot_id with index 0.
  */
-int get_curr_snapshot_id_idx();
+int get_curr_snapshot_id_idx(void);
 
 /* Returns the snapshot_id associated with the snapshot_id index. */
 char *get_snapshot_id_from_idx(int idx);
@@ -138,9 +138,9 @@ char *get_snapshot_id_from_idx(int idx);
 /* Pushes the current snapshot_id into the snapshot_id hierarchy (into the Image
  * Proxy and Image Cache).
  */
-int push_snapshot_id();
+int push_snapshot_id(void);
 
 /* Returns the snapshot id index that precedes the current snapshot_id. */
-int get_curr_parent_snapshot_id_idx();
+int get_curr_parent_snapshot_id_idx(void);
 
 #endif

--- a/criu/include/lsm.h
+++ b/criu/include/lsm.h
@@ -39,7 +39,7 @@ extern int lsm_check_opts(void);
 #ifdef CONFIG_HAS_SELINUX
 int dump_xattr_security_selinux(int fd, FdinfoEntry *e);
 int run_setsockcreatecon(FdinfoEntry *e);
-int reset_setsockcreatecon();
+int reset_setsockcreatecon(void);
 #else
 static inline int dump_xattr_security_selinux(int fd, FdinfoEntry *e) {
 	return 0;
@@ -47,7 +47,7 @@ static inline int dump_xattr_security_selinux(int fd, FdinfoEntry *e) {
 static inline int run_setsockcreatecon(FdinfoEntry *e) {
 	return 0;
 }
-static inline int reset_setsockcreatecon() {
+static inline int reset_setsockcreatecon(void) {
 	return 0;
 }
 #endif

--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -96,7 +96,7 @@ extern int collect_binfmt_misc(void);
 static inline int collect_binfmt_misc(void) { return 0; }
 #endif
 
-extern struct mount_info *mnt_entry_alloc();
+extern struct mount_info *mnt_entry_alloc(void);
 extern void mnt_entry_free(struct mount_info *mi);
 
 extern int __mntns_get_root_fd(pid_t pid);

--- a/criu/include/net.h
+++ b/criu/include/net.h
@@ -31,7 +31,7 @@ extern int collect_net_namespaces(bool for_dump);
 
 extern int network_lock(void);
 extern void network_unlock(void);
-extern int network_lock_internal();
+extern int network_lock_internal(void);
 
 extern struct ns_desc net_ns_desc;
 
@@ -47,11 +47,11 @@ extern int move_veth_to_bridge(void);
 
 extern int kerndat_link_nsid(void);
 extern int net_get_nsid(int rtsk, int fd, int *nsid);
-extern struct ns_id *net_get_root_ns();
+extern struct ns_id *net_get_root_ns(void);
 extern int kerndat_nsid(void);
 extern void check_has_netns_ioc(int fd, bool *kdat_val, const char *name);
 extern int net_set_ext(struct ns_id *ns);
-extern struct ns_id *get_root_netns();
-extern int read_net_ns_img();
+extern struct ns_id *get_root_netns(void);
+extern int read_net_ns_img(void);
 
 #endif /* __CR_NET_H__ */

--- a/criu/include/tls.h
+++ b/criu/include/tls.h
@@ -4,7 +4,7 @@
 # ifdef CONFIG_GNUTLS
 
 int tls_x509_init(int sockfd, bool is_server);
-void tls_terminate_session();
+void tls_terminate_session(void);
 
 ssize_t tls_send(const void *buf, size_t len, int flags);
 ssize_t tls_recv(void *buf, size_t len, int flags);

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -364,7 +364,7 @@ no_dt:
 }
 
 /* The page frame number (PFN) is constant for the zero page */
-static int init_zero_page_pfn()
+static int init_zero_page_pfn(void)
 {
 	void *addr;
 	int ret = 0;
@@ -429,7 +429,7 @@ static int get_task_size(void)
 	return 0;
 }
 
-static int kerndat_fdinfo_has_lock()
+static int kerndat_fdinfo_has_lock(void)
 {
 	int fd, pfd = -1, exit_code = -1, len;
 	char buf[PAGE_SIZE];
@@ -464,7 +464,7 @@ out:
 	return exit_code;
 }
 
-static int get_ipv6()
+static int get_ipv6(void)
 {
 	if (access("/proc/sys/net/ipv6", F_OK) < 0) {
 		if (errno == ENOENT) {

--- a/criu/lsm.c
+++ b/criu/lsm.c
@@ -133,7 +133,7 @@ static int selinux_get_sockcreate_label(pid_t pid, char **output)
 	return 0;
 }
 
-int reset_setsockcreatecon()
+int reset_setsockcreatecon(void)
 {
 	/* Currently this only works for SELinux. */
 	if (kdat.lsm != LSMTYPE__SELINUX)

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -2140,7 +2140,7 @@ static int restore_ext_mount(struct mount_info *mi)
 
 static char mnt_clean_path[] = "/tmp/cr-tmpfs.XXXXXX";
 
-static int mount_clean_path()
+static int mount_clean_path(void)
 {
 	/*
 	 * To make a bind mount, we need to have access to a source directory,
@@ -2167,7 +2167,7 @@ static int mount_clean_path()
 	return 0;
 }
 
-static int umount_clean_path()
+static int umount_clean_path(void)
 {
 	if (umount2(mnt_clean_path, MNT_DETACH)) {
 		pr_perror("Unable to umount %s", mnt_clean_path);
@@ -2659,7 +2659,7 @@ static int find_remap_mounts(struct mount_info *root)
 }
 
 /* Move remapped mounts to places where they have to be */
-static int fixup_remap_mounts()
+static int fixup_remap_mounts(void)
 {
 	struct mnt_remap_entry *r;
 

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -976,7 +976,7 @@ err:
 	return exit_code;
 }
 
-void free_userns_maps()
+void free_userns_maps(void)
 {
 	if (userns_entry.n_uid_map > 0) {
 		xfree(userns_entry.uid_map[0]);

--- a/criu/net.c
+++ b/criu/net.c
@@ -1765,7 +1765,7 @@ static int __restore_links(struct ns_id *nsid, int *nrlinks, int *nrcreated)
 	return 0;
 }
 
-static int restore_links()
+static int restore_links(void)
 {
 	int nrcreated, nrlinks;
 	struct ns_id *nsid;
@@ -2108,7 +2108,7 @@ out:
  * iptables-restore is executed from a target userns and it may have not enough
  * rights to open /run/xtables.lock. Here we try to workaround this problem.
  */
-static int prepare_xtable_lock()
+static int prepare_xtable_lock(void)
 {
 	int fd;
 
@@ -2729,7 +2729,7 @@ err:
 	return ret;
 }
 
-int network_lock_internal()
+int network_lock_internal(void)
 {
 	char conf[] =	"*filter\n"
 				":CRIU - [0:0]\n"
@@ -2760,7 +2760,7 @@ int network_lock_internal()
 	return ret;
 }
 
-static int network_unlock_internal()
+static int network_unlock_internal(void)
 {
 	char conf[] =	"*filter\n"
 			":CRIU - [0:0]\n"
@@ -3313,7 +3313,7 @@ static int check_link_nsid(int rtsk, void *args)
 	return do_rtnl_req(rtsk, &req, sizeof(req), check_one_link_nsid, NULL, NULL, args);
 }
 
-int kerndat_link_nsid()
+int kerndat_link_nsid(void)
 {
 	int status;
 	pid_t pid;

--- a/criu/net.c
+++ b/criu/net.c
@@ -2846,6 +2846,9 @@ int macvlan_ext_add(struct external *ext)
 static int prep_ns_sockets(struct ns_id *ns, bool for_dump)
 {
 	int nsret = -1, ret;
+#ifdef CONFIG_HAS_SELINUX
+	security_context_t ctx;
+#endif
 
 	if (ns->type != NS_CRIU) {
 		pr_info("Switching to %d's net for collecting sockets\n", ns->ns_pid);
@@ -2883,7 +2886,6 @@ static int prep_ns_sockets(struct ns_id *ns, bool for_dump)
 	 * policies installed. For Fedora based systems this is part
 	 * of the container-selinux package.
 	 */
-	security_context_t ctx;
 
 	/*
 	 * This assumes that all processes CRIU wants to dump are labeled
@@ -3323,6 +3325,7 @@ int kerndat_link_nsid()
 	}
 
 	if (pid == 0) {
+		bool has_link_nsid;
 		NetDeviceEntry nde = NET_DEVICE_ENTRY__INIT;
 		struct net_link link = {
 			.created = false,
@@ -3365,7 +3368,7 @@ int kerndat_link_nsid()
 			exit(1);
 		}
 
-		bool has_link_nsid = false;
+		has_link_nsid = false;
 		if (check_link_nsid(sk, &has_link_nsid))
 			exit(1);
 

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -643,16 +643,16 @@ unsigned long handle_faulty_iov(int pid, struct iovec* riov,
 				unsigned long* aux_len,
 				unsigned long partial_read_bytes)
 {
+	struct iovec dummy;
+	ssize_t bytes_read;
+	unsigned long offset = 0;
+	unsigned long final_read_cnt = 0;
+
 	/* Handling Case 2*/
 	if (riov[faulty_index].iov_len == PAGE_SIZE) {
 		cnt_sub(CNT_PAGES_WRITTEN, 1);
 		return 0;
 	}
-
-	struct iovec dummy;
-	ssize_t bytes_read;
-	unsigned long offset = 0;
-	unsigned long final_read_cnt = 0;
 
 	/* Handling Case 3-Part 3.2*/
 	offset = (partial_read_bytes)? partial_read_bytes : PAGE_SIZE;

--- a/criu/pie/util-vdso.c
+++ b/criu/pie/util-vdso.c
@@ -243,9 +243,10 @@ static void parse_elf_symbols(uintptr_t mem, size_t size, Phdr_t *load,
 		k = elf_hash((const unsigned char *)symbol);
 
 		for (j = bucket[k % nbucket]; j < nchain && j != STN_UNDEF; j = chain[j]) {
-			addr = mem + dyn_symtab->d_un.d_ptr - load->p_vaddr;
 			Sym_t *sym;
 			char *name;
+
+			addr = mem + dyn_symtab->d_un.d_ptr - load->p_vaddr;
 
 			addr += sizeof(Sym_t)*j;
 			if (__ptr_struct_oob(addr, sizeof(Sym_t), mem, size))

--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -608,7 +608,7 @@ err:
 }
 
 #define RESERVED_PIDS		300
-static int get_free_pid()
+static int get_free_pid(void)
 {
 	static struct pid *prev, *next;
 

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -194,7 +194,7 @@ static int seize_cgroup_tree(char *root_path, const char *state)
  * A freezer cgroup can contain tasks which will not be dumped
  * and we need to wait them, because the are interrupted them by ptrace.
  */
-static int freezer_wait_processes()
+static int freezer_wait_processes(void)
 {
 	int i;
 

--- a/criu/tls.c
+++ b/criu/tls.c
@@ -31,7 +31,7 @@ static gnutls_certificate_credentials_t x509_cred;
 static int tls_sk = -1;
 static int tls_sk_flags = 0;
 
-void tls_terminate_session()
+void tls_terminate_session(void)
 {
 	int ret;
 
@@ -227,7 +227,7 @@ static int tls_x509_verify_peer_cert(void)
 	return 0;
 }
 
-static int tls_handshake()
+static int tls_handshake(void)
 {
 	int ret = -1;
 	while (ret != GNUTLS_E_SUCCESS) {
@@ -241,7 +241,7 @@ static int tls_handshake()
 	return 0;
 }
 
-static int tls_x509_setup_creds()
+static int tls_x509_setup_creds(void)
 {
 	int ret;
 	char *cacert = CRIU_CACERT;

--- a/criu/util.c
+++ b/criu/util.c
@@ -325,7 +325,7 @@ int close_pid_proc(void)
 	return 0;
 }
 
-void close_proc()
+void close_proc(void)
 {
 	close_pid_proc();
 	close_service_fd(PROC_FD_OFF);
@@ -712,7 +712,7 @@ int cr_daemon(int nochdir, int noclose, int close_fd)
 	return 0;
 }
 
-int is_root_user()
+int is_root_user(void)
 {
 	if (geteuid() != 0) {
 		pr_err("You need to be root to run this command\n");

--- a/soccr/test/tcp-conn.c
+++ b/soccr/test/tcp-conn.c
@@ -23,7 +23,7 @@ static void pr_printf(unsigned int level, const char *fmt, ...)
 	va_end(args);
 }
 
-int main()
+int main(void)
 {
 	union libsoccr_addr addr, dst;
 	int srv, sock, clnt, rst;

--- a/soccr/test/tcp-constructor.c
+++ b/soccr/test/tcp-constructor.c
@@ -20,7 +20,7 @@ struct tcp {
 	uint16_t wscale;
 };
 
-static void usage()
+static void usage(void)
 {
 	printf(
 		"Usage: --addr ADDR -port PORT --seq SEQ --next --addr ADDR -port PORT --seq SEQ -- CMD ...\n"

--- a/test/others/unix-callback/unix-client.c
+++ b/test/others/unix-callback/unix-client.c
@@ -86,7 +86,7 @@ static int check_sock(int i)
 	return 0;
 }
 
-int main()
+int main(void)
 {
 	int i, fd;
 	sigset_t set;

--- a/test/others/unix-callback/unix-server.c
+++ b/test/others/unix-callback/unix-server.c
@@ -19,7 +19,7 @@ struct ticket *tickets;
 
 #define SK_NAME "/tmp/criu.unix.callback.test"
 
-int main()
+int main(void)
 {
 	int sk, ret, id;
 	char buf[4096];

--- a/test/zdtm/Makefile.inc
+++ b/test/zdtm/Makefile.inc
@@ -38,7 +38,7 @@ ifeq ($(origin CC), default)
         CC := $(CROSS_COMPILE)$(HOSTCC)
 endif
 CFLAGS	+= -g -O2 -Wall -Werror -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
-CFLAGS	+= -Wdeclaration-after-statement
+CFLAGS	+= -Wdeclaration-after-statement -Wstrict-prototypes
 CFLAGS	+= $(USERCFLAGS)
 CFLAGS	+= -D_GNU_SOURCE
 CPPFLAGS += -iquote $(LIBDIR)/arch/$(ARCH)/include

--- a/test/zdtm/Makefile.inc
+++ b/test/zdtm/Makefile.inc
@@ -38,6 +38,7 @@ ifeq ($(origin CC), default)
         CC := $(CROSS_COMPILE)$(HOSTCC)
 endif
 CFLAGS	+= -g -O2 -Wall -Werror -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
+CFLAGS	+= -Wdeclaration-after-statement
 CFLAGS	+= $(USERCFLAGS)
 CFLAGS	+= -D_GNU_SOURCE
 CPPFLAGS += -iquote $(LIBDIR)/arch/$(ARCH)/include

--- a/test/zdtm/lib/test.c
+++ b/test/zdtm/lib/test.c
@@ -71,7 +71,7 @@ static void test_fini(void)
 	unlinkat(cwd, pidfile, 0);
 }
 
-static void setup_outfile()
+static void setup_outfile(void)
 {
 	if (!access(outfile, F_OK) || errno != ENOENT) {
 		fprintf(stderr, "Output file %s appears to exist, aborting\n",
@@ -93,7 +93,7 @@ static void setup_outfile()
 		exit(1);
 }
 
-static void redir_stdfds()
+static void redir_stdfds(void)
 {
 	int nullfd;
 
@@ -346,7 +346,7 @@ void test_init(int argc, char **argv)
 	srand48(time(NULL));	/* just in case we need it */
 }
 
-void test_daemon()
+void test_daemon(void)
 {
 	futex_set_and_wake(&test_shared_state->stage, TEST_RUNNING_STAGE);
 }

--- a/test/zdtm/static/apparmor.c
+++ b/test/zdtm/static/apparmor.c
@@ -15,7 +15,7 @@ const char *test_author	= "Tycho Andersen <tycho.andersen@canonical.com>";
 
 #define PROFILE "criu_test"
 
-int setprofile()
+int setprofile(void)
 {
 	char profile[1024];
 	int fd, len;
@@ -45,7 +45,7 @@ int setprofile()
 	return 0;
 }
 
-int checkprofile()
+int checkprofile(void)
 {
 	FILE *f;
 	char path[PATH_MAX], profile[1024];

--- a/test/zdtm/static/arm-neon00.c
+++ b/test/zdtm/static/arm-neon00.c
@@ -12,13 +12,14 @@ const char *test_author	= "Alexander Karatshov <alekskartashov@parallels.com>";
 
 int main(int argc, char ** argv)
 {
+	int a, b, c, y1, y2;
+
 	srand(time(0));
 
-	int a = rand() % 100;
-	int b = rand() % 100;
-	int c = rand() % 100;
-	int y1 = a + b*c;
-	int y2;
+	a = rand() % 100;
+	b = rand() % 100;
+	c = rand() % 100;
+	y1 = a + b*c;
 
 	test_init(argc, argv);
 

--- a/test/zdtm/static/child_subreaper.c
+++ b/test/zdtm/static/child_subreaper.c
@@ -8,10 +8,11 @@ const char *test_author	= "Michał Cłapiński <mclapinski@google.com>";
 
 int main(int argc, char **argv)
 {
+	int cs_before = 1, cs_after, ret;
+
 	test_init(argc, argv);
 
-	int cs_before = 1;
-	int ret = prctl(PR_SET_CHILD_SUBREAPER, cs_before, 0, 0, 0);
+	ret = prctl(PR_SET_CHILD_SUBREAPER, cs_before, 0, 0, 0);
 	if (ret) {
 		pr_perror("Can't set child subreaper attribute, err = %d", ret);
 		exit(1);
@@ -20,7 +21,6 @@ int main(int argc, char **argv)
 	test_daemon();
 	test_waitsig();
 
-	int cs_after;
 	ret = prctl(PR_GET_CHILD_SUBREAPER, (unsigned long)&cs_after, 0, 0, 0);
 	if (ret) {
 		pr_perror("Can't get child subreaper attribute, err = %d", ret);

--- a/test/zdtm/static/child_subreaper_and_reparent.c
+++ b/test/zdtm/static/child_subreaper_and_reparent.c
@@ -25,7 +25,7 @@ struct shared {
 	int parent_after_cr;
 } *sh;
 
-int orphan()
+int orphan(void)
 {
 	/*
 	 * Wait until reparented to the pidns init. (By waiting
@@ -45,7 +45,7 @@ int orphan()
 	return 0;
 }
 
-int helper()
+int helper(void)
 {
 	int pid;
 
@@ -59,7 +59,7 @@ int helper()
 	return 0;
 }
 
-int subreaper()
+int subreaper(void)
 {
 	int pid, ret, status;
 

--- a/test/zdtm/static/child_subreaper_existing_child.c
+++ b/test/zdtm/static/child_subreaper_existing_child.c
@@ -24,7 +24,7 @@ struct shared {
 } *sh;
 
 
-int orphan()
+int orphan(void)
 {
 	/* Return the control back to MAIN worker to do C/R */
 	futex_set_and_wake(&sh->fstate, TEST_CRIU);
@@ -36,7 +36,7 @@ int orphan()
 	return 0;
 }
 
-int helper()
+int helper(void)
 {
 	int pid;
 
@@ -52,7 +52,7 @@ int helper()
 	return 0;
 }
 
-int subreaper()
+int subreaper(void)
 {
 	int pid, ret, status;
 

--- a/test/zdtm/static/config_inotify_irmap.c
+++ b/test/zdtm/static/config_inotify_irmap.c
@@ -31,6 +31,7 @@ char test_files[2][128] = {TDIR"/zdtm-test", TDIR"/zdtm-test1",};
 
 int main (int argc, char *argv[])
 {
+	FILE *configfile;
 	char buf[BUFF_SIZE];
 	int fd, wd, i;
 
@@ -56,7 +57,7 @@ int main (int argc, char *argv[])
 		}
 	}
 
-	FILE *configfile = fopen(CONFIG_PATH, "w");
+	configfile = fopen(CONFIG_PATH, "w");
 	if (configfile == NULL) {
 		pr_perror("Unable to create configuration file %s", CONFIG_PATH);
 		goto err;

--- a/test/zdtm/static/dumpable02.c
+++ b/test/zdtm/static/dumpable02.c
@@ -13,7 +13,7 @@
 const char *test_doc    = "Check dumpable flag handling (non-dumpable case)";
 const char *test_author = "Filipe Brandenburger <filbranden@google.com>";
 
-int dumpable_server() {
+int dumpable_server(void) {
 	char buf[256];
 	int ret;
 

--- a/test/zdtm/static/fdt_shared.c
+++ b/test/zdtm/static/fdt_shared.c
@@ -22,7 +22,7 @@ TEST_OPTION(filename, string, "file name", 1);
 #define CHILDREN 4
 static int fork_pfd[2];
 
-static void forked()
+static void forked(void)
 {
 	char c = 0;
 
@@ -32,7 +32,7 @@ static void forked()
 	}
 }
 
-static void wait_children()
+static void wait_children(void)
 {
 	int i;
 	char c;

--- a/test/zdtm/static/file_locks00.c
+++ b/test/zdtm/static/file_locks00.c
@@ -101,7 +101,7 @@ static int check_write_lock(int fd, int whence, off_t offset, off_t len)
 	return -1;
 }
 
-static int check_file_locks()
+static int check_file_locks(void)
 {
 	int fd_0, fd_1;
 	int ret0, ret1;

--- a/test/zdtm/static/inotify00.c
+++ b/test/zdtm/static/inotify00.c
@@ -125,8 +125,9 @@ int main (int argc, char *argv[])
 {
 	pid_t pid;
 	task_waiter_t t;
-	task_waiter_init(&t);
 	static char buf[PATH_MAX];
+
+	task_waiter_init(&t);
 
 	if (mount(NULL, "/", NULL, MS_PRIVATE | MS_REC, NULL)) {
 		pr_perror("Unable to remount /");

--- a/test/zdtm/static/inotify_system.c
+++ b/test/zdtm/static/inotify_system.c
@@ -68,7 +68,7 @@ typedef struct {
 	int dir;
 } desc;
 
-void do_wait() {
+void do_wait(void) {
 	test_daemon();
 	test_waitsig();
 }

--- a/test/zdtm/static/maps03.c
+++ b/test/zdtm/static/maps03.c
@@ -16,8 +16,9 @@ const char *test_author	= "Cyrill Gorcunov <gorcunov@openvz.org>";
 
 int main(int argc, char **argv)
 {
-	test_init(argc, argv);
 	unsigned char *mem;
+
+	test_init(argc, argv);
 
 	test_msg("Alloc huge VMA\n");
 	mem = (void *)mmap(NULL, (10L << 30), PROT_READ | PROT_WRITE,

--- a/test/zdtm/static/mnt_ext_dev.c
+++ b/test/zdtm/static/mnt_ext_dev.c
@@ -20,9 +20,10 @@ TEST_OPTION(dirname, string, "directory name", 1);
 int main(int argc, char **argv)
 {
 	char *loop, fd, dfd, fd2;
-	test_init(argc, argv);
 	struct stat st, stp, st2;
 	char dname[PATH_MAX], dname2[PATH_MAX];
+
+	test_init(argc, argv);
 
 	snprintf(dname, sizeof(dname), "%s/test_dir", dirname);
 	snprintf(dname2, sizeof(dname2), "%s/test_dir2", dirname);

--- a/test/zdtm/static/mntns_link_remap.c
+++ b/test/zdtm/static/mntns_link_remap.c
@@ -230,8 +230,8 @@ int main(int argc, char **argv)
 
 
 	if (pid > 0) {
-		kill(pid, SIGTERM);
 		int status = 1;
+		kill(pid, SIGTERM);
 		wait(&status);
 		if (WIFEXITED(status)) {
 			if (WEXITSTATUS(status) == AWK_OK)

--- a/test/zdtm/static/mntns_open.c
+++ b/test/zdtm/static/mntns_open.c
@@ -119,8 +119,8 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (pid > 0) {
-		kill(pid, SIGTERM);
 		int status = 1;
+		kill(pid, SIGTERM);
 		wait(&status);
 		if (WIFEXITED(status)) {
 			if (WEXITSTATUS(status) == AWK_OK)

--- a/test/zdtm/static/mountpoints.c
+++ b/test/zdtm/static/mountpoints.c
@@ -292,8 +292,8 @@ int main(int argc, char **argv)
 	}
 
 	if (pid > 0) {
-		kill(pid, SIGTERM);
 		int status = 1;
+		kill(pid, SIGTERM);
 		wait(&status);
 		if (status)
 			return 1;

--- a/test/zdtm/static/remap_dead_pid.c
+++ b/test/zdtm/static/remap_dead_pid.c
@@ -40,11 +40,11 @@ int main(int argc, char **argv)
 		while(1)
 			sleep(10);
 	} else {
-		test_msg("child is %d\n", pid);
-
 		int fd, ret;
 		char path[PATH_MAX];
 		pid_t result;
+
+		test_msg("child is %d\n", pid);
 
 		sprintf(path, proc_path, pid);
 		fd = open(path, O_RDONLY);

--- a/test/zdtm/static/selinux00.c
+++ b/test/zdtm/static/selinux00.c
@@ -26,14 +26,14 @@ const char *test_author	= "Adrian Reber <areber@redhat.com>";
  */
 char state;
 
-int check_for_selinux()
+int check_for_selinux(void)
 {
 	if (access("/sys/fs/selinux", F_OK) == 0)
 		return 0;
 	return 1;
 }
 
-int setprofile()
+int setprofile(void)
 {
 	int fd, len;
 
@@ -54,7 +54,7 @@ int setprofile()
 	return 0;
 }
 
-int checkprofile()
+int checkprofile(void)
 {
 	int fd;
 	char context[1024];
@@ -83,7 +83,7 @@ int checkprofile()
 	return 0;
 }
 
-int check_sockcreate()
+int check_sockcreate(void)
 {
 	char *output = NULL;
 	FILE *f = fopen("/proc/self/attr/sockcreate", "r");

--- a/test/zdtm/static/selinux01.c
+++ b/test/zdtm/static/selinux01.c
@@ -28,14 +28,14 @@ const char *test_author	= "Adrian Reber <areber@redhat.com>";
  */
 char state;
 
-int check_for_selinux()
+int check_for_selinux(void)
 {
 	if (access("/sys/fs/selinux", F_OK) == 0)
 		return 0;
 	return 1;
 }
 
-int setprofile()
+int setprofile(void)
 {
 	int fd, len;
 
@@ -56,7 +56,7 @@ int setprofile()
 	return 0;
 }
 
-int set_sockcreate()
+int set_sockcreate(void)
 {
 	int fd, len;
 
@@ -77,7 +77,7 @@ int set_sockcreate()
 	return 0;
 }
 
-int check_sockcreate()
+int check_sockcreate(void)
 {
 	int fd;
 	char context[1024];
@@ -106,7 +106,7 @@ int check_sockcreate()
 	return 0;
 }
 
-int check_sockcreate_empty()
+int check_sockcreate_empty(void)
 {
 	char *output = NULL;
 	FILE *f = fopen("/proc/self/attr/sockcreate", "r");

--- a/test/zdtm/static/selinux01.c
+++ b/test/zdtm/static/selinux01.c
@@ -133,6 +133,7 @@ int check_sockcreate_empty()
 
 int main(int argc, char **argv)
 {
+	int sk;
 	char ctx[1024];
 	test_init(argc, argv);
 
@@ -159,7 +160,7 @@ int main(int argc, char **argv)
 #endif
 
 	/* Open our test socket */
-	int sk = socket(AF_INET, SOCK_STREAM, 0);
+	sk = socket(AF_INET, SOCK_STREAM, 0);
 	memset(ctx, 0, 1024);
 	/* Read out the socket label */
 	if (fgetxattr(sk, "security.selinux", ctx, 1024) == -1) {

--- a/test/zdtm/static/session02.c
+++ b/test/zdtm/static/session02.c
@@ -25,7 +25,7 @@ struct process *processes;
 int nr_processes = 20;
 int current = 0;
 
-static void cleanup()
+static void cleanup(void)
 {
 	int i;
 
@@ -55,9 +55,9 @@ struct command
 	int		arg2;
 };
 
-static void handle_command();
+static void handle_command(void);
 
-static void mainloop()
+static void mainloop(void)
 {
 	while (1)
 		handle_command();
@@ -100,7 +100,7 @@ static int make_child(int id, int flags)
 	return cid;
 }
 
-static void handle_command()
+static void handle_command(void)
 {
 	int sk = processes[current].sks[0], ret, status = 0;
 	struct command cmd;

--- a/test/zdtm/static/session03.c
+++ b/test/zdtm/static/session03.c
@@ -36,7 +36,7 @@ static void sigchld_handler(int signal, siginfo_t *siginfo, void *data)
 		waitpid(pid, NULL, WNOHANG);
 }
 
-static void cleanup()
+static void cleanup(void)
 {
 	int i, ret;
 
@@ -72,7 +72,7 @@ enum commands
 
 int cmd_weght[TEST_MAX] = {10, 3, 1, 10, 7};
 int sum_weight = 0;
-static int get_rnd_op()
+static int get_rnd_op(void)
 {
 	int i, m;
 	if (sum_weight == 0) {
@@ -97,9 +97,9 @@ struct command
 	int		arg2;
 };
 
-static void handle_command();
+static void handle_command(void);
 
-static void mainloop()
+static void mainloop(void)
 {
 	while (1)
 		handle_command();
@@ -142,7 +142,7 @@ static int make_child(int id, int flags)
 	return cid;
 }
 
-static void handle_command()
+static void handle_command(void)
 {
 	int sk = processes[current].sks[0], ret, status = 0;
 	struct command cmd;

--- a/test/zdtm/static/sigaltstack.c
+++ b/test/zdtm/static/sigaltstack.c
@@ -61,15 +61,15 @@ void thread_sigaction(int signo, siginfo_t *info, void *context)
 
 static void *thread_func(void *arg)
 {
+	struct sigaction sa = {
+		.sa_sigaction	= thread_sigaction,
+		.sa_flags	= SA_RESTART | SA_ONSTACK,
+	};
+
 	sas_state[SAS_THRD_OLD] = (stack_t) {
 		.ss_size	= sizeof(stack_thread) - 8,
 		.ss_sp		= stack_thread,
 		.ss_flags	= 0,
-	};
-
-	struct sigaction sa = {
-		.sa_sigaction	= thread_sigaction,
-		.sa_flags	= SA_RESTART | SA_ONSTACK,
 	};
 
 	sigemptyset(&sa.sa_mask);
@@ -103,15 +103,15 @@ int main(int argc, char *argv[])
 {
 	pthread_t thread;
 
+	struct sigaction sa = {
+		.sa_sigaction	= leader_sigaction,
+		.sa_flags	= SA_RESTART | SA_ONSTACK,
+	};
+
 	sas_state[SAS_MAIN_OLD] = (stack_t) {
 		.ss_size	= sizeof(stack_main) - 8,
 		.ss_sp		= stack_main,
 		.ss_flags	= 0,
-	};
-
-	struct sigaction sa = {
-		.sa_sigaction	= leader_sigaction,
-		.sa_flags	= SA_RESTART | SA_ONSTACK,
 	};
 
 	sigemptyset(&sa.sa_mask);

--- a/test/zdtm/static/socket-tcp-syn-sent.c
+++ b/test/zdtm/static/socket-tcp-syn-sent.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
 {
 	int fd, fd_s, sock, sk;
 	union sockaddr_inet addr;
-	char cmd[4096];
+	char c, cmd[4096];
 
 	test_init(argc, argv);
 
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
 
 	fcntl(sock, F_SETFL, 0);
 
-	char c = 5;
+	c = 5;
 	if (write(sock, &c, 1) != 1) {
 		fail("Unable to send data");
 		return 1;

--- a/test/zdtm/static/unlink_multiple_largefiles.c
+++ b/test/zdtm/static/unlink_multiple_largefiles.c
@@ -30,9 +30,10 @@ void create_check_pattern(char *buf, size_t count, unsigned char seed)
 
 struct fiemap *read_fiemap(int fd)
 {
-	test_msg("Obtaining fiemap for fd %d\n", fd);
 	struct fiemap *fiemap, *tmp;
 	int extents_size;
+
+	test_msg("Obtaining fiemap for fd %d\n", fd);
 
 	fiemap = malloc(sizeof(struct fiemap));
 	if (fiemap == NULL) {

--- a/test/zdtm/transition/file_aio.c
+++ b/test/zdtm/transition/file_aio.c
@@ -17,13 +17,14 @@ const char *test_author = "Andrew Vagin <avagin@parallels.com>";
 
 int main(int argc, char **argv)
 {
-	test_init(argc, argv);
 	char buf[BUF_SIZE];
 	int fd;
 	struct aiocb aiocb;
 	const struct aiocb   *aioary[1];
 	char tmpfname[256]="/tmp/file_aio.XXXXXX";
 	int ret;
+
+	test_init(argc, argv);
 
 	fd = mkstemp(tmpfname);
 	if (fd == -1) {

--- a/test/zdtm/transition/file_read.c
+++ b/test/zdtm/transition/file_read.c
@@ -158,9 +158,11 @@ static void chew_some_file(int num)
 			rv = SEEK_FAILED;
 			goto out_exit;
 		case 1:
-			rv = FILE_CORRUPTED;
+			{
 			int fd1;
 			char str[PATH_MAX];
+
+			rv = FILE_CORRUPTED;
 			// create standard file
 			sprintf(str, "standard_%s.%d", filename, num);
 			fd1 = open(str, O_WRONLY | O_CREAT | O_TRUNC, 0666);
@@ -168,6 +170,7 @@ static void chew_some_file(int num)
 				pr_perror("can't write %s", str);
 			close(fd1);
 			goto out_exit;
+			}
 		}
 	}
 	rv = SUCCESS;

--- a/test/zdtm/transition/maps008.c
+++ b/test/zdtm/transition/maps008.c
@@ -348,6 +348,7 @@ static int proc11_func(task_waiter_t *setup_waiter)
 	void *mem3_old = mem3;
 	size_t mem3_size_old = mem3_size;
 	uint32_t crc_epoch = 0;
+	uint8_t *proc1_mem3;
 
 	pstree->proc11 = getpid();
 	xmunmap(mem3, MEM3_START_CUT);
@@ -382,7 +383,7 @@ static int proc11_func(task_waiter_t *setup_waiter)
 	chk_proc_mem_eq(pstree->proc11, mem3, mem3_size,
 		pstree->proc112, mem3, mem3_size + MEM3_END_CUT);
 
-	uint8_t *proc1_mem3 = mmap_proc_mem(pstree->proc1,
+	proc1_mem3 = mmap_proc_mem(pstree->proc1,
 			(unsigned long)mem3_old, mem3_size_old);
 	check_mem_eq(mem3, mem3_size, proc1_mem3 + MEM3_START_CUT, mem3_size);
 	xmunmap(proc1_mem3, mem3_size_old);
@@ -489,16 +490,17 @@ static void sigchld_hand(int signo, siginfo_t *info, void *ucontext)
 
 int main(int argc, char **argv)
 {
-	test_init(argc, argv);
-
-	pstree = (struct pstree *)mmap_ashmem(PAGE_SIZE);
-	test_sync = (struct test_sync *)mmap_ashmem(sizeof(*test_sync));
-
 	struct sigaction sa = {
 		.sa_sigaction = sigchld_hand,
 		.sa_flags = SA_RESTART | SA_SIGINFO | SA_NOCLDSTOP
 	};
 	sigemptyset(&sa.sa_mask);
+
+	test_init(argc, argv);
+
+	pstree = (struct pstree *)mmap_ashmem(PAGE_SIZE);
+	test_sync = (struct test_sync *)mmap_ashmem(sizeof(*test_sync));
+
 	if (sigaction(SIGCHLD, &sa, NULL)) {
 		pr_perror("SIGCHLD handler setup");
 		exit(1);

--- a/test/zdtm/transition/netlink00.c
+++ b/test/zdtm/transition/netlink00.c
@@ -56,12 +56,12 @@ struct rtmsg *rtp;
 int rtl;
 struct rtattr *rtap;
 
-int send_request();
-int recv_reply();
-int form_request_add();
-int form_request_del();
-int read_reply();
-typedef int (*cmd_t)();
+int send_request(void);
+int recv_reply(void);
+int form_request_add(void);
+int form_request_del(void);
+int read_reply(void);
+typedef int (*cmd_t)(void);
 #define CMD_NUM 2
 cmd_t cmd[CMD_NUM]={form_request_add, form_request_del};
 
@@ -120,7 +120,7 @@ out:
 	return 0;
 }
 
-int send_request()
+int send_request(void)
 {
 	// create the remote address
 	// to communicate
@@ -145,7 +145,7 @@ int send_request()
 	}
 	return 0;
 }
-int recv_reply()
+int recv_reply(void)
 {
 	char *p;
 	// initialize the socket read buffer
@@ -191,7 +191,7 @@ int recv_reply()
 	return 0;
 }
 
-int read_reply()
+int read_reply(void)
 {
 	//string to hold content of the route
 	// table (i.e. one entry)
@@ -250,7 +250,7 @@ int read_reply()
 #define NLMSG_TAIL(nmsg) \
         ((struct rtattr *) (((void *) (nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
 
-int form_request_del()
+int form_request_del(void)
 {
 	bzero(&req, sizeof(req));
 	req.nl.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
@@ -272,7 +272,7 @@ int form_request_del()
 	return 0;
 }
 
-int form_request_add()
+int form_request_add(void)
 {
 	int ifcn = 1; //interface number
 


### PR DESCRIPTION
This PR includes two warnings that the kernel uses during compilation:
1) `-Wdeclaration-after-statement`: this enforces having variables declared at the top of scopes
2) `-Wstrict-prototypes`: this enforces full declaration of functions.
  Previously, when declaring `extern void func()`, one can call `func(123)` and have no compilation error. This is dangerous. The correct declaration is `extern void func(void)`.