### PR TITLE
Add support of symlinks

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1817,11 +1817,17 @@ static int do_open_reg(int ns_root_fd, struct reg_file_info *rfi, void *arg)
 	if (fd < 0)
 		return fd;
 
-	if ((rfi->rfe->pos != -1ULL) &&
-			lseek(fd, rfi->rfe->pos, SEEK_SET) < 0) {
-		pr_perror("Can't restore file pos");
-		close(fd);
-		return -1;
+	/*
+	 * O_PATH opened files carry empty fops in kernel,
+	 * just ignore positioning at all.
+	 */
+	if (!(rfi->rfe->flags & O_PATH)) {
+		if (rfi->rfe->pos != -1ULL &&
+		    lseek(fd, rfi->rfe->pos, SEEK_SET) < 0) {
+			pr_perror("Can't restore file pos");
+			close(fd);
+			return -1;
+		}
 	}
 
 	return fd;

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -321,19 +321,53 @@ static int mkreg_ghost(char *path, GhostFileEntry *gfe, struct cr_img *img)
 	return ret;
 }
 
+static int mklnk_ghost(char *path, GhostFileEntry *gfe)
+{
+	if (!gfe->symlnk_target) {
+		pr_err("Ghost symlink target is NULL for %s. Image from old CRIU?\n", path);
+		return -1;
+	}
+
+	if (symlink(gfe->symlnk_target, path) < 0) {
+		/*
+		 * ENOENT case is OK
+		 * Take a look closer on create_ghost() function
+		 */
+		if (errno != ENOENT)
+			pr_perror("symlink(%s, %s) failed", gfe->symlnk_target, path);
+		return -1;
+	}
+
+	return 0;
+}
+
 static int ghost_apply_metadata(const char *path, GhostFileEntry *gfe)
 {
 	struct timeval tv[2];
 	int ret = -1;
 
-	if (chown(path, gfe->uid, gfe->gid) < 0) {
-		pr_perror("Can't reset user/group on ghost %s", path);
-		goto err;
-	}
+	if (S_ISLNK(gfe->mode)) {
+		if (lchown(path, gfe->uid, gfe->gid) < 0) {
+			pr_perror("Can't reset user/group on ghost %s", path);
+			goto err;
+		}
 
-	if (chmod(path, gfe->mode)) {
-		pr_perror("Can't set perms %o on ghost %s", gfe->mode, path);
-		goto err;
+		/*
+		 * We have no lchmod() function, and fchmod() will fail on
+		 * O_PATH | O_NOFOLLOW fd. Yes, we have fchmodat()
+		 * function and flag AT_SYMLINK_NOFOLLOW described in
+		 * man 2 fchmodat, but it is not currently implemented. %)
+		 */
+	} else {
+		if (chown(path, gfe->uid, gfe->gid) < 0) {
+			pr_perror("Can't reset user/group on ghost %s", path);
+			goto err;
+		}
+
+		if (chmod(path, gfe->mode)) {
+			pr_perror("Can't set perms %o on ghost %s", gfe->mode, path);
+			goto err;
+		}
 	}
 
 	if (gfe->atim) {
@@ -392,6 +426,9 @@ again:
 	} else if (S_ISDIR(gfe->mode)) {
 		if ((ret = mkdirpat(AT_FDCWD, path, gfe->mode)) < 0)
 			msg = "Can't make ghost dir";
+	} else if (S_ISLNK(gfe->mode)) {
+		if ((ret = mklnk_ghost(path, gfe)) < 0)
+			msg = "Can't create ghost symlink";
 	} else {
 		if ((ret = mkreg_ghost(path, gfe, img)) < 0)
 			msg = "Can't create ghost regfile";
@@ -779,6 +816,7 @@ static int dump_ghost_file(int _fd, u32 id, const struct stat *st, dev_t phys_de
 	int exit_code = -1;
 	GhostFileEntry gfe = GHOST_FILE_ENTRY__INIT;
 	Timeval atim = TIMEVAL__INIT, mtim = TIMEVAL__INIT;
+	char pathbuf[PATH_MAX];
 
 	pr_info("Dumping ghost file contents (id %#x)\n", id);
 
@@ -810,6 +848,36 @@ static int dump_ghost_file(int _fd, u32 id, const struct stat *st, dev_t phys_de
 		gfe.has_chunks = gfe.chunks = true;
 		gfe.has_size = true;
 		gfe.size = st->st_size;
+	}
+
+	/*
+	 * We set gfe.symlnk_target only if we need to dump
+	 * symlink content, otherwise we leave it NULL.
+	 * It will be taken into account on restore in mklnk_ghost function.
+	 */
+	if (S_ISLNK(st->st_mode)) {
+		ssize_t ret;
+
+		/*
+		 * We assume that _fd opened with O_PATH | O_NOFOLLOW
+		 * flags because S_ISLNK(st->st_mode). With current kernel version,
+		 * it's looks like correct assumption in any case.
+		 */
+		ret = readlinkat(_fd, "", pathbuf, sizeof(pathbuf) - 1);
+		if (ret < 0) {
+			pr_perror("Can't readlinkat");
+			goto err_out;
+		}
+
+		pathbuf[ret] = 0;
+
+		if (ret != st->st_size) {
+			pr_err("Buffer for readlinkat is too small: ret %zd, st_size %"PRId64", buf %u %s\n",
+					ret, st->st_size, PATH_MAX, pathbuf);
+			goto err_out;
+		}
+
+		gfe.symlnk_target = pathbuf;
 	}
 
 	if (pb_write_one(img, &gfe, PB_GHOST_FILE))
@@ -1157,6 +1225,7 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms,
 	int ret, mntns_root;
 	struct stat pst;
 	const struct stat *ost = &parms->stat;
+	int flags = 0;
 
 	if (parms->fs_type == PROC_SUPER_MAGIC) {
 		/* The file points to /proc/pid/<foo> where pid is a dead
@@ -1253,7 +1322,10 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms,
 	if (mntns_root < 0)
 		return -1;
 
-	ret = fstatat(mntns_root, rpath, &pst, 0);
+	if (S_ISLNK(parms->stat.st_mode))
+		flags = AT_SYMLINK_NOFOLLOW;
+
+	ret = fstatat(mntns_root, rpath, &pst, flags);
 	if (ret < 0) {
 		/*
 		 * Linked file, but path is not accessible (unless any

--- a/criu/files.c
+++ b/criu/files.c
@@ -544,7 +544,8 @@ static int dump_one_file(struct pid *pid, int fd, int lfd, struct fd_opts *opts,
 		return do_dump_gen_file(&p, lfd, ops, e);
 	}
 
-	if (S_ISREG(p.stat.st_mode) || S_ISDIR(p.stat.st_mode)) {
+	if (S_ISREG(p.stat.st_mode) || S_ISDIR(p.stat.st_mode) ||
+		S_ISLNK(p.stat.st_mode)) {
 		if (fill_fdlink(lfd, &p, &link))
 			return -1;
 

--- a/criu/files.c
+++ b/criu/files.c
@@ -398,7 +398,10 @@ static int fill_fd_params(struct pid *owner_pid, int fd, int lfd,
 	pr_info("%d fdinfo %d: pos: %#16"PRIx64" flags: %16o/%#x\n",
 			owner_pid->real, fd, p->pos, p->flags, (int)p->fd_flags);
 
-	ret = fcntl(lfd, F_GETSIG, 0);
+	if (p->flags & O_PATH)
+		ret = 0;
+	else
+		ret = fcntl(lfd, F_GETSIG, 0);
 	if (ret < 0) {
 		pr_perror("Can't get owner signum on %d", lfd);
 		return -1;

--- a/images/ghost-file.proto
+++ b/images/ghost-file.proto
@@ -15,6 +15,8 @@ message ghost_file_entry {
 	optional timeval	mtim		= 8;
 	optional bool		chunks		= 9;
 	optional uint64		size		= 10;
+	/* this field makes sense only when S_ISLNK(mode) */
+	optional string		symlnk_target	= 11;
 }
 
 message ghost_chunk_entry {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -360,6 +360,8 @@ TST_DIR		=				\
 		ghost_on_rofs			\
 		overmounted_file		\
 		opath_file			\
+		symlink				\
+		symlink01			\
 
 TST_DIR_FILE	=				\
 		chroot				\
@@ -535,6 +537,7 @@ clone_fs:		LDLIBS += -pthread
 # we have to explicitly specify both .o and .d for this case:
 netns_sub_veth.o netns_sub_veth.d: CPPFLAGS += $(call pkg-cflags, libnl-3.0)
 netns_sub_veth:		LDLIBS += $(call pkg-libs, libnl-route-3.0 libnl-3.0)
+symlink01:		CFLAGS += -DZDTM_UNLINK_SYMLINK
 
 socket-tcp-fin-wait1:	CFLAGS += -D ZDTM_TCP_FIN_WAIT1
 socket-tcp-fin-wait2:	CFLAGS += -D ZDTM_TCP_FIN_WAIT2

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -359,6 +359,7 @@ TST_DIR		=				\
 		private_bind_propagation	\
 		ghost_on_rofs			\
 		overmounted_file		\
+		opath_file			\
 
 TST_DIR_FILE	=				\
 		chroot				\

--- a/test/zdtm/static/opath_file.c
+++ b/test/zdtm/static/opath_file.c
@@ -36,7 +36,7 @@ static int parse_self_fdinfo(int fd, struct fdinfo *fi)
 
 	while (fgets(line, sizeof(line), file)) {
 		if (fdinfo_field(line, "flags")) {
-			if (sscanf(line, "%*s %llu", &val) != 1) {
+			if (sscanf(line, "%*s %llo", &val) != 1) {
 				pr_err("failed to read flags: %s", line);
 				goto fail;
 			}

--- a/test/zdtm/static/opath_file.c
+++ b/test/zdtm/static/opath_file.c
@@ -1,0 +1,95 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <limits.h>
+
+#include "zdtmtst.h"
+
+#define TEST_FILE "test_file"
+#define BUF_SIZE 4096
+#define fdinfo_field(str, field)        !strncmp(str, field":", sizeof(field))
+#define pr_debug(format, arg...) test_msg("DBG: %s:%d: " format, __FILE__, __LINE__, ## arg)
+
+const char *test_doc	= "Check open file with O_PATH preserved";
+const char *test_author	= "Pavel Tikhomirov <ptikhomirov@virtuozzo.com>";
+
+char *dirname;
+TEST_OPTION(dirname, string, "directory name", 1);
+
+struct fdinfo {
+	int flags;
+};
+
+static int parse_self_fdinfo(int fd, struct fdinfo *fi)
+{
+	char path[PATH_MAX], line[BUF_SIZE];
+	FILE *file;
+	int ret = -1;
+	unsigned long long val;
+
+	snprintf(path, sizeof(path), "/proc/self/fdinfo/%d", fd);
+	file = fopen(path, "r");
+	if (!file) {
+		pr_perror("fopen");
+		return -1;
+	}
+
+	while (fgets(line, sizeof(line), file)) {
+		if (fdinfo_field(line, "flags")) {
+			if (sscanf(line, "%*s %llu", &val) != 1) {
+				pr_err("failed to read flags: %s", line);
+				goto fail;
+			}
+			pr_debug("Open flags = %llu\n", val);
+			fi->flags = val;
+			ret = 0;
+			break;
+		}
+	}
+fail:
+	fclose(file);
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	char test_file[PATH_MAX];
+	struct fdinfo fi;
+	int fd;
+
+	test_init(argc, argv);
+
+	if (mkdir(dirname, 0700)) {
+		pr_perror("can't make directory %s", dirname);
+		exit(1);
+	}
+
+	snprintf(test_file, sizeof(test_file), "%s/%s", dirname, TEST_FILE);
+	fd = creat(test_file, 0644);
+	if (fd == -1) {
+		pr_perror("cat't create %s", test_file);
+		return 1;
+	}
+	close(fd);
+
+	fd = open(test_file, O_PATH);
+	if (fd == -1) {
+		pr_perror("cat't open file %s with O_PATH", test_file);
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	if (parse_self_fdinfo(fd, &fi))
+		return 1;
+
+	if (!(fi.flags & O_PATH)) {
+		fail("File lost O_PATH open flag");
+		return 1;
+	}
+
+	close(fd);
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/symlink.c
+++ b/test/zdtm/static/symlink.c
@@ -1,0 +1,102 @@
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <limits.h>
+
+#include "zdtmtst.h"
+
+#define TEST_FILE "test_file"
+#define TEST_SYMLINK "test_symlink"
+
+const char *test_doc	= "Check open symlink preserved";
+const char *test_author	= "Pavel Tikhomirov <ptikhomirov@virtuozzo.com>";
+
+char *dirname;
+TEST_OPTION(dirname, string, "directory name", 1);
+
+int main(int argc, char **argv)
+{
+	char test_symlink[PATH_MAX];
+	char test_file[PATH_MAX];
+	char pathbuf[PATH_MAX];
+	struct stat stb, sta;
+	int ret, fd;
+
+	test_init(argc, argv);
+
+	if (mkdir(dirname, 0700)) {
+		pr_perror("can't make directory %s", dirname);
+		exit(1);
+	}
+
+	snprintf(test_file, sizeof(test_file), "%s/%s", dirname, TEST_FILE);
+	ret = creat(test_file, 0644);
+	if (ret == -1) {
+		pr_perror("cat't create %s", test_file);
+		return 1;
+	}
+	close(ret);
+
+	snprintf(test_symlink, sizeof(test_symlink), "%s/%s", dirname, TEST_SYMLINK);
+	ret = symlink(test_file, test_symlink);
+	if (ret == -1) {
+		pr_perror("cat't symlink to %s", test_symlink);
+		return 1;
+	}
+
+	fd = open(test_symlink, O_PATH | O_NOFOLLOW);
+	if (fd == -1) {
+		pr_perror("cat't open symlink %s", test_symlink);
+		return 1;
+	}
+
+	ret = fstat(fd, &sta);
+	if (ret == -1) {
+		pr_perror("cat't fstat %s", test_symlink);
+		return 1;
+	}
+
+	if (!S_ISLNK(sta.st_mode)) {
+		pr_perror("file is not symlink %s", test_symlink);
+		return 1;
+	}
+
+#ifdef ZDTM_UNLINK_SYMLINK
+	if (unlink(test_symlink)) {
+		pr_perror("can't unlink symlink %s", test_symlink);
+		return 1;
+	}
+#endif
+
+	test_daemon();
+	test_waitsig();
+
+	ret = fstat(fd, &stb);
+	if (ret == -1) {
+		fail("cat't fstat %s", test_symlink);
+		return 1;
+	}
+
+	if (!S_ISLNK(stb.st_mode)) {
+		fail("file is not symlink %s", test_symlink);
+		return 1;
+	}
+
+	ret = readlinkat(fd, "", pathbuf, sizeof(pathbuf) - 1);
+	if (ret < 0) {
+		fail("Can't readlinkat");
+		return 1;
+	}
+	pathbuf[ret] = 0;
+
+	if (strcmp(test_file, pathbuf)) {
+		fail("symlink points to %s but %s expected", pathbuf, test_file);
+		return 1;
+	}
+
+	close(fd);
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/symlink01.c
+++ b/test/zdtm/static/symlink01.c
@@ -1,0 +1,1 @@
+symlink.c


### PR DESCRIPTION
This patchset adds support c/r of opened O_PATH fds and symlinks (ghost symlinks also)

Extract from commit messages:
1. fown: Don't fail on dumping files opened wit O_PATH
O_PATH opened files are special: they have empty
file operations in kernel space, so there not that
much we can do with them, even setting position is
not allowed. Same applies to a signal number for
owner settings.

2. files: allow dumping opened symlinks
To really open symlink file and not the regular file below it, one needs
to do open with O_PATH|O_NOFOLLOW flags. Looks like systemd started to
open /etc/localtime symlink this way sometimes, and before that nobody
actually used this and thus we never supported this in CRIU.

3. zdtm: add a test on open symlink migration 