### PR TITLE
socket: Add c/r support for SO_LINGER and SO_OOBINLINE

### DIFF
--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -526,6 +526,7 @@ int restore_socket_opts(int sk, SkOptsEntry *soe)
 {
 	int ret = 0, val = 1;
 	struct timeval tv;
+	struct linger so_linger;
 	/* In kernel a bufsize value is doubled. */
 	u32 bufs[2] = { soe->so_sndbuf / 2, soe->so_rcvbuf / 2};
 
@@ -569,6 +570,12 @@ int restore_socket_opts(int sk, SkOptsEntry *soe)
 	if (soe->has_so_oobinline && soe->so_oobinline) {
 		pr_debug("\tset oobinline for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_OOBINLINE, &val);
+	}
+	if (soe->has_so_linger) {
+		pr_debug("\tset so_linger for socket\n");
+		so_linger.l_onoff = true;
+		so_linger.l_linger = soe->so_linger;
+		ret |= restore_opt(sk, SOL_SOCKET, SO_LINGER, &so_linger);
 	}
 	if (soe->has_so_keepalive && soe->so_keepalive) {
 		pr_debug("\tset keepalive for socket\n");
@@ -625,6 +632,7 @@ int dump_socket_opts(int sk, SkOptsEntry *soe)
 {
 	int ret = 0, val;
 	struct timeval tv;
+	struct linger so_linger = {0, 0};
 
 	ret |= dump_opt(sk, SOL_SOCKET, SO_SNDBUF, &soe->so_sndbuf);
 	ret |= dump_opt(sk, SOL_SOCKET, SO_RCVBUF, &soe->so_rcvbuf);
@@ -678,6 +686,12 @@ int dump_socket_opts(int sk, SkOptsEntry *soe)
 	ret |= dump_opt(sk, SOL_SOCKET, SO_OOBINLINE, &val);
 	soe->has_so_oobinline = true;
 	soe->so_oobinline = val ? true : false;
+
+	ret |= dump_opt(sk, SOL_SOCKET, SO_LINGER, &so_linger);
+	if (so_linger.l_onoff) {
+		soe->has_so_linger = true;
+		soe->so_linger = so_linger.l_linger;
+	}
 
 	ret |= dump_bound_dev(sk, soe);
 	ret |= dump_socket_filter(sk, soe);

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -566,6 +566,10 @@ int restore_socket_opts(int sk, SkOptsEntry *soe)
 		pr_debug("\tset broadcast for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_BROADCAST, &val);
 	}
+	if (soe->has_so_oobinline && soe->so_oobinline) {
+		pr_debug("\tset oobinline for socket\n");
+		ret |= restore_opt(sk, SOL_SOCKET, SO_OOBINLINE, &val);
+	}
 	if (soe->has_so_keepalive && soe->so_keepalive) {
 		pr_debug("\tset keepalive for socket\n");
 		ret |= restore_opt(sk, SOL_SOCKET, SO_KEEPALIVE, &val);
@@ -670,6 +674,10 @@ int dump_socket_opts(int sk, SkOptsEntry *soe)
 	ret |= dump_opt(sk, SOL_SOCKET, SO_KEEPALIVE, &val);
 	soe->has_so_keepalive = true;
 	soe->so_keepalive = val ? true : false;
+
+	ret |= dump_opt(sk, SOL_SOCKET, SO_OOBINLINE, &val);
+	soe->has_so_oobinline = true;
+	soe->so_oobinline = val ? true : false;
 
 	ret |= dump_bound_dev(sk, soe);
 	ret |= dump_socket_filter(sk, soe);

--- a/images/sk-opts.proto
+++ b/images/sk-opts.proto
@@ -28,6 +28,7 @@ message sk_opts_entry {
 	optional uint32		tcp_keepidle	= 21;
 	optional uint32		tcp_keepintvl	= 22;
 	optional uint32		so_oobinline	= 23;
+	optional uint32		so_linger	= 24;
 }
 
 enum sk_shutdown {

--- a/images/sk-opts.proto
+++ b/images/sk-opts.proto
@@ -27,6 +27,7 @@ message sk_opts_entry {
 	optional uint32		tcp_keepcnt	= 20;
 	optional uint32		tcp_keepidle	= 21;
 	optional uint32		tcp_keepintvl	= 22;
+	optional uint32		so_oobinline	= 23;
 }
 
 enum sk_shutdown {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -107,6 +107,7 @@ TST_NOFILE	:=				\
 		socket-tcp-syn-sent		\
 		socket-tcp-skip-in-flight	\
 		socket-tcp-keepalive		\
+		socket-linger			\
 		sock_opts00			\
 		sock_opts01			\
 		sk-unix-unconn			\

--- a/test/zdtm/static/sock_opts00.c
+++ b/test/zdtm/static/sock_opts00.c
@@ -12,7 +12,7 @@ const char *test_author	= "Pavel Emelyanov <xemul@parallels.com>";
 #define TEST_PORT 59687
 #define TEST_ADDR INADDR_ANY
 
-#define NOPTS	7
+#define NOPTS	8
 
 int main(int argc, char ** argv)
 {
@@ -26,6 +26,7 @@ int main(int argc, char ** argv)
 	vname[4] = SO_PASSSEC;
 	vname[5] = SO_DONTROUTE;
 	vname[6] = SO_NO_CHECK;
+	vname[7] = SO_OOBINLINE;
 
 	test_init(argc, argv);
 

--- a/test/zdtm/static/socket-linger.c
+++ b/test/zdtm/static/socket-linger.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc	= "Check SO_LINGER socket option";
+const char *test_author	= "Radostin Stoyanov <rstoyanov1@gmail.com>";
+
+int main(int argc, char **argv)
+{
+	int sk;
+	struct linger dump = {true, 30}, restore = {0, 0};
+	socklen_t optlen = sizeof(restore);
+
+	test_init(argc, argv);
+
+	sk = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (sk < 0) {
+		pr_perror("Can't create socket");
+		return 1;
+	}
+
+	if (setsockopt(sk, SOL_SOCKET, SO_LINGER, &dump, sizeof(dump)) < 0) {
+		pr_perror("setsockopt SO_LINGER");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	if (getsockopt(sk, SOL_SOCKET, SO_LINGER, &restore, &optlen) < 0) {
+		pr_perror("getsockopt SO_LINGER");
+		return 1;
+	}
+
+	if (restore.l_onoff != dump.l_onoff) {
+		fail("linger.l_onoff has incorrect value (%d != %d)",
+			restore.l_onoff, dump.l_onoff);
+		return 1;
+	}
+
+	if (restore.l_linger != dump.l_linger) {
+		fail("linger.l_linger has incorrect value (%d != %d)",
+			restore.l_linger, dump.l_linger);
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
This PR adds checkpoint/restore support for `SO_LINGER` and `SO_OOBINLINE` socket options.