### PR TITLE
image: core -- Reserve start_time field

### DIFF
--- a/images/core.proto
+++ b/images/core.proto
@@ -53,6 +53,8 @@ message task_core_entry {
 	//optional int32		tty_pgrp	= 17;
 
 	optional bool			child_subreaper	= 18;
+	// Reserved for container relative start time
+	//optional uint64		start_time	= 19;
 }
 
 message task_kobj_ids_entry {


### PR DESCRIPTION
To ensure consistency of runtime environment processes within a container need to see same start time values over suspend/resume cycles. We introduce new field to the core image structure to store start time of a dumped process. Later same value would be restored to a newly created task. In future the feature is likely to be pulled here, so we reserve field id in the core's protobuf descriptor.