### PR TITLE
[RFC] compel: add -ffreestanding to force gcc not to use builtin memcpy...

### DIFF
--- a/compel/src/main.c
+++ b/compel/src/main.c
@@ -21,7 +21,7 @@
 
 #define CFLAGS_DEFAULT_SET					\
 	"-Wstrict-prototypes "					\
-	"-fno-stack-protector -nostdlib -fomit-frame-pointer "
+	"-fno-stack-protector -nostdlib -fomit-frame-pointer -ffreestanding "
 
 #define COMPEL_CFLAGS_PIE	CFLAGS_DEFAULT_SET "-fpie"
 #define COMPEL_CFLAGS_NOPIC	CFLAGS_DEFAULT_SET "-fno-pic"


### PR DESCRIPTION
compel: add -ffreestanding to force gcc not to use builtin memcpy, memset

This patch fixes the problem with SSE (xmm) registers corruption on amd64
architecture. The problem was that gcc generates parasite blob that uses
xmm registers, but we don't preserve this registers in CRIU when injecting
parasite. Also, gcc, even with -nostdlib option uses builtin memcpy,
memset functions that optimized for amd64 and involves SSE registers.

It seems, that optimal solution is to use -ffreestanding gcc option
to compile parasite. This option implies -fno-builtin and also it designed
for OS kernels compilation/another code that suited to work on non-hosted
environments and could prevent future sumilar bugs.

To check that you amd64 CRIU build affected by this problem you could simply
objdump -dS criu/pie/parasite.o | grep xmm
Output should be empty.

Reported-by: Diyu Zhou <zhoudiyupku at gmail.com>
Signed-off-by: Alexander Mikhalitsyn <alexander.mikhalitsyn@virtuozzo.com>
Signed-off-by: Alexander Mikhalitsyn <alexander@mihalicyn.com>