### PR TITLE
ppc64le: remove register '1' from clobber list

### DIFF
--- a/compel/arch/ppc64/src/lib/include/uapi/asm/sigframe.h
+++ b/compel/arch/ppc64/src/lib/include/uapi/asm/sigframe.h
@@ -50,7 +50,7 @@ struct rt_sigframe {
 		"sc \n"						\
 		:						\
 		: "r"(new_sp)					\
-		: "1", "memory")
+		: "memory")
 
 #if _CALL_ELF != 2
 # error Only supporting ABIv2.

--- a/criu/arch/ppc64/include/asm/restore.h
+++ b/criu/arch/ppc64/include/asm/restore.h
@@ -21,7 +21,7 @@
 		: "r"(new_sp),						\
 		  "r"((unsigned long)restore_task_exec_start),		\
 		  "r"(task_args)					\
-		: "1", "3", "12")
+		: "3", "12")
 
 /* There is nothing to do since TLS is accessed through r13 */
 #define core_get_tls(pcore, ptls)


### PR DESCRIPTION
Compiling 'criu-dev' on Fedora 31 gives two errors about wrong clobber lists:
```
compel/include/uapi/compel/asm/sigframe.h:47:9: error: listing the stack pointer register ‘1’ in a clobber list is deprecated [-Werror=deprecated]
criu/arch/ppc64/include/asm/restore.h:14:2: error: listing the stack pointer register ‘1’ in a clobber list is deprecated [-Werror=deprecated]
```
There was also a bug report from Debian that CRIU does not build because of this.

Each of these errors comes with the following note:
```
note: the value of the stack pointer after an ‘asm’ statement must be the same as it was before the statement
```
As far as I understand it this should not be a problem in this cases as the code never returns anyway.

Running zdtm very seldom fails during `zdtm/static/cgroup_ifpriomap` with a double free or corruption. This happens not very often and I cannot verify if it happens without this patch. As CRIU does not build without the patch.