### PR TITLE
s390x: remove stack pointer from clobber list

### DIFF
--- a/compel/arch/s390/src/lib/include/uapi/asm/sigframe.h
+++ b/compel/arch/s390/src/lib/include/uapi/asm/sigframe.h
@@ -66,7 +66,7 @@ struct rt_sigframe {
 		"svc	0\n"					\
 		:						\
 		: "d" (new_sp)					\
-		: "15", "memory")
+		: "memory")
 
 #define RT_SIGFRAME_UC(rt_sigframe) (&rt_sigframe->uc)
 #define RT_SIGFRAME_REGIP(rt_sigframe) (rt_sigframe)->uc.uc_mcontext.regs.psw.addr

--- a/criu/arch/s390/include/asm/restore.h
+++ b/criu/arch/s390/include/asm/restore.h
@@ -18,7 +18,7 @@
 		: "d" (new_sp),						\
 		  "d"((unsigned long)restore_task_exec_start),		\
 		  "d" (task_args)					\
-		: "2", "14", "15", "memory")
+		: "2", "14", "memory")
 
 /* There is nothing to do since TLS is accessed through %a01 */
 #define core_get_tls(pcore, ptls)


### PR DESCRIPTION
Just like on all other supported architectures gcc complains about the stack pointer register being part of the clobber list: `error: listing the stack pointer register ‘15’ in a clobber list is deprecated [-Werror=deprecated]`

This removes the stack pointer from the clobber list.

`zdtm.py run -a` still runs without any errors after this change.