### PR TITLE
ppc64le: use clone3() if possible

### DIFF
--- a/criu/arch/ppc64/include/asm/restorer.h
+++ b/criu/arch/ppc64/include/asm/restorer.h
@@ -48,12 +48,46 @@
 		  "r"(&thread_args[i])		/* %6 */		\
 		: "memory","0","3","4","5","6","7","14","15")
 
-#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
-			      clone_restore_fn)	do { \
-	pr_err("This architecture does not support clone3() with set_tid, yet!\n"); \
-	pr_err("Not creating a process with PID: %d\n", ((pid_t *)u64_to_ptr(clone_args.set_tid))[0]); \
-	ret = -1; \
-} while (0)
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args,		\
+			      clone_restore_fn)				\
+/*
+ * The clone3() function accepts following parameters:
+ *   int clone3(struct clone_args *args, size_t size)
+ *
+ * Always consult the CLONE3 wrappers for other architectures
+ * for additional details.
+ *
+ * For PPC64LE the first parameter (clone_args) is passed in r3 and
+ * the second parameter (size) is passed in r4.
+ *
+ * This clone3() wrapper is based on the clone() wrapper from above.
+ */									\
+	asm volatile(							\
+		"clone3_emul:					\n"	\
+		"/* Save fn, args across syscall. */		\n"	\
+		"mr	14, %3	/* clone_restore_fn in r14 */	\n"	\
+		"mr	15, %4	/* &thread_args[i] in r15 */	\n"	\
+		"mr	3, %1	/* clone_args */		\n"	\
+		"mr	4, %2	/* size */			\n"	\
+		"li	0,"__stringify(__NR_clone3)"		\n"	\
+		"sc						\n"	\
+		"/* Check for child process. */			\n"	\
+		"cmpdi	cr1,3,0					\n"	\
+		"crandc	cr1*4+eq,cr1*4+eq,cr0*4+so		\n"	\
+		"bne-	cr1,clone3_end				\n"	\
+		"/* child */					\n"	\
+		"addi	14, 14, 8 /* jump over r2 fixup */	\n"	\
+		"mtctr	14					\n"	\
+		"mr	3,15					\n"	\
+		"bctr						\n"	\
+		"clone3_end:					\n"	\
+		"mr	%0,3					\n"	\
+		: "=r"(ret)			/* %0 */		\
+		: "r"(&clone_args),		/* %1 */		\
+		  "r"(size),			/* %2 */		\
+		  "r"(clone_restore_fn),	/* %3 */		\
+		  "r"(args)			/* %4 */		\
+		: "memory","0","3","4","5","14","15")
 
 #define arch_map_vdso(map, compat)		-1
 

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -992,10 +992,10 @@ static bool kerndat_has_clone3_set_tid(void)
 	pid_t pid;
 	struct _clone_args args = {};
 
-#if !defined(CONFIG_X86_64) && !defined(CONFIG_S390)
+#if !defined(CONFIG_X86_64) && !defined(CONFIG_S390) && !defined(CONFIG_PPC64)
 	/*
 	 * Currently the CRIU PIE assembler clone3() wrapper is
-	 * only implemented for X86_64 and S390X.
+	 * only implemented for X86_64, S390X and PPC64LE.
 	 */
 	kdat.has_clone3_set_tid = false;
 	return 0;


### PR DESCRIPTION
This adds the parasite clone3() with set_tid wrapper for ppc64le.

Almost the same as #911 and depends on #911

Also see #882 and #890