### PR TITLE
aarch64: use clone3() if possible

### DIFF
--- a/criu/arch/aarch64/include/asm/restorer.h
+++ b/criu/arch/aarch64/include/asm/restorer.h
@@ -42,12 +42,67 @@
 			  "r"(&thread_args[i])					\
 			: "x0", "x1", "x2", "x3", "x8", "memory")
 
-#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
-			      clone_restore_fn)	do { \
-	pr_err("This architecture does not support clone3() with set_tid, yet!\n"); \
-	pr_err("Not creating a process with PID: %d\n", ((pid_t *)u64_to_ptr(clone_args.set_tid))[0]); \
-	ret = -1; \
-} while (0)
+/*
+ * Based on sysdeps/unix/sysv/linux/aarch64/clone.S
+ *
+ * int clone(int (*fn)(void *arg),            x0
+ *	     void *child_stack,               x1
+ *	     int flags,                       x2
+ *	     void *arg,                       x3
+ *	     pid_t *ptid,                     x4
+ *	     struct user_desc *tls,           x5
+ *	     pid_t *ctid);                    x6
+ *
+ * int clone3(struct clone_args *args,        x0
+ *	      size_t size);                   x1
+ *
+ * Always consult the CLONE3 wrappers for other architectures
+ * for additional details.
+ *
+ */
+
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args,			\
+			      clone_restore_fn)					\
+	asm volatile(								\
+	/* In contrast to the clone() wrapper above this does not put
+	 * the thread function and its arguments on the child stack,
+	 * but uses registers to pass these parameters to the child process.
+	 * Based on the glibc clone() wrapper at
+	 * sysdeps/unix/sysv/linux/aarch64/clone.S.
+	 */									\
+			"clone3_emul:					\n"	\
+	/*
+	 * Based on the glibc clone() wrapper, which uses x10 and x11
+	 * to save the arguments for the child process, this does the same.
+	 * x10 for the thread function and x11 for the thread arguments.
+	 */									\
+			"mov x10, %3	/* clone_restore_fn */		\n"	\
+			"mov x11, %4	/* args */			\n"	\
+			"mov x0, %1	/* &clone_args */		\n"	\
+			"mov x1, %2	/* size */			\n"	\
+	/* Load syscall number */						\
+			"mov x8, #"__stringify(__NR_clone3)"		\n"	\
+	/* Do the syscall */							\
+			"svc #0						\n"	\
+										\
+			"cbz x0, clone3_thread_run			\n"	\
+										\
+			"mov %0, x0					\n"	\
+			"b   clone3_end					\n"	\
+										\
+			"clone3_thread_run:				\n"	\
+	/* Move args to x0 */							\
+			"mov x0, x11					\n"	\
+	/* Jump to clone_restore_fn */						\
+			"br  x10					\n"	\
+										\
+			"clone3_end:					\n"	\
+			: "=r"(ret)						\
+			: "r"(&clone_args),					\
+			  "r"(size),						\
+			  "r"(clone_restore_fn),				\
+			  "r"(args)						\
+			: "x0", "x1", "x8", "x10", "x11", "memory")
 
 #define ARCH_FAIL_CORE_RESTORE					\
 	asm volatile(						\

--- a/criu/arch/ppc64/include/asm/restorer.h
+++ b/criu/arch/ppc64/include/asm/restorer.h
@@ -48,12 +48,46 @@
 		  "r"(&thread_args[i])		/* %6 */		\
 		: "memory","0","3","4","5","6","7","14","15")
 
-#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
-			      clone_restore_fn)	do { \
-	pr_err("This architecture does not support clone3() with set_tid, yet!\n"); \
-	pr_err("Not creating a process with PID: %d\n", ((pid_t *)u64_to_ptr(clone_args.set_tid))[0]); \
-	ret = -1; \
-} while (0)
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args,		\
+			      clone_restore_fn)				\
+/*
+ * The clone3() function accepts following parameters:
+ *   int clone3(struct clone_args *args, size_t size)
+ *
+ * Always consult the CLONE3 wrappers for other architectures
+ * for additional details.
+ *
+ * For PPC64LE the first parameter (clone_args) is passed in r3 and
+ * the second parameter (size) is passed in r4.
+ *
+ * This clone3() wrapper is based on the clone() wrapper from above.
+ */									\
+	asm volatile(							\
+		"clone3_emul:					\n"	\
+		"/* Save fn, args across syscall. */		\n"	\
+		"mr	14, %3	/* clone_restore_fn in r14 */	\n"	\
+		"mr	15, %4	/* &thread_args[i] in r15 */	\n"	\
+		"mr	3, %1	/* clone_args */		\n"	\
+		"mr	4, %2	/* size */			\n"	\
+		"li	0,"__stringify(__NR_clone3)"		\n"	\
+		"sc						\n"	\
+		"/* Check for child process. */			\n"	\
+		"cmpdi	cr1,3,0					\n"	\
+		"crandc	cr1*4+eq,cr1*4+eq,cr0*4+so		\n"	\
+		"bne-	cr1,clone3_end				\n"	\
+		"/* child */					\n"	\
+		"addi	14, 14, 8 /* jump over r2 fixup */	\n"	\
+		"mtctr	14					\n"	\
+		"mr	3,15					\n"	\
+		"bctr						\n"	\
+		"clone3_end:					\n"	\
+		"mr	%0,3					\n"	\
+		: "=r"(ret)			/* %0 */		\
+		: "r"(&clone_args),		/* %1 */		\
+		  "r"(size),			/* %2 */		\
+		  "r"(clone_restore_fn),	/* %3 */		\
+		  "r"(args)			/* %4 */		\
+		: "memory","0","3","4","5","14","15")
 
 #define arch_map_vdso(map, compat)		-1
 

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -992,10 +992,10 @@ static bool kerndat_has_clone3_set_tid(void)
 	pid_t pid;
 	struct _clone_args args = {};
 
-#if !defined(CONFIG_X86_64) && !defined(CONFIG_S390)
+#if !defined(CONFIG_X86_64) && !defined(CONFIG_S390) && !defined(CONFIG_PPC64)
 	/*
 	 * Currently the CRIU PIE assembler clone3() wrapper is
-	 * only implemented for X86_64 and S390X.
+	 * only implemented for X86_64, S390X and PPC64LE.
 	 */
 	kdat.has_clone3_set_tid = false;
 	return 0;

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -992,10 +992,10 @@ static bool kerndat_has_clone3_set_tid(void)
 	pid_t pid;
 	struct _clone_args args = {};
 
-#if !defined(CONFIG_X86_64) && !defined(CONFIG_S390) && !defined(CONFIG_PPC64)
+#if !defined(CONFIG_X86_64) && !defined(CONFIG_S390) && !defined(CONFIG_PPC64) && !defined(CONFIG_AARCH64)
 	/*
 	 * Currently the CRIU PIE assembler clone3() wrapper is
-	 * only implemented for X86_64, S390X and PPC64LE.
+	 * only implemented for X86_64, S390X, AARCH64 and PPC64LE.
 	 */
 	kdat.has_clone3_set_tid = false;
 	return 0;


### PR DESCRIPTION
This adds the parasite clone3() with set_tid wrapper for aarch64.
    
Tested on Fedora 31 with 5.5.0-rc6.

Depends on #911 and #914 

Also see #882 and #890
