### PR TITLE
arm: remove stack pointer from clobber list

### DIFF
--- a/criu/arch/arm/include/asm/restore.h
+++ b/criu/arch/arm/include/asm/restore.h
@@ -16,7 +16,7 @@
 		     : "r"(new_sp),					\
 		       "r"(restore_task_exec_start),			\
 		       "r"(task_args)					\
-		     : "sp", "r0", "r1", "memory")
+		     : "r0", "r1", "memory")
 
 static inline void core_get_tls(CoreEntry *pcore, tls_t *ptls)
 {


### PR DESCRIPTION
Just like on all other supported architectures gcc complains about the stack pointer register being part of the clobber list. This removes the stack pointer from the clobber list.

Fixes: #913 

Only compile tested so far.