### PR TITLE
vdso: repair C/R on nodes with CONFIG_VDSO unset

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3389,7 +3389,7 @@ static int sigreturn_restore(pid_t pid, struct task_restore_args *task_args, uns
 	if (vdso_maps_rt.sym.vdso_size != VDSO_BAD_SIZE) {
 		vdso_rt_size = vdso_maps_rt.sym.vdso_size;
 		if (vdso_maps_rt.sym.vvar_size != VVAR_BAD_SIZE)
-			vdso_rt_size += ALIGN(vdso_maps_rt.sym.vvar_size, PAGE_SIZE);
+			vdso_rt_size += vdso_maps_rt.sym.vvar_size;
 	}
 	task_args->bootstrap_len += vdso_rt_size;
 

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3384,10 +3384,13 @@ static int sigreturn_restore(pid_t pid, struct task_restore_args *task_args, uns
 		vdso_maps_rt = vdso_maps;
 	/*
 	 * Figure out how much memory runtime vdso and vvar will need.
+	 * Check if vDSO or VVAR is not provided by kernel.
 	 */
-	vdso_rt_size = vdso_maps_rt.sym.vdso_size;
-	if (vdso_rt_size && vdso_maps_rt.sym.vvar_size)
-		vdso_rt_size += ALIGN(vdso_maps_rt.sym.vvar_size, PAGE_SIZE);
+	if (vdso_maps_rt.sym.vdso_size != VDSO_BAD_SIZE) {
+		vdso_rt_size = vdso_maps_rt.sym.vdso_size;
+		if (vdso_maps_rt.sym.vvar_size != VVAR_BAD_SIZE)
+			vdso_rt_size += ALIGN(vdso_maps_rt.sym.vvar_size, PAGE_SIZE);
+	}
 	task_args->bootstrap_len += vdso_rt_size;
 
 	/*

--- a/criu/include/util-vdso.h
+++ b/criu/include/util-vdso.h
@@ -41,6 +41,11 @@ struct vdso_maps {
 	bool			compatible;
 };
 
+static inline bool vdso_is_present(struct vdso_maps *m)
+{
+	return m->vdso_start != VDSO_BAD_ADDR;
+}
+
 #define VDSO_SYMBOL_INIT	{ .offset = VDSO_BAD_ADDR, }
 
 #define VDSO_SYMTABLE_INIT						\

--- a/criu/pie/parasite-vdso.c
+++ b/criu/pie/parasite-vdso.c
@@ -293,6 +293,18 @@ int vdso_proxify(struct vdso_maps *rt, bool *added_proxy,
 	}
 
 	/*
+	 * We could still do something about it here..
+	 * 1. Hope that vDSO from images still works (might not be the case).
+	 * 2. Try to map vDSO.
+	 * But, hopefully no one intends to migrate application that uses
+	 * vDSO to a dut where kernel doesn't provide it.
+	 */
+	if (!vdso_is_present(rt)) {
+		pr_err("vDSO isn't provided by kernel, but exists in images\n");
+		return -1;
+	}
+
+	/*
 	 * vDSO mark overwrites Elf program header of proxy vDSO thus
 	 * it must never ever be greater in size.
 	 */

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1454,7 +1454,7 @@ long __export_restore_task(struct task_restore_args *args)
 	 * it's presence in original task: vdso will be used for fast
 	 * getttimeofday() in restorer's log timings.
 	 */
-	if (!args->can_map_vdso) {
+	if (!args->can_map_vdso && vdso_is_present(&args->vdso_maps_rt)) {
 		/* It's already checked in kdat, but let's check again */
 		if (args->compatible_mode) {
 			pr_err("Compatible mode without vdso map support\n");

--- a/criu/vdso.c
+++ b/criu/vdso.c
@@ -611,6 +611,12 @@ int kerndat_vdso_fill_symtable(void)
 		return -1;
 	}
 
+	if (!vdso_is_present(&vdso_maps)) {
+		pr_debug("Kernel doesn't premap vDSO - probably CONFIG_VDSO is not set\n");
+		kdat.vdso_sym = vdso_maps.sym;
+		return 0;
+	}
+
 	if (vdso_fill_self_symtable(&vdso_maps)) {
 		pr_err("Failed to fill self vdso symtable\n");
 		return -1;
@@ -643,7 +649,7 @@ int kerndat_vdso_preserves_hint(void)
 
 	kdat.vdso_hint_reliable = 0;
 
-	if (vdso_maps.vdso_start == VDSO_BAD_ADDR)
+	if (!vdso_is_present(&vdso_maps))
 		return 0;
 
 	child = fork();
@@ -693,7 +699,7 @@ int kerndat_vdso_preserves_hint(void)
 		goto out_kill;
 	}
 
-	if (vdso_maps_after.vdso_start != VDSO_BAD_ADDR)
+	if (vdso_is_present(&vdso_maps_after))
 		kdat.vdso_hint_reliable = 1;
 
 	ret = 0;


### PR DESCRIPTION
Apparently, after removing `CONFIG_VDSO` ifdefs from CRIU, C/R was broken on !CONFIG_VDSO duts.
Much help provided by @adrianreber to test this.
Unfortunately, there doesn't seem to be a way to disable vdso in kernel, except `vdso=` boot cmdline or .config option. So, in the result zdtm is not covering this platform-related code.