### PR TITLE
arm/aarch64: use clone3() if possible

### DIFF
--- a/criu/arch/aarch64/include/asm/restorer.h
+++ b/criu/arch/aarch64/include/asm/restorer.h
@@ -42,12 +42,67 @@
 			  "r"(&thread_args[i])					\
 			: "x0", "x1", "x2", "x3", "x8", "memory")
 
-#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
-			      clone_restore_fn)	do { \
-	pr_err("This architecture does not support clone3() with set_tid, yet!\n"); \
-	pr_err("Not creating a process with PID: %d\n", ((pid_t *)u64_to_ptr(clone_args.set_tid))[0]); \
-	ret = -1; \
-} while (0)
+/*
+ * Based on sysdeps/unix/sysv/linux/aarch64/clone.S
+ *
+ * int clone(int (*fn)(void *arg),            x0
+ *	     void *child_stack,               x1
+ *	     int flags,                       x2
+ *	     void *arg,                       x3
+ *	     pid_t *ptid,                     x4
+ *	     struct user_desc *tls,           x5
+ *	     pid_t *ctid);                    x6
+ *
+ * int clone3(struct clone_args *args,        x0
+ *	      size_t size);                   x1
+ *
+ * Always consult the CLONE3 wrappers for other architectures
+ * for additional details.
+ *
+ */
+
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args,			\
+			      clone_restore_fn)					\
+	asm volatile(								\
+	/* In contrast to the clone() wrapper above this does not put
+	 * the thread function and its arguments on the child stack,
+	 * but uses registers to pass these parameters to the child process.
+	 * Based on the glibc clone() wrapper at
+	 * sysdeps/unix/sysv/linux/aarch64/clone.S.
+	 */									\
+			"clone3_emul:					\n"	\
+	/*
+	 * Based on the glibc clone() wrapper, which uses x10 and x11
+	 * to save the arguments for the child process, this does the same.
+	 * x10 for the thread function and x11 for the thread arguments.
+	 */									\
+			"mov x10, %3	/* clone_restore_fn */		\n"	\
+			"mov x11, %4	/* args */			\n"	\
+			"mov x0, %1	/* &clone_args */		\n"	\
+			"mov x1, %2	/* size */			\n"	\
+	/* Load syscall number */						\
+			"mov x8, #"__stringify(__NR_clone3)"		\n"	\
+	/* Do the syscall */							\
+			"svc #0						\n"	\
+										\
+			"cbz x0, clone3_thread_run			\n"	\
+										\
+			"mov %0, x0					\n"	\
+			"b   clone3_end					\n"	\
+										\
+			"clone3_thread_run:				\n"	\
+	/* Move args to x0 */							\
+			"mov x0, x11					\n"	\
+	/* Jump to clone_restore_fn */						\
+			"br  x10					\n"	\
+										\
+			"clone3_end:					\n"	\
+			: "=r"(ret)						\
+			: "r"(&clone_args),					\
+			  "r"(size),						\
+			  "r"(clone_restore_fn),				\
+			  "r"(args)						\
+			: "x0", "x1", "x8", "x10", "x11", "memory")
 
 #define ARCH_FAIL_CORE_RESTORE					\
 	asm volatile(						\

--- a/criu/arch/arm/include/asm/restorer.h
+++ b/criu/arch/arm/include/asm/restorer.h
@@ -43,12 +43,62 @@
 		       "r"(&thread_args[i])				\
 		     : "r0", "r1", "r2", "r3", "r7", "memory")
 
-#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
-			      clone_restore_fn)	do { \
-	pr_err("This architecture does not support clone3() with set_tid, yet!\n"); \
-	pr_err("Not creating a process with PID: %d\n", ((pid_t *)u64_to_ptr(clone_args.set_tid))[0]); \
-	ret = -1; \
-} while (0)
+
+/*
+ * The clone3() assembler wrapper is based on the clone() wrapper above
+ * and on code from the glibc wrapper at
+ * sysdeps/unix/sysv/linux/arm/clone.S
+ *
+ * For arm it is necessary to change the child stack as on x86_64 as
+ * it seems there are not registers which stay the same over a syscall
+ * like on s390x, ppc64le and aarch64.
+ *
+ * Changing the child stack means that this code has to deal with the
+ * kernel doing stack + stack_size implicitly.
+ *
+ * int clone3(struct clone_args *args, size_t size)
+ */
+
+#define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args,		\
+			      clone_restore_fn)				\
+	asm volatile(							\
+		"clone3_emul:					\n"	\
+	/* Load thread stack pointer */					\
+		"ldr r1, [%3]					\n"	\
+	/* Load thread stack size */					\
+		"mov r2, %4					\n"	\
+	/* Goto to the end of stack */					\
+		"add r1, r1, r2					\n"	\
+	/* Load thread function and arguments and push on stack */	\
+		"mov r2, %6		/* args */		\n"	\
+		"str r2, [r1, #4]	/* args */		\n"	\
+		"mov r2, %5		/* function */		\n"	\
+		"str r2, [r1]		/* function */		\n"	\
+		"mov r0, %1		/* clone_args */	\n"	\
+		"mov r1, %2		/* size */		\n"	\
+		"mov r7, #"__stringify(__NR_clone3)"		\n"	\
+		"svc #0						\n"	\
+									\
+		"cmp r0, #0					\n"	\
+		"beq thread3_run				\n"	\
+									\
+		"mov %0, r0					\n"	\
+		"b   clone3_end					\n"	\
+									\
+		"thread3_run:					\n"	\
+		"pop { r1 }					\n"	\
+		"pop { r0 }					\n"	\
+		"bx  r1						\n"	\
+									\
+		"clone3_end:					\n"	\
+			: "=r"(ret)					\
+			: "r"(&clone_args),				\
+			  "r"(size),					\
+			  "r"(&clone_args.stack),			\
+			  "r"(clone_args.stack_size),			\
+			  "r"(clone_restore_fn),			\
+			  "r"(args)					\
+			: "r0", "r1", "r2", "r7", "memory")
 
 #define ARCH_FAIL_CORE_RESTORE					\
 	asm volatile(						\

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -992,15 +992,6 @@ static bool kerndat_has_clone3_set_tid(void)
 	pid_t pid;
 	struct _clone_args args = {};
 
-#if !defined(CONFIG_X86_64) && !defined(CONFIG_S390) && !defined(CONFIG_PPC64) && !defined(CONFIG_AARCH64)
-	/*
-	 * Currently the CRIU PIE assembler clone3() wrapper is
-	 * only implemented for X86_64, S390X, AARCH64 and PPC64LE.
-	 */
-	kdat.has_clone3_set_tid = false;
-	return 0;
-#endif
-
 	args.set_tid = -1;
 	/*
 	 * On a system without clone3() this will return ENOSYS.

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -992,10 +992,10 @@ static bool kerndat_has_clone3_set_tid(void)
 	pid_t pid;
 	struct _clone_args args = {};
 
-#if !defined(CONFIG_X86_64) && !defined(CONFIG_S390) && !defined(CONFIG_PPC64)
+#if !defined(CONFIG_X86_64) && !defined(CONFIG_S390) && !defined(CONFIG_PPC64) && !defined(CONFIG_AARCH64)
 	/*
 	 * Currently the CRIU PIE assembler clone3() wrapper is
-	 * only implemented for X86_64, S390X and PPC64LE.
+	 * only implemented for X86_64, S390X, AARCH64 and PPC64LE.
 	 */
 	kdat.has_clone3_set_tid = false;
 	return 0;


### PR DESCRIPTION
This is the last architecture specific change to make CRIU use clone3() with set_tid if available. Just as on all other architectures this adds a clone3() based assembler wrapper to be used in the restorer code.

Tested on Fedora 31 with the same 5.5.0-rc6 kernel as on the other architectures.

Depends on the other architecture specific assembler wrapper pull request.