### PR TITLE
In tests check current working directory permissions in filesystem operations with absolute paths.

### DIFF
--- a/test/zdtm/lib/Makefile
+++ b/test/zdtm/lib/Makefile
@@ -4,7 +4,7 @@ CFLAGS	+= $(USERCFLAGS)
 
 LIB	:= libzdtmtst.a
 
-LIBSRC	:= datagen.c msg.c parseargs.c test.c streamutil.c lock.c ns.c tcp.c fs.c sysctl.c
+LIBSRC	:= datagen.c msg.c parseargs.c test.c streamutil.c lock.c ns.c tcp.c unix.c fs.c sysctl.c
 LIBOBJ	:= $(LIBSRC:%.c=%.o)
 
 BIN	:= groups

--- a/test/zdtm/lib/fs.c
+++ b/test/zdtm/lib/fs.c
@@ -94,3 +94,27 @@ err:
 	mnt_info_free(&m);
 	goto out;
 }
+
+int get_cwd_check_perm(char **result)
+{
+	char *cwd;
+	*result = 0;
+	cwd = get_current_dir_name();
+	if (!cwd) {
+		pr_perror("failed to get current directory");
+		return -1;
+	}
+
+	if (access(cwd, X_OK)) {
+		pr_err("access check for bit X for current dir path '%s' "
+		       "failed for uid:%d,gid:%d, error: %d(%s). "
+		       "Bit 'x' should be set in all path components of "
+		       "this directory\n",
+		       cwd, getuid(), getgid(), errno, strerror(errno)
+		);
+		return -1;
+	}
+
+	*result = cwd;
+	return 0;
+}

--- a/test/zdtm/lib/fs.h
+++ b/test/zdtm/lib/fs.h
@@ -50,4 +50,28 @@ extern mnt_info_t *mnt_info_alloc(void);
 extern void mnt_info_free(mnt_info_t **m);
 extern mnt_info_t *get_cwd_mnt_info(void);
 
+/*
+ * get_cwd_check_perm is called to check that cwd is actually usable for a calling
+ * process.
+ *
+ * Example output of a stat command on a '/root' path shows file access bits:
+ * > stat /root
+ * File: ‘/root’
+ *   ...
+ *   Access: (0550/dr-xr-x---) Uid: (  0/root)   Gid: (  0/root)
+ *                          ^- no 'x' bit for other
+ *
+ * Here we can see that '/root' dir (that often can be part of cwd path) does not
+ * allow non-root user and non-root group to list contents of this directory.
+ * Calling process matching 'other' access category may succeed getting cwd path, but will
+ * fail performing further filesystem operations based on this path with confusing errors.
+ *
+ * This function calls get_current_dir_name and explicitly checks that bit 'x' is enabled for
+ * a calling process and logs the error.
+ *
+ * If check passes, stores get_current_dir's result in *result and returns 0
+ * If check fails, stores 0 in *result and returns -1
+ */
+extern int get_cwd_check_perm(char **result);
+
 #endif /* ZDTM_FS_H_ */

--- a/test/zdtm/lib/unix.c
+++ b/test/zdtm/lib/unix.c
@@ -1,0 +1,19 @@
+#include <sys/socket.h>
+#include <sys/un.h>
+#include "zdtmtst.h"
+#include "fs.h"
+
+int unix_fill_sock_name(struct sockaddr_un *name, char *relFilename)
+{
+	char *cwd;
+
+	if (get_cwd_check_perm(&cwd)) {
+		pr_err("failed to get current working directory with valid permissions.\n");
+		return -1;
+	}
+
+	name->sun_family = AF_LOCAL;
+	ssprintf(name->sun_path, "%s/%s", cwd, relFilename);
+	return 0;
+}
+

--- a/test/zdtm/lib/zdtmtst.h
+++ b/test/zdtm/lib/zdtmtst.h
@@ -149,6 +149,9 @@ extern int tcp_init_server(int family, int *port);
 extern int tcp_accept_server(int sock);
 extern int tcp_init_client(int family, char *servIP, unsigned short servPort);
 
+struct sockaddr_un;
+extern int unix_fill_sock_name(struct sockaddr_un *name, char *relFilename);
+
 struct zdtm_tcp_opts {
 	bool reuseaddr;
 	bool reuseport;

--- a/test/zdtm/static/del_standalone_un.c
+++ b/test/zdtm/static/del_standalone_un.c
@@ -16,19 +16,6 @@ const char *test_author	= "Tycho Andersen <tycho.andersen@canonical.com>";
 char *dirname;
 TEST_OPTION(dirname, string, "directory name", 1);
 
-static int fill_sock_name(struct sockaddr_un *name, const char *filename)
-{
-	char *cwd;
-
-	cwd = get_current_dir_name();
-	if (strlen(filename) + strlen(cwd) + 1 >= sizeof(name->sun_path))
-		return -1;
-
-	name->sun_family = AF_LOCAL;
-	ssprintf(name->sun_path, "%s/%s", cwd, filename);
-	return 0;
-}
-
 static int bind_and_listen(struct sockaddr_un *addr)
 {
 	int sk;
@@ -71,10 +58,8 @@ int main(int argc, char **argv)
 		goto out;
 	}
 
-	if (fill_sock_name(&addr, filename) < 0) {
-		pr_err("filename \"%s\" is too long\n", filename);
+	if (unix_fill_sock_name(&addr, filename))
 		goto out;
-	}
 
 	sk1 = bind_and_listen(&addr);
 	if (sk1 < 0)

--- a/test/zdtm/static/deleted_unix_sock.c
+++ b/test/zdtm/static/deleted_unix_sock.c
@@ -17,28 +17,13 @@ const char *test_author	= "Roman Kagan <rkagan@parallels.com>";
 char *filename;
 TEST_OPTION(filename, string, "file name", 1);
 
-static int fill_sock_name(struct sockaddr_un *name, const char *filename)
-{
-	char *cwd;
-
-	cwd = get_current_dir_name();
-	if (strlen(filename) + strlen(cwd) + 1 >= sizeof(name->sun_path))
-		return -1;
-
-	name->sun_family = AF_LOCAL;
-	sprintf(name->sun_path, "%s/%s", cwd, filename);
-	return 0;
-}
-
 static int setup_srv_sock(void)
 {
 	struct sockaddr_un name;
 	int sock;
 
-	if (fill_sock_name(&name, filename) < 0) {
-		pr_perror("filename \"%s\" is too long", filename);
+	if (unix_fill_sock_name(&name, filename))
 		return -1;
-	}
 
 	sock = socket(PF_LOCAL, SOCK_STREAM, 0);
 	if (sock < 0) {
@@ -67,7 +52,7 @@ static int setup_clnt_sock(void)
 	struct sockaddr_un name;
 	int sock;
 
-	if (fill_sock_name(&name, filename) < 0)
+	if (unix_fill_sock_name(&name, filename))
 		return -1;
 
 	sock = socket(PF_LOCAL, SOCK_STREAM, 0);

--- a/test/zdtm/static/sk-unix01.c
+++ b/test/zdtm/static/sk-unix01.c
@@ -24,22 +24,6 @@ const char *test_author	= "Cyrill Gorcunov <gorcunov@openvz.org>";
 char *dirname;
 TEST_OPTION(dirname, string, "directory name", 1);
 
-static int fill_sock_name(struct sockaddr_un *name, const char *filename)
-{
-	char *cwd;
-
-	cwd = get_current_dir_name();
-	if (strlen(filename) + strlen(cwd) + 1 >= sizeof(name->sun_path)) {
-		pr_err("Name %s/%s is too long for socket\n",
-		       cwd, filename);
-		return -1;
-	}
-
-	name->sun_family = AF_LOCAL;
-	ssprintf(name->sun_path, "%s/%s", cwd, filename);
-	return 0;
-}
-
 static int sk_alloc_bind(int type, struct sockaddr_un *addr)
 {
 	int sk;
@@ -155,10 +139,9 @@ int main(int argc, char **argv)
 	 */
 
 	ssprintf(filename, "%s/%s", subdir_dg, "sk-dt");
-	if (fill_sock_name(&addr, filename) < 0) {
-		pr_err("%s is too long for socket\n", filename);
+	if (unix_fill_sock_name(&addr, filename))
 		return 1;
-	}
+
 	unlink(addr.sun_path);
 
 	sk_dgram[0] = sk_alloc_bind(SOCK_DGRAM, &addr);
@@ -184,10 +167,9 @@ int main(int argc, char **argv)
 	test_msg("sk-dt: alloc/connect/unlink %d %s\n", sk_dgram[3], addr.sun_path);
 
 	ssprintf(filename, "%s/%s", dirname, "sole");
-	if (fill_sock_name(&addr, filename) < 0) {
-		pr_err("%s is too long for socket\n", filename);
+	if (unix_fill_sock_name(&addr, filename))
 		return 1;
-	}
+
 	unlink(addr.sun_path);
 
 	sk_dgram[4] = sk_alloc_bind(SOCK_DGRAM, &addr);
@@ -237,7 +219,7 @@ int main(int argc, char **argv)
 		 sk_dgram_pair[0], sk_dgram_pair[1]);
 	ssprintf(filename, "%s/%s", subdir_dg, "sk-dtp");
 
-	if (fill_sock_name(&addr, filename) < 0) {
+	if (unix_fill_sock_name(&addr, filename)) {
 		pr_err("%s is too long for socket\n", filename);
 		return 1;
 	}
@@ -270,10 +252,9 @@ int main(int argc, char **argv)
 	 *  - delete socket on fs
 	 */
 	ssprintf(filename, "%s/%s", subdir_st, "sk-st");
-	if (fill_sock_name(&addr, filename) < 0) {
-		pr_err("%s is too long for socket\n", filename);
+	if (unix_fill_sock_name(&addr, filename))
 		return 1;
-	}
+
 	unlink(addr.sun_path);
 
 	sk_st[0] = sk_alloc_bind(SOCK_STREAM, &addr);


### PR DESCRIPTION
Any filesystem syscall, that needs to navigate to inode by it's
absolute path performs successive lookup operations for each part of the
path. Lookup operation includes access rights check.
Usually but not always zdtm tests processes fall under 'other' access
category. Also, usually directories don't have 'x' bit set for other.
In case when bit 'x' is not set and user-ID and group-ID of a process
relate it to 'other', test's will not succeed in performing these
syscalls which are most of filesystem api, that has const char *path
as part of it arguments (open, openat, mkdir, bind, etc).
The observable behavior of that is that zdtm tests fail at file
creation ops on one system and pass on the other. The above is not
immediately clear to the developer by just looking at failed test's logs.
Investigation of that is also not quick for a developer due to the
complex structure of zdtm runtime where nested clones with
NAMESPACE flags take place alongside with bind-mounts.

As an additional note: 'get_current_dir_name' is documented as returning
EACCESS in case when some part of the path lacks read/list permissions.
But in fact it's not always so. Practice shows, that test processes can
get false success on this operation only to fail on later call to
something like mkdir/mknod/bind with a given path in arguments.

'get_cwd_check_perm' is a wrapper around 'get_current_dir_name'. It also
checks for permissions on the given filepath and logs the error. This
directs the developer towards the right investigation path or even
eliminates the need for investigation completely.

In the same PR added helper function that uses the above wrapper
to create absolute paths for a unix socket's with filling of sockaddr_un structre.
initialize unix socket address to an absolute file path, derived from
current working directory of the test + relative filename of a resulting
socket. Because the former code used cwd = get_current_dir_name() as
part of absolute filename generation, the resulting filepath could later
cause failure of bind systcall due to unchecked permissions and
introduce confusing permission errors.