### PR TITLE
travis: fix warning and errors from validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-sudo: required
+os: linux
 dist: bionic
 cache: ccache
 services:
@@ -12,7 +12,7 @@ env:
   - TR_ARCH=x86_64
   - TR_ARCH=x86_64      CLANG=1
   - TR_ARCH=openj9-test
-matrix:
+jobs:
   include:
     - os: linux
       arch: ppc64le


### PR DESCRIPTION
This fixes the validation errors from Travis:

 Build config validation
 root: deprecated key sudo (The key `sudo` has no effect anymore.)
 root: missing os, using the default linux
 root: key matrix is an alias for jobs, using jobs