### PR TITLE
Use cgroup v2 freezer if detected

### DIFF
--- a/criu/filesystems.c
+++ b/criu/filesystems.c
@@ -748,6 +748,11 @@ static struct fstype fstypes[] = {
 		.parse = cgroup_parse,
 		.sb_equal = cgroup_sb_equal,
 	}, {
+		.name = "cgroup2",
+		.code = FSTYPE__CGROUP2,
+		.parse = cgroup_parse,
+		.sb_equal = cgroup_sb_equal,
+	}, {
 		.name = "aufs",
 		.code = FSTYPE__AUFS,
 		.parse = aufs_parse,

--- a/images/mnt.proto
+++ b/images/mnt.proto
@@ -28,6 +28,8 @@ enum fstype {
 	// RPC_PIPEFS		= 20;
 	// NFS			= 21;
 	// NFS4			= 22;
+
+	CGROUP2			= 23;
 };
 
 message mnt_entry {


### PR DESCRIPTION
With these changes I am able to use runc again on a cgroup v2 system. I am also preparing a small runc patch to fall back to non-freezer based checkpointing if necessary.