### PR TITLE
Travis: fix podman test case

### DIFF
--- a/scripts/travis/podman-test.sh
+++ b/scripts/travis/podman-test.sh
@@ -39,12 +39,12 @@ for i in `seq 20`; do
 	echo "Test $i for podman container checkpoint"
 	podman exec cr ps axf
 	podman logs cr
-	[ `podman ps -f name=cr -q | wc -l` -eq "1" ]
+	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
 	podman container checkpoint cr
-	[ `podman ps -f name=cr -q | wc -l` -eq "0" ]
+	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "0" ]
 	podman ps -a
 	podman container restore cr
-	[ `podman ps -f name=cr -q | wc -l` -eq "1" ]
+	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
 	podman logs cr
 done
 
@@ -53,16 +53,16 @@ for i in `seq 20`; do
 	podman ps -a
 	podman exec cr ps axf
 	podman logs cr
-	[ `podman ps -f name=cr -q | wc -l` -eq "1" ]
+	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
 	podman container checkpoint -l --export /tmp/chkpt.tar.gz
-	[ `podman ps -f name=cr -q | wc -l` -eq "0" ]
+	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "0" ]
 	podman ps -a
 	podman rm -fa
 	podman ps -a
 	podman container restore --import /tmp/chkpt.tar.gz
-	[ `podman ps -f name=cr -q | wc -l` -eq "1" ]
+	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
 	podman container restore --name cr2 --import /tmp/chkpt.tar.gz
-	[ `podman ps -f name=cr2 -q | wc -l` -eq "1" ]
+	[ `podman ps -f name=cr2 -q -f status=running | wc -l` -eq "1" ]
 	podman ps -a
 	podman logs cr
 	podman logs cr2
@@ -70,7 +70,7 @@ for i in `seq 20`; do
 	podman rm -fa
 	podman ps -a
 	podman container restore --import /tmp/chkpt.tar.gz
-	[ `podman ps -f name=cr -q | wc -l` -eq "1" ]
+	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
 	podman ps -a
 	rm -f /tmp/chkpt.tar.gz
 done


### PR DESCRIPTION
Podman changed the output of 'podman ps'. For the test only running containers are interesting. Adding the filter '-f status=running' only returns running containers as previously.