### PR TITLE
 criu(8): Add documentation for --enable-fs 

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -90,6 +90,19 @@ The following levels are available:
 *-L*, *--libdir* 'path'::
     Path to plugins directory.
 
+*--enable-fs* ['fs'[,'fs'...]]::
+    Specify a comma-separated list of filesystem names that should
+    be auto-detected. The value 'all' enables auto-detection for
+    all filesystems.
++
+Note: This option is not safe, use at your own risk.
+Auto-detecting a filesystem mount assumes that the mountpoint can
+be restored with *mount(src, mountpoint, flags, options)*. When used,
+*dump* is expected to always succeed if a mountpoint is to be
+auto-detected, however *restore* may fail (or do something wrong)
+if the assumption for restore logic is incorrect. This option is
+not compatable with *--external* *dev*.
+
 *--action-script* 'script'::
     Add an external action script to be executed at certain stages.
     The environment variable *CRTOOLS_SCRIPT_ACTION* is available

--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -477,7 +477,7 @@ The 'mode' may be one of the following:
 
     *soft*:::   Restore cgroup properties if only cgroup has been created
                 by *criu*, otherwise do not restore properties. This is the
-		default if mode is unspecified.
+                default if mode is unspecified.
 
     *full*:::   Always restore all cgroups and their properties.
 
@@ -575,17 +575,17 @@ check* always checks Category 1 features unless *--feature* is specified
 which only checks a specified feature.
 
 *Category 1*::: Absolutely required. These are features like support for
-		*/proc/PID/map_files*, *NETLINK_SOCK_DIAG* socket
-		monitoring, */proc/sys/kernel/ns_last_pid* etc.
+        */proc/PID/map_files*, *NETLINK_SOCK_DIAG* socket
+        monitoring, */proc/sys/kernel/ns_last_pid* etc.
 
 *Category 2*::: Required only for specific cases. These are features
-		like AIO remap, */dev/net/tun* and others that are only
-		required if a process being dumped or restored
-		is using those.
+        like AIO remap, */dev/net/tun* and others that are only
+        required if a process being dumped or restored
+        is using those.
 
 *Category 3*::: Experimental. These are features like *task-diag* that
-		are used for experimental purposes (mostly
-		during development).
+        are used for experimental purposes (mostly
+        during development).
 
 If there are no errors or warnings, *criu* prints "Looks good." and its
 exit code is 0.


### PR DESCRIPTION
This option was introduced with commit https://github.com/checkpoint-restore/criu/commit/e2c38245c613df5e36dcf0253c7652f928e46abf.