### PR TITLE
MAINTAINERS: add Mike

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,3 @@
 Pavel Emelyanov <ovzxemul@gmail.com> (chief)
 Andrey Vagin <avagin@gmail.com>
+Mike Rapoport <rppt@kernel.org>


### PR DESCRIPTION
The following changes since commit 872b795a5678d82a415419e139d680cbf81391ff:

  Maintainers: Suggest the maintainers codex (#932) (2020-02-21 18:48:41 +0300)

are available in the Git repository at:

  https://github.com/rppt/criu maint

for you to fetch changes up to a7903240259af2e66ab8896cd39bf4e0f912b63a:

  MAINTAINERS: add Mike (2020-02-26 20:35:12 +0200)

----------------------------------------------------------------
Mike Rapoport (1):
      MAINTAINERS: add Mike

 MAINTAINERS | 1 +
 1 file changed, 1 insertion(+)
