### PR TITLE
[RFC] MAINTAINERS: add (myself) Alexander Mikhalitsyn

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,3 @@
 Pavel Emelyanov <ovzxemul@gmail.com> (chief)
 Andrey Vagin <avagin@gmail.com>
+Alexander Mikhalitsyn <alexander@mihalicyn.com> <alexander.mikhalitsyn@virtuozzo.com>


### PR DESCRIPTION
This is my self-proposal as a maintainer to the CRIU project.
It would be more honest if there was a role of "maintainer assistant"
or "maintainer candidate" and I would fit better in that position.
I've not so much experience in the project, but I will be glad to help project
in submitting / reviewing patches and reducing the workload to other more
experienced maintainers with reviewing patches.

Moreover, I have a full-time job in Virtuozzo where we
are working on CRIU. And CRIU is a key part of our product. So, it means,
that I have a lot of time to work on CRIU not only on my spare-time :)

So, I will be glad to receive comments / reactions / rejections ( :) )
from all members of our great project about my self-proposal.

Regards, Alex

Signed-off-by: Alexander Mikhalitsyn <alexander.mikhalitsyn@virtuozzo.com>
Signed-off-by: Alexander Mikhalitsyn <alexander@mihalicyn.com>