### PR TITLE
zdtm/inhfd: force python to read new data from a file

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -697,7 +697,10 @@ class inhfd_test:
                     # regular files, so we loop.
                     data = b''
                     while not data:
-                        data = peer_file.read(16)
+                        # In python 2.7, peer_file.read() doesn't call the read
+                        # system call if it's read file to the end once. The
+                        # next seek allows to workaround this problem.
+                        data = os.read(peer_file.fileno(), 16)
                         time.sleep(0.1)
                 except Exception as e:
                     print("Unable to read a peer file: %s" % e)


### PR DESCRIPTION
python 2.7 doesn't call the read system call if it's read file to the
end once. The next seek allows to workaround this problem.

inhfd/memfd.py hangs due to this issue.

Reported-by: Mr Jenkins
Signed-off-by: Andrei Vagin <avagin@gmail.com>