### PR TITLE
memfd: use __open_proc instead of open("/proc/...", ... )

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -819,14 +819,12 @@ static int dump_ghost_file(int _fd, u32 id, const struct stat *st, dev_t phys_de
 
 	if (S_ISREG(st->st_mode)) {
 		int fd, ret;
-		char lpath[PSFDS];
 
 		/*
 		 * Reopen file locally since it may have no read
 		 * permissions when drained
 		 */
-		sprintf(lpath, "/proc/self/fd/%d", _fd);
-		fd = open(lpath, O_RDONLY);
+		fd = open_proc(PROC_SELF, "fd/%d", _fd);
 		if (fd < 0) {
 			pr_perror("Can't open ghost original file");
 			goto err_out;

--- a/criu/memfd.c
+++ b/criu/memfd.c
@@ -299,7 +299,6 @@ static int memfd_open_inode(struct memfd_inode *inode)
 
 int memfd_open(struct file_desc *d, u32 *fdflags)
 {
-	char lpath[PSFDS];
 	struct memfd_info *mfi;
 	MemfdFileEntry *mfe;
 	int fd, _fd;
@@ -318,14 +317,13 @@ int memfd_open(struct file_desc *d, u32 *fdflags)
 		goto err;
 
 	/* Reopen the fd with original permissions */
-	sprintf(lpath, "/proc/self/fd/%d", fd);
 	flags = fdflags ? *fdflags : mfe->flags;
 	/*
 	 * Ideally we should call compat version open() to not force the
 	 * O_LARGEFILE file flag with regular open(). It doesn't seem that
 	 * important though.
 	 */
-	_fd = open(lpath, flags);
+	_fd = __open_proc(getpid(), 0, flags, "fd/%d", fd);
 	if (_fd < 0) {
 		pr_perror("Can't reopen memfd id=%d", mfe->id);
 		goto err;


### PR DESCRIPTION
Processes can run in a mount namespace without /proc.

Fixes #970 

```
$ python test/zdtm.py run --iter 2  -t zdtm/static/clean_mntns 
=== Run 1/1 ================ zdtm/static/clean_mntns
====================== Run zdtm/static/clean_mntns in ns =======================
Start test
Test is SUID
./clean_mntns --pidfile=clean_mntns.pid --outfile=clean_mntns.out
Run criu dump
Run criu restore
Run criu dump
Run criu restore
=[log]=> dump/zdtm/static/clean_mntns/51/2/restore.log
------------------------ grep Error ------------------------
b'(00.100914)      4: pr167872-3 Read 0 1 pages'
b'(00.100915)      1: `- render 1 iovs (0x7f60da7c0000:4096...)'
b'(00.100927)      4: \tpr167872-3 Read page from self 0/0'
b'(00.100961)      1: Restore via sigreturn'
b"(00.101052)      4: Error (criu/memfd.c:330): Can't reopen memfd id=8: No such file or directory"
b"(00.101069)      4: Error (criu/mem.c:1383): `- Can't open vma"
b'(00.101988)      1: Error (criu/cr-restore.c:1475): 4 exited, status=1'
```