### PR TITLE
travis: add ppc64-cross test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,10 @@ jobs:
       arch: amd64
       env: TR_ARCH=aarch64-cross
       dist: bionic
+    - os: linux
+      arch: amd64
+      env: TR_ARCH=ppc64-cross
+      dist: bionic
   allow_failures:
     - env: TR_ARCH=docker-test
     - env: TR_ARCH=docker-test DIST=xenial

--- a/scripts/build/Dockerfile.ppc64-cross
+++ b/scripts/build/Dockerfile.ppc64-cross
@@ -1,0 +1,45 @@
+FROM dockcross/base:latest
+
+# Add the cross compiler sources
+RUN echo "deb http://ftp.us.debian.org/debian/ buster main" >> /etc/apt/sources.list && \
+  dpkg --add-architecture ppc64el && \
+  apt-get install emdebian-archive-keyring
+
+RUN apt-get update && apt-get install -y \
+	crossbuild-essential-ppc64el	\
+	libc6-dev-ppc64el-cross		\
+	libc6-ppc64el-cross		\
+	libbz2-dev:ppc64el		\
+	libexpat1-dev:ppc64el		\
+	ncurses-dev:ppc64el		\
+	libssl-dev:ppc64el		\
+	protobuf-c-compiler		\
+	protobuf-compiler		\
+	python-protobuf			\
+	libnl-3-dev:ppc64el		\
+	libprotobuf-dev:ppc64el		\
+	libnet-dev:ppc64el		\
+	libprotobuf-c-dev:ppc64el		\
+	libcap-dev:ppc64el		\
+	libaio-dev:ppc64el		\
+	libnl-route-3-dev:ppc64el
+
+ENV CROSS_TRIPLE=powerpc64le-linux-gnu
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-				\
+	CROSS_ROOT=/usr/${CROSS_TRIPLE}				\
+	AS=/usr/bin/${CROSS_TRIPLE}-as				\
+	AR=/usr/bin/${CROSS_TRIPLE}-ar				\
+	CC=/usr/bin/${CROSS_TRIPLE}-gcc				\
+	CPP=/usr/bin/${CROSS_TRIPLE}-cpp			\
+	CXX=/usr/bin/${CROSS_TRIPLE}-g++			\
+	LD=/usr/bin/${CROSS_TRIPLE}-ld				\
+	FC=/usr/bin/${CROSS_TRIPLE}-gfortran
+
+ENV PATH="${PATH}:${CROSS_ROOT}/bin"				\
+	PKG_CONFIG_PATH=/usr/lib/${CROSS_TRIPLE}/pkgconfig	\
+	ARCH=ppc64
+
+COPY . /criu
+WORKDIR /criu
+
+RUN	make mrproper && date && make -j $(nproc) zdtm && date

--- a/scripts/build/Makefile
+++ b/scripts/build/Makefile
@@ -2,7 +2,7 @@ ARCHES := x86_64 fedora-asan fedora-rawhide centos armv7hf
 TARGETS := $(ARCHES) alpine
 TARGETS_CLANG := $(addsuffix $(TARGETS),-clang)
 CONTAINER_RUNTIME := docker
-TARGETS += armv7-cross aarch64-cross
+TARGETS += armv7-cross aarch64-cross ppc64-cross
 
 all: $(TARGETS) $(TARGETS_CLANG)
 .PHONY: all


### PR DESCRIPTION
Now when @0x7f454c46 did the heavy lifting of resolving compel headers mess, it's easy to add another cross-build target :)