### PR TITLE
crit-recode: skip (not try to parse) nftables raw image

### DIFF
--- a/test/crit-recode.py
+++ b/test/crit-recode.py
@@ -47,6 +47,8 @@ for imgf in find.stdout.readlines():
         continue
     if imgf_b.startswith(b'ip6tables-'):
         continue
+    if imgf_b.startswith(b'nftables-'):
+        continue
     if imgf_b.startswith(b'route-'):
         continue
     if imgf_b.startswith(b'route6-'):


### PR DESCRIPTION
Reported-by: Mr Jenkins

fix tests https://ci.openvz.org/job/CRIU/job/CRIU-crit/job/criu-dev/6027/consoleText