### PR TITLE
Add build directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ lib/.crit-setup.files
 compel/include/asm
 include/common/asm
 include/common/config.h
+build/


### PR DESCRIPTION
After running make install, build directory is generated but not ignored
in gitignore. So this commit add build directory to gitignore.

Signed-off-by: Byeonggon Lee <gonny952@gmail.com>