### PR TITLE
mem: dump shared memory file descriptors

### DIFF
--- a/criu/files.c
+++ b/criu/files.c
@@ -552,7 +552,7 @@ static int dump_one_file(struct pid *pid, int fd, int lfd, struct fd_opts *opts,
 
 		p.link = &link;
 
-		if (is_memfd(p.stat.st_dev, &link.name[1]))
+		if (is_memfd(p.stat.st_dev))
 			ops = &memfd_dump_ops;
 		else if (link.name[1] == '/')
 			ops = &regfile_dump_ops;

--- a/criu/include/memfd.h
+++ b/criu/include/memfd.h
@@ -8,7 +8,7 @@
 struct fd_parms;
 struct file_desc;
 
-extern int is_memfd(dev_t dev, const char *path);
+extern int is_memfd(dev_t dev);
 extern int dump_one_memfd_cond(int lfd, u32 *id, struct fd_parms *parms);
 extern const struct fdtype_ops memfd_dump_ops;
 

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -584,6 +584,14 @@ static int handle_vma(pid_t pid, struct vma_area *vma_area,
 		vma_area->e->shmid = prev->e->shmid;
 		vma_area->vmst = prev->vmst;
 		vma_area->mnt_id = prev->mnt_id;
+
+		if (!(vma_area->e->status & VMA_AREA_SYSVIPC)) {
+			vma_area->e->status &= ~(VMA_FILE_PRIVATE | VMA_FILE_SHARED);
+			if (vma_area->e->flags & MAP_PRIVATE)
+				vma_area->e->status |= VMA_FILE_PRIVATE;
+			else
+				vma_area->e->status |= VMA_FILE_SHARED;
+		}
 	} else if (*vm_file_fd >= 0) {
 		struct stat *st_buf = vma_area->vmst;
 

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -305,7 +305,7 @@ static int vma_get_mapfile_user(const char *fname, struct vma_area *vma,
 
 	vfi_dev = makedev(vfi->dev_maj, vfi->dev_min);
 
-	if (is_memfd(vfi_dev, fname)) {
+	if (is_memfd(vfi_dev)) {
 		struct fd_link link;
 		link.len = strlen(fname);
 		strlcpy(link.name, fname, sizeof(link.name));
@@ -596,39 +596,21 @@ static int handle_vma(pid_t pid, struct vma_area *vma_area,
 			goto err;
 		}
 
-		/*
-		 * /dev/zero stands for anon-shared mapping
-		 * otherwise it's some file mapping.
-		 *
-		 * We treat memfd mappings as regular file mappings because
-		 * their backing can be seen as files, which is easy to
-		 * support. So even though memfd is an anonymous shmem, we
-		 * treat it differently.
-		 * Note: maybe we should revisit this as /proc/map_files/<vma>
-		 * may not always be accessible.
-		 */
-
-		if (is_memfd(st_buf->st_dev, file_path)) {
-			vma_area->e->status |= VMA_AREA_MEMFD;
-			goto normal_file;
-		}
-
-		if (is_anon_shmem_map(st_buf->st_dev)) {
-			if (!(vma_area->e->flags & MAP_SHARED))
-				goto err_bogus_mapping;
+		if (is_anon_shmem_map(st_buf->st_dev) && !strncmp(file_path, "/SYSV", 5)) {
 			vma_area->e->flags  |= MAP_ANONYMOUS;
 			vma_area->e->status |= VMA_ANON_SHARED;
 			vma_area->e->shmid = st_buf->st_ino;
-
-			if (!strncmp(file_path, "/SYSV", 5)) {
-				pr_info("path: %s\n", file_path);
-				vma_area->e->status |= VMA_AREA_SYSVIPC;
-			} else {
+			if (!(vma_area->e->flags & MAP_SHARED))
+				goto err_bogus_mapping;
+			pr_info("path: %s\n", file_path);
+			vma_area->e->status |= VMA_AREA_SYSVIPC;
+		} else {
+			if (is_anon_shmem_map(st_buf->st_dev)) {
+				vma_area->e->status |= VMA_AREA_MEMFD;
 				if (fault_injected(FI_HUGE_ANON_SHMEM_ID))
 					vma_area->e->shmid += FI_HUGE_ANON_SHMEM_ID_BASE;
 			}
-		} else {
-normal_file:
+
 			if (vma_area->e->flags & MAP_PRIVATE)
 				vma_area->e->status |= VMA_FILE_PRIVATE;
 			else

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -224,6 +224,8 @@ TST_NOFILE	:=				\
 		memfd01				\
 		memfd02				\
 		memfd03				\
+		shmemfd				\
+		shmemfd-priv			\
 #		jobctl00			\
 
 ifneq ($(ARCH),arm)

--- a/test/zdtm/static/shmemfd-priv.c
+++ b/test/zdtm/static/shmemfd-priv.c
@@ -1,0 +1,84 @@
+#include <unistd.h>
+#include <stdio.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/vfs.h>
+#include <fcntl.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc	= "Test C/R of shared memory file descriptors";
+const char *test_author	= "Andrei Vagin <avagin@gmail.com>";
+
+#define err(exitcode, msg, ...) ({ pr_perror(msg, ##__VA_ARGS__); exit(exitcode); })
+
+int main(int argc, char *argv[])
+{
+	void *addr, *priv_addr, *addr2;
+	char path[4096];
+	int fd;
+
+	test_init(argc, argv);
+
+	addr = mmap(NULL, 5 * PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+	if (addr == MAP_FAILED) {
+		pr_perror("mmap");
+		return 1;
+	}
+
+	*(int *) addr = 1;
+	*(int *) (addr + PAGE_SIZE) = 11;
+	*(int *) (addr +  2 * PAGE_SIZE) = 111;
+
+	snprintf(path, sizeof(path), "/proc/self/map_files/%lx-%lx",
+					(long)addr, (long)addr + 5 * PAGE_SIZE);
+	fd = open(path, O_RDWR | O_LARGEFILE);
+	if (fd < 0)
+		err(1, "Can't open %s", path);
+
+	priv_addr = mmap(NULL, 5 * PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_FILE | MAP_PRIVATE, fd, PAGE_SIZE);
+	if (priv_addr == MAP_FAILED) {
+		pr_perror("mmap");
+		return 1;
+	}
+
+	addr2 = mmap(NULL, 5 * PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 2 * PAGE_SIZE);
+	if (addr2 == MAP_FAILED) {
+		pr_perror("mmap");
+		return 1;
+	}
+
+	*(int *) (priv_addr + PAGE_SIZE) = 22;
+
+	test_daemon();
+	test_waitsig();
+
+	if (*(int *) (priv_addr + PAGE_SIZE) != 22) {
+		fail("the second page of the private mapping is corrupted");
+		return 1;
+	}
+	if (*(int *) (priv_addr) != 11) {
+		fail("the first page of the private mapping is corrupted");
+		return 1;
+	}
+	if (*(int *) (addr2) != 111) {
+		fail("the first page of the second shared mapping is corrupted");
+		return 1;
+	}
+	*(int *) (addr2) = 333;
+	if (*(int *) (addr + 2 * PAGE_SIZE) != 333) {
+		fail("the first page of the second shared mapping isn't shared");
+		return 1;
+	}
+	*(int *) (addr + 3 * PAGE_SIZE) = 444;
+	if (*(int *) (priv_addr + 2 * PAGE_SIZE) != 444) {
+		fail("the third page of the private mapping is corrupted");
+		return 1;
+	}
+
+	pass();
+
+	return 0;
+}

--- a/test/zdtm/static/shmemfd-priv.desc
+++ b/test/zdtm/static/shmemfd-priv.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h ns', 'flags': 'suid'}

--- a/test/zdtm/static/shmemfd.c
+++ b/test/zdtm/static/shmemfd.c
@@ -1,0 +1,107 @@
+#include <unistd.h>
+#include <stdio.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/vfs.h>
+#include <fcntl.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc	= "Test C/R of shared memory file descriptors";
+const char *test_author	= "Andrei Vagin <avagin@gmail.com>";
+
+#define err(exitcode, msg, ...) ({ pr_perror(msg, ##__VA_ARGS__); exit(exitcode); })
+
+int main(int argc, char *argv[])
+{
+	int fd, fl_flags1, fl_flags2, fd_flags1, fd_flags2;
+	struct statfs statfs1, statfs2;
+	off_t pos1, pos2;
+	char path[4096];
+	char buf[5];
+	void *addr;
+
+	test_init(argc, argv);
+
+	addr = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+	if (addr == MAP_FAILED) {
+		pr_perror("mmap");
+		return 1;
+	}
+
+	snprintf(path, sizeof(path), "/proc/self/map_files/%lx-%lx",
+					(long)addr, (long)addr + PAGE_SIZE);
+	fd = open(path, O_RDWR | O_LARGEFILE);
+	if (fd < 0)
+		err(1, "Can't open %s", path);
+	ftruncate(fd, 0);
+	munmap(addr, PAGE_SIZE);
+
+	if (fcntl(fd, F_SETFL, O_APPEND) < 0)
+		err(1, "Can't get fl flags");
+
+	if ((fl_flags1 = fcntl(fd, F_GETFL)) == -1)
+		err(1, "Can't get fl flags");
+
+	if ((fd_flags1 = fcntl(fd, F_GETFD)) == -1)
+		err(1, "Can't get fd flags");
+
+	if (fstatfs(fd, &statfs1) < 0)
+		err(1, "statfs issue");
+
+	if (write(fd, "hello", 5) != 5)
+		err(1, "write error");
+
+	pos1 = 3;
+	if (lseek(fd, pos1, SEEK_SET) < 0)
+		err(1, "seek error");
+
+	test_daemon();
+	test_waitsig();
+
+	if ((fl_flags2 = fcntl(fd, F_GETFL)) == -1)
+		err(1, "Can't get fl flags");
+
+	if (fl_flags1 != fl_flags2) {
+		fail("fl flags differs %x %x", fl_flags1, fl_flags2);
+		return 1;
+	}
+
+	if ((fd_flags2 = fcntl(fd, F_GETFD)) == -1)
+		err(1, "Can't get fd flags");
+
+	if (fd_flags1 != fd_flags2) {
+		fail("fd flags differs");
+		return 1;
+	}
+
+	if (fstatfs(fd, &statfs2) < 0)
+		err(1, "statfs issue");
+
+	if (statfs1.f_type != statfs2.f_type) {
+		fail("statfs.f_type differs");
+		return 1;
+	}
+
+	pos2 = lseek(fd, 0, SEEK_CUR);
+	if (pos1 != pos2) {
+		fail("position differs");
+		return 1;
+	}
+
+	if (pread(fd, buf, sizeof(buf), 0) != sizeof(buf)) {
+		fail("read problem");
+		return 1;
+	}
+
+	if (memcmp(buf, "hello", sizeof(buf))) {
+		fail("content mismatch");
+		return 1;
+	}
+
+	pass();
+
+	return 0;
+}

--- a/test/zdtm/static/shmemfd.desc
+++ b/test/zdtm/static/shmemfd.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h ns', 'flags': 'suid'}


### PR DESCRIPTION
Any shared memory mapping can be opened via /proc/self/maps_files/.
Such file descriptors look like memfd file descriptors, so they can be dumped by the same way.

Cc: @nviennot 
