### PR TITLE
namespaces: fix error handling in dump_user_ns

### DIFF
--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -938,9 +938,9 @@ static int check_user_ns(int pid)
 
 int dump_user_ns(pid_t pid, int ns_id)
 {
-	int ret, exit_code = -1;
 	UsernsEntry *e = &userns_entry;
 	struct cr_img *img;
+	int ret;
 
 	ret = parse_id_map(pid, "uid_map", &e->uid_map);
 	if (ret < 0)
@@ -953,7 +953,7 @@ int dump_user_ns(pid_t pid, int ns_id)
 	e->n_gid_map = ret;
 
 	if (check_user_ns(pid))
-		return -1;
+		goto err;
 
 	img = open_image(CR_FD_USERNS, O_DUMP, ns_id);
 	if (!img)
@@ -973,7 +973,7 @@ err:
 		xfree(e->gid_map[0]);
 		xfree(e->gid_map);
 	}
-	return exit_code;
+	return -1;
 }
 
 void free_userns_maps(void)


### PR DESCRIPTION
Fix n_xid_map leaks on error path and remove useless exit_code.

Fixes: 6e1726f8 ("userns: set uid and gid before entering into userns")
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>