### PR TITLE
Fix deadlock for ghost DGRAM unix socket

### DIFF
--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -1845,7 +1845,7 @@ static int open_unixsk_standalone(struct unix_sk_info *ui, int *new_fd)
 {
 	struct unix_sk_info *queuer = ui->queuer;
 	struct unix_sk_info *peer = ui->peer;
-	struct fdinfo_list_entry *fle, *fle_peer;
+	struct fdinfo_list_entry *fle;
 	int sk;
 
 	fle = file_master(&ui->d);
@@ -1859,10 +1859,12 @@ static int open_unixsk_standalone(struct unix_sk_info *ui, int *new_fd)
 	 * into it in a special way.
 	 */
 	if (peer && (peer->flags & USK_GHOST_FDSTORE)) {
-		fle_peer = file_master(&peer->d);
-		if (fle_peer->stage < FLE_OPEN) {
+		/*
+		 * Here we return 1 which says "try again" to
+		 * the caller if peer is not yet bounded.
+		 */
+		if (peer_is_not_prepared(peer))
 			return 1;
-		}
 	}
 
 	if (fle->stage == FLE_OPEN)

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -379,6 +379,7 @@ TST_DIR		=				\
 		del_standalone_un		\
 		sk-unix-mntns			\
 		sk-unix01			\
+		sk-unix-dgram-ghost		\
 		unsupported_children_collision  \
 		shared_slave_mount_children	\
 		non_uniform_share_propagation	\

--- a/test/zdtm/static/sk-unix-dgram-ghost.c
+++ b/test/zdtm/static/sk-unix-dgram-ghost.c
@@ -1,0 +1,230 @@
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdbool.h>
+#include <limits.h>
+#include <errno.h>
+#include <dirent.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/stat.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc	= "Check data of bound ghost DGRAM unix socket and possibility to connect";
+const char *test_author	= "Alexander Mikhalitsyn <alexander@mihalicyn.com>";
+
+/*
+ * PROCESS_NUM | FREEZE_FREQ
+ * 3           | 1 / 5
+ * 4           | 1 / 5
+ * 5           | 2 / 5
+ * 10          | 10 / 10
+ */
+#define PROCESSES_NUM 10
+
+#define MSG "hello"
+char filename[PATH_MAX];
+char *dirname;
+TEST_OPTION(dirname, string, "directory name", 1);
+
+static int fill_sock_name(struct sockaddr_un *name, const char *filename)
+{
+	char *cwd;
+
+	cwd = get_current_dir_name();
+	if (strlen(filename) + strlen(cwd) + 1 >= sizeof(name->sun_path)) {
+		pr_err("Name %s/%s is too long for socket\n",
+		       cwd, filename);
+		return -1;
+	}
+
+	name->sun_family = AF_LOCAL;
+	ssprintf(name->sun_path, "%s/%s", cwd, filename);
+	return 0;
+}
+
+static int client(int i, task_waiter_t t)
+{
+	struct sockaddr_un addr;
+	int sk;
+
+	sk = socket(AF_UNIX, SOCK_DGRAM, 0);
+	if (sk < 0) {
+		pr_perror("open client %d", i);
+		return 1;
+	}
+
+	if (fill_sock_name(&addr, filename) < 0) {
+		pr_err("%s is too long for socket\n", filename);
+		return 1;
+	}
+
+	if (connect(sk, (struct sockaddr *) &addr, sizeof(struct sockaddr_un)) < 0) {
+		pr_perror("connect failed %d", i);
+		return 1;
+	}
+
+	/* we are ready to c/r */
+	task_waiter_complete(&t, 1);
+
+	/* wait for server let us to send data */
+	task_waiter_wait4(&t, 2);
+
+	test_msg("child %d: lets send\n", i);
+
+	if (send(sk, MSG, sizeof(MSG), 0) != sizeof(MSG)) {
+		pr_perror("send failed %d", i);
+		return 1;
+	}
+
+	test_msg("child %d: MSG was sent\n", i);
+
+	/* notify server that we sent data */
+	task_waiter_complete(&t, 3);
+
+	return 0;
+}
+
+static void child_exited(int signo)
+{
+	int status;
+	pid_t pid;
+
+	while (1) {
+		pid = waitpid(-1, &status, WNOHANG);
+		if (pid == -1) {
+			if (errno == ECHILD)
+				break;
+
+			fail("wait failed");
+			exit(1);
+		}
+
+		if (pid == 0)
+			return;
+
+		if (status) {
+			pr_err("A child (pid: %d) exited with 0x%x\n", pid, status);
+			exit(1);
+		}
+	}
+}
+
+int main(int argc, char **argv)
+{
+	struct sockaddr_un addr;
+	int srv, ret;
+	size_t i;
+	char buf[1024];
+	task_waiter_t t[PROCESSES_NUM];
+
+	test_init(argc, argv);
+
+	ssprintf(filename, "%s/%s", dirname, "sk");
+
+	if (fill_sock_name(&addr, filename) < 0) {
+		pr_err("%s is too long for socket\n", filename);
+		ret = 1;
+		goto clean;
+	}
+
+	if (signal(SIGCHLD, child_exited) == SIG_ERR) {
+		pr_perror("can't set SIGCHLD handler");
+		exit(1);
+	}
+
+	for (i = 0; i < PROCESSES_NUM; i++)
+		task_waiter_init(&t[i]);
+
+	if (mkdir(dirname, 0755) < 0) {
+		if (errno != EEXIST) {
+			pr_perror("Can't create %s", dirname);
+			return 1;
+		}
+	}
+
+	/*
+	 * Freeze happens if unix socket is the *last* file descriptor.
+	 * So, if we for example, move task_waiter_init() after server
+	 * socket creation we loose reproduce.
+	 */
+	srv = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+	if (srv < 0) {
+		pr_perror("open srv");
+		ret = 1;
+		goto clean;
+	}
+
+	if (bind(srv, (struct sockaddr *) &addr, sizeof(struct sockaddr_un))) {
+		pr_perror("bind srv");
+		ret = 1;
+		goto clean;
+	}
+
+	for (i = 0; i < PROCESSES_NUM; i++) {
+		ret = test_fork();
+		if (ret == -1) {
+			pr_perror("fork");
+			ret = 1;
+			goto clean;
+		}
+
+		if (ret == 0) {
+			close(srv);
+			exit(client(i, t[i]));
+		}
+
+		task_waiter_wait4(&t[i], 1);
+	}
+
+	/*
+	 * It's very important part of this test-case to make
+	 * *ghost* unix socket. Because problem with criu freeze
+	 * appears especially with *ghost* unix socket.
+	 */
+	unlink(addr.sun_path);
+
+	ret = 1;
+
+	test_daemon();
+	test_waitsig();
+
+	test_msg("C/R complete\n");
+
+	/* let childs to send data to server socket */
+	for (i = 0; i < PROCESSES_NUM; i++)
+		task_waiter_complete(&t[i], 2);
+
+	/* wait childs for send data */
+	for (i = 0; i < PROCESSES_NUM; i++)
+		task_waiter_wait4(&t[i], 3);
+
+	test_msg("Checking result\n");
+
+	/* check we can read all client messages */
+	for (i = 0; i < PROCESSES_NUM; i++) {
+		ret = read(srv, buf, sizeof(MSG));
+		buf[ret > 0 ? ret : 0] = 0;
+		if (ret != sizeof(MSG)) {
+			fail("%d: %s", ret, buf);
+			ret = 1;
+			goto clean;
+		}
+	}
+
+	ret = 0;
+	pass();
+
+clean:
+	unlink(addr.sun_path);
+	rmdir(dirname);
+	return ret;
+}

--- a/test/zdtm/static/sk-unix-dgram-ghost.desc
+++ b/test/zdtm/static/sk-unix-dgram-ghost.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h ns uns', 'flags': 'suid'}


### PR DESCRIPTION
This patch fixes deadlock that appears on ghost DGRAM unix sockets.
Problem is that wake_connected_sockets() function *should* be called
strictly after fle->stage >= FLE_OPEN.

Explanation:
Consider situation, we have ghost unix DGRAM socket (peer socket),
and also have several sockets that connected to this peer socket.

How restore of that picture works?
In files subsystem we have open_fdinfos(pstree_item*) function that calls open_fd()
function for *every* fd of task. open_fd() function calls appropriate
file descriptor "open" handler that may return "1" which means "try again later".
This retcode means, that some additional resources is needed to fully restore file
descriptor. For *ghost* UNIX sockets, for instance, we need to have peer socket
file descriptor *before* we can open and restore client sockets. Here is the main problem.
open_fdinfos() called from separate tasks simultaneously, so, when we get "1" retcode
we stay on futex (wait_fds_event() function) and waiting for someone another task
restore some resource and notify us that we can retry opening of file descriptor.

With *ghost* UNIX socket I've managed to caught next behaviour.
1. From one task (that holds client socket) open_fdinfos() called open_fd() that called
open_unixsk_standalone(). In open_unixsk_standalone we have check that means
"if socket have peer and that peer is GHOST and that peer fle->stage < FLE_OPEN"
return "try again". Ok. So, this task will stay on wait_fds_event().

2. Second task, that holds *peer* tried to open peer socket fd. So,
it also calls open_fd() -> open_unixsk_standalone() -> opening socket
-> bind_unix_sk() -> in bind_unix_sk we have call to wake_connected_sockets().
So, after that call we will "wake up" task from first point and it may proceed
fd restoring. Yes? No. In first point we need to "peer_fle->stage >= FLE_OPEN"
but fle->stage of our peer socket will become FLE_OPEN in open_fd(). After we
return from open_unixsk_standalone we proceed to setup_and_serve_out() where we have
appropriate stage change.
Between call of wake_connected_sockets and moment when we set stage to FLE_OPEN
should pass very small amount of time. But it may happen, so we "wake up"
tasks that holds client sockets but did not have enough time to change fle->stage
to FLE_OPEN. Exactly that case I've managed to reproduce.
(Really, ossec-hids application managed to reproduce this problem at first %) )

This patch changes place, where we call wake_connected_sockets(). After
introducing callback in file_desc_ops on_stage_change it's very easy.