### PR TITLE
make: use cflags/ldflags for config.h detection mechanism

### DIFF
--- a/scripts/nmk/scripts/utils.mk
+++ b/scripts/nmk/scripts/utils.mk
@@ -3,7 +3,7 @@ ifndef ____nmk_defined__utils
 #
 # Usage: option := $(call try-compile,language,source-to-build,cc-options,cc-defines)
 try-compile = $(shell sh -c 'echo "$(2)" |					\
-        $(CC) $(4) -x $(1) - $(3) -o /dev/null > /dev/null 2>&1 &&		\
+        $(CC) $(CFLAGS) $(LDFLAGS) $(4) -x $(1) - $(3) -o /dev/null > /dev/null 2>&1 &&		\
         echo true || echo false')
 
 #


### PR DESCRIPTION
The config.h detection scripts should use the provided CFLAGS/LDFLAGS
as it tries to link libnl, libnet, and others.