### PR TITLE
pipe: restore pipe size even if a pipe is empty

### DIFF
--- a/test/zdtm/static/pipe03.c
+++ b/test/zdtm/static/pipe03.c
@@ -13,27 +13,28 @@ const char *test_author	= "Andrei Vagin <avagin@gmail.com>";
 
 int main(int argc, char **argv)
 {
-	int p[2], i;
+	int p[2][2], i;
 	uint8_t buf[BUF_SIZE];
 	uint32_t crc;
 
 	test_init(argc, argv);
 
-	if (pipe2(p, O_NONBLOCK)) {
-		pr_perror("pipe");
-		return 1;
-	}
-
-	if (fcntl(p[1], F_SETPIPE_SZ, DATA_SIZE) == -1) {
-		pr_perror("Unable to change a pipe size");
-		return 1;
+	for (i = 0; i < 2; i++) {
+		if (pipe2(p[i], O_NONBLOCK)) {
+			pr_perror("pipe");
+			return 1;
+		}
+		if (fcntl(p[i][1], F_SETPIPE_SZ, DATA_SIZE) == -1) {
+			pr_perror("Unable to change a pipe size");
+			return 1;
+		}
 	}
 
 	crc = ~0;
 	datagen(buf, BUF_SIZE, &crc);
 
 	for (i = 0; i < DATA_SIZE / BUF_SIZE; i++) {
-		if (write(p[1], buf, BUF_SIZE) != BUF_SIZE) {
+		if (write(p[0][1], buf, BUF_SIZE) != BUF_SIZE) {
 			pr_perror("write");
 			return 1;
 		}
@@ -43,8 +44,22 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	for (i = 0; i < DATA_SIZE / BUF_SIZE; i++) {
-		if (read(p[0], buf, BUF_SIZE) != BUF_SIZE) {
+		if (read(p[0][0], buf, BUF_SIZE) != BUF_SIZE) {
 			pr_perror("read");
+			return 1;
+		}
+	}
+
+	for (i = 0; i < 2; i++) {
+		int size;
+
+		size = fcntl(p[i][1], F_GETPIPE_SZ);
+		if (size < 0) {
+			pr_perror("Unable to get a pipe size");
+			return 1;
+		}
+		if (size != DATA_SIZE) {
+			fail("%d: size %d expected %d", i, size, DATA_SIZE);
 			return 1;
 		}
 	}

--- a/test/zdtm/transition/fifo_loop.c
+++ b/test/zdtm/transition/fifo_loop.c
@@ -84,6 +84,14 @@ int main(int argc, char **argv)
 				ret = errno;
 				return ret;
 			}
+
+			pipe_size = fcntl(writefd, F_SETPIPE_SZ, sizeof(buf));
+			if (pipe_size != sizeof(buf)) {
+				pr_perror("fcntl(writefd, F_SETPIPE_SZ) -> %d", pipe_size);
+				kill(0, SIGKILL);
+				exit(1);
+			}
+
 			signal(SIGPIPE, SIG_IGN);
 			if (pipe_in2out(readfd, writefd, buf, sizeof(buf)) < 0)
 				/* pass errno as exit code to the parent */
@@ -107,7 +115,7 @@ int main(int argc, char **argv)
 
 	pipe_size = fcntl(writefd, F_SETPIPE_SZ, sizeof(buf));
 	if (pipe_size != sizeof(buf)) {
-		pr_perror("fcntl(writefd, F_GETPIPE_SZ) -> %d", pipe_size);
+		pr_perror("fcntl(writefd, F_SETPIPE_SZ) -> %d", pipe_size);
 		kill(0, SIGKILL);
 		exit(1);
 	}


### PR DESCRIPTION
Without this patch, pipe size is restored only if a pipe has queued data.

Fixes #995

Reported-by: Mr Jenkins