### PR TITLE
config/nftables: include string.h for strlen

### DIFF
--- a/scripts/feature-tests.mak
+++ b/scripts/feature-tests.mak
@@ -152,6 +152,8 @@ endef
 
 define FEATURE_TEST_NFTABLES_LIB_API_0
 
+#include <string.h>
+
 #include <nftables/libnftables.h>
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Fixes: 9433b7b9db3e ("make: use cflags/ldflags for config.h detection mechanism")
