### PR TITLE
Remove header include statements duplicates v3.14 part2

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -76,7 +76,6 @@
 #include "fdstore.h"
 #include "string.h"
 #include "memfd.h"
-#include "string.h"
 
 #include "parasite-syscall.h"
 #include "files-reg.h"

--- a/criu/util.c
+++ b/criu/util.c
@@ -30,8 +30,6 @@
 
 #include "linux/mount.h"
 
-#include "linux/mount.h"
-
 #include "kerndat.h"
 #include "page.h"
 #include "util.h"


### PR DESCRIPTION
See my review comments to https://github.com/checkpoint-restore/criu/pull/1003, these headers seem excess, so I remove them.