### PR TITLE
img: fix image_name() when image is empty

### DIFF
--- a/criu/protobuf.c
+++ b/criu/protobuf.c
@@ -25,8 +25,13 @@ static char *image_name(struct cr_img *img)
 	int fd = img->_x.fd;
 	static char image_path[PATH_MAX];
 
-	if (read_fd_link(fd, image_path, sizeof(image_path)) > 0)
+	if (lazy_image(img))
+		return img->path;
+	else if (empty_image(img))
+		return "(empty-image)";
+	else if (fd >= 0 && read_fd_link(fd, image_path, sizeof(image_path)) > 0)
 		return image_path;
+
 	return NULL;
 }
 


### PR DESCRIPTION
When an image is opened but errored with a ENOENT error, the image is still valid. Later on, do_pb_read_one() can fail and will invoke image_name(). The image fd is EMPTY_IMG_FD (-404). read_fd_link fails.