### PR TITLE
Optimize find_unix_sk_by_ino()

### DIFF
--- a/criu/include/sockets.h
+++ b/criu/include/sockets.h
@@ -16,10 +16,15 @@ struct cr_imgset;
 struct nlmsghdr;
 struct cr_img;
 
+struct socket_table_entry {
+	unsigned int			ino;
+	struct socket_table_entry	*next;
+	void				*obj;
+};
+
 struct socket_desc {
 	unsigned int		family;
 	unsigned int		ino;
-	struct socket_desc	*next;
 	struct ns_id		*sk_ns;
 	int			already_dumped;
 };
@@ -45,8 +50,10 @@ extern int unix_note_scm_rights(int id_for, uint32_t *file_ids, int *fds, int n_
 
 extern struct collect_image_info netlink_sk_cinfo;
 
-extern struct socket_desc *lookup_socket_ino(unsigned int ino, int family);
-extern struct socket_desc *lookup_socket(unsigned int ino, int family, int proto);
+extern int add_socket_table_entry(int ino, void *obj);
+extern struct socket_table_entry *lookup_socket_ino(unsigned int ino);
+extern struct socket_desc *lookup_socket_desc_ino(unsigned int ino, int family);
+extern struct socket_desc *lookup_socket_desc(unsigned int ino, int family, int proto);
 
 extern const struct fdtype_ops unix_dump_ops;
 extern const struct fdtype_ops inet_dump_ops;

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -437,9 +437,9 @@ static int do_dump_one_inet_fd(int lfd, u32 id, const struct fd_parms *p, int fa
 		goto err;
 
 	if (type == SOCK_RAW)
-		sk = (struct inet_sk_desc *)lookup_socket_ino(p->stat.st_ino, family);
+		sk = (struct inet_sk_desc *)lookup_socket_desc_ino(p->stat.st_ino, family);
 	else
-		sk = (struct inet_sk_desc *)lookup_socket(p->stat.st_ino, family, proto);
+		sk = (struct inet_sk_desc *)lookup_socket_desc(p->stat.st_ino, family, proto);
 	if (IS_ERR(sk))
 		goto err;
 	if (!sk) {

--- a/criu/sk-netlink.c
+++ b/criu/sk-netlink.c
@@ -86,7 +86,7 @@ static int dump_one_netlink_fd(int lfd, u32 id, const struct fd_parms *p)
 	NetlinkSkEntry ne = NETLINK_SK_ENTRY__INIT;
 	SkOptsEntry skopts = SK_OPTS_ENTRY__INIT;
 
-	sk = (struct netlink_sk_desc *)lookup_socket(p->stat.st_ino, PF_NETLINK, 0);
+	sk = (struct netlink_sk_desc *)lookup_socket_desc(p->stat.st_ino, PF_NETLINK, 0);
 	if (IS_ERR(sk))
 		goto err;
 

--- a/criu/sk-packet.c
+++ b/criu/sk-packet.c
@@ -156,7 +156,7 @@ static int dump_one_packet_fd(int lfd, u32 id, const struct fd_parms *p)
 	struct packet_sock_desc *sd;
 	int i, ret;
 
-	sd = (struct packet_sock_desc *)lookup_socket(p->stat.st_ino, PF_PACKET, 0);
+	sd = (struct packet_sock_desc *)lookup_socket_desc(p->stat.st_ino, PF_PACKET, 0);
 	if (IS_ERR_OR_NULL(sd)) {
 		pr_err("Can't find packet socket %"PRIu64"\n", p->stat.st_ino);
 		return -1;
@@ -225,7 +225,7 @@ int dump_socket_map(struct vma_area *vma)
 {
 	struct packet_sock_desc *sd;
 
-	sd = (struct packet_sock_desc *)lookup_socket(vma->vm_socket_id, PF_PACKET, 0);
+	sd = (struct packet_sock_desc *)lookup_socket_desc(vma->vm_socket_id, PF_PACKET, 0);
 	if (IS_ERR_OR_NULL(sd)) {
 		pr_err("Can't find packet socket %u to mmap\n", vma->vm_socket_id);
 		return -1;

--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -356,7 +356,7 @@ static int dump_one_unix_fd(int lfd, uint32_t id, const struct fd_parms *p)
 
 	*fown = p->fown;
 
-	sk = (struct unix_sk_desc *)lookup_socket(p->stat.st_ino, PF_UNIX, 0);
+	sk = (struct unix_sk_desc *)lookup_socket_desc(p->stat.st_ino, PF_UNIX, 0);
 	if (IS_ERR_OR_NULL(sk)) {
 		pr_err("Unix socket %d not found\n", (int)p->stat.st_ino);
 		goto err;
@@ -424,7 +424,7 @@ static int dump_one_unix_fd(int lfd, uint32_t id, const struct fd_parms *p)
 	}
 
 	if (ue->peer) {
-		peer = (struct unix_sk_desc *)lookup_socket(ue->peer, PF_UNIX, 0);
+		peer = (struct unix_sk_desc *)lookup_socket_desc(ue->peer, PF_UNIX, 0);
 		if (IS_ERR_OR_NULL(peer)) {
 			pr_err("Unix socket %u without peer %u\n",
 					ue->ino, ue->peer);


### PR DESCRIPTION
1. Generalize sockets hashtable so it could be used in restoration. Now the hashtable stores a void pointer (obj) to entry, which could point to socket_desc or unix_sk_info.
2. Refactor lookup functions names to be more descriptive.
3. Optimize find_unix_sk_by_ino(). Replaced the loop with a hashtable lookup.

Fixes #339