### PR TITLE
Optimize find_unix_sk_by_ino()

### DIFF
--- a/criu/files.c
+++ b/criu/files.c
@@ -1749,5 +1749,6 @@ struct collect_image_info files_cinfo = {
 int prepare_files(void)
 {
 	init_fdesc_hash();
+	init_sk_info_hash();
 	return collect_image(&files_cinfo);
 }

--- a/criu/include/sockets.h
+++ b/criu/include/sockets.h
@@ -62,6 +62,8 @@ extern int unix_sk_id_add(unsigned int ino);
 extern int unix_sk_ids_parse(char *optarg);
 extern int unix_prepare_root_shared(void);
 
+extern void init_sk_info_hash(void);
+
 extern int do_dump_opt(int sk, int level, int name, void *val, int len);
 #define dump_opt(s, l, n, f)	do_dump_opt(s, l, n, f, sizeof(*f))
 extern int do_restore_opt(int sk, int level, int name, void *val, int len);


### PR DESCRIPTION
Optimize find_unix_sk_by_ino().
Replaced the linear search with a hashtable lookup.
Fixes #339