### PR TITLE
criu: put statement continuation on the same line as the closing bracket

### DIFF
--- a/compel/arch/ppc64/src/lib/infect.c
+++ b/compel/arch/ppc64/src/lib/infect.c
@@ -222,8 +222,7 @@ static int get_altivec_regs(pid_t pid, user_fpregs_struct_t *fp)
 			return -1;
 		}
 		pr_debug("Altivec not supported\n");
-	}
-	else {
+	} else {
 		pr_debug("Dumping Altivec registers\n");
 		fp->flags |= USER_FPREGS_FL_ALTIVEC;
 	}
@@ -251,8 +250,7 @@ static int get_vsx_regs(pid_t pid, user_fpregs_struct_t *fp)
 			return -1;
 		}
 		pr_debug("VSX register's dump not supported.\n");
-	}
-	else {
+	} else {
 		pr_debug("Dumping VSX registers\n");
 		fp->flags |= USER_FPREGS_FL_VSX;
 	}

--- a/compel/src/main.c
+++ b/compel/src/main.c
@@ -184,8 +184,7 @@ static void print_ldflags(bool compat)
 	if (uninst_root) {
 		printf("%s/arch/%s/scripts/compel-pack%s.lds.S\n",
 				uninst_root, flags.arch, compat_str);
-	}
-	else {
+	} else {
 		printf("%s/compel/scripts/compel-pack%s.lds.S\n",
 				LIBEXECDIR, compat_str);
 
@@ -225,8 +224,7 @@ static int print_libs(bool is_static)
 			return 1;
 		}
 		printf("%s/%s\n", uninst_root, STATIC_LIB);
-	}
-	else {
+	} else {
 		printf("%s/%s\n", LIBDIR, (is_static) ? STATIC_LIB : DYN_LIB);
 	}
 
@@ -258,8 +256,7 @@ static char *gen_prefix(const char *path)
 	for (i = len - 1; i >= 0; i--) {
 		if (!p1 && path[i] == '.') {
 			p2 = path + i - 1;
-		}
-		else if (!p1 && path[i] == '/') {
+		} else if (!p1 && path[i] == '/') {
 			p1 = path + i + 1;
 			break;
 		}

--- a/criu/arch/ppc64/crtools.c
+++ b/criu/arch/ppc64/crtools.c
@@ -374,8 +374,7 @@ static int __copy_task_regs(user_regs_struct_t *regs,
 		fpstate = &(core->ti_ppc64->tmstate->fpstate);
 		vrstate = &(core->ti_ppc64->tmstate->vrstate);
 		vsxstate = &(core->ti_ppc64->tmstate->vsxstate);
-	}
-	else {
+	} else {
 		gpregs = core->ti_ppc64->gpregs;
 		fpstate = &(core->ti_ppc64->fpstate);
 		vrstate = &(core->ti_ppc64->vrstate);

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1530,8 +1530,7 @@ static int cr_pre_dump_finish(int status)
 			timing_stop(TIME_MEMWRITE);
 			ret = page_xfer_predump_pages(item->pid->real,
 							&xfer, mem_pp);
-		}
-		else {
+		} else {
 			ret = page_xfer_dump_pages(&xfer, mem_pp);
 		}
 

--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -419,8 +419,7 @@ static int maybe_read_page_img_cache(struct page_read *pr, unsigned long vaddr,
 		if (ret == 0) {
 			pr_err("Reached EOF unexpectedly while reading page from image\n");
 			return -1;
-		}
-		else if (ret < 0) {
+		} else if (ret < 0) {
 			pr_perror("Can't read mapping page %d", ret);
 			return -1;
 		}

--- a/test/zdtm/static/fifo_wronly.c
+++ b/test/zdtm/static/fifo_wronly.c
@@ -55,8 +55,7 @@ int main(int argc, char **argv)
 			pr_perror("read error %s", filename);
 			chret = errno;
 			return chret;
-		}
-		else if (res == 0) {
+		} else if (res == 0) {
 			pr_perror("read(%d, rbuf, 7) return 0", fd1);
 			return 1;
 		}

--- a/test/zdtm/static/inotify_system.c
+++ b/test/zdtm/static/inotify_system.c
@@ -280,8 +280,7 @@ int errors(int exp_len, int len, char *etalon_buf, char *buf) {
 			fail("Incorrect length of field name.");
 			error++;
 			break;
-		}
-		else if (event->len && strncmp(event->name, exp_event->name, event->len)) {
+		} else if (event->len && strncmp(event->name, exp_event->name, event->len)) {
 			fail("Handled file name %s, expected %s",
 				event->name,
 				exp_event->name);

--- a/test/zdtm/static/ptrace_sig.c
+++ b/test/zdtm/static/ptrace_sig.c
@@ -74,8 +74,7 @@ int main(int argc, char ** argv)
 	if (cpid < 0) {
 		pr_perror("fork failed");
 		return 1;
-	}
-	else if (cpid == 0) {
+	} else if (cpid == 0) {
 		close(child_pipe[0]);
 		return child(child_pipe[1]);
 	}

--- a/test/zdtm/static/vsx.c
+++ b/test/zdtm/static/vsx.c
@@ -388,8 +388,7 @@ int main(int argc, char *argv[])
 			test_msg("Data mismatch\n");
 			fail();
 		}
-	}
-	else {
+	} else {
 		test_msg("The CPU is missing some features.\n");
 		fail();
 	}

--- a/test/zdtm/transition/epoll.c
+++ b/test/zdtm/transition/epoll.c
@@ -181,8 +181,7 @@ int main(int argc, char **argv)
 			fail("waitpid error: %m\n");
 			counter++;
 			continue;
-		}
-		else {
+		} else {
 			rv = WEXITSTATUS(rv);
 			if (rv < MAX_EXIT_CODE && rv > SUCCESS) {
 				fail("Child failed: %s (%d)\n",


### PR DESCRIPTION
We should follow Linux Kernel Codding Style:

... the closing brace is empty on a line of its own, except in the cases
where it is followed by a continuation of the same statement, ie ... an
else in an if-statement ...

https://www.kernel.org/doc/html/v4.10/process/coding-style.html#placing-braces-and-spaces

Automaticly fixing with:

```
:!git grep --files-with-matches "^\s*else[^{]*{" | xargs
:argadd <files>
:argdo :%s/}\s*\n\s*\(else[^{]*{\)/} \1/g | update
```

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>