### PR TITLE
kerndat: remove duplicate call to kerndat_socket_netns()

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1078,8 +1078,6 @@ int kerndat_init(void)
 	if (!ret)
 		ret = kerndat_compat_restore();
 	if (!ret)
-		ret = kerndat_socket_netns();
-	if (!ret)
 		ret = kerndat_tun_netns();
 	if (!ret)
 		ret = kerndat_socket_unix_file();


### PR DESCRIPTION
kerndat_socket_netns() is called twice. We keep the latter to avoid
changing the behavior.

Signed-off-by: Nicolas Viennot <Nicolas.Viennot@twosigma.com>