### PR TITLE
kerndat remove duplicate call to kerndat_nsid()

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1102,8 +1102,6 @@ int kerndat_init(void)
 	if (!ret)
 		ret = kerndat_socket_netns();
 	if (!ret)
-		ret = kerndat_nsid();
-	if (!ret)
 		ret = kerndat_x86_has_ptrace_fpu_xsave_bug();
 	if (!ret)
 		ret = kerndat_has_inotify_setnextwd();


### PR DESCRIPTION
Func kerndat_nsid() is called twice.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>