### PR TITLE
test/jenkins: use bash to run jenkins scripts

### DIFF
--- a/test/jenkins/criu-btrfs.sh
+++ b/test/jenkins/criu-btrfs.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This is a job which is executed on btrfs
 
 source `dirname $0`/criu-lib.sh &&

--- a/test/jenkins/criu-by-id.sh
+++ b/test/jenkins/criu-by-id.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 echo 950000 > /sys/fs/cgroup/cpu,cpuacct/system/cpu.rt_runtime_us
 echo 950000 > /sys/fs/cgroup/cpu,cpuacct/system/jenkins.service/cpu.rt_runtime_us
 git checkout -f ${TEST_COMMIT}

--- a/test/jenkins/criu-dedup.sh
+++ b/test/jenkins/criu-dedup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check auto-deduplication of pagemaps
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-dump.sh
+++ b/test/jenkins/criu-dump.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check that dump is not destructive
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-fault.sh
+++ b/test/jenkins/criu-fault.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Check known fault injections
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-fcg.sh
+++ b/test/jenkins/criu-fcg.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Test how freeze cgroup works
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-groups.sh
+++ b/test/jenkins/criu-groups.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Make one regular C/R cycle over randomly-generated groups
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-inhfd.sh
+++ b/test/jenkins/criu-inhfd.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check known fault injections
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-iter.sh
+++ b/test/jenkins/criu-iter.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Make 3 iteration of dump/restore for each test
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-join-ns.sh
+++ b/test/jenkins/criu-join-ns.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Make one regular C/R cycle
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-lazy-common.sh
+++ b/test/jenkins/criu-lazy-common.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 KERN_MAJ=`uname -r | cut -d. -f1`
 KERN_MIN=`uname -r | cut -d. -f2`
 if [ $KERN_MAJ -ge "4" ] && [ $KERN_MIN -ge "11" ]; then

--- a/test/jenkins/criu-lazy-migration.sh
+++ b/test/jenkins/criu-lazy-migration.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check lazy-pages
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-lazy-pages.sh
+++ b/test/jenkins/criu-lazy-pages.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check lazy-pages
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-other.sh
+++ b/test/jenkins/criu-other.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source `dirname $0`/criu-lib.sh &&
 prep &&
 make -C test other &&

--- a/test/jenkins/criu-overlay.sh
+++ b/test/jenkins/criu-overlay.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Make one regular C/R cycle
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-pre-dump.sh
+++ b/test/jenkins/criu-pre-dump.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check 3 pre-dump-s before dump (with and w/o page server)
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-remote-lazy-pages.sh
+++ b/test/jenkins/criu-remote-lazy-pages.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check remote-lazy-pages
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-sibling.sh
+++ b/test/jenkins/criu-sibling.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Make 3 iteration of dump/restore for each test
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-snap.sh
+++ b/test/jenkins/criu-snap.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check snapshots
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-stop.sh
+++ b/test/jenkins/criu-stop.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check --leave-stopped option
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu-user.sh
+++ b/test/jenkins/criu-user.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Make 3 iteration of dump/restore for each test
 set -e
 source `dirname $0`/criu-lib.sh

--- a/test/jenkins/criu.sh
+++ b/test/jenkins/criu.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Make one regular C/R cycle
 set -e
 source `dirname $0`/criu-lib.sh


### PR DESCRIPTION
We permanently have issues like this:
./test/jenkins/criu-iter.sh: 3: source: not found

It looks like a good idea to use one shell to run our jenkins scripts.

Reported-by: Mr Jenkins