### PR TITLE
get_clean_mount: demote an error to a warning

### DIFF
--- a/criu/mount.c
+++ b/criu/mount.c
@@ -1104,7 +1104,7 @@ static char *get_clean_mnt(struct mount_info *mi, char *mnt_path_tmp, char *mnt_
 	if (mnt_path == NULL && errno == ENOENT)
 		mnt_path = mkdtemp(mnt_path_root);
 	if (mnt_path == NULL) {
-		pr_perror("Can't create a temporary directory");
+		pr_warn("Can't create a temporary directory: %s\n", strerror(errno));
 		return NULL;
 	}
 


### PR DESCRIPTION
The error here is not fatal since it is handled in ns_open_mountpoint(),
(at least since #520 is fixed), so demote this error to a warning
to avoid confusing a user.