### PR TITLE
Also report clone3() errors correctly

### DIFF
--- a/criu/clone-noasan.c
+++ b/criu/clone-noasan.c
@@ -70,6 +70,7 @@ int clone3_with_pid_noasan(int (*fn)(void *), void *arg, int flags,
 	if (!(flags & CLONE_PARENT)) {
 		if (exit_signal != SIGCHLD) {
 			pr_err("Exit signal not SIGCHLD\n");
+			errno = EINVAL;
 			return -1;
 		}
 		c_args.exit_signal = exit_signal;

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1439,6 +1439,8 @@ static inline int fork_with_pid(struct pstree_item *item)
 
 	if (ret < 0) {
 		pr_perror("Can't fork for %d", pid);
+		if (errno == EEXIST)
+			set_cr_errno(EEXIST);
 		goto err_unlock;
 	}
 


### PR DESCRIPTION
Without clone3() CRIU was able to detect a process with a wrong PID only in the already created child process. With clone3() this error can happen before the process is created.

The clone3() function will now return -errno if something does not work correctly and in the case of EEXIST this error will also be correctly forwarded to an RPC client.

This was detected by running test/others/libcriu on a clone3() system.