### PR TITLE
criu swrk: fix usage, allow common options

### DIFF
--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -87,12 +87,18 @@ int main(int argc, char *argv[], char *envp[])
 		return 1;
 	if (ret == 2)
 		goto usage;
+	if (optind >= argc) {
+		pr_err("command is required\n");
+		goto usage;
+	}
 
 	log_set_loglevel(opts.log_level);
 
-	if (!strcmp(argv[1], "swrk")) {
-		if (argc < 3)
-			goto usage;
+	if (optind < argc && !strcmp(argv[optind], "swrk")) {
+		if (argc != optind+2) {
+			fprintf(stderr, "Usage: criu swrk <fd>\n");
+			return 1;
+		}
 		/*
 		 * This is to start criu service worker from libcriu calls.
 		 * The usage is "criu swrk <fd>" and is not for CLI/scripts.
@@ -100,7 +106,7 @@ int main(int argc, char *argv[], char *envp[])
 		 * corresponding lib call change.
 		 */
 		opts.swrk_restore = true;
-		return cr_service_work(atoi(argv[2]));
+		return cr_service_work(atoi(argv[optind+1]));
 	}
 
 	if (check_options())
@@ -111,11 +117,6 @@ int main(int argc, char *argv[], char *envp[])
 
 	if (opts.work_dir == NULL)
 		SET_CHAR_OPTS(work_dir, opts.imgs_dir);
-
-	if (optind >= argc) {
-		pr_err("command is required\n");
-		goto usage;
-	}
 
 	has_sub_command = (argc - optind) > 1;
 


### PR DESCRIPTION
TL;DR: this makes possible to use `-v` with `criu swrk`, and removes showing
default usage which is useless in swrk mode.

1. Since criu swrk command is not described in usage, there is no sense
   in showing it. Instead, show a one-line hint about how to use it.

2. In case some global options (like `-v`) are used, `argv[1]` might not
   point to "swrk". Use `optind` to point to a correct non-option
   argument. Same for `fd` argument.

3. While at it, also error out in case we have extra arguments.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>