### PR TITLE
images: re-license as Expat license (MIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@ itself, and we have it available as the [libsoccr library](https://criu.org/Libs
 ## Licence
 
 The project is licensed under GPLv2 (though files sitting in the lib/ directory are LGPLv2.1).
+
+All files in the images/ directory are licensed under the Expat license (so-called MIT).
+See the images/LICENSE file.

--- a/images/LICENSE
+++ b/images/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 The CRIU developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/images/autofs.proto
+++ b/images/autofs.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message autofs_entry {

--- a/images/binfmt-misc.proto
+++ b/images/binfmt-misc.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message binfmt_misc_entry {

--- a/images/bpfmap-data.proto
+++ b/images/bpfmap-data.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message bpfmap_data_entry {

--- a/images/bpfmap-file.proto
+++ b/images/bpfmap-file.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/cgroup.proto
+++ b/images/cgroup.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message cgroup_perms {

--- a/images/core-aarch64.proto
+++ b/images/core-aarch64.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/core-arm.proto
+++ b/images/core-arm.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/core-mips.proto
+++ b/images/core-mips.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/core-ppc64.proto
+++ b/images/core-ppc64.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/core-s390.proto
+++ b/images/core-s390.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/core-x86.proto
+++ b/images/core-x86.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/core.proto
+++ b/images/core.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "core-x86.proto";

--- a/images/cpuinfo.proto
+++ b/images/cpuinfo.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message cpuinfo_x86_entry {

--- a/images/creds.proto
+++ b/images/creds.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message creds_entry {

--- a/images/eventfd.proto
+++ b/images/eventfd.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "fown.proto";

--- a/images/eventpoll.proto
+++ b/images/eventpoll.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "fown.proto";

--- a/images/ext-file.proto
+++ b/images/ext-file.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "fown.proto";

--- a/images/fdinfo.proto
+++ b/images/fdinfo.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "regfile.proto";

--- a/images/fh.proto
+++ b/images/fh.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/fifo.proto
+++ b/images/fifo.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message fifo_entry {

--- a/images/file-lock.proto
+++ b/images/file-lock.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message file_lock_entry {

--- a/images/fown.proto
+++ b/images/fown.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message fown_entry {

--- a/images/fs.proto
+++ b/images/fs.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message fs_entry {

--- a/images/fsnotify.proto
+++ b/images/fsnotify.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/ghost-file.proto
+++ b/images/ghost-file.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/img-streamer.proto
+++ b/images/img-streamer.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 // This message is sent from CRIU to the streamer.

--- a/images/inventory.proto
+++ b/images/inventory.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "core.proto";

--- a/images/ipc-desc.proto
+++ b/images/ipc-desc.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message ipc_desc_entry {

--- a/images/ipc-msg.proto
+++ b/images/ipc-msg.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "ipc-desc.proto";

--- a/images/ipc-sem.proto
+++ b/images/ipc-sem.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "ipc-desc.proto";

--- a/images/ipc-shm.proto
+++ b/images/ipc-shm.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "ipc-desc.proto";

--- a/images/ipc-var.proto
+++ b/images/ipc-var.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message ipc_var_entry {

--- a/images/macvlan.proto
+++ b/images/macvlan.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message macvlan_link_entry {

--- a/images/memfd.proto
+++ b/images/memfd.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/mm.proto
+++ b/images/mm.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/mnt.proto
+++ b/images/mnt.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/netdev.proto
+++ b/images/netdev.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "macvlan.proto";

--- a/images/ns.proto
+++ b/images/ns.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message ns_file_entry {

--- a/images/opts.proto
+++ b/images/opts.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "google/protobuf/descriptor.proto";

--- a/images/packet-sock.proto
+++ b/images/packet-sock.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/pagemap.proto
+++ b/images/pagemap.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/pidns.proto
+++ b/images/pidns.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message pidns_entry {

--- a/images/pipe-data.proto
+++ b/images/pipe-data.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message pipe_data_entry {

--- a/images/pipe.proto
+++ b/images/pipe.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/pstree.proto
+++ b/images/pstree.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message pstree_entry {

--- a/images/regfile.proto
+++ b/images/regfile.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/remap-file-path.proto
+++ b/images/remap-file-path.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 enum remap_type {

--- a/images/rlimit.proto
+++ b/images/rlimit.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message rlimit_entry {

--- a/images/rpc.proto
+++ b/images/rpc.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message criu_page_server_info {

--- a/images/sa.proto
+++ b/images/sa.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/seccomp.proto
+++ b/images/seccomp.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message seccomp_filter {

--- a/images/siginfo.proto
+++ b/images/siginfo.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message siginfo_entry {

--- a/images/signalfd.proto
+++ b/images/signalfd.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/sit.proto
+++ b/images/sit.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/sk-inet.proto
+++ b/images/sk-inet.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/sk-netlink.proto
+++ b/images/sk-netlink.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/sk-opts.proto
+++ b/images/sk-opts.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message sk_opts_entry {

--- a/images/sk-packet.proto
+++ b/images/sk-packet.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message scm_entry {

--- a/images/sk-unix.proto
+++ b/images/sk-unix.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/stats.proto
+++ b/images/stats.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 // This one contains statistics about dump/restore process

--- a/images/sysctl.proto
+++ b/images/sysctl.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 enum SysctlType {

--- a/images/tcp-stream.proto
+++ b/images/tcp-stream.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/time.proto
+++ b/images/time.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message timeval {

--- a/images/timens.proto
+++ b/images/timens.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message timespec {

--- a/images/timer.proto
+++ b/images/timer.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message itimer_entry {

--- a/images/timerfd.proto
+++ b/images/timerfd.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/tty.proto
+++ b/images/tty.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/tun.proto
+++ b/images/tun.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";

--- a/images/userns.proto
+++ b/images/userns.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message uid_gid_extent {

--- a/images/utsns.proto
+++ b/images/utsns.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 message utsns_entry {

--- a/images/vma.proto
+++ b/images/vma.proto
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 syntax = "proto2";
 
 import "opts.proto";


### PR DESCRIPTION
This changes the license of all files in the images/ directory from GPLv2 to Expat license (MIT).

This is motivated to make it possible to integrate CRIU's protobuf definition in other projects (Go, Rust) which are often licensed differently under Apache 2.0 which makes it difficult (impossible) to integrate GPLv2 code. Even if these files are only used as input for the protobuf compiler it still seems not totally clear if this is possible. Although CRIU usually does not have a license header, I added a header to all protobuf files to make sure the license information of these files is clear.

As the Expat license (MIT) is more permissive than Apache 2.0 the protobuf definitions can be used in Apache 2.0 and GPLv2 code.

According to git the files have been authored by (checked means the author has agreed)

 - [x] Abhishek Dubey
 - [x] Adrian Reber
 - [x]  Alexander Mikhalitsyn
 - [x] Alice Frosi
 - [x]  Andrei Vagin (Andrew Vagin, Andrey Vagin)
 - [x]  Cyrill Gorcunov
 - [x]  Dengguangxing
 - [x]  Dmitry Safonov
 - [x]  Guoyun Sun
 - [x]  Kirill Tkhai
 - [x]  Kir Kolyshkin
 - [x] Laurent Dufour
 - [x] Michael Holzheu
 - [x] Michał Cłapiński
 - [x] Mike Rapoport
 - [x] Nicolas Viennot
 - [x] Nikita Spiridonov
 - [x] Pavel Emelianov (Pavel Emelyanov)
 - [x] Pavel Tikhomirov
 - [x] Radostin Stoyanov
 - [x] rbruno@gsd.inesc-id.pt
 - [x] Sebastian Pipping
 - [x] Stanislav Kinsburskiy
 - [x] Tycho Andersen (via Stéphane Graber for Canonical)
 - [x]  Valeriy Vdovin

Let's see if all authors agree to re-license these files.

If we think this is a good idea please help me to get all people listed here accept this re-licensing.