### PR TITLE
Remove dupe of "deprecated stuff on" msg

### DIFF
--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -180,9 +180,6 @@ int main(int argc, char *argv[], char *envp[])
        if (fault_injected(FI_CANNOT_MAP_VDSO))
                kdat.can_map_vdso = 0;
 
-	if (opts.deprecated_ok)
-		pr_debug("DEPRECATED ON\n");
-
 	if (!list_empty(&opts.inherit_fds)) {
 		if (strcmp(argv[optind], "restore")) {
 			pr_err("--inherit-fd is restore-only option\n");


### PR DESCRIPTION
A similar one is already printed in check_options().

Before this patch:
> $ ./criu/criu -vvvvvv --deprecated --log-file=/dev/stdout xxx
> (00.000000) Turn deprecated stuff ON
> ...
> (00.029680) DEPRECATED ON
> (00.029687) Error (criu/crtools.c:284): unknown command: xxx

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>