### PR TITLE
lib/c: extend receive to handle incoming FDs

### DIFF
--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -117,6 +117,17 @@ void criu_set_notify_cb(int (*cb)(char *action, criu_notify_arg_t na));
 /* Get pid of root task. 0 if not available */
 int criu_notify_pid(criu_notify_arg_t na);
 
+/*
+ * If CRIU sends and FD in the case of 'orphan-pts-master',
+ * this FD can be retrieved with criu_get_orphan_pts_master_fd().
+ *
+ * If no FD has been received this will return -1.
+ *
+ * To make sure the FD returned is valid this function has to be
+ * called after the callback with the 'action' 'orphan-pts-master'.
+ */
+int criu_get_orphan_pts_master_fd(void);
+
 /* Here is a table of return values and errno's of functions
  * from the list down below.
  *


### PR DESCRIPTION
When using libcriu with the notify callback functionality CRIU transmits an FD during 'orphan-pts-master' back to libcriu user. This is message is sent via sendmsg() to transmit the FD and not via write() as all other protobuf messages.

libcriu was using recv() and to be able to receive the FD this needs to be changed to recvmsg() and if an FD is attached to it (currently only for 'orphan-pts-master' this FD is stored in a variable which can be retrieved with the function criu_get_orphan_pts_master_fd().

This (and #959) are the last changes to make it possible to use crun instead of runc to checkpoint and restore a container with Podman.