### PR TITLE
travis: use bionic almost everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     - os: linux
       arch: amd64
       env: TR_ARCH=fedora-rawhide
-      dist: xenial # test hangs on bionic
+      dist: bionic
     - os: linux
       arch: amd64
       env: TR_ARCH=podman-test
@@ -69,19 +69,19 @@ jobs:
     - os: linux
       arch: amd64
       env: TR_ARCH=alpine      CLANG=1
-      dist: xenial # test hangs on bionic
+      dist: bionic
     - os: linux
       arch: amd64
       env: TR_ARCH=alpine
-      dist: xenial # test hangs on bionic
+      dist: bionic
     - os: linux
       arch: amd64
       env: TR_ARCH=centos
-      dist: xenial # test hangs on bionic
+      dist: bionic
     - os: linux
       arch: amd64
       env: TR_ARCH=fedora-asan
-      dist: xenial # test hangs on bionic
+      dist: bionic
     - os: linux
       arch: amd64
       env: TR_ARCH=armv7-cross


### PR DESCRIPTION
A few tests were still running on xenial because at some point they were hanging. This switches now all tests to bionic except one docker test which still uses xenial to test with overlayfs.