### PR TITLE
tests: move cross compilation to github actions

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,0 +1,23 @@
+name: Cross Compile Tests
+
+on:
+  push:
+    branches: [ criu-dev ]
+  pull_request:
+    branches: [ criu-dev ]
+  schedule:
+    - cron:  '55 5 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [armv7-cross, aarch64-cross, ppc64-cross, mips64el-cross]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Cross Compilation Targets
+      run: >
+        sudo make -C scripts/travis ${{ matrix.target }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,22 +82,6 @@ jobs:
       arch: amd64
       env: TR_ARCH=fedora-asan
       dist: bionic
-    - os: linux
-      arch: amd64
-      env: TR_ARCH=armv7-cross
-      dist: bionic
-    - os: linux
-      arch: amd64
-      env: TR_ARCH=aarch64-cross
-      dist: bionic
-    - os: linux
-      arch: amd64
-      env: TR_ARCH=ppc64-cross
-      dist: bionic
-    - os: linux
-      arch: amd64
-      env: TR_ARCH=mips64el-cross
-      dist: bionic
   allow_failures:
     - env: TR_ARCH=docker-test
     - env: TR_ARCH=docker-test DIST=xenial


### PR DESCRIPTION
This moves the cross compilation tests to github actions, to slightly reduce the number of Travis tests and run them in parallel on github actions.