### PR TITLE
cr-service: message fixes

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -126,6 +126,8 @@ static char ** parse_config(char *filepath)
 	if (!configfile)
 		return NULL;
 
+	pr_debug("Parsing config file %s\n", filepath);
+
 	configuration = xmalloc(config_size * sizeof(char *));
 	if (configuration == NULL) {
 		fclose(configfile);

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -673,8 +673,10 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 	if (req->has_status_fd) {
 		sprintf(status_fd, "/proc/%d/fd/%d", ids.pid, req->status_fd);
 		opts.status_fd = open(status_fd, O_WRONLY);
-		if (opts.status_fd < 0)
+		if (opts.status_fd < 0) {
+			pr_perror("Can't reopen status fd %s", status_fd);
 			goto err;
+		}
 	}
 
 	if (req->orphan_pts_master)

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -398,7 +398,7 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 	}
 
 	if (req->config_file) {
-		pr_debug("Overwriting RPC settings with values from %s\n", req->config_file);
+		pr_debug("Would overwrite RPC settings with values from %s\n", req->config_file);
 	}
 
 	if (kerndat_init())


### PR DESCRIPTION
A couple of nits for messages printed by cr-service.

### 1. cr-service: fix wording in debug messages
    
The message "Overwriting RPC settings with values from <filename>" is
misleading, giving the impression that file is being read and consumed.
It really puzzled me, since <filename> didn't exist.
    
What it needs to say is "Would overwrite", i.e. if a file with such name
is present, it would be used.
    
Also, add actual "Parsing file ..." so it will be clear which files are
being used.

### 2. cr-service: spell out an error
    
While working on runc checkpointing, I incorrectly closed status_fd
prematurely, and received an error from CRIU, but it was
non-descriptive.
    
Do print the error from open().

