### PR TITLE
[RFC] swrk: send notification instead of using status fd

### DIFF
--- a/criu/action-scripts.c
+++ b/criu/action-scripts.c
@@ -29,6 +29,7 @@ static const char *action_names[ACT_MAX] = {
 	[ ACT_PRE_RESUME ]	= "pre-resume",
 	[ ACT_POST_RESUME ]	= "post-resume",
 	[ ACT_ORPHAN_PTS_MASTER ] = "orphan-pts-master",
+	[ ACT_STATUS_READY ]    = "status-ready",
 };
 
 struct script {

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -1385,7 +1385,7 @@ int cr_service(bool daemon_mode)
 	if (setup_sigchld_handler())
 		goto err;
 
-	if (close_status_fd())
+	if (status_ready())
 		goto err;
 
 	while (1) {

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -671,6 +671,8 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 	}
 
 	if (req->has_status_fd) {
+		pr_warn("status_fd is obsoleted; use status-ready notification instead\n");
+
 		sprintf(status_fd, "/proc/%d/fd/%d", ids.pid, req->status_fd);
 		opts.status_fd = open(status_fd, O_WRONLY);
 		if (opts.status_fd < 0)

--- a/criu/include/action-scripts.h
+++ b/criu/include/action-scripts.h
@@ -15,6 +15,7 @@ enum script_actions {
 	ACT_POST_RESUME,
 	ACT_PRE_RESUME,
 	ACT_ORPHAN_PTS_MASTER,
+	ACT_STATUS_READY,
 
 	ACT_MAX
 };

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -177,7 +177,7 @@ extern int cr_system(int in, int out, int err, char *cmd, char *const argv[], un
 extern int cr_system_userns(int in, int out, int err, char *cmd,
 				char *const argv[], unsigned flags, int userns_pid);
 extern int cr_daemon(int nochdir, int noclose, int close_fd);
-extern int close_status_fd(void);
+extern int status_ready(void);
 extern int is_root_user(void);
 
 extern void set_proc_self_fd(int fd);

--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -1456,7 +1456,7 @@ int cr_lazy_pages(bool daemon)
 		}
 	}
 
-	if (close_status_fd())
+	if (status_ready())
 		return -1;
 
 	/*

--- a/criu/util.c
+++ b/criu/util.c
@@ -660,7 +660,7 @@ out:
 	return ret;
 }
 
-int close_status_fd(void)
+int status_ready(void)
 {
 	char c = 0;
 
@@ -1121,7 +1121,7 @@ int run_tcp_server(bool daemon_mode, int *ask, int cfd, int sk)
 		}
 	}
 
-	if (close_status_fd())
+	if (status_ready())
 		return -1;
 
 	if (sk >= 0) {

--- a/criu/util.c
+++ b/criu/util.c
@@ -45,6 +45,7 @@
 #include "pstree.h"
 
 #include "cr-errno.h"
+#include "action-scripts.h"
 
 #define VMA_OPT_LEN	128
 
@@ -663,6 +664,9 @@ out:
 int status_ready(void)
 {
 	char c = 0;
+
+	if (run_scripts(ACT_STATUS_READY))
+		return -1;
 
 	if (opts.status_fd < 0)
 		return 0;


### PR DESCRIPTION
When we use swrk, we have a mechanism to send notifications over RPC.
It is cleaner and more straightforward than sending `\0` to status fd.

For now, both mechanisms are supported, although status fd request
option is now deprecated, so a warning is logged in case it's used.

Guess we can remove it in a few years.

The corresponding runc PR is here: https://github.com/opencontainers/runc/pull/2414