### PR TITLE
travis: switch travis to Python 3

### DIFF
--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -1,12 +1,26 @@
 #!/bin/bash
 set -x -e
 
-TRAVIS_PKGS="protobuf-c-compiler libprotobuf-c-dev libaio-dev python-future
-		libgnutls28-dev libgnutls30 libprotobuf-dev protobuf-compiler
-		libcap-dev libnl-3-dev gdb bash python-protobuf python-yaml
-		libnet-dev util-linux asciidoctor libnl-route-3-dev
-		python-junit.xml python-ipaddress time ccache flake8
-		libbsd-dev"
+TRAVIS_PKGS="protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
+		libgnutls30 libprotobuf-dev protobuf-compiler libcap-dev
+		libnl-3-dev gdb bash libnet-dev util-linux asciidoctor
+		libnl-route-3-dev time ccache flake8 libbsd-dev"
+
+
+if [ -e /etc/lsb-release ]; then
+	# This file does not exist on non Ubuntu
+	. /etc/lsb-release
+	if [ "$DISTRIB_RELEASE" = "16.04" ]; then
+		# There is one last test running on 16.04 because of the broken
+		# overlayfs in 18.04. Once that is fixed we can remove the last
+		# 16.04 based test and this if clause.
+		TRAVIS_PKGS="$TRAVIS_PKGS python-future python-protobuf python-yaml
+				python-junit.xml python-ipaddress"
+	else
+		TRAVIS_PKGS="$TRAVIS_PKGS python3-future python3-protobuf python3-yaml
+				python3-junit.xml"
+	fi
+fi
 
 X86_64_PKGS="gcc-multilib"
 
@@ -78,6 +92,10 @@ travis_prep () {
 
 	apt_install $TRAVIS_PKGS
 	chmod a+x $HOME
+
+	# zdtm uses an unversioned python binary to run the tests.
+	# let's point python to python3
+	ln -sf /usr/bin/python3 /usr/bin/python
 }
 
 test_stream() {


### PR DESCRIPTION
Python2 has reached its EOL. Let's switch to Python3 in our Travis runs.

We are still using Python 2 in the CentOS 7 test run.