### PR TITLE
Restrict Checks for Open/MMAPed Files - CLI & Build-ID

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -280,6 +280,7 @@ void init_opts(void)
 	opts.status_fd = -1;
 	opts.log_level = DEFAULT_LOGLEVEL;
 	opts.pre_dump_mode = PRE_DUMP_SPLICE;
+	opts.file_validation_method = FILE_VALIDATION_DEFAULT;
 }
 
 bool deprecated_ok(char *what)
@@ -420,6 +421,22 @@ static int parse_join_ns(const char *ptr)
 	return 0;
 }
 
+static int parse_file_validation_method(struct cr_options *opts, const char *optarg)
+{
+	if (!strcmp(optarg, "filesize"))
+		opts->file_validation_method = FILE_VALIDATION_FILE_SIZE;
+	else if (!strcmp(optarg, "buildid"))
+		opts->file_validation_method = FILE_VALIDATION_BUILD_ID;
+	else
+		goto Esyntax;
+
+	return 0;
+
+Esyntax:
+	pr_err("Unknown file validation method `%s' selected\n", optarg);
+	return -1;
+}
+
 /*
  * parse_options() is the point where the getopt parsing happens. The CLI
  * parsing as well as the configuration file parsing happens here.
@@ -523,6 +540,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 		{"tls-no-cn-verify",		no_argument,		&opts.tls_no_cn_verify, true},
 		{ "cgroup-yard",		required_argument,	0, 1096 },
 		{ "pre-dump-mode",		required_argument,	0, 1097},
+		{ "file-validation",		required_argument,	0, 1098	},
 		{ },
 	};
 
@@ -831,6 +849,10 @@ int parse_options(int argc, char **argv, bool *usage_error,
 				pr_err("Unable to parse value of --pre-dump-mode\n");
 				return 1;
 			}
+			break;
+		case 1098:
+			if (parse_file_validation_method(&opts, optarg))
+				return 2;
 			break;
 		case 'V':
 			pr_msg("Version: %s\n", CRIU_VERSION);

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1649,7 +1649,8 @@ static bool store_validation_data(RegFileEntry *rfe,
 	rfe->has_size = true;
 	rfe->size = p->stat.st_size;
 
-	result = store_validation_data_build_id(rfe, lfd, p);
+	if (opts.file_validation_method == FILE_VALIDATION_BUILD_ID)
+		result = store_validation_data_build_id(rfe, lfd, p);
 
 	if (result == -1)
 		pr_info("Only file size could be stored for validation for file %s\n",
@@ -2069,7 +2070,8 @@ static bool validate_file(const int fd, const struct stat *fd_status,
 		return false;
 	}
 
-	result = validate_with_build_id(fd, fd_status, rfi);
+	if (opts.file_validation_method == FILE_VALIDATION_BUILD_ID)
+		result = validate_with_build_id(fd, fd_status, rfi);
 
 
 	if (result == -1)

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -63,6 +63,14 @@ struct cg_root_opt {
 
 #define DEFAULT_TIMEOUT		10
 
+/*
+ * File validation options
+ */
+#define FILE_VALIDATION_FILE_SIZE		1
+#define FILE_VALIDATION_BUILD_ID		2
+
+#define FILE_VALIDATION_DEFAULT			FILE_VALIDATION_BUILD_ID
+
 struct irmap;
 
 struct irmap_path_opt {
@@ -153,6 +161,9 @@ struct cr_options {
 	char			*tls_key;
 	int			tls;
 	int			tls_no_cn_verify;
+
+	/* Options for file validation */
+	int 			file_validation_method;
 };
 
 extern struct cr_options opts;

--- a/images/regfile.proto
+++ b/images/regfile.proto
@@ -4,13 +4,17 @@ import "opts.proto";
 import "fown.proto";
 
 message reg_file_entry {
-	required uint32		id	= 1;
-	required uint32		flags	= 2 [(criu).flags = "rfile.flags"];
-	required uint64		pos	= 3;
-	required fown_entry	fown	= 5;
-	required string		name	= 6;
-	optional sint32		mnt_id	= 7 [default = -1];
-	optional uint64		size	= 8;
-	optional bool		ext	= 9;
-	optional uint32         mode    = 10;
+	required uint32		id			= 1;
+	required uint32		flags			= 2 [(criu).flags = "rfile.flags"];
+	required uint64		pos			= 3;
+	required fown_entry	fown			= 5;
+	required string		name			= 6;
+	optional sint32		mnt_id			= 7 [default = -1];
+	optional uint64		size			= 8;
+	optional bool		ext			= 9;
+	optional uint32         mode    		= 10;
+	repeated uint32 	build_id 		= 11;
+	optional uint32 	checksum 		= 12;
+	optional uint32 	checksum_config 	= 13;
+	optional uint32 	checksum_parameter 	= 14;
 }


### PR DESCRIPTION
This adds CLI options and the build-ID file verification method in addition to the current file size check as part of GSoC 2020.

This will make CRIU use the build-ID validation method by default whenever possible (The file size check is now a preliminary check) and if that cannot be done, it will use only the file size check. To explicitly use only the file size check all the time, the following command line option can be used: `--file-validation="filesize"`
In other words, `--file-validation="buildid"` will not make a difference as this is the default method.

Mentors: @avagin @0x7f454c46