### PR TITLE
travis: fix alpine builds

### DIFF
--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -15,9 +15,12 @@ RUN apk update && apk add \
 	libnet-dev \
 	libnl3-dev \
 	nftables \
+	nftables-dev \
 	pkgconfig \
 	protobuf-c-dev \
 	protobuf-dev \
+	py3-pip \
+	py3-protobuf \
 	python3 \
 	sudo
 
@@ -43,7 +46,7 @@ RUN apk add \
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 -D test
 
-RUN pip3 install protobuf junit_xml
+RUN pip3 install junit_xml
 
 # For zdtm we need an unversioned python binary
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -2077,11 +2077,11 @@ def grep_errors(fname):
     print_next = False
     before = []
     with open(fname, errors='replace') as fd:
-        for l in fd:
-            before.append(l)
+        for line in fd:
+            before.append(line)
             if len(before) > 5:
                 before.pop(0)
-            if "Error" in l or "Warn" in l:
+            if "Error" in line or "Warn" in line:
                 if first:
                     print_fname(fname, 'log')
                     print_sep("grep Error", "-", 60)
@@ -2091,7 +2091,7 @@ def grep_errors(fname):
                 before = []
             else:
                 if print_next:
-                    print_next = print_error(l)
+                    print_next = print_error(line)
                     before = []
     if not first:
         print_sep("ERROR OVER", "-", 60)


### PR DESCRIPTION
With the latest version of the alpine container image it seems that alpine changed a few package names. This adapts the alpine container to solve the travis failures.

This also includes a small change to zdtm.py because the latest run of flake8 complains about having variables named 'l'.