### PR TITLE
uffd: uffd_open prints info, caller prints error

### DIFF
--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -269,7 +269,7 @@ int uffd_open(int flags, unsigned long *features)
 
 	uffd = syscall(SYS_userfaultfd, flags);
 	if (uffd == -1) {
-		pr_perror("Lazy pages are not available");
+		pr_info("Lazy pages are not available: %s\n", strerror(errno));
 		return -errno;
 	}
 


### PR DESCRIPTION
When uffd_open is called from kerndat_uffd, userfaultfd failure is not
considered an error, so the goal is to suppress the error message --
instead, we print this message as info.

If the function fails, it is the responsibility of the caller
to print the error message.