### PR TITLE
CONTRIBUTING.md: fixups and additions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,6 +216,44 @@ commit message. To append such line to a commit you already made, use
 We accept GitHub pull requests and this is the preferred way to contribute to CRIU.
 For that you should push your work to your fork of CRIU at [GitHub](https://github.com) and create a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
 
+### Pull request guidelines
+
+Pull request comment should contain description of the problem your changes
+solve and a brief outline of the changes included in the pull request.
+
+Please avoid pushing fixup commits to an existent pull request. Each commit
+should be self contained and there should not be fixup commits in a patch
+series. Pull requests that contain one commit which breaks something
+and another commit which fixes it, will be rejected.
+
+Please merge the fixup commits into the commits that has introduced the
+problem before creating a pull request.
+
+It may happen that the reviewers were not completely happy with your
+changes and requested changes to your patches. After you updated your
+changes please close the old pull request and create a new one that
+contains the following:
+
+* Description of the problem your changes solve and a brief outline of the
+  changes
+* Link to the previous version of the pull request
+* Brief description of the changes between old and new versions of the pull
+  request. If there were more than one previous pull request, all the
+  revisions should be listed. For example:
+
+```
+	v3: rebase on the current criu-dev
+	v2: add commit to foo() and update bar() coding style
+```
+
+If there are only minor updates to the commits in a pull request, it is
+possible to force-push them into an existing pull request. This only applies
+to small changes and should be used with care. If you update an existing
+pull request, remember to add the description of the changes from the
+previous version.
+
+### Mailing list submission
+
 Historically, CRIU worked with mailing lists and patches so if you still prefer this way continue reading till the end of this section.
 
 ### Make a patch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,15 +13,15 @@ Here are some useful hints to get involved.
 * We have both -- [very simple](https://github.com/checkpoint-restore/criu/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) and [more sophisticated](https://github.com/checkpoint-restore/criu/issues?q=is%3Aissue+is%3Aopen+label%3A%22new+feature%22) coding tasks;
 * CRIU does need [extensive testing](https://github.com/checkpoint-restore/criu/issues?q=is%3Aissue+is%3Aopen+label%3Atesting);
 * Documentation is always hard, we have [some information](https://criu.org/Category:Empty_articles) that is to be extracted from people's heads into wiki pages as well as [some texts](https://criu.org/Category:Editor_help_needed) that all need to be converted into useful articles;
-* Feedback is expected on the github issues page and on the [mailing list](https://lists.openvz.org/mailman/listinfo/criu);
-* We accept github pull requests and this is the preferred way to contribute to CRIU. If you prefer to send patches by email, you are welcome to send them to [CRIU development mailing list](https://lists.openvz.org/mailman/listinfo/criu).
-Below we describe in more detail recommend practices for CRIU developemnt.
+* Feedback is expected on the GitHub issues page and on the [mailing list](https://lists.openvz.org/mailman/listinfo/criu);
+* We accept GitHub pull requests and this is the preferred way to contribute to CRIU. If you prefer to send patches by email, you are welcome to send them to [CRIU development mailing list](https://lists.openvz.org/mailman/listinfo/criu).
+Below we describe in more detail recommend practices for CRIU development.
 * Spread the word about CRIU in [social networks](http://criu.org/Contacts);
 * If you're giving a talk about CRIU -- let us know, we'll mention it on the [wiki main page](https://criu.org/News/events);
 
-### Seting up the developemnt environment
+### Setting up the development environment
 
-Although criu could be run as non-root (see [Security](https://criu.org/Security), development is better to be done as root. For example, some tests require root. So, it would be a good idea to set up some recent Linux distro on a virtual machine.
+Although `criu` could be run as non-root (see [Security](https://criu.org/Security)), development is better to be done as root. For example, some tests require root. So, it would be a good idea to set up some recent Linux distro on a virtual machine.
 
 ### Get the source code
 
@@ -76,14 +76,14 @@ CRIU comes with an extensive test suite. To check whether your changes introduce
 The command runs [ZDTM Test Suite](https://criu.org/ZDTM_Test_Suite). Check for any error messages produced by it.
 
 In case you'd rather have someone else run the tests, you can use travis-ci for your
-own github fork of CRIU. It will check the compilation for various supported platforms,
+own GitHub fork of CRIU. It will check the compilation for various supported platforms,
 as well as run most of the tests from the suite. See https://travis-ci.org/checkpoint-restore/criu
 for more details.
 
 ## Sign your work
 
-To improve tracking of who did what, we ask you to sign off the patches
-that are to be emailed.
+To improve tracking of who did what, we ask you to sign off the commits in
+your fork of CRIU or the patches that are to be emailed.
 
 The sign-off is a simple line at the end of the explanation for the
 patch, which certifies that you wrote it or otherwise have the right to
@@ -142,7 +142,7 @@ commit message. To append such line to a commit you already made, use
 
 ## Submit your work upstream
 
-We accept github pull requests and this is the preferred way to contribute to CRIU.
+We accept GitHub pull requests and this is the preferred way to contribute to CRIU.
 For that you should push your work to your fork of CRIU at [GitHub](https://github.com) and create a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
 
 Historically, CRIU worked with mailing lists and patches so if you still prefer this way continue reading till the end of this section.
@@ -200,7 +200,7 @@ The patches should be sent to CRIU development mailing list, `criu AT openvz.org
 
 Please make sure the email client you're using doesn't screw your patch (line wrapping and so on).
 
-{{Note| When sending a patch set that consists of more than one patch, please, push your changes in your local repo and provide the URL of the branch in the cover-letter}}
+>  **Note:** When sending a patch set that consists of more than one patch, please, push your changes in your local repo and provide the URL of the branch in the cover-letter
 
 ### Wait for response
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,77 @@ own GitHub fork of CRIU. It will check the compilation for various supported pla
 as well as run most of the tests from the suite. See https://travis-ci.org/checkpoint-restore/criu
 for more details.
 
+## Describe your changes
+
+Describe your problem.  Whether your change is a one-line bug fix or
+5000 lines of a new feature, there must be an underlying problem that
+motivated you to do this work.  Convince the reviewer that there is a
+problem worth fixing and that it makes sense for them to read past the
+first paragraph.
+
+Once the problem is established, describe what you are actually doing
+about it in technical detail. It's important to describe the change
+in plain English for the reviewer to verify that the code is behaving
+as you intend it to.
+
+Solve only one problem per commit. If your description starts to get
+long, that's a sign that you probably need to split up your commit.
+See [Separate your changes](#separate-your-changes).
+
+Describe your changes in imperative mood, e.g. "make xyzzy do frotz"
+instead of "[This commit] makes xyzzy do frotz" or "[I] changed xyzzy
+to do frotz", as if you are giving orders to the codebase to change
+its behaviour.
+
+If your change fixes a bug in a specific commit, e.g. you found an issue using
+`git bisect`, please use the `Fixes:` tag with the abbreviation of
+the SHA-1 ID, and the one line summary. For example:
+
+```
+	Fixes: 9433b7b9db3e ("make: use cflags/ldflags for config.h detection mechanism")
+```
+
+The following `git config` settings can be used to add a pretty format for
+outputting the above style in the `git log` or `git show` commands:
+
+```
+	[pretty]
+		fixes = Fixes: %h (\"%s\")
+```
+
+If your change address an issue listed in GitHub, please use `Fixes:` tag with the number of the issue. For instance:
+
+```
+	Fixes: #339
+```
+
+You may refer to [How to Write a Git Commit
+Message](https://chris.beams.io/posts/git-commit/) article for
+recommendations for good commit message.
+
+## Separate your changes
+
+Separate each **logical change** into a separate commit.
+
+For example, if your changes include both bug fixes and performance
+enhancements for a single driver, separate those changes into two
+or more commits.  If your changes include an API update, and a new
+driver which uses that new API, separate those into two commits.
+
+On the other hand, if you make a single change to numerous files,
+group those changes into a single commit.  Thus a single logical change
+is contained within a single commit.
+
+The point to remember is that each commit should make an easily understood
+change that can be verified by reviewers.  Each commit should be justifiable
+on its own merits.
+
+When dividing your change into a series of commits, take special care to
+ensure that CRIU builds and runs properly after each commit in the
+series.  Developers using `git bisect` to track down a problem can end up
+splitting your patch series at any point; they will not thank you if you
+introduce bugs in the middle.
+
 ## Sign your work
 
 To improve tracking of who did what, we ask you to sign off the commits in


### PR DESCRIPTION
Following the discussions at #1096 and #1100, start updating the contributor's guide.
* Fix spelling and formatting
* Add sections about describing and splitting patches
* Add section about pull request creation