### PR TITLE
travis: Cache Vagrant VM images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: c
 os: linux
 dist: bionic
-cache: ccache
+cache:
+  ccache: true
+  directories:
+  - /home/travis/.vagrant.d/boxes
 services:
   - docker
 env:


### PR DESCRIPTION
This commit enables caching for Vagrant VM images in Travis-CI.