### PR TITLE
Fix segfault restoring tasks mntns

### DIFF
--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -1210,14 +1210,19 @@ static int move_in_cgroup(CgSetEntry *se, bool setup_cgns)
 
 int prepare_task_cgroup(struct pstree_item *me)
 {
+	struct pstree_item *parent = me->parent;
 	CgSetEntry *se;
 	u32 current_cgset;
 
 	if (!rsti(me)->cg_set)
 		return 0;
 
-	if (me->parent)
-		current_cgset = rsti(me->parent)->cg_set;
+	/* Zombies and helpers can have cg_set == 0 so we skip them */
+	while (parent && !rsti(parent)->cg_set)
+		parent = parent->parent;
+
+	if (parent)
+		current_cgset = rsti(parent)->cg_set;
 	else
 		current_cgset = root_cg_set;
 

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -229,6 +229,7 @@ TST_NOFILE	:=				\
 		time				\
 		timens_nested			\
 		timens_for_kids			\
+		zombie_leader			\
 #		jobctl00			\
 
 ifneq ($(ARCH),arm)

--- a/test/zdtm/static/zombie_leader.c
+++ b/test/zdtm/static/zombie_leader.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc	= "Check non-empty session with zombie leader";
+const char *test_author	= "Pavel Tikhomirov <ptikhomirov@virtuozzo.com>";
+
+int child(void)
+{
+	while (1)
+		sleep(1);
+
+	return 0;
+}
+
+int zombie_leader(int *cpid)
+{
+	int pid;
+
+	setsid();
+
+	pid = fork();
+	if (pid < 0) {
+		pr_perror("Failed to fork child");
+		return 1;
+	} else if (pid == 0) {
+		exit(child());
+	}
+
+	*cpid = pid;
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	int ret = -1, status;
+	int pid, *cpid;
+	siginfo_t infop;
+
+	test_init(argc, argv);
+
+	cpid = (int *)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+			   MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+	*cpid = 0;
+
+	pid = fork();
+	if (pid < 0) {
+		pr_perror("Failed to fork zombie");
+		return 1;
+	} else if (pid == 0) {
+		exit(zombie_leader(cpid));
+	}
+
+	if (waitid(P_PID, pid, &infop, WNOWAIT | WEXITED) < 0) {
+		pr_perror("Failed to waitid zombie");
+		goto err;
+	}
+
+	if (!*cpid) {
+		pr_err("Don't know grand child's pid");
+		goto err;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	ret = 0;
+err:
+	waitpid(pid, &status, 0);
+
+	if (*cpid)
+		kill(*cpid, SIGKILL);
+
+	if (!ret)
+		pass();
+
+	return 0;
+}

--- a/test/zdtm/static/zombie_leader.desc
+++ b/test/zdtm/static/zombie_leader.desc
@@ -1,0 +1,1 @@
+{'flavor': 'ns uns'}


### PR DESCRIPTION
Zombies have zero cg_set and ids on pstree they are just not dumped for them. Zombies can have children (Yes Run, Run, Run...! and see prepare_pstree_ids). So we can get segfault on ids and fail cgroup restore on zero parent cg_set, fix it.

Fixes: #1066 