### PR TITLE
Add error logging to kerndat init

### DIFF
--- a/criu/net.c
+++ b/criu/net.c
@@ -3484,11 +3484,15 @@ int kerndat_link_nsid(void)
 		}
 
 		has_link_nsid = false;
-		if (check_link_nsid(sk, &has_link_nsid))
+		if (check_link_nsid(sk, &has_link_nsid)) {
+			pr_err("check_link_nsid failed\n");
 			exit(1);
+		}
 
-		if (!has_link_nsid)
+		if (!has_link_nsid) {
+			pr_err("check_link_nsid succeeded but has_link_nsid is false\n");
 			exit(5);
+		}
 
 		close(sk);
 


### PR DESCRIPTION
CRIU sometimes returns 1 from main() with no explanation.
These changes add additional logging for initialization errors in kerndat.

There may be discourse surrounding the messages themselves -- specific alternatives are written and recorded elsewhere for each "foo failed" message. Given the large number of functions I've written error messages for in this commit, it may be safer to start with generic "foo failed" messages. These can be replaced depending on the preference of the CRIU maintainers. 

Signed-off-by: Angie Ni <avtni@google.com>