### PR TITLE
mount: adjust log & fsnotify: rework redundant code

### DIFF
--- a/criu/fsnotify.c
+++ b/criu/fsnotify.c
@@ -209,7 +209,7 @@ static int open_handle(unsigned int s_dev, unsigned long i_ino,
 
 		mntfd = __open_mountpoint(m, -1);
 		if (mntfd < 0) {
-			pr_err("Can't open mount for s_dev %x, continue\n", s_dev);
+			pr_warn("Can't open mount for s_dev %x, continue\n", s_dev);
 			continue;
 		}
 

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -235,6 +235,7 @@ struct mount_info *lookup_mnt_sdev(unsigned int s_dev)
 		if (m->s_dev == s_dev && mnt_is_dir(m))
 			return m;
 
+	pr_err("Unable to find suitable mount point for s_dev %x\n", s_dev);
 	return NULL;
 }
 
@@ -1016,12 +1017,12 @@ int mnt_is_dir(struct mount_info *pm)
 
 	mntns_root = mntns_get_root_fd(pm->nsid);
 	if (mntns_root < 0) {
-		pr_perror("Can't get root fd of mntns for %d", pm->mnt_id);
+		pr_warn("Can't get root fd of mntns for %d: %s\n", pm->mnt_id, strerror(errno));
 		return 0;
 	}
 
 	if (fstatat(mntns_root, pm->ns_mountpoint, &st, 0)) {
-		pr_perror("Can't fstatat on %s", pm->ns_mountpoint);
+		pr_warn("Can't fstatat on %s: %s\n", pm->ns_mountpoint, strerror(errno));
 		return 0;
 	}
 

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -1111,8 +1111,8 @@ static char *get_clean_mnt(struct mount_info *mi, char *mnt_path_tmp, char *mnt_
 	}
 
 	if (mount(mi->mountpoint, mnt_path, NULL, MS_BIND, NULL)) {
-		pr_perror("Can't bind-mount %d:%s to %s",
-				mi->mnt_id, mi->mountpoint, mnt_path);
+		pr_warn("Can't bind-mount %d:%s to %s: %s\n",
+				mi->mnt_id, mi->mountpoint, mnt_path, strerror(errno));
 		rmdir(mnt_path);
 		return NULL;
 	}


### PR DESCRIPTION
Adjust some log levels:
1) get_clean_mnt() pr_perror  -> pr_warn since the caller may resolve this situation or print error in the worst case (similar to this [commit](https://github.com/checkpoint-restore/criu/commit/5c5e7695a51318b17e3d982df8231ac83971641c))
2) mnt_is_dir() pr_perror->pr_warn since it may fail several times before finding suitable mountpoint. Added error in lookup_mnt_sdev. Other callers of mnt_is_dir() have corresponding errors.

Remove redundant call to open_handle() in check_open_handle() since alloc_openable() do exactly the same work plus some code.