### PR TITLE
tests: criu-image-streamer change dev branch to master branch

### DIFF
--- a/scripts/install-criu-image-streamer.sh
+++ b/scripts/install-criu-image-streamer.sh
@@ -6,8 +6,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Clone criu-image-streamer in a sibling directory of the criu project directory
 cd $(dirname "$0")/../../
-# TODO change dev branch to master once PR is merged
-git clone --depth=1 https://github.com/checkpoint-restore/criu-image-streamer.git -b dev
+git clone --depth=1 https://github.com/checkpoint-restore/criu-image-streamer.git
 
 # Compile
 cd criu-image-streamer


### PR DESCRIPTION
Now that the new protocol is in, we can move to the master branch on criu-image-streamer