### PR TITLE
Reserve images fields for new virtuozzo features

### DIFF
--- a/images/core.proto
+++ b/images/core.proto
@@ -73,6 +73,10 @@ message task_kobj_ids_entry {
 	optional uint32			user_ns_id	= 10;
 	optional uint32			cgroup_ns_id	= 11;
 	optional uint32			time_ns_id	= 12;
+/*
+ * These field is reserved for Virtuozzo criu nested pidns feature
+ *	optional uint32			pid_for_children_ns_id	= 13;
+ */
 }
 
 message thread_sas_entry {

--- a/images/mnt.proto
+++ b/images/mnt.proto
@@ -30,6 +30,10 @@ enum fstype {
 	// NFS4			= 22;
 
 	CGROUP2			= 23;
+/*
+ * These field is reserved for Virtuozzo criu new mounts engine
+ * 	NSFS			= 24;
+ */
 };
 
 message mnt_entry {
@@ -57,4 +61,10 @@ message mnt_entry {
 	optional uint32		sb_flags		= 17 [(criu).hex = true];
 	/* user defined mapping for external mount */
 	optional string		ext_key			= 18;
+/*
+ * These fields are reserved for Virtuozzo criu new mounts engine
+ *	optional uint32		ns_bind_id		= 19;
+ *	optional uint32		ns_bind_desc		= 20;
+ *	optional mnt_nses_entry	nses			= 21;
+ */
 }

--- a/images/pstree.proto
+++ b/images/pstree.proto
@@ -6,4 +6,11 @@ message pstree_entry {
 	required uint32			pgid		= 3;
 	required uint32			sid		= 4;
 	repeated uint32			threads		= 5;
+/*
+ * These fields are reserved for Virtuozzo criu nested pidns feature
+ *	repeated uint32			ns_pid		= 6;
+ *	repeated uint32			ns_pgid		= 7;
+ *	repeated uint32			ns_sid		= 8;
+ *	repeated ns_tid			tids		= 9;
+ */
 }

--- a/images/rpc.proto
+++ b/images/rpc.proto
@@ -127,7 +127,11 @@ message criu_opts {
 	optional bool			tls_no_cn_verify	= 59;
 	optional string			cgroup_yard		= 60;
 	optional criu_pre_dump_mode	pre_dump_mode		= 61 [default = SPLICE];
-/*	optional bool			check_mounts		= 128;	*/
+/*
+ *	These fields are reserved for Virtuozzo criu new mounts engine
+ *	optional bool			check_mounts		= 128;
+ *	optional bool			mounts_v2		= 129;
+ */
 }
 
 message criu_dump_resp {

--- a/images/sk-unix.proto
+++ b/images/sk-unix.proto
@@ -51,4 +51,9 @@ message unix_sk_entry {
 
 	optional uint32			ns_id		= 16;
 	optional sint32			mnt_id		= 17 [default = -1];
+/*
+ * These field is reserved for Virtuozzo criu multiple unix socket bindmounts feature
+ *	repeated uint32			vz_mnt_id	= 18;
+ *	repeated uint32			bind_mnt_ids	= 19;
+ */
 }


### PR DESCRIPTION
We've prepared several CRIU restore improvements for Virtuozzo criu to make it possible dumping Virtuozzo containers with Docker containers inside in our next update. So to maintain images format compatibility between mscriu and vzcriu lets reserve field ids in images.