### PR TITLE
Fix usage of logging functionality

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1304,7 +1304,7 @@ static int (*chk_feature)(void);
 			"dump or restore failure."
 #define CHECK_CAT1(fn)	do { \
 				if ((ret = fn) != 0) { \
-					print_on_level(DEFAULT_LOGLEVEL, "%s\n", CHECK_BAD); \
+					pr_warn("%s\n", CHECK_BAD); \
 					return ret; \
 				} \
 			} while (0)
@@ -1336,8 +1336,7 @@ int cr_check(void)
 	if (chk_feature) {
 		if (chk_feature())
 			return -1;
-		print_on_level(DEFAULT_LOGLEVEL, "%s is supported\n",
-			feature_name(chk_feature));
+		pr_msg("%s is supported\n", feature_name(chk_feature));
 		return 0;
 	}
 
@@ -1405,7 +1404,7 @@ int cr_check(void)
 		ret |= check_compat_cr();
 	}
 
-	print_on_level(DEFAULT_LOGLEVEL, "%s\n", ret ? CHECK_MAYBE : CHECK_GOOD);
+	pr_msg("%s\n", ret ? CHECK_MAYBE : CHECK_GOOD);
 	return ret;
 }
 #undef CHECK_GOOD

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -864,9 +864,11 @@ static int prepare_proc_misc(pid_t pid, TaskCoreEntry *tc, struct task_restore_a
 	/* loginuid value is critical to restore */
 	if (kdat.luid == LUID_FULL && tc->has_loginuid &&
 			tc->loginuid != INVALID_UID) {
-		ret = prepare_loginuid(tc->loginuid, LOG_ERROR);
-		if (ret < 0)
+		ret = prepare_loginuid(tc->loginuid);
+		if (ret < 0) {
+			pr_err("Setting loginuid for %d task failed\n", pid);
 			return ret;
+		}
 	}
 
 	/* oom_score_adj is not critical: only log errors */
@@ -2152,7 +2154,7 @@ static int prepare_userns_hook(void)
 	if (ret < 0)
 		return -1;
 
-	if (prepare_loginuid(INVALID_UID, LOG_ERROR) < 0) {
+	if (prepare_loginuid(INVALID_UID) < 0) {
 		pr_err("Setting loginuid for CT init task failed, CAP_AUDIT_CONTROL?\n");
 		return -1;
 	}
@@ -2165,7 +2167,7 @@ static void restore_origin_ns_hook(void)
 		return;
 
 	/* not critical: it does not affect CT in any way */
-	if (prepare_loginuid(saved_loginuid, LOG_ERROR) < 0)
+	if (prepare_loginuid(saved_loginuid) < 0)
 		pr_err("Restore original /proc/self/loginuid failed\n");
 }
 

--- a/criu/include/log.h
+++ b/criu/include/log.h
@@ -9,9 +9,6 @@
 #include <errno.h>
 #include <stdarg.h>
 
-extern void vprint_on_level(unsigned int loglevel, const char *format,
-		va_list params);
-
 #endif /* CR_NOGLIBC */
 
 #define LOG_UNSET	(-1)

--- a/criu/include/log.h
+++ b/criu/include/log.h
@@ -20,6 +20,10 @@
 
 #define DEFAULT_LOGLEVEL	LOG_WARN
 
+/*
+ * This is low-level printing helper, try hard not to use it directly
+ * and use the pr_foo() helpers below.
+ */
 extern void print_on_level(unsigned int loglevel, const char *format, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)));
 

--- a/criu/include/proc_parse.h
+++ b/criu/include/proc_parse.h
@@ -88,7 +88,7 @@ struct proc_status_creds {
 extern int parse_pid_stat(pid_t pid, struct proc_pid_stat *s);
 extern unsigned int parse_pid_loginuid(pid_t pid, int *err, bool ignore_noent);
 extern int parse_pid_oom_score_adj(pid_t pid, int *err);
-extern int prepare_loginuid(unsigned int value, unsigned int loglevel);
+extern int prepare_loginuid(unsigned int value);
 extern int parse_pid_status(pid_t pid, struct seize_task_status *, void *data);
 extern int parse_file_locks(void);
 extern int get_fd_mntid(int fd, int *mnt_id);

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -39,17 +39,17 @@ struct list_head;
 
 extern int service_fd_rlim_cur;
 
-extern void pr_vma(unsigned int loglevel, const struct vma_area *vma_area);
+extern void pr_vma(const struct vma_area *vma_area);
 
-#define pr_info_vma(vma_area)	pr_vma(LOG_INFO, vma_area)
+#define pr_info_vma(vma_area)	pr_vma(vma_area)
 
-#define pr_vma_list(level, head)				\
+#define pr_vma_list(head)					\
 	do {							\
 		struct vma_area *vma;				\
 		list_for_each_entry(vma, head, list)		\
-			pr_vma(level, vma);			\
+			pr_vma(vma);				\
 	} while (0)
-#define pr_info_vma_list(head)	pr_vma_list(LOG_INFO, head)
+#define pr_info_vma_list(head)	pr_vma_list(head)
 
 extern int move_fd_from(int *img_fd, int want_fd);
 extern int close_safe(int *fd);

--- a/criu/ipc_ns.c
+++ b/criu/ipc_ns.c
@@ -36,9 +36,9 @@
 #define MSG_COPY		040000
 #endif
 
-static void pr_ipc_desc_entry(unsigned int loglevel, const IpcDescEntry *desc)
+static void pr_ipc_desc_entry(const IpcDescEntry *desc)
 {
-	print_on_level(loglevel, "id: %-10d key: %#08x uid: %-10d gid: %-10d "
+	pr_info("id: %-10d key: %#08x uid: %-10d gid: %-10d "
 		       "cuid: %-10d cgid: %-10d mode: %-10o ",
 		       desc->id, desc->key, desc->uid, desc->gid,
 		       desc->cuid, desc->cgid, desc->mode);
@@ -55,19 +55,19 @@ static void fill_ipc_desc(int id, IpcDescEntry *desc, const struct ipc_perm *ipc
 	desc->mode = ipcp->mode;
 }
 
-static void pr_ipc_sem_array(unsigned int loglevel, int nr, u16 *values)
+static void pr_ipc_sem_array(int nr, u16 *values)
 {
 	while (nr--)
-		print_on_level(loglevel, "  %-5d", values[nr]);
-	print_on_level(loglevel, "\n");
+		pr_info("  %-5d", values[nr]);
+	pr_info("\n");
 }
 
-#define pr_info_ipc_sem_array(nr, values)	pr_ipc_sem_array(LOG_INFO, nr, values)
+#define pr_info_ipc_sem_array(nr, values)	pr_ipc_sem_array(nr, values)
 
 static void pr_info_ipc_sem_entry(const IpcSemEntry *sem)
 {
-	pr_ipc_desc_entry(LOG_INFO, sem->desc);
-	print_on_level(LOG_INFO, "nsems: %-10d\n", sem->nsems);
+	pr_ipc_desc_entry(sem->desc);
+	pr_info("nsems: %-10d\n", sem->nsems);
 }
 
 static int dump_ipc_sem_set(struct cr_img *img, const IpcSemEntry *sem)
@@ -160,15 +160,14 @@ static int dump_ipc_sem(struct cr_img *img)
 
 static void pr_info_ipc_msg(int nr, const IpcMsg *msg)
 {
-	print_on_level(LOG_INFO, "  %-5d: type: %-20"PRId64" size: %-10d\n",
+	pr_info("  %-5d: type: %-20"PRId64" size: %-10d\n",
 		       nr++, msg->mtype, msg->msize);
 }
 
 static void pr_info_ipc_msg_entry(const IpcMsgEntry *msg)
 {
-	pr_ipc_desc_entry(LOG_INFO, msg->desc);
-	print_on_level(LOG_INFO, "qbytes: %-10d qnum: %-10d\n",
-		       msg->qbytes, msg->qnum);
+	pr_ipc_desc_entry(msg->desc);
+	pr_info("qbytes: %-10d qnum: %-10d\n", msg->qbytes, msg->qnum);
 }
 
 static int dump_ipc_msg_queue_messages(struct cr_img *img, const IpcMsgEntry *msq,
@@ -287,8 +286,8 @@ static int dump_ipc_msg(struct cr_img *img)
 
 static void pr_info_ipc_shm(const IpcShmEntry *shm)
 {
-	pr_ipc_desc_entry(LOG_INFO, shm->desc);
-	print_on_level(LOG_INFO, "size: %-10"PRIu64"\n", shm->size);
+	pr_ipc_desc_entry(shm->desc);
+	pr_info("size: %-10"PRIu64"\n", shm->size);
 }
 
 #define NR_MANDATORY_IPC_SYSCTLS 9

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -500,10 +500,10 @@ static int kerndat_loginuid(void)
 	 * on that rely dump/restore code.
 	 * See also: marc.info/?l=git-commits-head&m=138509506407067
 	 */
-	if (prepare_loginuid(INVALID_UID, LOG_WARN) < 0)
+	if (prepare_loginuid(INVALID_UID) < 0)
 		return 0;
 	/* Cleaning value back as it was */
-	if (prepare_loginuid(saved_loginuid, LOG_WARN) < 0)
+	if (prepare_loginuid(saved_loginuid) < 0)
 		return 0;
 
 	kdat.luid = LUID_FULL;

--- a/criu/log.c
+++ b/criu/log.c
@@ -34,6 +34,7 @@
 #define EARLY_LOG_BUF_LEN	1024
 
 static unsigned int current_loglevel = DEFAULT_LOGLEVEL;
+static void vprint_on_level(unsigned int, const char *, va_list);
 
 static char buffer[LOG_BUF_LEN];
 static char buf_off = 0;
@@ -350,7 +351,7 @@ static void early_vprint(const char *format, unsigned int loglevel, va_list para
 	early_log_buf_off += log_size;
 }
 
-void vprint_on_level(unsigned int loglevel, const char *format, va_list params)
+static void vprint_on_level(unsigned int loglevel, const char *format, va_list params)
 {
 	int fd, size, ret, off = 0;
 	int _errno = errno;

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -944,7 +944,7 @@ err:
 	return -1;
 }
 
-int prepare_loginuid(unsigned int value, unsigned int loglevel)
+int prepare_loginuid(unsigned int value)
 {
 	int fd, ret = 0;
 	char buf[11]; /* 4294967295 is maximum for u32 */
@@ -956,8 +956,7 @@ int prepare_loginuid(unsigned int value, unsigned int loglevel)
 	snprintf(buf, 11, "%u", value);
 
 	if (write(fd, buf, 11) < 0) {
-		print_on_level(loglevel,
-			"Write %s to /proc/self/loginuid failed: %s\n",
+		pr_warn("Write %s to /proc/self/loginuid failed: %s\n",
 			buf, strerror(errno));
 		ret = -1;
 	}

--- a/criu/util.c
+++ b/criu/util.c
@@ -191,7 +191,7 @@ static void vma_opt_str(const struct vma_area *v, char *opt)
 #undef opt2s
 }
 
-void pr_vma(unsigned int loglevel, const struct vma_area *vma_area)
+void pr_vma(const struct vma_area *vma_area)
 {
 	char opt[VMA_OPT_LEN];
 	memset(opt, 0, VMA_OPT_LEN);
@@ -200,7 +200,7 @@ void pr_vma(unsigned int loglevel, const struct vma_area *vma_area)
 		return;
 
 	vma_opt_str(vma_area, opt);
-	print_on_level(loglevel, "%#"PRIx64"-%#"PRIx64" (%"PRIi64"K) prot %#x flags %#x fdflags %#o st %#x off %#"PRIx64" "
+	pr_info("%#"PRIx64"-%#"PRIx64" (%"PRIi64"K) prot %#x flags %#x fdflags %#o st %#x off %#"PRIx64" "
 			"%s shmid: %#"PRIx64"\n",
 			vma_area->e->start, vma_area->e->end,
 			KBYTES(vma_area_len(vma_area)),


### PR DESCRIPTION
I've found that the print_on_level helper is used in several places of code. This is not correct, the decision if the message is info/warning/error/whatever should be taken based on the place in the code where it happens, not by some C-expression. With this, the set of pr_foo()-s should be enough to use log.h