### PR TITLE
Fixes #1165

### DIFF
--- a/lib/py/images/pb2dict.py
+++ b/lib/py/images/pb2dict.py
@@ -357,7 +357,7 @@ def pb2dict(pb, pretty=False, is_hex=False):
         else:
             d_val = _pb2dict_cast(field, value, pretty, is_hex)
 
-        d[field.name] = d_val
+        d[field.name] = d_val.decode() if type(d_val) == bytes else d_val
     return d
 
 


### PR DESCRIPTION
This PR fixes #1165. 

We were experiencing cases where parsed snapshot images included byte string in the resulting dictionaries. These byte strings where not handled correctly and are properly decoded with this change.

Reported by: liikt