### PR TITLE
CONTRIBUTING.md: clarify placement of Fixes: tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,8 @@ If your change address an issue listed in GitHub, please use `Fixes:` tag with t
 	Fixes: #339
 ```
 
+The `Fixes:` tags should be put at the end of the detailed description.
+
 You may refer to [How to Write a Git Commit
 Message](https://chris.beams.io/posts/git-commit/) article for
 recommendations for good commit message.


### PR DESCRIPTION
The description of the Fixes: tags could be misleading and may be
understood as if "Fixes: " should be the commit summary.

Add a sentence with explicit description of Fixme: tags placement.

Reported-by: Otto Bittner <otto-bittner@gmx.de>
Signed-off-by: Mike Rapoport <rppt@linux.ibm.com>