### PR TITLE
Images: kindly ask not to use fields with id 18 in unix_sk_entry 

### DIFF
--- a/images/sk-unix.proto
+++ b/images/sk-unix.proto
@@ -51,4 +51,5 @@ message unix_sk_entry {
 
 	optional uint32			ns_id		= 16;
 	optional sint32			mnt_id		= 17 [default = -1];
+	/* Please, don't use field with number 18. */
 }


### PR DESCRIPTION
The id 18 in unix_sk_entry is already used in Virtuozzo criu for a long time so we can't easily change it to new ```vz_<field> 1000+<id>``` model so let's kindly ask not to use it.

Previous PR: https://github.com/checkpoint-restore/criu/pull/1152

v2: instead of reserving new fields in original image, lets reserve special vendor message field with id 1024, so that all extra fields are put in it
v3: We will use `vz_<field> 1000+<id>` semantics in Virtuozzo so that it would be easier to handle porting to mainstream and rebasing on mainstream with the ported id. Only thing which is left is id 18 in unix_sk_entry, for which we would kindly ask not to use it.