### PR TITLE
github: disable daily cross-compile for mips

### DIFF
--- a/.github/workflows/cross-compile-daily.yml
+++ b/.github/workflows/cross-compile-daily.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [armv7-cross, aarch64-cross, ppc64-cross, mips64el-cross]
+        target: [armv7-cross, aarch64-cross, ppc64-cross]
         branches: [criu-dev, master]
 
     steps:


### PR DESCRIPTION
The daily cross compile for mips failed on master, because master has no mips support yet. This removes mips for master and criu-dev for now.

Cross compiles for mips will still happen for pull requests and pushes.