### PR TITLE
github: disable cross-compule for mips on master branch

### DIFF
--- a/.github/workflows/cross-compile-daily-mips.yml
+++ b/.github/workflows/cross-compile-daily-mips.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [armv7-cross, aarch64-cross, ppc64-cross]
-        branches: [criu-dev, master]
+        target: [mips64el-cross]
+        branches: [criu-dev]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cross-compile-mips.yml
+++ b/.github/workflows/cross-compile-mips.yml
@@ -1,8 +1,10 @@
-name: Daily Cross Compile Tests
+name: Cross Compile Tests
 
 on:
-  schedule:
-    - cron:  '30 * * * *'
+  push:
+    branches: [criu-dev]
+  pull_request:
+    branches: [criu-dev]
 
 jobs:
   build:
@@ -10,13 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [armv7-cross, aarch64-cross, ppc64-cross]
-        branches: [criu-dev, master]
+        target: [mips64el-cross]
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ matrix.branches }}
     - name: Run Cross Compilation Targets
       run: >
         sudo make -C scripts/travis ${{ matrix.target }}

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [armv7-cross, aarch64-cross, ppc64-cross, mips64el-cross]
+        target: [armv7-cross, aarch64-cross, ppc64-cross]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Master branch does not have mips support yet, so automated builds for
mips on the master branch fail.

Temporarily split mips cross-build into a separate files until mips
support will be mergded into the master branch.

Suggested-by: Adrian Reber <areber@redhat.com>
Signed-off-by: Mike Rapoport <rppt@linux.ibm.com>