### PR TITLE
CI: switch to loop based apt-get

### DIFF
--- a/scripts/build/Dockerfile.aarch64-cross
+++ b/scripts/build/Dockerfile.aarch64-cross
@@ -1,11 +1,13 @@
 FROM dockcross/base:latest
 
+COPY scripts/travis/apt-install /bin/apt-install
+
 # Add the cross compiler sources
 RUN echo "deb http://ftp.us.debian.org/debian/ buster main" >> /etc/apt/sources.list && \
   dpkg --add-architecture arm64 && \
-  apt-get install emdebian-archive-keyring
+  apt-install emdebian-archive-keyring
 
-RUN apt-get update && apt-get install -y \
+RUN apt-install \
 	crossbuild-essential-arm64	\
 	libc6-dev-arm64-cross		\
 	libc6-arm64-cross		\

--- a/scripts/build/Dockerfile.armv7-cross
+++ b/scripts/build/Dockerfile.armv7-cross
@@ -1,11 +1,13 @@
 FROM dockcross/base:latest
 
+COPY scripts/travis/apt-install /bin/apt-install
+
 # Add the cross compiler sources
 RUN echo "deb http://ftp.us.debian.org/debian/ buster main" >> /etc/apt/sources.list && \
   dpkg --add-architecture armhf && \
-  apt-get install emdebian-archive-keyring
+  apt-install emdebian-archive-keyring
 
-RUN apt-get update && apt-get install -y \
+RUN apt-install \
 	crossbuild-essential-armhf	\
 	libbz2-dev:armhf		\
 	libexpat1-dev:armhf		\

--- a/scripts/build/Dockerfile.linux32.tmpl
+++ b/scripts/build/Dockerfile.linux32.tmpl
@@ -1,7 +1,9 @@
 ARG CC=gcc
 ARG ENV1=FOOBAR
 
-RUN apt-get update && apt-get install -y \
+COPY scripts/travis/apt-install /bin/apt-install
+
+RUN apt-install \
 	ccache \
 	libnet-dev \
 	libnl-route-3-dev \

--- a/scripts/build/Dockerfile.mips64el-cross
+++ b/scripts/build/Dockerfile.mips64el-cross
@@ -1,11 +1,13 @@
 FROM dockcross/base:latest
 
+COPY scripts/travis/apt-install /bin/apt-install
+
 # Add the cross compiler sources
 RUN echo "deb http://ftp.us.debian.org/debian/ buster main" >> /etc/apt/sources.list && \
   dpkg --add-architecture mips64el && \
-  apt-get install emdebian-archive-keyring
+  apt-install emdebian-archive-keyring
 
-RUN apt-get update && apt-get install -y \
+RUN apt-install \
 	crossbuild-essential-mips64el	\
 	libbz2-dev:mips64el		\
 	libexpat1-dev:mips64el		\

--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -1,6 +1,8 @@
 FROM adoptopenjdk/openjdk8-openj9:latest
 
-RUN apt-get update && apt-get install -y --no-install-recommends protobuf-c-compiler \
+COPY scripts/travis/apt-install /bin/apt-install
+
+RUN apt-install protobuf-c-compiler \
 	libprotobuf-c-dev \
 	libaio-dev \
 	python-future \

--- a/scripts/build/Dockerfile.ppc64-cross
+++ b/scripts/build/Dockerfile.ppc64-cross
@@ -1,11 +1,13 @@
 FROM dockcross/base:latest
 
+COPY scripts/travis/apt-install /bin/apt-install
+
 # Add the cross compiler sources
 RUN echo "deb http://ftp.us.debian.org/debian/ buster main" >> /etc/apt/sources.list && \
   dpkg --add-architecture ppc64el && \
-  apt-get install emdebian-archive-keyring
+  apt-install emdebian-archive-keyring
 
-RUN apt-get update && apt-get install -y \
+RUN apt-install \
 	crossbuild-essential-ppc64el	\
 	libc6-dev-ppc64el-cross		\
 	libc6-ppc64el-cross		\

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -1,7 +1,9 @@
 ARG CC=gcc
 ARG ENV1=FOOBAR
 
-RUN apt-get update && apt-get install -y \
+COPY scripts/travis/apt-install /bin/apt-install
+
+RUN apt-install \
 	ccache \
 	libnet-dev \
 	libnl-route-3-dev \

--- a/scripts/build/Dockerfile.x86_64.hdr
+++ b/scripts/build/Dockerfile.x86_64.hdr
@@ -1,4 +1,5 @@
 FROM ubuntu:xenial
 
-RUN apt-get update -qq && apt-get install -qq \
-                gcc-multilib
+COPY scripts/travis/apt-install /bin/apt-install
+
+RUN apt-install gcc-multilib

--- a/scripts/travis/apt-install
+++ b/scripts/travis/apt-install
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e -x
+
+export DEBIAN_FRONTEND=noninteractive
+
+install_retry_counter=0
+max_apt_retries=5
+
+# This function loops a couple of times over apt-get, hoping to
+# avoid CI errors due to errors during apt-get
+# hashsum mismatches, DNS errors and similar things
+while true; do
+	let install_retry_counter+=1
+	if [ ${install_retry_counter} -gt ${max_apt_retries} ]; then
+		exit 1
+	fi
+	apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-install-recommends $@ && break
+
+	# In case it is a network error let's wait a bit.
+	echo "Retrying attempt ${install_retry_counter}"
+	sleep ${install_retry_counter}
+done

--- a/scripts/travis/docker-test.sh
+++ b/scripts/travis/docker-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x -e -o pipefail
 
-apt-get install -qq \
+./apt-install \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -14,10 +14,7 @@ add-apt-repository \
    $(lsb_release -cs) \
    stable test"
 
-
-apt-get update -qq
-
-apt-get install -qq docker-ce
+./apt-install docker-ce
 
 . /etc/lsb-release
 

--- a/scripts/travis/podman-test.sh
+++ b/scripts/travis/podman-test.sh
@@ -9,14 +9,13 @@ wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:st
 # this is a podman packaging bug (https://github.com/containers/libpod/issues/4747)
 apt-get -y purge docker-ce
 
-apt-get install -qq \
+./apt-install \
     apt-transport-https \
     ca-certificates \
     curl \
     software-properties-common
 
-apt-get update -qq
-apt-get install -qqy podman containernetworking-plugins
+./apt-install podman containernetworking-plugins
 
 export SKIP_TRAVIS_TEST=1
 

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -33,27 +33,6 @@ if [ "$UNAME_M" != "x86_64" ]; then
 	SKIP_TRAVIS_TEST=1
 fi
 
-install_retry_counter=0
-max_apt_retries=5
-
-# This function loops a couple of times over apt-get, hoping to
-# avoid CI errors due to errors during apt-get
-# hashsum mismatches, DNS errors and similar things
-apt_install () {
-	while true; do
-		let install_retry_counter+=1
-		if [ $install_retry_counter -gt $max_apt_retries ]; then
-			exit 1
-		fi
-		apt-get clean -qqy || continue
-		apt-get update -qqy || continue
-		apt-get install -qqy --no-install-recommends $@ && break
-
-		# In case it is a network error let's wait a bit.
-		sleep $install_retry_counter
-	done
-}
-
 travis_prep () {
 	[ -n "$SKIP_TRAVIS_PREP" ] && return
 
@@ -76,7 +55,7 @@ travis_prep () {
 
 	[ -n "$GCOV" ] && {
 		apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-		apt_install --no-install-suggests g++-7
+		scripts/travis/apt-install --no-install-suggests g++-7
 		CC=gcc-7
 	}
 
@@ -95,7 +74,7 @@ travis_prep () {
 		TRAVIS_PKGS="$TRAVIS_PKGS $X86_64_PKGS"
 	fi
 
-	apt_install $TRAVIS_PKGS
+	scripts/travis/apt-install $TRAVIS_PKGS
 	chmod a+x $HOME
 
 	# zdtm uses an unversioned python binary to run the tests.
@@ -153,7 +132,7 @@ if [ "${COMPAT_TEST}x" = "yx" ] ; then
 		IA32_PKGS="$IA32_PKGS $i:i386"
 	done
 	apt-get remove $INCOMPATIBLE_LIBS
-	apt_install $IA32_PKGS
+	scripts/travis/apt-install $IA32_PKGS
 	mkdir -p /usr/lib/x86_64-linux-gnu/
 	mv "$REFUGE"/* /usr/lib/x86_64-linux-gnu/
 fi

--- a/scripts/travis/vagrant.sh
+++ b/scripts/travis/vagrant.sh
@@ -20,7 +20,7 @@ setup() {
 	wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_$(uname -m).deb -O /tmp/vagrant.deb && \
 		dpkg -i /tmp/vagrant.deb
 
-	apt-get -qq install -y libvirt-bin libvirt-dev qemu-utils qemu
+	./apt-install libvirt-bin libvirt-dev qemu-utils qemu
 	systemctl restart libvirt-bin
 	vagrant plugin install vagrant-libvirt
 	vagrant init fedora/${FEDORA_VERSION}-cloud-base --box-version ${FEDORA_BOX_VERSION}


### PR DESCRIPTION
The previously introduced apt_install loop function to make package install more robust against network errors is now moved to its own script used in multiple places.