### PR TITLE
travis: add a focal based test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
 jobs:
   include:
     - os: linux
+      arch: amd64
+      env: TR_ARCH=local
+      dist: focal
+    - os: linux
       arch: ppc64le
       env: TR_ARCH=local
       dist: bionic

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -59,6 +59,11 @@ travis_prep () {
 
 	cd ../../
 
+	# At least one of the test cases run by this script (others/rpc)
+	# expects a user with the ID 1000. sudo from 20.04 (focal) does
+	# not run anymore with 'sudo -u \#1000' if the UID does not exist.
+	adduser -u 1000 --disabled-password --gecos "criutest" criutest || :
+
 	# This can fail on aarch64 travis
 	service apport stop || :
 
@@ -201,7 +206,7 @@ LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps04"
 # we cannot run lazy-pages tests in uns
 LAZY_FLAVORS=""
 if [ $KERN_MAJ -ge "5" ] && [ $KERN_MIN -ge "4" ]; then
-    LAZY_FLAVORS = "-f h,ns"
+    LAZY_FLAVORS="-f h,ns"
 fi
 
 LAZY_TESTS=.*\(maps0\|uffd-events\|lazy-thp\|futex\|fork\).*


### PR DESCRIPTION
It seems travis supports now Ubuntu 20.04. Let's run at least one test also on 20.04 (focal).

This depends on #1074 because 20.04 seems to have limited Python 2 support. 

Tests will fail without #1074. Only opening as a draft until  #1074 is merged.