### PR TITLE
travis: use Fedora rawhide images from Fedora

### DIFF
--- a/scripts/build/Dockerfile.fedora-rawhide.hdr
+++ b/scripts/build/Dockerfile.fedora-rawhide.hdr
@@ -1,1 +1,1 @@
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide


### PR DESCRIPTION
The docker hub container registry is not updated as fast as Fedora's registry at registry.fedoraproject.org. Fedora's registry gets a new image whenever there is a new version of rawhide, docker hub's rawhide image can take a couple of weeks because the process is not automated.

Especially when Fedora branches of a new release we see lot's of errors in CRIU's Fedora rawhide based Travis runs. Switch to Fedora's registry to always have the newest rawhide images for our tests.