### PR TITLE
eventpoll: resort toff back by idx

### DIFF
--- a/criu/eventpoll.c
+++ b/criu/eventpoll.c
@@ -205,6 +205,15 @@ static int toff_cmp(const void *a, const void *b)
 	return 0;
 }
 
+static int toff_cmp_idx(const void *a, const void *b)
+{
+	if (((toff_t *)a)[0].idx > ((toff_t *)b)[0].idx)
+		return 1;
+	if (((toff_t *)a)[0].idx < ((toff_t *)b)[0].idx)
+		return -1;
+	return 0;
+}
+
 /*
  * fds in fd_parms are sorted so we can use binary search
  * for better performance.
@@ -300,6 +309,8 @@ static int dump_one_eventpoll(int lfd, u32 id, const struct fd_parms *p)
 			} else
 				toff_base = NULL;
 		}
+
+		qsort(toff, e->n_tfd, sizeof(*toff), toff_cmp_idx);
 	}
 
 	/*

--- a/criu/eventpoll.c
+++ b/criu/eventpoll.c
@@ -256,7 +256,7 @@ static int find_tfd_bsearch(pid_t pid, int efd, int fds[], size_t nr_fds,
 
 static int dump_one_eventpoll(int lfd, u32 id, const struct fd_parms *p)
 {
-	toff_t *toff_base, *toff = NULL;
+	toff_t *toff = NULL;
 	EventpollFileEntry *e = NULL;
 	FileEntry *fe = NULL;
 	int ret = -1;
@@ -300,15 +300,9 @@ static int dump_one_eventpoll(int lfd, u32 id, const struct fd_parms *p)
 
 		qsort(toff, e->n_tfd, sizeof(*toff), toff_cmp);
 
-		toff_base = NULL;
-		for (i = 1; i < e->n_tfd; i++) {
-			if (toff[i].tfd == toff[i - 1].tfd) {
-				if (!toff_base)
-					toff_base = &toff[i - 1];
-				toff[i].off = toff[i].idx - toff_base->idx;
-			} else
-				toff_base = NULL;
-		}
+		for (i = 1; i < e->n_tfd; i++)
+			if (toff[i].tfd == toff[i - 1].tfd)
+				toff[i].off = toff[i - 1].off + 1;
 
 		qsort(toff, e->n_tfd, sizeof(*toff), toff_cmp_idx);
 	}

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -126,6 +126,7 @@ TST_NOFILE	:=				\
 		proc-self			\
 		eventfs00			\
 		epoll				\
+		epoll01				\
 		signalfd00			\
 		inotify_irmap			\
 		fanotify00			\

--- a/test/zdtm/static/epoll01.c
+++ b/test/zdtm/static/epoll01.c
@@ -1,0 +1,121 @@
+#include <unistd.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/eventfd.h>
+#include <sys/ioctl.h>
+#include <sys/epoll.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc	= "Check another case of epoll: This adds three epoll "
+			  "targets on tfd 702 and then adds two epoll targets "
+			  "on tfd 701. This test is for off calculation in "
+			  "dump_one_eventpoll, the reverse order makes qsort "
+			  "to actually work.";
+const char *test_author	= "Pavel Tikhomirov <ptikhomirov@virtuozzo.com>";
+
+int main(int argc, char *argv[])
+{
+	int epollfd;
+	struct epoll_event ev;
+	int i, ret;
+
+	struct {
+		int	pipefd[2];
+		int	dupfd;
+		bool	close;
+	} pipes[5] = {
+		{ {}, 702, true },
+		{ {}, 702, true },
+		{ {}, 702, false },
+		{ {}, 701, true },
+		{ {}, 701, false },
+	};
+
+	test_init(argc, argv);
+
+	epollfd = epoll_create(1);
+	if (epollfd < 0) {
+		pr_perror("epoll_create failed");
+		exit(1);
+	}
+
+	memset(&ev, 0, sizeof(ev));
+	ev.events = EPOLLIN | EPOLLOUT;
+
+	for (i = 0; i < ARRAY_SIZE(pipes); i++) {
+		int fd;
+
+		if (pipe(pipes[i].pipefd)) {
+			pr_err("Can't create pipe %d\n", i);
+			exit(1);
+		}
+
+		ev.data.u64 = i;
+
+		fd = dup2(pipes[i].pipefd[0], pipes[i].dupfd);
+		if (fd < 0 || fd != pipes[i].dupfd) {
+			pr_perror("Can't dup %d to %d", pipes[i].pipefd[0], pipes[i].dupfd);
+			exit(1);
+		}
+
+		test_msg("epoll %d add %d dup'ed from %d\n", epollfd, fd, pipes[i].pipefd[0]);
+		if (epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev)) {
+			pr_perror("Can't add pipe %d", fd);
+			close(fd);
+			exit(1);
+		}
+
+		if (pipes[i].close) {
+			close(fd);
+			test_msg("epoll source %d closed\n", fd);
+		}
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	ret = 0;
+	for (i = 0; i < ARRAY_SIZE(pipes); i++) {
+		uint8_t cw = 1, cr;
+
+		if (write(pipes[i].pipefd[1], &cw, sizeof(cw)) != sizeof(cw)) {
+			pr_perror("Unable to write into a pipe\n");
+			return 1;
+		}
+
+		if (epoll_wait(epollfd, &ev, 1, -1) != 1) {
+			pr_perror("Unable to wait events");
+			return 1;
+		}
+
+		if (ev.data.u64 != i) {
+			pr_err("ev.fd=%d ev.data.u64=%#llx (%d expected)\n",
+			       ev.data.fd, (long long)ev.data.u64, i);
+			ret |= 1;
+		}
+
+		if (read(pipes[i].pipefd[0], &cr, sizeof(cr)) != sizeof(cr)) {
+			pr_perror("read");
+			return 1;
+		}
+	}
+
+	if (ret)
+		return 1;
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/epoll01.desc
+++ b/test/zdtm/static/epoll01.desc
@@ -1,0 +1,1 @@
+{ 'feature' : 'kcmp_epoll' }


### PR DESCRIPTION
In dump_one_eventpoll we call find_tfd_bsearch with arguments
"e->tfd[i]->tfd, toff[i].off". By this we want to check if
"toff[i].off"-th inclusion of target "e->tfd[i]->tfd" in an eventpoll
coresponds to our fd "e->tfd[i]->tfd" in terms of kcmp.

But because of toff was sorted to calculate off, indexes in e->tfd and
toff does not address the same eventpoll target at this point.

Let's sort toff back to original state to make indexes consistent.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>