### PR TITLE
travis: restore lazy-pages tests for uns flavor

### DIFF
--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -202,15 +202,8 @@ else
 fi
 LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps04"
 
-# Starting with 5.4 kernel requires SYS_CAP_PTRACE to use uffd events; as such
-# we cannot run lazy-pages tests in uns
-LAZY_FLAVORS=""
-if [ $KERN_MAJ -ge "5" ] && [ $KERN_MIN -ge "4" ]; then
-    LAZY_FLAVORS="-f h,ns"
-fi
-
 LAZY_TESTS=.*\(maps0\|uffd-events\|lazy-thp\|futex\|fork\).*
-LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $LAZY_FLAVORS $ZDTM_OPTS"
+LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $ZDTM_OPTS"
 
 ./test/zdtm.py run $LAZY_OPTS --lazy-pages
 ./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages


### PR DESCRIPTION
Since commit cdd08cdff ("uffd: use userns_call() to execute
ioctl(UFFDIO_API)") UFFD_API ioctl() is wrapped with userns_call() and this
allows runing lazy-pages tests on recent kernels in uns.

Restore testing of lazy-pages in uns in travis.

Signed-off-by: Mike Rapoport <rppt@linux.ibm.com>