### PR TITLE
bpf: frozen maps, refactoring zdtm tests

### DIFF
--- a/images/bpfmap-file.proto
+++ b/images/bpfmap-file.proto
@@ -15,6 +15,8 @@ message bpfmap_file_entry {
 	required uint32		max_entries	= 9;
 	required uint32		map_flags	= 10;
 	required uint64		memlock		= 11;
-	required bool		frozen		= 12;
-	optional sint32		mnt_id		= 13 [default = -1];
+	required bool		frozen		= 12 [default = false];
+	required string		map_name	= 13;
+	required uint32		ifindex		= 14 [default = 0];
+	optional sint32		mnt_id		= 15 [default = -1];
 }

--- a/test/zdtm/lib/Makefile
+++ b/test/zdtm/lib/Makefile
@@ -5,6 +5,12 @@ CFLAGS	+= $(USERCFLAGS)
 LIB	:= libzdtmtst.a
 
 LIBSRC	:= datagen.c msg.c parseargs.c test.c streamutil.c lock.c ns.c tcp.c unix.c fs.c sysctl.c
+
+pkg-config-check = $(shell sh -c 'pkg-config $(1) && echo y')
+ifeq ($(call pkg-config-check,libbpf),y)
+LIBSRC	+= bpfmap_zdtm.c
+endif
+
 LIBOBJ	:= $(LIBSRC:%.c=%.o)
 
 BIN	:= groups

--- a/test/zdtm/lib/bpfmap_zdtm.c
+++ b/test/zdtm/lib/bpfmap_zdtm.c
@@ -1,0 +1,126 @@
+#include "bpfmap_zdtm.h"
+
+int parse_bpfmap_fdinfo(int fd, struct bpfmap_fdinfo_obj *obj, uint32_t expected_to_meet)
+{
+	uint32_t met = 0;
+	char str[512];
+	FILE *f;
+
+	sprintf(str, "/proc/self/fdinfo/%d", fd);
+	f = fopen(str, "r");
+	if (!f) {
+		pr_perror("Can't open fdinfo to parse");
+		return -1;
+	}
+
+	while (fgets(str, sizeof(str), f)) {
+		if (fdinfo_field(str, "map_type")) {
+			if (sscanf(str, "map_type: %u", &obj->map_type) != 1)
+				goto parse_err;
+			met++;
+			continue;
+		}
+		if (fdinfo_field(str, "key_size")) {
+			if (sscanf(str, "key_size: %u", &obj->key_size) != 1)
+				goto parse_err;
+			met++;
+			continue;
+		}
+		if (fdinfo_field(str, "value_size")) {
+			if (sscanf(str, "value_size: %u", &obj->value_size) != 1)
+				goto parse_err;
+			met++;
+			continue;
+		}
+		if (fdinfo_field(str, "max_entries")) {
+			if (sscanf(str, "max_entries: %u", &obj->max_entries) != 1)
+				goto parse_err;
+			met++;
+			continue;
+		}
+		if (fdinfo_field(str, "map_flags")) {
+			if (sscanf(str, "map_flags: %"PRIx32"", &obj->map_flags) != 1)
+				goto parse_err;
+			met++;
+			continue;
+		}
+		if (fdinfo_field(str, "memlock")) {
+			if (sscanf(str, "memlock: %"PRIu64"", &obj->memlock) != 1)
+				goto parse_err;
+			met++;
+			continue;
+		}
+		if (fdinfo_field(str, "map_id")) {
+			if (sscanf(str, "map_id: %u", &obj->map_id) != 1)
+				goto parse_err;
+			met++;
+			continue;
+		}
+		if (fdinfo_field(str, "frozen")) {
+			if (sscanf(str, "frozen: %d", &obj->frozen) != 1)
+				goto parse_err;
+			met++;
+			continue;
+		}
+	}
+
+	if (expected_to_meet != met) {
+		pr_err("Expected to meet %d entries but got %d\n", expected_to_meet, met);
+		return -1;
+	}
+
+	fclose(f);
+	return 0;
+
+parse_err:
+	pr_perror("Can't parse '%s'", str);
+	fclose(f);
+	return -1;
+}
+
+int cmp_bpf_map_info(struct bpf_map_info *old, struct bpf_map_info *new)
+{
+	/*
+	 * We skip the check for old->id and new->id because every time a new BPF
+	 * map is created, it is internally allocated a new map id. Therefore,
+	 * the new BPF map created by CRIU (during restore) will have a different
+	 * map id than the old one
+	 */
+	if ((old->type != new->type)				||
+	    (old->key_size != new->key_size)			||
+	    (old->value_size != new->value_size)		||
+	    (old->max_entries != new->max_entries)		||
+	    (old->map_flags != new->map_flags)			||
+	    (old->ifindex != new->ifindex)			||
+	    (old->netns_dev != new->netns_dev)			||
+	    (old->netns_ino != new->netns_ino)			||
+	    (old->btf_id != new->btf_id)			||
+	    (old->btf_key_type_id != new->btf_key_type_id)	||
+	    (old->btf_value_type_id != new->btf_value_type_id))
+		return -1;
+
+	if (strcmp(old->name, new->name) != 0)
+		return -1;
+
+	return 0;
+}
+
+int cmp_bpfmap_fdinfo(struct bpfmap_fdinfo_obj *old, struct bpfmap_fdinfo_obj *new)
+{
+	/*
+	 * We skip the check for old->map_id and new->map_id because every time a
+	 * new BPF map is created, it is internally allocated a new map id. Therefore,
+	 * the new BPF map created by CRIU (during restore) will have a different map
+	 * id than the old one
+	 */
+	if ((old->map_type != new->map_type)		||
+	    (old->key_size != new->key_size)		||
+	    (old->value_size != new->value_size)	||
+	    (old->max_entries != new->max_entries)	||
+	    (old->map_flags != new->map_flags)		||
+	    (old->memlock != new->memlock)		||
+	    (old->frozen != new->frozen))
+		return -1;
+
+	return 0;
+} 

--- a/test/zdtm/lib/bpfmap_zdtm.h
+++ b/test/zdtm/lib/bpfmap_zdtm.h
@@ -1,0 +1,21 @@
+#include <bpf/bpf.h>
+#include <inttypes.h>
+
+#include "zdtmtst.h"
+
+#define fdinfo_field(str, field)	!strncmp(str, field":", sizeof(field))
+
+struct bpfmap_fdinfo_obj {
+	uint32_t	map_type;
+	uint32_t	key_size;
+	uint32_t	value_size;
+	uint32_t	max_entries;
+	uint32_t	map_flags;
+	uint64_t	memlock;
+	uint32_t	map_id;
+	uint32_t	frozen;
+};
+
+extern int parse_bpfmap_fdinfo(int, struct bpfmap_fdinfo_obj *, uint32_t);
+extern int cmp_bpf_map_info(struct bpf_map_info *, struct bpf_map_info *);
+extern int cmp_bpfmap_fdinfo(struct bpfmap_fdinfo_obj *, struct bpfmap_fdinfo_obj *);

--- a/test/zdtm/static/bpf_array.c
+++ b/test/zdtm/static/bpf_array.c
@@ -3,6 +3,7 @@
 #include <sys/mman.h>
 
 #include "zdtmtst.h"
+#include "bpfmap_zdtm.h"
 
 const char *test_doc	= "Check that data and meta-data for BPF_MAP_TYPE_ARRAY"
 							"is correctly restored";
@@ -58,9 +59,13 @@ int main(int argc, char **argv)
 	int *keys = NULL, *values = NULL, *visited = NULL;
 	const uint32_t max_entries = 10;
 	int ret;
-	struct bpf_map_info map_info = {};
-	uint32_t info_len = sizeof(map_info);
+	struct bpf_map_info old_map_info = {};
+	struct bpf_map_info new_map_info = {};
+	struct bpfmap_fdinfo_obj old_fdinfo = {};
+	struct bpfmap_fdinfo_obj new_fdinfo = {};
+	uint32_t info_len = sizeof(struct bpf_map_info);
 	struct bpf_create_map_attr xattr = {
+		.name = "array_test_map",
 		.map_type = BPF_MAP_TYPE_ARRAY,
 		.key_size = sizeof(int),
 		.value_size = sizeof(int),
@@ -95,34 +100,47 @@ int main(int argc, char **argv)
 	if (map_batch_update(map_fd, max_entries, keys, values))
 		goto err;
 
+	ret = bpf_map_freeze(map_fd);
+	if (ret) {
+		pr_perror("Could not freeze map");
+		goto err;
+	}
+
+	ret = bpf_obj_get_info_by_fd(map_fd, &old_map_info, &info_len);
+	if (ret) {
+		pr_perror("Could not get old map info");
+		goto err;
+	}
+
+	ret = parse_bpfmap_fdinfo(map_fd, &old_fdinfo, 8);
+	if (ret) {
+		pr_perror("Could not parse old map fdinfo from procfs");
+		goto err;
+	}
+
 	test_daemon();
 
 	test_waitsig();
 
-	ret = bpf_obj_get_info_by_fd(map_fd, &map_info, &info_len);
+	ret = bpf_obj_get_info_by_fd(map_fd, &new_map_info, &info_len);
 	if (ret) {
-		pr_perror("Could not get map info");
+		pr_perror("Could not get new map info");
+		goto err;
+	}
+
+	ret = parse_bpfmap_fdinfo(map_fd, &new_fdinfo, 8);
+	if (ret) {
+		pr_perror("Could not parse new map fdinfo from procfs");
 		goto err;
 	}
 	
-	if (map_info.type != BPF_MAP_TYPE_ARRAY) {
-		pr_err("Map type should be BPF_MAP_TYPE_ARRAY\n");
+	if (cmp_bpf_map_info(&old_map_info, &new_map_info)) {
+		pr_err("bpf_map_info mismatch\n");
 		goto err;
 	}
-	if (map_info.key_size != sizeof(*keys)) {
-		pr_err("Key size should be %zu\n", sizeof(*keys));
-		goto err;
-	}
-	if (map_info.value_size != sizeof(*values)) {
-		pr_err("Value size should be %zu\n", sizeof(*values));
-		goto err;
-	}
-	if (map_info.max_entries != max_entries) {
-		pr_err("Max entries should be %d\n", max_entries);
-		goto err;
-	}
-	if (!(map_info.map_flags & BPF_F_NUMA_NODE)) {
-		pr_err("Map flag BPF_F_NUMA_NODE should be set\n");
+
+	if (cmp_bpfmap_fdinfo(&old_fdinfo, &new_fdinfo)) {
+		pr_err("bpfmap fdinfo mismatch\n");
 		goto err;
 	}
 

--- a/test/zdtm/static/bpf_array.desc
+++ b/test/zdtm/static/bpf_array.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h ns', 'flags': 'suid'}

--- a/test/zdtm/static/bpf_hash.desc
+++ b/test/zdtm/static/bpf_hash.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h ns', 'flags': 'suid'}


### PR DESCRIPTION
This PR accomplishes the following:

a) Adds support for frozen BPF maps
b) Allows c/r of map names and ifindex
c) Creates a ZDTM library for BPF test helper functions
d) Refactors ZDTM tests to use the BPF test library functions
e) Updates tests to check for frozen maps

The commit messages provide detailed explanations for all code changes.

I look forward to hearing your kind feedback.

Thank you.