### PR TITLE
Add shellcheck to lint target and run 'make lint' only once

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Run code linter
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install tools
+      run: sudo apt-get install -qqy flake8 shellcheck
+    - name: Run make lint
+      run: make lint

--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,8 @@ lint:
 	flake8 --config=scripts/flake8.cfg test/inhfd/*.py
 	flake8 --config=scripts/flake8.cfg test/others/rpc/config_file.py
 	flake8 --config=scripts/flake8.cfg lib/py/images/pb2dict.py
+	shellcheck scripts/*.sh
+	shellcheck scripts/travis/*.sh
 
 include Makefile.install
 

--- a/scripts/install-criu-image-streamer.sh
+++ b/scripts/install-criu-image-streamer.sh
@@ -5,7 +5,7 @@ set -eux
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Clone criu-image-streamer in a sibling directory of the criu project directory
-cd $(dirname "$0")/../../
+cd "$(dirname "$0")"/../../
 git clone --depth=1 https://github.com/checkpoint-restore/criu-image-streamer.git
 
 # Compile

--- a/scripts/install-debian-pkgs.sh
+++ b/scripts/install-debian-pkgs.sh
@@ -15,7 +15,7 @@ function print_help()
 function process()
 {
 	sudo apt-get update
-	sudo apt-get install -yq $( sed 's/\#.*$//' ${REQ_PKGS} )
+	sudo apt-get install -yq "$( sed 's/\#.*$//' ${REQ_PKGS} )"
 }
 
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then

--- a/scripts/protobuf-gen.sh
+++ b/scripts/protobuf-gen.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+# shellcheck disable=SC2013,SC1004
+
 TR="y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
 
 for x in $(sed -n '/PB_AUTOGEN_START/,/PB_AUTOGEN_STOP/ {
@@ -6,8 +10,8 @@ for x in $(sed -n '/PB_AUTOGEN_START/,/PB_AUTOGEN_STOP/ {
 		s/\tPB_//;
 		p;
 	   }' criu/include/protobuf-desc.h); do
-	x_la=$(echo $x | sed $TR)
-	x_uf=$(echo $x | sed -nr 's/^./&#\\\
+	x_la=$(echo "$x" | sed $TR)
+	x_uf=$(echo "$x" | sed -nr 's/^./&#\\\
 /;
 		s/_(.)/\\\
 \1#\\\

--- a/scripts/systemd-autofs-restart.sh
+++ b/scripts/systemd-autofs-restart.sh
@@ -16,7 +16,7 @@
 #
 [ "$CRTOOLS_SCRIPT_ACTION" == "post-resume" ] || exit 0
 
-if [ ! -n "$CRTOOLS_INIT_PID" ]; then
+if [ -z "$CRTOOLS_INIT_PID" ]; then
 	echo "CRTOOLS_INIT_PID environment variable is not set"
 	exit 1
 fi
@@ -37,7 +37,7 @@ fi
 JOIN_CT="$NS_ENTER -t $CRTOOLS_INIT_PID -m -u -p"
 
 # Skip container, if it's not systemd based
-[ "$($JOIN_CT basename -- $($JOIN_CT readlink /proc/1/exe))" == "systemd" ] || exit 0
+[ "$($JOIN_CT basename -- "$($JOIN_CT readlink /proc/1/exe)")" == "systemd" ] || exit 0
 
 AUTOFS_SERVICES="proc-sys-fs-binfmt_misc.automount"
 
@@ -60,11 +60,14 @@ function get_fs_type {
 
 	while IFS='' read -r line; do
 		# Skip those entries which do not match the mountpoint
-		[ "$(echo $line | awk '{print $5;}')" = "$mountpoint" ] || continue
+		[ "$(echo "$line" | awk '{print $5;}')" = "$mountpoint" ] || continue
 
-		local mnt_id=$(echo $line | awk '{print $1;}')
-		local mnt_parent_id=$(echo $line | awk '{print $2;}')
-		local mnt_fs_type=$(echo $line | sed 's/.* - //g' | awk '{print $1;}')
+		local mnt_id
+		mnt_id=$(echo "$line" | awk '{print $1;}')
+		local mnt_parent_id
+		mnt_parent_id=$(echo "$line" | awk '{print $2;}')
+		local mnt_fs_type
+		mnt_fs_type=$(echo "$line" | sed 's/.* - //g' | awk '{print $1;}')
 
 		# Skip mount entry, if not the first one and not a child
 		[ -n "$top_mount_id" ] && [ "$mnt_parent_id" != "$top_mount_id" ] && continue
@@ -78,7 +81,7 @@ function get_fs_type {
 		return 1
 	fi
 
-	echo $top_mount_fs_type
+	echo "$top_mount_fs_type"
 	return 0
 }
 
@@ -86,7 +89,7 @@ function bind_mount {
 	local from=$1
 	local to=$2
 
-	$JOIN_CT mount --bind $from $to && return 0
+	$JOIN_CT mount --bind "$from" "$to" && return 0
 
 	echo "Failed to bind mount $from to $to"
 	return 1
@@ -96,8 +99,7 @@ function save_mountpoint {
 	local mountpoint=$1
 	local top_mount_fs_type=""
 
-	top_mount_fs_type=$(get_fs_type $mountpoint)
-	if [ $? -ne 0 ]; then
+	if ! top_mount_fs_type=$(get_fs_type "$mountpoint"); then
 		echo "$top_mount_fs_type"
 		return
 	fi
@@ -113,7 +115,7 @@ function save_mountpoint {
 
 	# No need to unmount fs on top of autofs:
 	# systemd will does it for us on service restart
-	bind_mount $mountpoint $bindmount || $JOIN_CT rm -rf $bindmount
+	bind_mount "$mountpoint" "$bindmount" || $JOIN_CT rm -rf "$bindmount"
 }
 
 function restore_mountpoint {
@@ -122,25 +124,25 @@ function restore_mountpoint {
 	[ -n "$bindmount" ] || return
 
 	# Umount file system, remounted by systemd, if any
-	top_mount_fs_type=$(get_fs_type $mountpoint)
-	if [ $? -ne 0 ]; then
+	if ! top_mount_fs_type=$(get_fs_type "$mountpoint"); then
 		echo "$top_mount_fs_type"
 		return
 	fi
 
 	# Nothing to do, if no file system is on top of autofs
 	if [ "$top_mount_fs_type" != "autofs" ]; then
-		$JOIN_CT umount $mountpoint || echo "Failed to umount $mountpoint"
+		$JOIN_CT umount "$mountpoint" || echo "Failed to umount $mountpoint"
 	fi
 
 	# Restore origin file system even if we failed to unmount the new one
-	bind_mount $bindmount $mountpoint
+	bind_mount "$bindmount" "$mountpoint"
 	remove_bindmount
 }
 
 function restart_service {
 	local service=$1
-	local mountpoint=$($JOIN_CT systemctl show $service -p Where | sed 's/.*=//g')
+	local mountpoint
+	mountpoint=$($JOIN_CT systemctl show "$service" -p Where | sed 's/.*=//g')
 
 	if [ -z "$mountpoint" ]; then
 		echo "Failed to discover $service mountpoint"
@@ -149,24 +151,23 @@ function restart_service {
 
 	# Try to move restored bind-mount aside and exit if Failed
 	# Nothing to do, if we Failed
-	save_mountpoint $mountpoint || return
+	save_mountpoint "$mountpoint" || return
 
-	$JOIN_CT systemctl restart $service
-	if [ $? -ne 0 ]; then
+	if ! $JOIN_CT systemctl restart "$service"; then
 		echo "Failed to restart $service service"
 		return
 	fi
 	echo "$service restarted"
 
 	# Try to move saved monutpoint back on top of autofs
-	restore_mountpoint $mountpoint
+	restore_mountpoint "$mountpoint"
 }
 
 for service in $AUTOFS_SERVICES; do
-	status=$($JOIN_CT systemctl is-active $service)
+	status=$($JOIN_CT systemctl is-active "$service")
 
-	if [ $status == "active" ]; then
-		restart_service $service
+	if [ "$status" == "active" ]; then
+		restart_service "$service"
 	else
 		echo "$service skipped ($status)"
 	fi

--- a/scripts/tmp-files.sh
+++ b/scripts/tmp-files.sh
@@ -23,7 +23,7 @@ DUMPARGS="--create --absolute-names --gzip --no-unquote --no-wildcards --file"
 RESTOREARGS="--extract --gzip --no-unquote --no-wildcards --absolute-names --directory / --file"
 IMGFILE=$CRTOOLS_IMAGE_DIR"/tmpfiles.tar.gz"
 
-MY_NAME=`basename "$0"`
+MY_NAME=$(basename "$0")
 
 case "$CRTOOLS_SCRIPT_ACTION" in
 	$POSTDUMP )
@@ -31,7 +31,7 @@ case "$CRTOOLS_SCRIPT_ACTION" in
 			echo "$MY_NAME: ERROR! No files are given."
 			exit 1
 		fi
-		tar $DUMPARGS $IMGFILE -- "$@"
+		tar "$DUMPARGS" "$IMGFILE" -- "$@"
 		exit $?
 		;;
 	$PRERESTORE )
@@ -39,7 +39,7 @@ case "$CRTOOLS_SCRIPT_ACTION" in
 			echo "$MY_NAME: ERROR! Not expected script args."
 			exit 1
 		fi
-		tar $RESTOREARGS $IMGFILE
+		tar "$RESTOREARGS" "$IMGFILE"
 		exit $?
 		;;
 esac

--- a/scripts/travis/asan.sh
+++ b/scripts/travis/asan.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+# shellcheck disable=2044
 
 set -x
 
@@ -11,11 +13,11 @@ chmod 0777 test/zdtm/static
 ./test/zdtm.py run -a --keep-going -k always --parallel 4 -x zdtm/static/rtc "$@"
 ret=$?
 
-for i in `find / -name 'asan.log*'`; do
-	echo $i;
+for i in $(find / -name 'asan.log*'); do
+	echo "$i"
 	echo ========================================
-	cat $i;
+	cat "$i"
 	echo ========================================
-	ret=1;
-done;
+	ret=1
+done
 exit $ret

--- a/scripts/travis/docker-test.sh
+++ b/scripts/travis/docker-test.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# shellcheck disable=SC1091,SC2015
+
 set -x -e -o pipefail
 
 apt-get install -qq \
@@ -44,21 +47,22 @@ docker info
 
 criu --version
 
+# shellcheck disable=SC2016
 docker run --tmpfs /tmp --tmpfs /run --read-only --security-opt seccomp=unconfined --name cr -d alpine /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
 
 sleep 1
-for i in `seq 50`; do
+for i in $(seq 50); do
 	# docker start returns 0 silently if a container is already started
 	# docker checkpoint doesn't wait when docker updates a container state
 	# Due to both these points, we need to sleep after docker checkpoint to
 	# avoid races with docker start.
 	docker exec cr ps axf &&
-	docker checkpoint create cr checkpoint$i &&
+	docker checkpoint create cr checkpoint"$i" &&
 	sleep 1 &&
 	docker ps &&
 	(docker exec cr true && exit 1 || exit 0) &&
-	docker start --checkpoint checkpoint$i cr 2>&1 | tee log || {
-		cat "`cat log | grep 'log file:' | sed 's/log file:\s*//'`" || true
+	docker start --checkpoint checkpoint"$i" cr 2>&1 | tee log || {
+	cat "$(grep log 'log file:' | sed 's/log file:\s*//')" || true
 		docker logs cr || true
 		cat /tmp/zdtm-core-* || true
 		dmesg

--- a/scripts/travis/openj9-test.sh
+++ b/scripts/travis/openj9-test.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
 
-cd ../..
+cd ../.. || exit 1
 
 failures=""
 
 docker build -t criu-openj9-ubuntu-test:latest -f scripts/build/Dockerfile.openj9-ubuntu .
-docker run --rm --privileged criu-openj9-ubuntu-test:latest
-if [ $? -ne 0 ]; then
-	failures=`echo "$failures ubuntu"`
+if ! docker run --rm --privileged criu-openj9-ubuntu-test:latest; then
+	failures="$failures ubuntu"
 fi
 
 docker build -t criu-openj9-alpine-test:latest -f scripts/build/Dockerfile.openj9-alpine .
-docker run --rm --privileged criu-openj9-alpine-test:latest
-if [ $? -ne 0 ]; then
-	failures=`echo "$failures alpine"`
+if ! docker run --rm --privileged criu-openj9-alpine-test:latest; then
+	failures="$failures alpine"
 fi
 
 if [ -n "$failures" ]; then

--- a/scripts/travis/podman-test.sh
+++ b/scripts/travis/podman-test.sh
@@ -32,37 +32,38 @@ podman --storage-driver vfs info
 
 criu --version
 
+# shellcheck disable=SC2016
 podman run --name cr -d docker.io/library/alpine /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
 
 sleep 1
-for i in `seq 20`; do
+for i in $(seq 20); do
 	echo "Test $i for podman container checkpoint"
 	podman exec cr ps axf
 	podman logs cr
-	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
+	[ "$(podman ps -f name=cr -q -f status=running | wc -l)" -eq "1" ]
 	podman container checkpoint cr
-	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "0" ]
+	[ "$(podman ps -f name=cr -q -f status=running | wc -l)" -eq "0" ]
 	podman ps -a
 	podman container restore cr
-	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
+	[ "$(podman ps -f name=cr -q -f status=running | wc -l)" -eq "1" ]
 	podman logs cr
 done
 
-for i in `seq 20`; do
+for i in $(seq 20); do
 	echo "Test $i for podman container checkpoint --export"
 	podman ps -a
 	podman exec cr ps axf
 	podman logs cr
-	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
+	[ "$(podman ps -f name=cr -q -f status=running | wc -l)" -eq "1" ]
 	podman container checkpoint -l --export /tmp/chkpt.tar.gz
-	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "0" ]
+	[ "$(podman ps -f name=cr -q -f status=running | wc -l)" -eq "0" ]
 	podman ps -a
 	podman rm -fa
 	podman ps -a
 	podman container restore --import /tmp/chkpt.tar.gz
-	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
+	[ "$(podman ps -f name=cr -q -f status=running | wc -l)" -eq "1" ]
 	podman container restore --name cr2 --import /tmp/chkpt.tar.gz
-	[ `podman ps -f name=cr2 -q -f status=running | wc -l` -eq "1" ]
+	[ "$(podman ps -f name=cr2 -q -f status=running | wc -l)" -eq "1" ]
 	podman ps -a
 	podman logs cr
 	podman logs cr2
@@ -70,7 +71,7 @@ for i in `seq 20`; do
 	podman rm -fa
 	podman ps -a
 	podman container restore --import /tmp/chkpt.tar.gz
-	[ `podman ps -f name=cr -q -f status=running | wc -l` -eq "1" ]
+	[ "$(podman ps -f name=cr -q -f status=running | wc -l)" -eq "1" ]
 	podman ps -a
 	rm -f /tmp/chkpt.tar.gz
 done

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -119,8 +119,6 @@ time make CC="$CC" -j4
 ./criu/criu -v4 cpuinfo dump || :
 ./criu/criu -v4 cpuinfo check || :
 
-make lint
-
 # Check that help output fits into 80 columns
 WIDTH=$(./criu/criu --help | wc --max-line-length)
 if [ "$WIDTH" -gt 80 ]; then

--- a/scripts/travis/vagrant.sh
+++ b/scripts/travis/vagrant.sh
@@ -17,7 +17,7 @@ setup() {
 
 	# Tar up the git checkout to have vagrant rsync it to the VM
 	tar cf criu.tar ../../../criu
-	wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_$(uname -m).deb -O /tmp/vagrant.deb && \
+	wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_"$(uname -m)".deb -O /tmp/vagrant.deb && \
 		dpkg -i /tmp/vagrant.deb
 
 	apt-get -qq install -y libvirt-bin libvirt-dev qemu-utils qemu


### PR DESCRIPTION
Seeing that the tool *shellcheck* exists and that other projects started to include it in their CI process (and our discussion about `clang-format`), I included `shellcheck` into our CI setup. The easy and simple change is to not run `make test` for every Travis target but to only run it once through github actions. This does not change CI runtime in any way, but I think it makes kind of sense to run `make lint` in just a single place.

I also included the tool `shellcheck` into the Makefile target `lint`. I only added all `*.sh` files in the `scripts/` folder for now as `shellcheck` wants changes to almost all our scripts.

I am not totally convinced that the changes to the shellscripts in this PR actually fix anything. Knowing the environment the scripts are running in and what they are used for (and that they have been working just alright) the complaints of `shellcheck` are not really important to fix. On the other hand it sounds useful to have a common baseline for all our shell scripts to make sure they are no obvious errors. So this actually does not fix anything, but maybe it helps to avoid introducing new errors in the future.

Please have a look at changes to the shell scripts to make sure I did not introduce any regression with my 'fixes'.