### PR TITLE
CI: run cross compile on all branches

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,10 +1,6 @@
 name: Cross Compile Tests
 
-on:
-  push:
-    branches: [criu-dev, master]
-  pull_request:
-    branches: [criu-dev, master]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
The github action based cross compile tests are only running when pushing to master or criu-dev. This changes this to have it run on all branches. Useful to have all CI tests running on personal CRIU checkouts on branches with other names.

If I prepare a branch to create a new pull request, the cross compile tests have not been running if my branch has another name than criu-dev or master. With this change these tests will run on all branches.