### PR TITLE
CI: add Travis test script to 'lint'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ lint:
 	flake8 --config=scripts/flake8.cfg test/others/rpc/config_file.py
 	flake8 --config=scripts/flake8.cfg lib/py/images/pb2dict.py
 	shellcheck scripts/*.sh
-	shellcheck scripts/travis/*.sh
+	shellcheck scripts/travis/*.sh scripts/travis/travis* scripts/travis/apt-install
 
 include Makefile.install
 

--- a/scripts/travis/apt-install
+++ b/scripts/travis/apt-install
@@ -11,10 +11,11 @@ max_apt_retries=5
 # avoid CI errors due to errors during apt-get
 # hashsum mismatches, DNS errors and similar things
 while true; do
-	let install_retry_counter+=1
+	(( install_retry_counter+=1 ))
 	if [ ${install_retry_counter} -gt ${max_apt_retries} ]; then
 		exit 1
 	fi
+	# shellcheck disable=SC2068
 	apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-install-recommends $@ && break
 
 	# In case it is a network error let's wait a bit.

--- a/scripts/travis/travis-tests
+++ b/scripts/travis/travis-tests
@@ -9,6 +9,7 @@ TRAVIS_PKGS="protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
 
 if [ -e /etc/lsb-release ]; then
 	# This file does not exist on non Ubuntu
+	# shellcheck disable=SC1091
 	. /etc/lsb-release
 	if [ "$DISTRIB_RELEASE" = "16.04" ]; then
 		# There is one last test running on 16.04 because of the broken
@@ -24,7 +25,7 @@ fi
 
 X86_64_PKGS="gcc-multilib"
 
-UNAME_M=`uname -m`
+UNAME_M=$(uname -m)
 
 if [ "$UNAME_M" != "x86_64" ]; then
 	# For Travis only x86_64 seems to be baremetal. Other
@@ -60,7 +61,7 @@ travis_prep () {
 	}
 
 	# ccache support, only enable for non-GCOV case
-	if [ "$CCACHE" = "1" -a -z "$GCOV" ]; then
+	if [ "$CCACHE" = "1" ] && [ -z "$GCOV" ]; then
 		# ccache is installed by default, need to set it up
 		export CCACHE_DIR=$HOME/.ccache
 		[ "$CC" = "clang" ] && export CCACHE_CPP2=yes
@@ -74,8 +75,8 @@ travis_prep () {
 		TRAVIS_PKGS="$TRAVIS_PKGS $X86_64_PKGS"
 	fi
 
-	scripts/travis/apt-install $TRAVIS_PKGS
-	chmod a+x $HOME
+	scripts/travis/apt-install "$TRAVIS_PKGS"
+	chmod a+x "$HOME"
 
 	# zdtm uses an unversioned python binary to run the tests.
 	# let's point python to python3
@@ -86,7 +87,8 @@ test_stream() {
 	# We must test CRIU features that dump content into an image file to ensure
 	# streaming compatibility.
 	STREAM_TEST_PATTERN='.*(ghost|fifo|unlink|memfd|shmem|socket_queue).*'
-	./test/zdtm.py run --stream -p 2 --keep-going -T $STREAM_TEST_PATTERN $ZDTM_OPTS
+	# shellcheck disable=SC2086
+	./test/zdtm.py run --stream -p 2 --keep-going -T "$STREAM_TEST_PATTERN" $ZDTM_OPTS
 }
 
 travis_prep
@@ -109,7 +111,7 @@ fi
 
 ulimit -c unlimited
 
-echo "|`pwd`/test/abrt.sh %P %p %s %e" > /proc/sys/kernel/core_pattern
+echo "|$(pwd)/test/abrt.sh %P %p %s %e" > /proc/sys/kernel/core_pattern
 
 if [ "${COMPAT_TEST}x" = "yx" ] ; then
 	# Dirty hack to keep both ia32 & x86_64 shared libs on a machine:
@@ -124,20 +126,21 @@ if [ "${COMPAT_TEST}x" = "yx" ] ; then
 
 	mkdir "$REFUGE"
 	for i in $INCOMPATIBLE_LIBS ; do
-		for j in $(dpkg --listfiles $i | grep '\.so$') ; do
+		for j in $(dpkg --listfiles "$i" | grep '\.so$') ; do
 			cp "$j" "$REFUGE/"
 		done
 		IA32_PKGS="$IA32_PKGS $i:i386"
 	done
+	# shellcheck disable=SC2086
 	apt-get remove $INCOMPATIBLE_LIBS
-	scripts/travis/apt-install $IA32_PKGS
+	scripts/travis/apt-install "$IA32_PKGS"
 	mkdir -p /usr/lib/x86_64-linux-gnu/
 	mv "$REFUGE"/* /usr/lib/x86_64-linux-gnu/
 fi
 
 time make CC="$CC" -j4 -C test/zdtm
 
-[ -f "$CCACHE_LOGFILE" ] && cat $CCACHE_LOGFILE
+[ -f "$CCACHE_LOGFILE" ] && cat "$CCACHE_LOGFILE"
 
 # umask has to be called before a first criu run, so that .gcda (coverage data)
 # files are created with read-write permissions for all.
@@ -166,11 +169,12 @@ if [ "${STREAM_TEST}" = "1" ]; then
 	exit 0
 fi
 
+# shellcheck disable=SC2086
 ./test/zdtm.py run -a -p 2 --keep-going $ZDTM_OPTS
 
-KERN_MAJ=`uname -r | cut -d. -f1`
-KERN_MIN=`uname -r | cut -d. -f2`
-if [ $KERN_MAJ -ge "4" ] && [ $KERN_MIN -ge "18" ]; then
+KERN_MAJ=$(uname -r | cut -d. -f1)
+KERN_MIN=$(uname -r | cut -d. -f2)
+if [ "$KERN_MAJ" -ge "4" ] && [ "$KERN_MIN" -ge "18" ]; then
 	LAZY_EXCLUDE="-x cmdlinenv00 -x maps007"
 else
 	LAZY_EXCLUDE="-x maps007 -x fork -x fork2 -x uffd-events -x cgroupns
@@ -179,12 +183,12 @@ else
 fi
 LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps04"
 
-LAZY_TESTS=.*\(maps0\|uffd-events\|lazy-thp\|futex\|fork\).*
+LAZY_TESTS='.*\(maps0\|uffd-events\|lazy-thp\|futex\|fork\).*'
 LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $ZDTM_OPTS"
 
-./test/zdtm.py run $LAZY_OPTS --lazy-pages
-./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages
-./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls
+./test/zdtm.py run "$LAZY_OPTS" --lazy-pages
+./test/zdtm.py run "$LAZY_OPTS" --remote-lazy-pages
+./test/zdtm.py run "$LAZY_OPTS" --remote-lazy-pages --tls
 
 bash ./test/jenkins/criu-fault.sh
 bash ./test/jenkins/criu-fcg.sh


### PR DESCRIPTION
Running 'make lint' will now also check our travis-tests script with shellcheck.
