### PR TITLE
criu: check matching the tcp-close option on restore only

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2526,7 +2526,7 @@ int cr_restore_tasks(void)
 	if (cr_plugin_init(CR_PLUGIN_STAGE__RESTORE))
 		return -1;
 
-	if (check_img_inventory() < 0)
+	if (check_img_inventory(/* restore = */ true) < 0)
 		goto err;
 
 	if (init_stats(RESTORE_STATS))

--- a/criu/image.c
+++ b/criu/image.c
@@ -26,7 +26,7 @@ TaskKobjIdsEntry *root_ids;
 u32 root_cg_set;
 Lsmtype image_lsm;
 
-int check_img_inventory(void)
+int check_img_inventory(bool restore)
 {
 	int ret = -1;
 	struct cr_img *img;
@@ -81,8 +81,8 @@ int check_img_inventory(void)
 		goto out_err;
 	}
 
-	if (he->tcp_close && !opts.tcp_close) {
-		pr_err("Need to set the --tcp-close option.");
+	if (restore && he->tcp_close && !opts.tcp_close) {
+		pr_err("Need to set the --tcp-close options.\n");
 		goto out_err;
 	}
 

--- a/criu/include/crtools.h
+++ b/criu/include/crtools.h
@@ -10,7 +10,7 @@
 
 #define CR_FD_PERM		(S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
 
-extern int check_img_inventory(void);
+extern int check_img_inventory(bool restore);
 extern int write_img_inventory(InventoryEntry *he);
 extern int inventory_save_uptime(InventoryEntry *he);
 extern InventoryEntry *get_parent_inventory(void);

--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -997,7 +997,7 @@ int prepare_dummy_pstree(void)
 {
 	pid_t dummy = 0;
 
-	if (check_img_inventory() == -1)
+	if (check_img_inventory(/* restore = */ false) == -1)
 		return -1;
 
 	if (prepare_task_entries() == -1)


### PR DESCRIPTION
If the tcp-close has been set for dump, it has to set for restore too.

But we don't need to require matching of tcp-close for criu lazy-pages.

Reported-by: Mr Travis