### PR TITLE
servicefd: close temporary fd on error path

### DIFF
--- a/criu/servicefd.c
+++ b/criu/servicefd.c
@@ -178,6 +178,7 @@ int install_service_fd(enum sfd_type type, int fd)
 		return -1;
 	} else if (tmp != sfd) {
 		pr_err("%s busy target %d -> %d\n", sfd_type_name(type), fd, sfd);
+		close(tmp);
 		close(fd);
 		return -1;
 	}


### PR DESCRIPTION
We can have tmp != sfd if fcntl(F_DUPFD) sees that sfd is already used,
but tmp is left open on this error path, lets close it.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>