### PR TITLE
sockets: fix incorrect malloc size

### DIFF
--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -414,12 +414,15 @@ static int restore_socket_filter(int sk, SkOptsEntry *soe)
 
 	pr_info("Restoring socket filter\n");
 	sfp.len = soe->n_so_filter;
-	sfp.filter = xmalloc(soe->n_so_filter * sfp.len);
+	sfp.filter = xmalloc(sfp.len * sizeof(struct sock_filter));
 	if (!sfp.filter)
 		return -1;
 
 	decode_filter(soe->so_filter, sfp.filter, sfp.len);
 	ret = restore_opt(sk, SOL_SOCKET, SO_ATTACH_FILTER, &sfp);
+	if (ret)
+		pr_err("Can't restore filter\n");
+
 	xfree(sfp.filter);
 
 	return ret;

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -44,7 +44,8 @@ TST_NOFILE	:=				\
 		packet_sock			\
 		packet_sock_mmap		\
 		packet_sock_spkt		\
-		sock_filter			\
+		sock_filter00			\
+		sock_filter01			\
 		msgque				\
 		inotify_system			\
 		inotify_system_nodel		\
@@ -515,6 +516,7 @@ msgque:			CFLAGS += -DNEW_IPC_NS
 sem:			CFLAGS += -DNEW_IPC_NS
 posix_timers:		LDLIBS += -lrt -pthread
 remap_dead_pid_root:	CFLAGS += -DREMAP_PID_ROOT
+sock_filter01:		CFLAGS += -DSOCK_FILTER01
 socket-tcp6:		CFLAGS += -D ZDTM_IPV6
 socket-tcp4v6:		CFLAGS += -D ZDTM_IPV4V6
 socket-tcpbuf6:		CFLAGS += -D ZDTM_IPV6

--- a/test/zdtm/static/sock_filter00.c
+++ b/test/zdtm/static/sock_filter00.c
@@ -15,12 +15,24 @@ const char *test_author	= "Pavel Emelyanov <xemul@parallels.com>";
 #define SO_GET_FILTER           SO_ATTACH_FILTER
 #endif
 
+#ifdef SOCK_FILTER01
+#define SFLEN	4
+#else
 #define SFLEN	14
+#endif
 
 int main(int argc, char **argv)
 {
 	int sk;
 	struct sock_fprog p;
+#ifdef SOCK_FILTER01
+	struct sock_filter f[SFLEN] = {
+		{ 0x6,  0, 0, 0x0000ffff },
+		{ 0x6,  0, 0, 0x0000ffff },
+		{ 0x6,  0, 0, 0x0000ffff },
+		{ 0x6,  0, 0, 0x0000ffff },
+	};
+#else
 	struct sock_filter f[SFLEN] = {
 		{ 0x28, 0, 0, 0x0000000c },
 		{ 0x15, 0, 4, 0x00000800 },
@@ -37,6 +49,7 @@ int main(int argc, char **argv)
 		{ 0x6,  0, 0, 0x0000ffff },
 		{ 0x6,  0, 0, 0x00000000 },
 	};
+#endif
 	struct sock_filter f2[SFLEN], f3[SFLEN];
 	socklen_t len;
 

--- a/test/zdtm/static/sock_filter01.c
+++ b/test/zdtm/static/sock_filter01.c
@@ -1,0 +1,1 @@
+sock_filter00.c


### PR DESCRIPTION
Fix malloc size: use size * filter_size instead of typo size * size.

In case when there are filter with 4 commands this would corrupt malloc chunk ([reproduce](https://src.openvz.org/users/andrey.zhadchenko/repos/criu/commits/1fc43fa1e5af4d8c2c4c74195c6422d22c807b1d))

```
(1732.81300 Error (criu/cr-restore.c:1968): 38 killed by signal 6: Aborted
(1732.81304 Error (criu/cr-restore.c:3022): Restoring FAILED. 
```

```
backtrace:
Program received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50  ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f2eab371535 in __GI_abort () at abort.c:79
#2  0x00007f2eab3c8508 in __libc_message (action=action@entry=do_abort, 
    fmt=fmt@entry=0x7f2eab4d328d "%s\n") at ../sysdeps/posix/libc_fatal.c:181
#3  0x00007f2eab3cec1a in malloc_printerr (
    str=str@entry=0x7f2eab4d4bf8 "munmap_chunk(): invalid pointer") at malloc.c:5341
#4  0x00007f2eab3cf184 in munmap_chunk (p=<optimized out>) at malloc.c:2830
#5  0x00005567a718c3d9 in core_entry__free_unpacked (message=0x5567a7cc62b0, allocator=0x0)
    at images/core.pb-c.c:323
#6  0x00005567a71c2b16 in sigreturn_restore (pid=38, task_args=0x28000, alen=4096, core=0x5567a7cc62b0)
    at criu/cr-restore.c:4318
#7  0x00005567a71bac90 in restore_one_alive_task (pid=38, core=0x5567a7cc62b0)
    at criu/cr-restore.c:1291
#8  0x00005567a71bb889 in restore_one_task (pid=38, core=0x5567a7cc62b0) at criu/cr-restore.c:1657
#9  0x00005567a71bd9b7 in restore_task_with_children (_arg=0x7ffff01f2230) at criu/cr-restore.c:2368
#10 0x00007f2eab4484cf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
(gdb)