### PR TITLE
criu-ns: Use PID 1 on restore

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2192,6 +2192,17 @@ static int write_restored_pid(void)
 	return 0;
 }
 
+static void reap_zombies(void) {
+	while (1) {
+		pid_t pid = wait(NULL);
+		if (pid == -1) {
+			if (errno != ECHILD)
+				pr_perror("Error while waiting for pids");
+			return;
+		}
+	}
+}
+
 static int restore_root_task(struct pstree_item *init)
 {
 	enum trace_flags flag = TRACE_ALL;
@@ -2445,8 +2456,9 @@ skip_ns_bouncing:
 	if (ret != 0)
 		pr_err("Post-resume script ret code %d\n", ret);
 
-	if (!opts.restore_detach && !opts.exec_cmd)
-		wait(NULL);
+	if (!opts.restore_detach && !opts.exec_cmd) {
+		reap_zombies();
+	}
 
 	return 0;
 

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -67,12 +67,8 @@ def wrap_restore():
 		_errno = ctypes.get_errno()
 		raise OSError(_errno, errno.errorcode[_errno])
 
-	(r_pipe, w_pipe) = os.pipe()
-
-	# Spawn the init
-	if os.fork() == 0:
-		os.close(r_pipe)
-
+	criu_pid = os.fork()
+	if criu_pid == 0:
 		# Mount new /proc
 		if _mount(None, b"/", None, MS_SLAVE|MS_REC, None) != 0:
 			_errno = ctypes.get_errno()
@@ -83,44 +79,22 @@ def wrap_restore():
 			raise OSError(_errno, errno.errorcode[_errno])
 
 		# Spawn CRIU binary
-		criu_pid = os.fork()
-		if criu_pid == 0:
-			run_criu()
-			raise OSError(errno.ENOENT, "No such command")
-
-		while True:
-			try:
-				(pid, status) = os.wait()
-				if pid == criu_pid:
-					status = os.WEXITSTATUS(status)
-					break
-			except OSError:
-				status = -251
-				break
-
-		os.write(w_pipe, b"%d" % status)
-		os.close(w_pipe)
-
-		if status != 0:
-			sys.exit(status)
-
-		while True:
-			try:
-				os.wait()
-			except OSError:
-				break
-
+		run_criu()
+		raise OSError(errno.ENOENT, "No such command")
 		sys.exit(0)
 
 	# Wait for CRIU to exit and report the status back
-	os.close(w_pipe)
-	status = os.read(r_pipe, 1024)
-	if not status.isdigit():
-		status_i = -252
-	else:
-		status_i = int(status)
+	while True:
+		try:
+			(pid, status) = os.wait()
+			if pid == criu_pid:
+				status = os.WEXITSTATUS(status)
+				break
+		except OSError:
+			status = -251
+			break
 
-	return status_i
+	return status
 
 
 def get_varg(args):


### PR DESCRIPTION
`criu-ns` performs double fork, which results in `criu restore` using PID 2. Thus, if a user is trying to restore a process with that PID, the restore will fail.