### PR TITLE
compel: don't mmap parasite as RWX

### DIFF
--- a/compel/arch/ppc64/scripts/compel-pack.lds.S
+++ b/compel/arch/ppc64/scripts/compel-pack.lds.S
@@ -12,7 +12,7 @@ SECTIONS
 		*(.compel.init)
 	}
 
-	.data : {
+	.data : ALIGN(0x10000) {
 		*(.data*)
 		*(.bss*)
 	}

--- a/compel/arch/s390/scripts/compel-pack.lds.S
+++ b/compel/arch/s390/scripts/compel-pack.lds.S
@@ -12,7 +12,7 @@ SECTIONS
 		*(.compel.init)
 	}
 
-	.data : {
+	.data : ALIGN(0x1000) {
 		*(.data*)
 		*(.bss*)
 	}

--- a/compel/arch/x86/scripts/compel-pack.lds.S
+++ b/compel/arch/x86/scripts/compel-pack.lds.S
@@ -13,7 +13,7 @@ SECTIONS
 		*(.compel.init)
 	}
 
-	.data : {
+	.data : ALIGN(0x1000) {
 		*(.data*)
 		*(.bss*)
 	}

--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -155,6 +155,7 @@ struct parasite_blob_desc {
 			unsigned long		args_ptr_off;
 			unsigned long		got_off;
 			unsigned long		args_off;
+			unsigned long		data_off;
 			compel_reloc_t		*relocs;
 			unsigned int		nr_relocs;
 		} hdr;

--- a/compel/src/lib/handle-elf.c
+++ b/compel/src/lib/handle-elf.c
@@ -155,6 +155,7 @@ int __handle_elf(void *mem, size_t size)
 	int64_t toc_offset = 0;
 #endif
 	int ret = -EINVAL;
+	unsigned long data_off = 0;
 
 	pr_debug("Header\n");
 	pr_debug("------------\n");
@@ -698,6 +699,9 @@ int __handle_elf(void *mem, size_t size)
 				pr_out("\n\t");
 			pr_out("0x%02x,", shdata[j]);
 		}
+
+		if (!strcmp(&secstrings[sh->sh_name], ".data"))
+			data_off = sh->sh_addr;
 	}
 	pr_out("};\n");
 	pr_out("\n");
@@ -722,6 +726,7 @@ int __handle_elf(void *mem, size_t size)
 	pr_out("\tpbd->hdr.args_ptr_off	= %s_sym__export_parasite_service_args_ptr;\n", opts.prefix);
 	pr_out("\tpbd->hdr.got_off	= round_up(pbd->hdr.bsize, sizeof(long));\n");
 	pr_out("\tpbd->hdr.args_off	= pbd->hdr.got_off + %zd*sizeof(long);\n", nr_gotpcrel);
+	pr_out("\tpbd->hdr.data_off	= %#lx;\n", data_off);
 	pr_out("\tpbd->hdr.relocs		= %s_relocs;\n", opts.prefix);
 	pr_out("\tpbd->hdr.nr_relocs	= "
 			"sizeof(%s_relocs) / sizeof(%s_relocs[0]);\n",


### PR DESCRIPTION
Some kernels have W^X mitigation, which means they won't execute memory blocks if that memory block is also writable or ever was writable. This patch enables CRIU to run on such kernels.

1. Align .data section to a page.
2. mmap a memory block for parasite as RX.
3. mprotect everything after .text as RW.

I'm not sure if this is the best way to achieve this goal. If anyone has a better idea, feel free to share.

v2: add alignment for ppc64 and s390