### PR TITLE
Even more static code analysis fixes

### DIFF
--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -355,6 +355,7 @@ static int gen_parasite_saddr(struct sockaddr_un *saddr, int key)
 	int sun_len;
 
 	saddr->sun_family = AF_UNIX;
+	/* cppcheck-suppress nullPointer */
 	snprintf(saddr->sun_path, UNIX_PATH_MAX,
 			"X/crtools-pr-%d", key);
 

--- a/criu/autofs.c
+++ b/criu/autofs.c
@@ -1114,6 +1114,7 @@ close_pipe:
 free_info:
 	free(info);
 umount:
+	/* coverity[toctou] */
 	if (umount(mi->mountpoint) < 0)
 		pr_perror("Failed to umount %s", mi->mountpoint);
 	goto close_pipe;

--- a/criu/cgroup-props.c
+++ b/criu/cgroup-props.c
@@ -395,6 +395,7 @@ static int cgp_parse_file(char *path)
 	ret = 0;
 err:
 	if (mem != MAP_FAILED)
+		/* coverity[uninit_use_in_call] */
 		munmap(mem, st.st_size);
 	close_safe(&fd);
 	return ret;

--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -1809,6 +1809,7 @@ static int prepare_cgroup_sfd(CgroupEntry *ce)
 				fstype = "cgroup2";
 
 			pr_debug("\tMaking controller dir %s (%s)\n", paux, opt);
+			/* coverity[toctou] */
 			if (mkdir(paux, 0700)) {
 				pr_perror("\tCan't make controller dir %s", paux);
 				goto err;

--- a/criu/config.c
+++ b/criu/config.c
@@ -872,6 +872,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 			break;
 		case 'V':
 			pr_msg("Version: %s\n", CRIU_VERSION);
+			/* coverity[pointless_string_compare] */
 			if (strcmp(CRIU_GITID, "0"))
 				pr_msg("GitID: %s\n", CRIU_GITID);
 			exit(0);

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3633,7 +3633,13 @@ static int sigreturn_restore(pid_t pid, struct task_restore_args *task_args, uns
 	 * it gets unmapped at the very end of __export_restore_task
 	 */
 
-	task_args->proc_fd = dup(get_service_fd(PROC_FD_OFF));
+	i = get_service_fd(PROC_FD_OFF);
+	if (i < 0) {
+		pr_err("Cannot get PROC_FD_OFF fd\n");
+		goto err;
+	}
+
+	task_args->proc_fd = dup(i);
 	if (task_args->proc_fd < 0) {
 		pr_perror("can't dup proc fd");
 		goto err;

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3240,7 +3240,7 @@ static bool groups_match(gid_t* groups, int n_groups)
 	n = getgroups(0, NULL);
 	if (n == -1) {
 		pr_perror("Failed to get number of supplementary groups");
-		ret = false;
+		return false;
 	}
 	if (n != n_groups)
 		return false;

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -1019,6 +1019,7 @@ static int handle_version(int sk, CriuReq * msg)
 	/* This assumes we will always have a major and minor version */
 	version.major_number = CRIU_VERSION_MAJOR;
 	version.minor_number = CRIU_VERSION_MINOR;
+	/* coverity[pointless_string_compare] */
 	if (strcmp(CRIU_GITID, "0")) {
 		version.gitid = CRIU_GITID;
 	}

--- a/criu/fdstore.c
+++ b/criu/fdstore.c
@@ -110,6 +110,11 @@ int fdstore_get(int id)
 	int sk = get_service_fd(FDSTORE_SK_OFF);
 	int fd;
 
+	if (sk < 0) {
+		pr_err("Cannot get FDSTORE_SK_OFF fd\n");
+		return -1;
+	}
+
 	mutex_lock(&desc->lock);
 	if (setsockopt(sk, SOL_SOCKET, SO_PEEK_OFF, &id, sizeof(id))) {
 		mutex_unlock(&desc->lock);

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -341,6 +341,7 @@ static int kerndat_get_dirty_track(void)
 
 	map[0] = '\0';
 
+	/* coverity[check_return] */
 	lseek(pm2, (unsigned long)map / PAGE_SIZE * sizeof(u64), SEEK_SET);
 	ret = read(pm2, &pmap, sizeof(pmap));
 	if (ret < 0)

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -2781,6 +2781,7 @@ err_tmpfs:
 	}
 
 err_root:
+	/* coverity[toctou] */
 	if (tmp_dir && rmdir(put_root)) {
 		pr_perror("Can't remove the directory %s", put_root);
 		return -1;

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -2852,6 +2852,7 @@ static int create_mnt_roots(void)
 		mnt_roots = NULL;
 		goto out;
 	}
+	/* coverity[check_return] */
 	chmod(mnt_roots, 0777);
 
 	exit_code = 0;

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -526,7 +526,7 @@ static int open_ns_fd(struct file_desc *d, int *new_fd)
 	struct ns_desc *nd = NULL;
 	struct ns_id *ns;
 	int nsfd_id, fd;
-	char path[64];
+	char path[64] = "";
 
 	for (ns = ns_ids; ns != NULL; ns = ns->next) {
 		if (ns->id != nfi->nfe->ns_id)

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -1366,6 +1366,10 @@ int __userns_call(const char *func_name, uns_call_t call, int flags,
 		return call(arg, fd, getpid());
 
 	sk = get_service_fd(USERNSD_SK);
+	if (sk < 0) {
+		pr_err("Cannot get USERNSD_SK fd\n");
+		return -1;
+	}
 	pr_debug("uns: calling %s (%d, %x)\n", func_name, fd, flags);
 
 	if (!async)

--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -151,6 +151,7 @@ static void skip_pagemap_pages(struct page_read *pr, unsigned long len)
 static int seek_pagemap(struct page_read *pr, unsigned long vaddr)
 {
 	if (!pr->pe)
+		/* coverity[branch_past_initialization] */
 		goto adv;
 
 	do {

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -1381,6 +1381,7 @@ static int parse_mountinfo_ent(char *str, struct mount_info *new, char **fsname)
 	}
 	strcpy(root_link.name, new->root);
 	if (strip_deleted(&root_link)) {
+		root_link.name[sizeof(root_link.name) - 2] = 0;
 		strcpy(new->root, root_link.name);
 		new->deleted = true;
 	}

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -757,6 +757,7 @@ int parse_smaps(pid_t pid, struct vm_area_list *vma_area_list,
 		if (!eof && !__is_vma_range_fmt(str)) {
 			if (!strncmp(str, "Nonlinear", 9)) {
 				BUG_ON(!vma_area);
+				/* coverity[var_deref_op] */
 				pr_err("Nonlinear mapping found %016"PRIx64"-%016"PRIx64"\n",
 				       vma_area->e->start, vma_area->e->end);
 				/*
@@ -767,6 +768,7 @@ int parse_smaps(pid_t pid, struct vm_area_list *vma_area_list,
 				goto err;
 			} else if (!strncmp(str, "VmFlags: ", 9)) {
 				BUG_ON(!vma_area);
+				/* coverity[var_deref_model] */
 				parse_vma_vmflags(&str[9], vma_area);
 				continue;
 			} else

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -853,7 +853,7 @@ int parse_pid_stat(pid_t pid, struct proc_pid_stat *s)
 	if (fd < 0)
 		return -1;
 
-	n = read(fd, buf, BUF_SIZE);
+	n = read(fd, buf, BUF_SIZE - 1);
 	close(fd);
 	if (n < 1) {
 		pr_err("stat for %d is corrupted\n", pid);
@@ -862,6 +862,7 @@ int parse_pid_stat(pid_t pid, struct proc_pid_stat *s)
 
 	memset(s, 0, sizeof(*s));
 
+	buf[n] = 0;
 	tok = strchr(buf, ' ');
 	if (!tok)
 		goto err;

--- a/criu/protobuf.c
+++ b/criu/protobuf.c
@@ -51,7 +51,7 @@ int do_pb_read_one(struct cr_img *img, void **pobj, int type, bool eof)
 	char img_name_buf[PATH_MAX];
 	u8 local[PB_PKOBJ_LOCAL_SIZE];
 	void *buf = (void *)&local;
-	u32 size;
+	u32 size = 0;
 	int ret;
 
 	if (!cr_pb_descs[type].pb_desc) {
@@ -66,6 +66,10 @@ int do_pb_read_one(struct cr_img *img, void **pobj, int type, bool eof)
 		ret = 0;
 	else
 		ret = bread(&img->_x, &size, sizeof(size));
+
+	/* This is to make coverity happy and to not report TAINTED_SCALAR. */
+	size &= UINT32_MAX;
+
 	if (ret == 0) {
 		if (eof) {
 			return 0;

--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -1485,6 +1485,5 @@ int cr_lazy_pages(bool daemon)
 
 	tls_terminate_session();
 
-	xfree(events);
 	return ret;
 }

--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -284,6 +284,7 @@ int uffd_open(int flags, unsigned long *features)
 	}
 
 	if (uffdio_api.api != UFFD_API) {
+		/* coverity[format_error] */
 		pr_err("Incompatible uffd API: expected %Lu, got %Lu\n",
 		       UFFD_API, uffdio_api.api);
 		goto err;


### PR DESCRIPTION
This tries to fix even more reports from different static code analyzers (coverity, cppcheck, scan-build).

Some of the 'fixes' are just to mark certain things as false positive, so that the checkers can ignore it the next time.

CI seems happy with the changes, but as it touches many different parts I hope I did not break something.