### PR TITLE
travis: install gzip for Fedora Rawhide based tests

### DIFF
--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -8,6 +8,7 @@ RUN dnf install -y \
 	gcc \
 	git \
 	gnutls-devel \
+	gzip \
 	iproute \
 	iptables \
 	nftables \
@@ -26,6 +27,7 @@ RUN dnf install -y \
 	python3-future \
 	python3-protobuf \
 	python3-junit_xml \
+	redhat-rpm-config \
 	sudo \
 	tar \
 	which \


### PR DESCRIPTION
travis fails on Rawhide because gzip is missing