### PR TITLE
Enable codeql security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [criu-dev]
+  pull_request:
+    branches: [criu-dev]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: cpp, python
+
+    - name: Build CRIU
+      run: |
+        sudo make -C scripts/ci local SKIP_CI_BUILD=1
+        make -j 8
+        make install DESTDIR=/tmp/install PYTHON=python3
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -138,6 +138,8 @@ if [ "$CLANG" = "1" ]; then
 	export LDFLAGS
 fi
 
+[ -n "$SKIP_CI_BUILD" ] && exit 0
+
 export GCOV CC
 $CC --version
 time make CC="$CC" -j4 V=1


### PR DESCRIPTION
Now that github announced its code analysis feature, this tries to enable it.

As far as I understand it, it is based on pre-loading libraries, so we need to build it as non-root to make sure it can actually analyse our files during the build process.

Once this is enabled the possible security related messages will be seen under 'Security' in github and once it is part of 'criu-dev' each PR will get the information if new security related problems might have been introduced.

The initial scan on my repository shows 6 possible security warnings.

This is a new version of #1218 because I pushed to much to that branch without knowing.