### PR TITLE
vdso: Printing fixes

### DIFF
--- a/compel/plugins/std/log.c
+++ b/compel/plugins/std/log.c
@@ -330,9 +330,10 @@ static void sbuf_printf(struct simple_buf *b, const char *format, va_list args)
 			print_hex_l((unsigned long)va_arg(args, void *), b);
 			break;
 		default:
-			print_string("UNKNOWN FORMAT ", b);
+			print_string("\nError: Unknown printf format %", b);
 			sbuf_putc(b, *s);
-			break;
+			sbuf_putc(b, '\n');
+			return;
 		}
 		s++;
 	}

--- a/compel/plugins/std/log.c
+++ b/compel/plugins/std/log.c
@@ -225,6 +225,22 @@ done:
 	print_string(s, b);
 }
 
+static void print_num_u(unsigned long num, struct simple_buf *b)
+{
+	char buf[22], *s;
+
+	buf[21] = '\0';
+	s = &buf[21];
+
+	do {
+		s--;
+		*s = (num % 10) + '0';
+		num /= 10;
+	} while (num > 0);
+
+	print_string(s, b);
+}
+
 static void hexdigit(unsigned int v, char *to, char **z)
 {
 	*to = "0123456789abcdef"[v & 0xf];
@@ -328,6 +344,12 @@ static void sbuf_printf(struct simple_buf *b, const char *format, va_list args)
 			break;
 		case 'p':
 			print_hex_l((unsigned long)va_arg(args, void *), b);
+			break;
+		case 'u':
+			if (along)
+				print_num_u(va_arg(args, unsigned long), b);
+			else
+				print_num_u(va_arg(args, unsigned), b);
 			break;
 		default:
 			print_string("\nError: Unknown printf format %", b);

--- a/criu/pie/util-vdso.c
+++ b/criu/pie/util-vdso.c
@@ -222,7 +222,7 @@ static void parse_elf_symbols(uintptr_t mem, size_t size, Phdr_t *load,
 	const char *vdso_symbols[VDSO_SYMBOL_MAX] = {
 		ARCH_VDSO_SYMBOLS
 	};
-	const size_t vdso_symbol_length = sizeof(t->symbols[0].name);
+	const size_t vdso_symbol_length = sizeof(t->symbols[0].name) - 1;
 
 	Hash_t nbucket, nchain;
 	Hash_t *bucket, *chain;
@@ -265,6 +265,7 @@ static void parse_elf_symbols(uintptr_t mem, size_t size, Phdr_t *load,
 			if (std_strncmp(name, symbol, vdso_symbol_length))
 				continue;
 
+			/* XXX: provide strncpy() implementation for PIE */
 			memcpy(t->symbols[i].name, name, vdso_symbol_length);
 			t->symbols[i].offset = (unsigned long)sym->st_value - load->p_vaddr;
 			break;


### PR DESCRIPTION
Three printing fixes:
- copy string with (len - 1) to leave '\0' at the end (the buffer is big enough for now, but it may change)
- try to avoid crashing PIE whenever unknown specifier is found on logging
- support %u specifier