### PR TITLE
Move first job to Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,16 @@
+environment:
+  CIRRUS_WORKING_DIR: "/tmp/criu"
+container:
+  # This test case does not work on focal, because the newer version
+  # of libvirt fails during 'vagrant up' with ip6tables errors.
+  image: ubuntu:bionic
+  kvm: true
+  cpu: 4
+  memory: 8G
+task:
+  name: Vagrant Fedora based test (no VDSO)
+  setup_script: |
+    scripts/ci/apt-install make gcc pkg-config git perl-modules iproute2 kmod wget
+    ln -sf /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto
+  build_script: |
+    make -C scripts/ci vagrant-fedora-no-vdso

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
 env:
   - TR_ARCH=local       COMPAT_TEST=y
   - TR_ARCH=local       CLANG=1 COMPAT_TEST=y
-  - TR_ARCH=vagrant-fedora-no-vdso
 jobs:
   include:
     - os: linux

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -6,29 +6,55 @@
 set -e
 set -x
 
-VAGRANT_VERSION=2.2.7
+VAGRANT_VERSION=2.2.10
 FEDORA_VERSION=32
 FEDORA_BOX_VERSION=32.20200422.0
 
 setup() {
-	apt-get -qq update
-	# Load the kvm modules for vagrant to use qemu
-	modprobe kvm kvm_intel
+	if [ -n "$TRAVIS" ]; then
+		# Load the kvm modules for vagrant to use qemu
+		modprobe kvm kvm_intel
+	fi
+	if [ -n "$CIRRUS_CI" ]; then
+		# Running modprobe is not possible on Cirrus, because
+		# we are running in a container with potentially other
+		# modules than the host.
+		# Vagrant can still use /dev/kvm later if we do
+		chmod 666 /dev/kvm
+	fi
 
 	# Tar up the git checkout to have vagrant rsync it to the VM
 	tar cf criu.tar ../../../criu
-	wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_"$(uname -m)".deb -O /tmp/vagrant.deb && \
+	# Cirrus has problems with the following certificate.
+	wget --no-check-certificate https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_"$(uname -m)".deb -O /tmp/vagrant.deb && \
 		dpkg -i /tmp/vagrant.deb
 
-	./apt-install libvirt-bin libvirt-dev qemu-utils qemu
-	systemctl restart libvirt-bin
+	./apt-install libvirt-clients libvirt-daemon-system libvirt-dev qemu-utils qemu \
+		ruby build-essential libxml2-dev qemu-kvm rsync ebtables dnsmasq-base \
+		openssh-client
+	if [ -n "$CIRRUS_CI" ]; then
+		# On Cirrus systemctl does not work, because we are running in
+		# a container without access to systemd
+		/usr/sbin/virtlogd -d
+		/usr/sbin/libvirtd -d
+	else
+		systemctl restart libvirtd
+	fi
 	vagrant plugin install vagrant-libvirt
 	vagrant init fedora/${FEDORA_VERSION}-cloud-base --box-version ${FEDORA_BOX_VERSION}
 	# The default libvirt Vagrant VM uses 512MB.
 	# Travis VMs should have around 7.5GB.
 	# Increasing it to 4GB should work.
 	sed -i Vagrantfile -e 's,^end$,  config.vm.provider :libvirt do |libvirt|'"\n"'    libvirt.memory = 4096;end'"\n"'end,g'
-	vagrant up --provider=libvirt
+	if [ -n "$CIRRUS_CI" ]; then
+		# Work around for:
+		# Error while activating network: Call to virNetworkCreate failed: internal error:
+		# Failed to apply firewall rules /usr/sbin/ip6tables --table filter --list-rules: modprobe: FATAL: Module ip6_tables not found in directory /lib/modules/5.4.0-1025-gcp
+		# On cirrus-ci.com. Running in a container without access to the host's kernel modules
+		rm -f /sbin/ip6tables
+		cp /bin/true /sbin/ip6tables
+	fi
+	vagrant up --provider=libvirt > /dev/null
 	mkdir -p /root/.ssh
 	vagrant ssh-config >> /root/.ssh/config
 	ssh default sudo dnf install -y gcc git gnutls-devel nftables-devel libaio-devel \
@@ -45,7 +71,6 @@ fedora-no-vdso() {
 	vagrant reload
 	ssh default cat /proc/cmdline
 	ssh default 'cd /vagrant; tar xf criu.tar; cd criu; make -j 4'
-	# Excluding two cgroup tests which seem to fail because of cgroup2
 	ssh default 'cd /vagrant/criu/test; sudo ./zdtm.py run -a --keep-going'
 }
 


### PR DESCRIPTION
This includes the changes to run the Vagrant based CI run on Cirrus CI. Cirrus CI seems to be one of the few (only) services which enable nested virtualization besides Travis. With the upcoming shutdown of travis-ci.org (end of 2020) and the necessary move the travis-ci.com I am trying to move all long running jobs away from Travis. To activate the Cirrus CI based job the Cirrus CI integration into checkpoint-restore/criu is necessary. Let me know if I should do that. Once we know it works on Cirrus CI I would disable it on Travis.

This is also includes a commit to prepare our aarch64 based run to work on aws-graviton2 based system. That would be the first non x86_64 based Travis CI run doing actual tests instead of just building CRIU. This is only available on travis-ci.com. If we actually enable this depends if we have enough minutes on travis-ci.com once we do the switch.