### PR TITLE
CI: run aarch64 compile tests on Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,65 @@
+---
+kind: pipeline
+type: docker
+name: aarch64 build GCC (native)
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: ubuntu:focal
+  commands:
+  - scripts/ci/apt-install make
+  - make -C scripts/ci local
+
+---
+kind: pipeline
+type: docker
+name: aarch64 build CLANG (native)
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: ubuntu:focal
+  commands:
+  - scripts/ci/apt-install make
+  - make -C scripts/ci local CLANG=1
+
+---
+kind: pipeline
+type: docker
+name: armhf build GCC (native)
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  # At the time of setting up focal did not work
+  image: ubuntu:bionic
+  commands:
+  - scripts/ci/apt-install make
+  - make -C scripts/ci local
+
+---
+kind: pipeline
+type: docker
+name: armhf build CLANG (native)
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  # At the time of setting up focal did not work
+  image: ubuntu:bionic
+  commands:
+  - scripts/ci/apt-install make
+  - make -C scripts/ci local CLANG=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,16 +36,6 @@ jobs:
       dist: bionic
     - os: linux
       arch: arm64
-      # This runs on aarch64 with 'setarch linux32'
-      env: TR_ARCH=armv7hf
-      dist: bionic
-    - os: linux
-      arch: arm64
-      # This runs on aarch64 with 'setarch linux32'
-      env: TR_ARCH=armv7hf     CLANG=1
-      dist: bionic
-    - os: linux
-      arch: arm64
       env: TR_ARCH=fedora-rawhide
       dist: bionic
     - os: linux

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -4,7 +4,8 @@ set -x -e
 CI_PKGS="protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
 		libgnutls30 libprotobuf-dev protobuf-compiler libcap-dev
 		libnl-3-dev gdb bash libnet-dev util-linux asciidoctor
-		libnl-route-3-dev time ccache flake8 libbsd-dev"
+		libnl-route-3-dev time ccache flake8 libbsd-dev
+		libperl-dev pkg-config"
 
 
 if [ -e /etc/lsb-release ]; then
@@ -51,12 +52,13 @@ ci_prep () {
 	# This can fail on aarch64 travis
 	service apport stop || :
 
-	CC=gcc
-	# clang support
 	if [ "$CLANG" = "1" ]; then
-		CI_PKGS="$CI_PKGS clang"
+		# clang support
 		CC=clang
+	else
+		CC=gcc
 	fi
+	CI_PKGS="$CI_PKGS $CC"
 
 	[ -n "$GCOV" ] && {
 		apt-add-repository -y "ppa:ubuntu-toolchain-r/test"

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -55,6 +55,10 @@ ci_prep () {
 	if [ "$CLANG" = "1" ]; then
 		# clang support
 		CC=clang
+		# If this is running in an environment without gcc installed
+		# compel-host-bin will fail as it is using HOSTCC. Also
+		# set HOSTCC to clang to build compel-host-bin with it.
+		export HOSTCC=clang
 	else
 		CC=gcc
 	fi


### PR DESCRIPTION
Besides Travis CI Drone CI seems to be only service providing ARM based builds. This switches the aarch64 and arm32 builds to drone.io.

Because Drone CI is running in a Docker container we cannot use 'setarch linux32' as it requires the blocked syscall 'personality(2)'.

But Drone CI provides an 'arch: arm' which gives the same architecture as 'setarch linux32' on Travis aarch64: armv8l

The goal from all this CI changes it to be able to move as much away from Travis as possible. Except maybe ppc64le and s390x (and maybe bare metal graviton2 based aarch64).

Using so many different CI systems is on the one hand not the nicest solution, but if one of the free CI systems decides to go the same way as Travis does we already are comfortable with setting up runs on other CI systems.

If this get merged I will remove the corresponding Travis runs.