### PR TITLE
Replace occurrences of python with python3

### DIFF
--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -48,7 +48,4 @@ RUN adduser -u 1000 -D test
 
 RUN pip3 install junit_xml
 
-# For zdtm we need an unversioned python binary
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
 RUN make -C test/zdtm

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import ctypes
 import ctypes.util
 import errno

--- a/soccr/test/run.py
+++ b/soccr/test/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os
 import hashlib

--- a/test/check_actions.py
+++ b/test/check_actions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/test/crit-recode.py
+++ b/test/crit-recode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # vim: noet ts=8 sw=8 sts=8
 
 import pycriu

--- a/test/exhaustive/pipe.py
+++ b/test/exhaustive/pipe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/test/exhaustive/unix.py
+++ b/test/exhaustive/unix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/test/inhfd/memfd.py.checkskip
+++ b/test/inhfd/memfd.py.checkskip
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import ctypes
 libc = ctypes.CDLL(None)

--- a/test/others/ext-tty/run.py
+++ b/test/others/ext-tty/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import subprocess
 import os, sys, time, signal, pty
 

--- a/test/others/shell-job/run.py
+++ b/test/others/shell-job/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os, pty, sys, subprocess
 import termios, fcntl, time
 

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # vim: noet ts=8 sw=8 sts=8
 from __future__ import absolute_import, division, print_function, unicode_literals
 

--- a/test/zdtm/static/cgroup_yard.hook
+++ b/test/zdtm/static/cgroup_yard.hook
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/test/zdtm/static/file_locks06.checkskip
+++ b/test/zdtm/static/file_locks06.checkskip
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import fcntl
 import tempfile
 import struct

--- a/test/zdtm/static/socket-tcp-fin-wait1.hook
+++ b/test/zdtm/static/socket-tcp-fin-wait1.hook
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 sys.path.append("../crit")


### PR DESCRIPTION
Some distributions have no /usr/bin/python executable (e.g., on Ubuntu 20.04, where Python2 was never installed).

This patch allows running on a system that has no `/usr/bin/python` executable at all, only python3.