### PR TITLE
vim: remove wrong 8-space tabs indent from python files

### DIFF
--- a/test/crit-recode.py
+++ b/test/crit-recode.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# vim: noet ts=8 sw=8 sts=8
-
 import pycriu
 import sys
 import os

--- a/test/inhfd/tty.py
+++ b/test/inhfd/tty.py
@@ -1,4 +1,3 @@
-# vim: noet ts=8 sw=8 sts=8
 import fcntl
 import os
 import pty

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# vim: noet ts=8 sw=8 sts=8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse


### PR DESCRIPTION
Probably all vim users can setup their desired indent in their vimrc by
themselfs.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>