### PR TITLE
criu-ns: Fix --restore-detached option

### DIFF
--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -47,14 +47,6 @@ else:
     ]
     _mount.restype = ctypes.c_int
 
-try:
-    _umount = _libc.umount
-except AttributeError:
-    raise OSError(errno.EINVAL, "umount is not supported on this platform")
-else:
-    _umount.argtypes = [ctypes.c_char]
-    _umount.restype = ctypes.c_int
-
 
 def _mount_new_proc():
     """

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -18,190 +18,190 @@ MS_SLAVE = 1 << 19
 _libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
 
 try:
-	_unshare = _libc.unshare
+    _unshare = _libc.unshare
 except AttributeError:
-	raise OSError(errno.EINVAL, "unshare is not supported on this platform")
+    raise OSError(errno.EINVAL, "unshare is not supported on this platform")
 else:
-	_unshare.argtypes = [ ctypes.c_int ]
-	_unshare.restype = ctypes.c_int
+    _unshare.argtypes = [ ctypes.c_int ]
+    _unshare.restype = ctypes.c_int
 
 try:
-	_setns = _libc.setns
+    _setns = _libc.setns
 except AttributeError:
-	raise OSError(errno.EINVAL, "setns is not supported on this platform")
+    raise OSError(errno.EINVAL, "setns is not supported on this platform")
 else:
-	_setns.argtypes = [ ctypes.c_int, ctypes.c_int ]
-	_setns.restype = ctypes.c_int
+    _setns.argtypes = [ ctypes.c_int, ctypes.c_int ]
+    _setns.restype = ctypes.c_int
 
 try:
-	_mount = _libc.mount
+    _mount = _libc.mount
 except AttributeError:
-	raise OSError(errno.EINVAL, "mount is not supported on this platform")
+    raise OSError(errno.EINVAL, "mount is not supported on this platform")
 else:
-	_mount.argtypes = [
-		ctypes.c_char_p,
-		ctypes.c_char_p,
-		ctypes.c_char_p,
-		ctypes.c_ulong,
-		ctypes.c_void_p
-	]
-	_mount.restype = ctypes.c_int
+    _mount.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_ulong,
+        ctypes.c_void_p
+    ]
+    _mount.restype = ctypes.c_int
 
 try:
-	_umount = _libc.umount
+    _umount = _libc.umount
 except AttributeError:
-	raise OSError(errno.EINVAL, "umount is not supported on this platform")
+    raise OSError(errno.EINVAL, "umount is not supported on this platform")
 else:
-	_umount.argtypes = [ctypes.c_char]
-	_umount.restype = ctypes.c_int
+    _umount.argtypes = [ctypes.c_char]
+    _umount.restype = ctypes.c_int
 
 
 def run_criu():
-	print(sys.argv)
-	os.execlp('criu', *['criu'] + sys.argv[1:])
+    print(sys.argv)
+    os.execlp('criu', *['criu'] + sys.argv[1:])
 
 
 def wrap_restore():
-	# Unshare pid and mount namespaces
-	if _unshare(CLONE_NEWNS | CLONE_NEWPID) != 0:
-		_errno = ctypes.get_errno()
-		raise OSError(_errno, errno.errorcode[_errno])
+    # Unshare pid and mount namespaces
+    if _unshare(CLONE_NEWNS | CLONE_NEWPID) != 0:
+        _errno = ctypes.get_errno()
+        raise OSError(_errno, errno.errorcode[_errno])
 
-	criu_pid = os.fork()
-	if criu_pid == 0:
-		# Mount new /proc
-		if _mount(None, b"/", None, MS_SLAVE|MS_REC, None) != 0:
-			_errno = ctypes.get_errno()
-			raise OSError(_errno, errno.errorcode[_errno])
+    criu_pid = os.fork()
+    if criu_pid == 0:
+        # Mount new /proc
+        if _mount(None, b"/", None, MS_SLAVE|MS_REC, None) != 0:
+            _errno = ctypes.get_errno()
+            raise OSError(_errno, errno.errorcode[_errno])
 
-		if _mount(b'proc', b'/proc', b'proc', 0, None) != 0:
-			_errno = ctypes.get_errno()
-			raise OSError(_errno, errno.errorcode[_errno])
+        if _mount(b'proc', b'/proc', b'proc', 0, None) != 0:
+            _errno = ctypes.get_errno()
+            raise OSError(_errno, errno.errorcode[_errno])
 
-		# Spawn CRIU binary
-		run_criu()
-		raise OSError(errno.ENOENT, "No such command")
+        # Spawn CRIU binary
+        run_criu()
+        raise OSError(errno.ENOENT, "No such command")
 
-	# Wait for CRIU to exit and report the status back
-	while True:
-		try:
-			(pid, status) = os.wait()
-			if pid == criu_pid:
-				status = os.WEXITSTATUS(status)
-				break
-		except OSError:
-			status = -251
-			break
+    # Wait for CRIU to exit and report the status back
+    while True:
+        try:
+            (pid, status) = os.wait()
+            if pid == criu_pid:
+                status = os.WEXITSTATUS(status)
+                break
+        except OSError:
+            status = -251
+            break
 
-	return status
+    return status
 
 
 def get_varg(args):
-	for i in range(1, len(sys.argv)):
-		if not sys.argv[i] in args:
-			continue
+    for i in range(1, len(sys.argv)):
+        if not sys.argv[i] in args:
+            continue
 
-		if i + 1 >= len(sys.argv):
-			break
+        if i + 1 >= len(sys.argv):
+            break
 
-		return (sys.argv[i + 1], i + 1)
+        return (sys.argv[i + 1], i + 1)
 
-	return (None, None)
+    return (None, None)
 
 
 
 def set_pidns(tpid, pid_idx):
-	# Joind pid namespace. Note, that the given pid should
-	# be changed in -t option, as task lives in different
-	# pid namespace.
+    # Joind pid namespace. Note, that the given pid should
+    # be changed in -t option, as task lives in different
+    # pid namespace.
 
-	myns = os.stat('/proc/self/ns/pid').st_ino
+    myns = os.stat('/proc/self/ns/pid').st_ino
 
-	ns_fd = os.open('/proc/%s/ns/pid' % tpid, os.O_RDONLY)
-	if myns != os.fstat(ns_fd).st_ino:
+    ns_fd = os.open('/proc/%s/ns/pid' % tpid, os.O_RDONLY)
+    if myns != os.fstat(ns_fd).st_ino:
 
-		for l in open('/proc/%s/status' % tpid):
-			if not l.startswith('NSpid:'):
-				continue
+        for l in open('/proc/%s/status' % tpid):
+            if not l.startswith('NSpid:'):
+                continue
 
-			ls = l.split()
-			if ls[1] != tpid:
-				raise OSError(errno.ESRCH, 'No such pid')
+            ls = l.split()
+            if ls[1] != tpid:
+                raise OSError(errno.ESRCH, 'No such pid')
 
-			print('Replace pid {} with {}'.format(tpid, ls[2]))
-			sys.argv[pid_idx] = ls[2]
-			break
-		else:
-			raise OSError(errno.ENOENT, 'Cannot find NSpid field in proc')
+            print('Replace pid {} with {}'.format(tpid, ls[2]))
+            sys.argv[pid_idx] = ls[2]
+            break
+        else:
+            raise OSError(errno.ENOENT, 'Cannot find NSpid field in proc')
 
-		if _setns(ns_fd, 0) != 0:
-			_errno = ctypes.get_errno()
-			raise OSError(_errno, errno.errorcode[_errno])
+        if _setns(ns_fd, 0) != 0:
+            _errno = ctypes.get_errno()
+            raise OSError(_errno, errno.errorcode[_errno])
 
-	os.close(ns_fd)
+    os.close(ns_fd)
 
 
 def set_mntns(tpid):
-	# Join mount namespace. Trick here too -- check / and .
-	# will be the same in target mntns.
+    # Join mount namespace. Trick here too -- check / and .
+    # will be the same in target mntns.
 
-	myns = os.stat('/proc/self/ns/mnt').st_ino
-	ns_fd = os.open('/proc/%s/ns/mnt' % tpid, os.O_RDONLY)
-	if myns != os.fstat(ns_fd).st_ino:
-		root_st = os.stat('/')
-		cwd_st = os.stat('.')
-		cwd_path = os.path.realpath('.')
+    myns = os.stat('/proc/self/ns/mnt').st_ino
+    ns_fd = os.open('/proc/%s/ns/mnt' % tpid, os.O_RDONLY)
+    if myns != os.fstat(ns_fd).st_ino:
+        root_st = os.stat('/')
+        cwd_st = os.stat('.')
+        cwd_path = os.path.realpath('.')
 
-		if _setns(ns_fd, 0) != 0:
-			_errno = ctypes.get_errno()
-			raise OSError(_errno, errno.errorcode[_errno])
+        if _setns(ns_fd, 0) != 0:
+            _errno = ctypes.get_errno()
+            raise OSError(_errno, errno.errorcode[_errno])
 
-		os.chdir(cwd_path)
-		root_nst = os.stat('/')
-		cwd_nst = os.stat('.')
+        os.chdir(cwd_path)
+        root_nst = os.stat('/')
+        cwd_nst = os.stat('.')
 
-		def steq(st, nst):
-			return (st.st_dev, st.st_ino) == (nst.st_dev, nst.st_ino)
+        def steq(st, nst):
+            return (st.st_dev, st.st_ino) == (nst.st_dev, nst.st_ino)
 
-		if not steq(root_st, root_nst):
-			raise OSError(errno.EXDEV, 'Target ns / is not as current')
-		if not steq(cwd_st, cwd_nst):
-			raise OSError(errno.EXDEV, 'Target ns . is not as current')
+        if not steq(root_st, root_nst):
+            raise OSError(errno.EXDEV, 'Target ns / is not as current')
+        if not steq(cwd_st, cwd_nst):
+            raise OSError(errno.EXDEV, 'Target ns . is not as current')
 
 
-	os.close(ns_fd)
+    os.close(ns_fd)
 
 
 def wrap_dump():
-	(pid, pid_idx) = get_varg(('-t', '--tree'))
-	if pid is None:
-		raise OSError(errno.EINVAL, 'No --tree option given')
+    (pid, pid_idx) = get_varg(('-t', '--tree'))
+    if pid is None:
+        raise OSError(errno.EINVAL, 'No --tree option given')
 
-	set_pidns(pid, pid_idx)
-	set_mntns(pid)
+    set_pidns(pid, pid_idx)
+    set_mntns(pid)
 
-	# Spawn CRIU binary
-	criu_pid = os.fork()
-	if criu_pid == 0:
-		run_criu()
-		raise OSError(errno.ENOENT, "No such command")
+    # Spawn CRIU binary
+    criu_pid = os.fork()
+    if criu_pid == 0:
+        run_criu()
+        raise OSError(errno.ENOENT, "No such command")
 
-	# Wait for CRIU to exit and report the status back
-	while True:
-		try:
-			(pid, status) = os.wait()
-			if pid == criu_pid:
-				status = os.WEXITSTATUS(status)
-				break
-		except OSError:
-			status = -251
-			break
+    # Wait for CRIU to exit and report the status back
+    while True:
+        try:
+            (pid, status) = os.wait()
+            if pid == criu_pid:
+                status = os.WEXITSTATUS(status)
+                break
+        except OSError:
+            status = -251
+            break
 
-	return status
+    return status
 
 
 if len(sys.argv) == 1:
-	print("""
+    print("""
 Usage:
   {0} dump|pre-dump -t PID [<options>]
   {0} restore [<options>]
@@ -210,16 +210,16 @@ Usage:
   pre-dump       pre-dump task(s) minimizing their frozen time
   restore        restore a process/tree
 """.format(sys.argv[0]))
-	exit(1)
+    exit(1)
 
 action = sys.argv[1]
 
 if action == 'restore':
-	res = wrap_restore()
+    res = wrap_restore()
 elif action == 'dump' or action == 'pre-dump':
-	res = wrap_dump()
+    res = wrap_dump()
 else:
-	print('Unsupported action {} for nswrap'.format(action))
-	res = -1
+    print('Unsupported action {} for nswrap'.format(action))
+    res = -1
 
 sys.exit(res)

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -88,10 +88,23 @@ def wrap_restore():
         _errno = ctypes.get_errno()
         raise OSError(_errno, errno.errorcode[_errno])
 
+    restore_detached = False
+    restore_args = sys.argv[1:]
+    if '-d' in restore_args:
+        restore_detached = True
+        restore_args.remove('-d')
+    if '--restore-detached' in restore_args:
+        restore_detached = True
+        restore_args.remove('--restore-detached')
+
     criu_pid = os.fork()
     if criu_pid == 0:
         _mount_new_proc()
-        run_criu(sys.argv[1:])
+        run_criu(restore_args)
+
+    if restore_detached:
+        return 0
+
     return _wait_for_process_status(criu_pid)
 
 

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -221,7 +221,7 @@ action = sys.argv[1]
 
 if action == 'restore':
     res = wrap_restore()
-elif action == 'dump' or action == 'pre-dump':
+elif action in ['dump', 'pre-dump']:
     res = wrap_dump()
 else:
     print('Unsupported action {} for nswrap'.format(action))

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -82,6 +82,9 @@ def _wait_for_process_status(criu_pid):
 
 
 def run_criu():
+    """
+    Spawn CRIU binary
+    """
     print(sys.argv)
     os.execlp('criu', *['criu'] + sys.argv[1:])
 
@@ -96,7 +99,6 @@ def wrap_restore():
     if criu_pid == 0:
         _mount_new_proc()
 
-        # Spawn CRIU binary
         run_criu()
         raise OSError(errno.ENOENT, "No such command")
 
@@ -118,12 +120,12 @@ def get_varg(args):
 
 
 def set_pidns(tpid, pid_idx):
-    # Joind pid namespace. Note, that the given pid should
-    # be changed in -t option, as task lives in different
-    # pid namespace.
-
+    """
+    Join pid namespace. Note, that the given pid should
+    be changed in -t option, as task lives in different
+    pid namespace.
+    """
     myns = os.stat('/proc/self/ns/pid').st_ino
-
     ns_fd = os.open('/proc/%s/ns/pid' % tpid, os.O_RDONLY)
     if myns != os.fstat(ns_fd).st_ino:
 
@@ -149,9 +151,10 @@ def set_pidns(tpid, pid_idx):
 
 
 def set_mntns(tpid):
-    # Join mount namespace. Trick here too -- check / and .
-    # will be the same in target mntns.
-
+    """
+    Join mount namespace. Trick here too -- check / and .
+    will be the same in target mntns.
+    """
     myns = os.stat('/proc/self/ns/mnt').st_ino
     ns_fd = os.open('/proc/%s/ns/mnt' % tpid, os.O_RDONLY)
     if myns != os.fstat(ns_fd).st_ino:
@@ -187,7 +190,6 @@ def wrap_dump():
     set_pidns(pid, pid_idx)
     set_mntns(pid)
 
-    # Spawn CRIU binary
     criu_pid = os.fork()
     if criu_pid == 0:
         run_criu()

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -22,7 +22,7 @@ try:
 except AttributeError:
     raise OSError(errno.EINVAL, "unshare is not supported on this platform")
 else:
-    _unshare.argtypes = [ ctypes.c_int ]
+    _unshare.argtypes = [ctypes.c_int]
     _unshare.restype = ctypes.c_int
 
 try:
@@ -30,7 +30,7 @@ try:
 except AttributeError:
     raise OSError(errno.EINVAL, "setns is not supported on this platform")
 else:
-    _setns.argtypes = [ ctypes.c_int, ctypes.c_int ]
+    _setns.argtypes = [ctypes.c_int, ctypes.c_int]
     _setns.restype = ctypes.c_int
 
 try:

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -135,12 +135,14 @@ def set_pidns(tpid, pid_idx):
                 continue
             ls = l.split()
             if ls[1] != tpid:
+                os.close(ns_fd)
                 raise OSError(errno.ESRCH, 'No such pid')
 
             print('Replace pid {} with {}'.format(tpid, ls[2]))
             sys.argv[pid_idx] = ls[2]
             break
         else:
+            os.close(ns_fd)
             raise OSError(errno.ENOENT, 'Cannot find NSpid field in proc')
         _set_namespace(ns_fd)
     os.close(ns_fd)
@@ -167,8 +169,10 @@ def set_mntns(tpid):
             return (st.st_dev, st.st_ino) == (nst.st_dev, nst.st_ino)
 
         if not steq(root_st, root_nst):
+            os.close(ns_fd)
             raise OSError(errno.EXDEV, 'Target ns / is not as current')
         if not steq(cwd_st, cwd_nst):
+            os.close(ns_fd)
             raise OSError(errno.EXDEV, 'Target ns . is not as current')
     os.close(ns_fd)
 

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -56,6 +56,18 @@ else:
     _umount.restype = ctypes.c_int
 
 
+def _mount_new_proc():
+    """
+    Mount new /proc filesystem.
+    """
+    if _mount(None, b"/", None, MS_SLAVE|MS_REC, None):
+        _errno = ctypes.get_errno()
+        raise OSError(_errno, errno.errorcode[_errno])
+    if _mount(b'proc', b'/proc', b'proc', 0, None):
+        _errno = ctypes.get_errno()
+        raise OSError(_errno, errno.errorcode[_errno])
+
+
 def run_criu():
     print(sys.argv)
     os.execlp('criu', *['criu'] + sys.argv[1:])
@@ -69,14 +81,7 @@ def wrap_restore():
 
     criu_pid = os.fork()
     if criu_pid == 0:
-        # Mount new /proc
-        if _mount(None, b"/", None, MS_SLAVE|MS_REC, None) != 0:
-            _errno = ctypes.get_errno()
-            raise OSError(_errno, errno.errorcode[_errno])
-
-        if _mount(b'proc', b'/proc', b'proc', 0, None) != 0:
-            _errno = ctypes.get_errno()
-            raise OSError(_errno, errno.errorcode[_errno])
+        _mount_new_proc()
 
         # Spawn CRIU binary
         run_criu()

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -73,12 +73,13 @@ def _wait_for_process_status(criu_pid):
             return -251
 
 
-def run_criu():
+def run_criu(args):
     """
     Spawn CRIU binary
     """
     print(sys.argv)
-    os.execlp('criu', *['criu'] + sys.argv[1:])
+    os.execlp('criu', *['criu'] + args)
+    raise OSError(errno.ENOENT, "No such command")
 
 
 def wrap_restore():
@@ -90,10 +91,7 @@ def wrap_restore():
     criu_pid = os.fork()
     if criu_pid == 0:
         _mount_new_proc()
-
-        run_criu()
-        raise OSError(errno.ENOENT, "No such command")
-
+        run_criu(sys.argv[1:])
     return _wait_for_process_status(criu_pid)
 
 
@@ -187,9 +185,7 @@ def wrap_dump():
 
     criu_pid = os.fork()
     if criu_pid == 0:
-        run_criu()
-        raise OSError(errno.ENOENT, "No such command")
-
+        run_criu(sys.argv[1:])
     return _wait_for_process_status(pid)
 
 

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -110,6 +110,17 @@ def get_varg(args):
     return (None, None)
 
 
+def _set_namespace(fd):
+    """Join namespace referred to by fd"""
+    if _setns(fd, 0) != 0:
+        _errno = ctypes.get_errno()
+        raise OSError(_errno, errno.errorcode[_errno])
+
+
+def is_my_namespace(fd):
+    """Returns True if fd refers to current namespace"""
+    return os.stat('/proc/self/ns/pid').st_ino != os.fstat(fd).st_ino
+
 
 def set_pidns(tpid, pid_idx):
     """
@@ -117,14 +128,11 @@ def set_pidns(tpid, pid_idx):
     be changed in -t option, as task lives in different
     pid namespace.
     """
-    myns = os.stat('/proc/self/ns/pid').st_ino
     ns_fd = os.open('/proc/%s/ns/pid' % tpid, os.O_RDONLY)
-    if myns != os.fstat(ns_fd).st_ino:
-
+    if is_my_namespace(ns_fd):
         for l in open('/proc/%s/status' % tpid):
             if not l.startswith('NSpid:'):
                 continue
-
             ls = l.split()
             if ls[1] != tpid:
                 raise OSError(errno.ESRCH, 'No such pid')
@@ -134,11 +142,7 @@ def set_pidns(tpid, pid_idx):
             break
         else:
             raise OSError(errno.ENOENT, 'Cannot find NSpid field in proc')
-
-        if _setns(ns_fd, 0) != 0:
-            _errno = ctypes.get_errno()
-            raise OSError(_errno, errno.errorcode[_errno])
-
+        _set_namespace(ns_fd)
     os.close(ns_fd)
 
 
@@ -147,16 +151,13 @@ def set_mntns(tpid):
     Join mount namespace. Trick here too -- check / and .
     will be the same in target mntns.
     """
-    myns = os.stat('/proc/self/ns/mnt').st_ino
     ns_fd = os.open('/proc/%s/ns/mnt' % tpid, os.O_RDONLY)
-    if myns != os.fstat(ns_fd).st_ino:
+    if is_my_namespace(ns_fd):
         root_st = os.stat('/')
         cwd_st = os.stat('.')
         cwd_path = os.path.realpath('.')
 
-        if _setns(ns_fd, 0) != 0:
-            _errno = ctypes.get_errno()
-            raise OSError(_errno, errno.errorcode[_errno])
+        _set_namespace(ns_fd)
 
         os.chdir(cwd_path)
         root_nst = os.stat('/')
@@ -169,8 +170,6 @@ def set_mntns(tpid):
             raise OSError(errno.EXDEV, 'Target ns / is not as current')
         if not steq(cwd_st, cwd_nst):
             raise OSError(errno.EXDEV, 'Target ns . is not as current')
-
-
     os.close(ns_fd)
 
 

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -68,6 +68,19 @@ def _mount_new_proc():
         raise OSError(_errno, errno.errorcode[_errno])
 
 
+def _wait_for_process_status(criu_pid):
+    """
+    Wait for CRIU to exit and report the status back.
+    """
+    while True:
+        try:
+            (pid, status) = os.wait()
+            if pid == criu_pid:
+                return os.WEXITSTATUS(status)
+        except OSError:
+            return -251
+
+
 def run_criu():
     print(sys.argv)
     os.execlp('criu', *['criu'] + sys.argv[1:])
@@ -87,18 +100,7 @@ def wrap_restore():
         run_criu()
         raise OSError(errno.ENOENT, "No such command")
 
-    # Wait for CRIU to exit and report the status back
-    while True:
-        try:
-            (pid, status) = os.wait()
-            if pid == criu_pid:
-                status = os.WEXITSTATUS(status)
-                break
-        except OSError:
-            status = -251
-            break
-
-    return status
+    return _wait_for_process_status(criu_pid)
 
 
 def get_varg(args):
@@ -191,18 +193,7 @@ def wrap_dump():
         run_criu()
         raise OSError(errno.ENOENT, "No such command")
 
-    # Wait for CRIU to exit and report the status back
-    while True:
-        try:
-            (pid, status) = os.wait()
-            if pid == criu_pid:
-                status = os.WEXITSTATUS(status)
-                break
-        except OSError:
-            status = -251
-            break
-
-    return status
+    return _wait_for_process_status(pid)
 
 
 if len(sys.argv) == 1:

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -83,13 +83,16 @@ def run_criu(args):
 
 
 def wrap_restore():
+    restore_args = sys.argv[1:]
+    if '--restore-sibling' in restore_args:
+        raise OSError(errno.EINVAL, "--restore-sibling is not supported")
+
     # Unshare pid and mount namespaces
     if _unshare(CLONE_NEWNS | CLONE_NEWPID) != 0:
         _errno = ctypes.get_errno()
         raise OSError(_errno, errno.errorcode[_errno])
 
     restore_detached = False
-    restore_args = sys.argv[1:]
     if '-d' in restore_args:
         restore_detached = True
         restore_args.remove('-d')


### PR DESCRIPTION
The `criu-ns` script creates a new PID namespace where CRIU runs as the "init" process.

When using the `--restore-detached` option with `criu-ns`, users expect `criu-ns` to exit without killing the restored process tree. Thus, `criu-ns` should exit instead of waiting for CRIU's status and it should not pass the `--restore-detached` to CRIU to prevent terminating the init process.

Resolves #1278
Resolves #807