### PR TITLE
tls: Add logging within send/recv callbacks

### DIFF
--- a/criu/tls.c
+++ b/criu/tls.c
@@ -303,13 +303,25 @@ static int tls_x509_setup_creds(void)
 static ssize_t _tls_push_cb(void *p, const void* data, size_t sz)
 {
 	int fd = *(int *)(p);
-	return send(fd, data, sz, tls_sk_flags);
+	int ret = send(fd, data, sz, tls_sk_flags);
+	if (ret < 0 && errno != EAGAIN) {
+		int _errno = errno;
+		pr_perror("Push callback send failed");
+		errno = _errno;
+	}
+	return ret;
 }
 
 static ssize_t _tls_pull_cb(void *p, void* data, size_t sz)
 {
 	int fd = *(int *)(p);
-	return recv(fd, data, sz, tls_sk_flags);
+	int ret = recv(fd, data, sz, tls_sk_flags);
+	if (ret < 0 && errno != EAGAIN) {
+		int _errno = errno;
+		pr_perror("Pull callback recv failed");
+		errno = _errno;
+	}
+	return ret;
 }
 
 static int tls_x509_setup_session(unsigned int flags)


### PR DESCRIPTION
Log messages showing the send/recv errno value would help us to debug issues such as #1280.

```
Error (criu/tls.c:321): tls: Pull callback recv failed: Connection reset by peer
Error (criu/tls.c:147): tls: Failed receiving data: Error in the pull function.
Error (criu/page-xfer.c:1225): page-xfer: Can't read pagemap from socket: I/O error
```