### PR TITLE
uffd: check for exited task when reading uffd_msg

### DIFF
--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -1213,6 +1213,10 @@ static int handle_uffd_event(struct epoll_rfd *lpfd)
 		/* we've already handled the page fault for another thread */
 		if (errno == EAGAIN)
 			return 0;
+		if (errno == EBADF && lpi->exited) {
+			lp_debug(lpi, "excess message in queue: %d", msg.event);
+			return 0;
+		}
 		lp_perror(lpi, "Can't read uffd message");
 		return -1;
 	} else if (ret == 0) {


### PR DESCRIPTION
Sometimes there are uffd messages in a queue of a dying task and by the
time these messages are processed in handle_request, the uffd is no
longer valid and reading from it causes errors.

Add processing of EBADF in handle_uffd_event() to gracefully handle such
situation.

Signed-off-by: Mike Rapoport <rppt@linux.ibm.com>