### PR TITLE
dump: check the --file-locks flag when dumping

### DIFF
--- a/criu/file-lock.c
+++ b/criu/file-lock.c
@@ -95,6 +95,9 @@ int dump_file_locks(void)
 	struct file_lock *fl;
 	int	ret = 0;
 
+	if (!opts.handle_file_locks)
+		return 0;
+
 	pr_info("Dumping file-locks\n");
 
 	list_for_each_entry(fl, &file_lock_list, list) {


### PR DESCRIPTION
When the --file-locks flag is not enabled, it still dump the file-locks msg
to image file. We should check the --file-locks flags when dumping.

Signed-off-by: Xiaoguang Li <lixiaoguang2@huawei.com>