### PR TITLE
docs: fix simple typo, clietn -> client

### DIFF
--- a/test/zdtm/static/socket_aio.c
+++ b/test/zdtm/static/socket_aio.c
@@ -5,7 +5,7 @@ const char *test_author = "Andrew Vagin <avagin@parallels.com>";
 
 /* Description:
  * Create two tcp socket, server send asynchronous request on
- * read data and clietn write data after migration
+ * read data and client write data after migration
  */
 
 #include <stdio.h>

--- a/test/zdtm/static/socket_listen.c
+++ b/test/zdtm/static/socket_listen.c
@@ -16,7 +16,7 @@ const char *test_author = "Stanislav Kinsbursky <skinsbursky@openvz.org>";
 
 /* Description:
  * Create two tcp socket, server send asynchronous request on
- * read data and clietn write data after migration
+ * read data and client write data after migration
  */
 
 #include <stdio.h>

--- a/test/zdtm/static/socket_udp-corked.c
+++ b/test/zdtm/static/socket_udp-corked.c
@@ -5,7 +5,7 @@ const char *test_author = "Pavel Emelyanov <xemul@parallels.com<>\n";
 
 /* Description:
  * Create two tcp socket, server send asynchronous request on
- * read data and clietn write data after migration
+ * read data and client write data after migration
  */
 
 #include <stdio.h>

--- a/test/zdtm/static/socket_udp.c
+++ b/test/zdtm/static/socket_udp.c
@@ -5,7 +5,7 @@ const char *test_author = "Pavel Emelyanov <xemul@parallels.com<>\n";
 
 /* Description:
  * Create two tcp socket, server send asynchronous request on
- * read data and clietn write data after migration
+ * read data and client write data after migration
  */
 
 #include <stdio.h>

--- a/test/zdtm/static/socket_udplite.c
+++ b/test/zdtm/static/socket_udplite.c
@@ -5,7 +5,7 @@ const char *test_author = "Pavel Emelyanov <xemul@parallels.com<>\n";
 
 /* Description:
  * Create two tcp socket, server send asynchronous request on
- * read data and clietn write data after migration
+ * read data and client write data after migration
  */
 
 #include <stdio.h>


### PR DESCRIPTION
There is a small typo in test/zdtm/static/socket_aio.c, test/zdtm/static/socket_listen.c, test/zdtm/static/socket_listen4v6.c, test/zdtm/static/socket_listen6.c, test/zdtm/static/socket_udp-corked.c, test/zdtm/static/socket_udp.c, test/zdtm/static/socket_udplite.c.

Should read `client` rather than `clietn`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md