### PR TITLE
x86/asm: fix compile error in bitops.h

### DIFF
--- a/include/common/arch/x86/asm/asm.h
+++ b/include/common/arch/x86/asm/asm.h
@@ -1,0 +1,28 @@
+#ifndef __CR_ASM_H__
+#define __CR_ASM_H__
+
+#ifdef __GCC_ASM_FLAG_OUTPUTS__
+# define CC_SET(c) "\n\t/* output condition code " #c "*/\n"
+# define CC_OUT(c) "=@cc" #c
+#else
+# define CC_SET(c) "\n\tset" #c " %[_cc_" #c "]\n"
+# define CC_OUT(c) [_cc_ ## c] "=qm"
+#endif
+
+#ifdef __ASSEMBLY__
+# define __ASM_FORM(x)	x
+#else
+# define __ASM_FORM(x)	" " #x " "
+#endif
+
+#ifndef __x86_64__
+/* 32 bit */
+# define __ASM_SEL(a,b) __ASM_FORM(a)
+#else
+/* 64 bit */
+# define __ASM_SEL(a,b) __ASM_FORM(b)
+#endif
+
+#define __ASM_SIZE(inst, ...)	__ASM_SEL(inst##l##__VA_ARGS__, inst##q##__VA_ARGS__)
+
+#endif /* __CR_ASM_H__ */


### PR DESCRIPTION
When I try to compile criu in ubuntu amd64 with command "make DEBUG=1", it produces following errors:

include/common/asm/bitops.h: Assembler messages:
include/common/asm/bitops.h:71: Error: incorrect register `%edx' used with `q' suffix

The problem is caused by following code:
`
static inline bool test_and_set_bit(int nr, volatile unsigned long *addr)
{
	bool oldbit;

	asm("btsq %2,%1"
	    CC_SET(c)
	    : CC_OUT(c) (oldbit)
	    : "m" (*(unsigned long *)addr), "Ir" (nr) : "memory");
	return oldbit;
}
`

since nr is a int, it can not be used with 'q' suffix.
