### PR TITLE
Make proc/self a service fd and use it for memfd

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -418,6 +418,10 @@ static int populate_pid_proc(void)
 		pr_err("Can't open PROC_SELF\n");
 		return -1;
 	}
+	if (open_pid_proc(PROC_SELF) < 0) {
+		pr_err("Can't open PROC_SELF\n");
+		return -1;
+	}
 	return 0;
 }
 

--- a/criu/include/servicefd.h
+++ b/criu/include/servicefd.h
@@ -17,6 +17,7 @@ enum sfd_type {
 	IMG_STREAMER_FD_OFF,
 	PROC_FD_OFF,		/* fd with /proc for all proc_ calls */
 	PROC_PID_FD_OFF,
+	PROC_SELF_FD_OFF,
 	CR_PROC_FD_OFF,		/* some other's proc fd:
 				 *  - For dump -- target ns' proc
 				 *  - For restore -- CRIU ns' proc
@@ -44,6 +45,7 @@ extern bool is_service_fd(int fd, enum sfd_type type);
 extern int service_fd_min_fd(struct pstree_item *item);
 extern int install_service_fd(enum sfd_type type, int fd);
 extern int close_service_fd(enum sfd_type type);
+extern void __close_service_fd(enum sfd_type type);
 extern int clone_service_fd(struct pstree_item *me);
 
 #endif /* __CR_SERVICE_FD_H__ */

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -180,7 +180,7 @@ extern int cr_daemon(int nochdir, int noclose, int close_fd);
 extern int status_ready(void);
 extern int is_root_user(void);
 
-extern void set_proc_self_fd(int fd);
+extern int set_proc_self_fd(int fd);
 
 static inline bool dir_dots(const struct dirent *de)
 {

--- a/criu/memfd.c
+++ b/criu/memfd.c
@@ -332,7 +332,7 @@ int memfd_open(struct file_desc *d, u32 *fdflags)
 	 * O_LARGEFILE file flag with regular open(). It doesn't seem that
 	 * important though.
 	 */
-	_fd = __open_proc(getpid(), 0, flags, "fd/%d", fd);
+	_fd = __open_proc(PROC_SELF, 0, flags, "fd/%d", fd);
 	if (_fd < 0) {
 		pr_perror("Can't reopen memfd id=%d", mfe->id);
 		goto err;

--- a/criu/servicefd.c
+++ b/criu/servicefd.c
@@ -46,6 +46,7 @@ const char *sfd_type_name(enum sfd_type type)
 		[IMG_FD_OFF]		= __stringify_1(IMG_FD_OFF),
 		[PROC_FD_OFF]		= __stringify_1(PROC_FD_OFF),
 		[PROC_PID_FD_OFF]	= __stringify_1(PROC_PID_FD_OFF),
+		[PROC_SELF_FD_OFF]	= __stringify_1(PROC_SELF_FD_OFF),
 		[CR_PROC_FD_OFF]	= __stringify_1(CR_PROC_FD_OFF),
 		[ROOT_FD_OFF]		= __stringify_1(ROOT_FD_OFF),
 		[CGROUP_YARD]		= __stringify_1(CGROUP_YARD),
@@ -204,6 +205,15 @@ int close_service_fd(enum sfd_type type)
 
 	clear_bit(type, sfd_map);
 	return 0;
+}
+
+void __close_service_fd(enum sfd_type type)
+{
+	int fd;
+
+	fd = __get_service_fd(type, service_fd_id);
+	close(fd);
+	clear_bit(type, sfd_map);
 }
 
 static int move_service_fd(struct pstree_item *me, int type, int new_id, int new_base)

--- a/criu/servicefd.c
+++ b/criu/servicefd.c
@@ -290,7 +290,8 @@ int clone_service_fd(struct pstree_item *me)
 
 	if (new_base == -1)
 		return -1;
-	if (service_fd_base == new_base && service_fd_id == id)
+
+	if (get_service_fd(LOG_FD_OFF) == new_base - LOG_FD_OFF - SERVICE_FD_MAX * id)
 		return 0;
 
 	/* Dup sfds in memmove() style: they may overlap */

--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -1211,7 +1211,6 @@ static int prep_unix_sk_cwd(struct unix_sk_info *ui, int *prev_cwd_fd,
 		if (switch_ns_by_fd(ns_fd, &mnt_ns_desc, prev_mntns_fd))
 			return -1;
 
-		set_proc_self_fd(-1);
 		close(ns_fd);
 	}
 


### PR DESCRIPTION
This is an attempt to cleanup service fds and put "self" to service fds. Also now we can use it instead of getpid() variant in memfd_open, it is a more general way because in case we would support nested pid namespaces opening by getpid is not an option.