### PR TITLE
ci: Alpine's busybox based free does not understand -h

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -118,7 +118,12 @@ print_env() {
 	print_header "ulimit -a"
 	ulimit -a
 	print_header "Available memory"
-	free -h
+	if [ -e /etc/alpine-release ]; then
+		# Alpine's busybox based free does not understand -h
+		free
+	else
+		free -h
+	fi
 	print_header "Available CPUs"
 	lscpu || :
 }


### PR DESCRIPTION
Quick fix for the broken Alpine based CI runs using 'free -h' which busybox does not understand.