### PR TITLE
github: auto-close stale issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: Mark stale issues and pull requests
+
+# Please refer to https://github.com/actions/stale/blob/master/action.yml
+# to see all config knobs of the stale action.
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'A friendly reminder that this issue had no activity for 30 days.'
+        stale-pr-message: 'A friendly reminder that this PR had no activity for 30 days.'
+        stale-issue-label: 'stale-issue'
+        stale-pr-label: 'stale-pr'
+        days-before-stale: 30
+        days-before-close: 365
+        remove-stale-when-updated: true
+        exempt-pr-labels: 'no-auto-close'
+        exempt-issue-labels: 'no-auto-close'


### PR DESCRIPTION
This is a copy of stale.yml from the Podman repository to automatically close tickets after 365 days. After 30 days tickets and issues are marked as stale and after 365 tickets and issues are finally closed.

We have lots of old open issues and pull requests in GitHub. I think auto-closing, as done in this PR, issues and pull requests after 365 days of inactivity would make sense. I do not think any of our old issues and pull requests will every get any attention.

There are currently over 300 open issues against CRIU and I think it is difficult to see which of those are still relevant. 365 days is a long enough period for someone interested in a issue or pull request to still work on it, but if after 365 days no one is doing anything on an issue or pull request it makes more sense to close it. Issues and pull requests can still be re-opened if necessary and we can also add special labels to issues and pull requests which should be exempt from auto-close.

Based on: https://github.com/marketplace/actions/close-stale-issues