### PR TITLE
zdtm: look up iptables in /sbin and /usr/sbin

### DIFF
--- a/test/zdtm/static/netns-nf.desc
+++ b/test/zdtm/static/netns-nf.desc
@@ -1,5 +1,5 @@
 {   'deps': [   '/bin/sh',
-                '/sbin/iptables',
+                '/sbin/iptables|/usr/sbin/iptables',
                 '/usr/lib64/xtables/libxt_standard.so|/usr/lib/iptables/libxt_standard.so|/lib/xtables/libxt_standard.so|/usr/lib/powerpc64le-linux-gnu/xtables/libxt_standard.so|/usr/lib/x86_64-linux-gnu/xtables/libxt_standard.so|/usr/lib/s390x-linux-gnu/xtables/libxt_standard.so|/usr/lib/xtables/libxt_standard.so|/usr/lib/aarch64-linux-gnu/xtables/libxt_standard.so',
                 '/usr/bin/diff'],
     'flags': 'suid',

--- a/test/zdtm/static/socket-tcp-closed-last-ack.desc
+++ b/test/zdtm/static/socket-tcp-closed-last-ack.desc
@@ -1,5 +1,5 @@
 {   'deps': [   '/bin/sh',
-                '/sbin/iptables',
+                '/sbin/iptables|/usr/sbin/iptables',
                 '/usr/lib64/xtables/libxt_tcp.so|/lib/xtables/libxt_tcp.so|/usr/lib/powerpc64le-linux-gnu/xtables/libxt_tcp.so|/usr/lib/x86_64-linux-gnu/xtables/libxt_tcp.so|/usr/lib/s390x-linux-gnu/xtables/libxt_tcp.so|/usr/lib/xtables/libxt_tcp.so|/usr/lib/aarch64-linux-gnu/xtables/libxt_tcp.so',
                 '/usr/lib64/xtables/libxt_standard.so|/lib/xtables/libxt_standard.so|/usr/lib/powerpc64le-linux-gnu/xtables/libxt_standard.so|/usr/lib/x86_64-linux-gnu/xtables/libxt_standard.so|/usr/lib/s390x-linux-gnu/xtables/libxt_standard.so|/usr/lib/xtables/libxt_standard.so|/usr/lib/aarch64-linux-gnu/xtables/libxt_standard.so',
 	],

--- a/test/zdtm/static/socket-tcp-reseted.desc
+++ b/test/zdtm/static/socket-tcp-reseted.desc
@@ -1,5 +1,5 @@
 {   'deps': [   '/bin/sh',
-                '/sbin/iptables',
+                '/sbin/iptables|/usr/sbin/iptables',
                 '/usr/lib64/xtables/libxt_tcp.so|/lib/xtables/libxt_tcp.so|/usr/lib/powerpc64le-linux-gnu/xtables/libxt_tcp.so|/usr/lib/x86_64-linux-gnu/xtables/libxt_tcp.so|/usr/lib/xtables/libxt_tcp.so|/usr/lib/s390x-linux-gnu/xtables/libxt_tcp.so|/usr/lib/aarch64-linux-gnu/xtables/libxt_tcp.so',
                 '/usr/lib64/xtables/libxt_standard.so|/lib/xtables/libxt_standard.so|/usr/lib/powerpc64le-linux-gnu/xtables/libxt_standard.so|/usr/lib/x86_64-linux-gnu/xtables/libxt_standard.so|/usr/lib/xtables/libxt_standard.so|/usr/lib/s390x-linux-gnu/xtables/libxt_standard.so|/usr/lib/aarch64-linux-gnu/xtables/libxt_standard.so',
 		'/usr/lib64/xtables/libipt_REJECT.so|/lib/xtables/libipt_REJECT.so|/usr/lib/powerpc64le-linux-gnu/xtables/libipt_REJECT.so|/usr/lib/x86_64-linux-gnu/xtables/libipt_REJECT.so|/usr/lib/xtables/libipt_REJECT.so|/usr/lib/s390x-linux-gnu/xtables/libipt_REJECT.so|/usr/lib/aarch64-linux-gnu/xtables/libipt_REJECT.so',

--- a/test/zdtm/static/socket-tcp-syn-sent.desc
+++ b/test/zdtm/static/socket-tcp-syn-sent.desc
@@ -1,5 +1,5 @@
 {   'deps': [   '/bin/sh',
-                '/sbin/iptables',
+                '/sbin/iptables|/usr/sbin/iptables',
                 '/usr/lib64/xtables/libxt_tcp.so|/lib/xtables/libxt_tcp.so|/usr/lib/powerpc64le-linux-gnu/xtables/libxt_tcp.so|/usr/lib/x86_64-linux-gnu/xtables/libxt_tcp.so|/usr/lib/xtables/libxt_tcp.so|/usr/lib/s390x-linux-gnu/xtables/libxt_tcp.so|/usr/lib/aarch64-linux-gnu/xtables/libxt_tcp.so',
                 '/usr/lib64/xtables/libxt_standard.so|/lib/xtables/libxt_standard.so|/usr/lib/powerpc64le-linux-gnu/xtables/libxt_standard.so|/usr/lib/x86_64-linux-gnu/xtables/libxt_standard.so|/usr/lib/xtables/libxt_standard.so|/usr/lib/s390x-linux-gnu/xtables/libxt_standard.so|/usr/lib/aarch64-linux-gnu/xtables/libxt_standard.so',
 	],


### PR DESCRIPTION
On Ubuntu 20.04, iptables is in /usr/sbin/.

Reported-by: Mr Jenkins
