### PR TITLE
Run zdtm/transition/pid_reuse with pre-dumps in ci tests

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -259,6 +259,8 @@ make -C test/others/rpc/ run
 ./test/zdtm.py run -t zdtm/transition/maps007 --pre 2 --page-server
 ./test/zdtm.py run -t zdtm/transition/maps007 --pre 2 --page-server --dedup
 
+./test/zdtm.py run -t zdtm/transition/pid_reuse --pre 2
+
 ./test/zdtm.py run -t zdtm/static/socket-tcp-local --norst
 
 ip net add test


### PR DESCRIPTION
This test should be run with at least 1 pre-dump to trigger the problem as mentioned in commit 4d9bf608b59b6e323f346b0beb956b02ecbef294.