### PR TITLE
pie/vdso: fix Segmentation fault caused by char pointer array

### DIFF
--- a/criu/arch/aarch64/include/asm/vdso.h
+++ b/criu/arch/aarch64/include/asm/vdso.h
@@ -16,15 +16,16 @@
  * Workaround for VDSO array symbol table's relocation.
  * XXX: remove when compel/piegen will support aarch64.
  */
-static const char* __maybe_unused aarch_vdso_symbol1 = "__kernel_clock_getres";
-static const char* __maybe_unused aarch_vdso_symbol2 = "__kernel_clock_gettime";
-static const char* __maybe_unused aarch_vdso_symbol3 = "__kernel_gettimeofday";
-static const char* __maybe_unused aarch_vdso_symbol4 = "__kernel_rt_sigreturn";
+#define ARCH_VDSO_SYMBOLS_LIST \
+	const char* aarch_vdso_symbol1 = "__kernel_clock_getres"; \
+	const char* aarch_vdso_symbol2 = "__kernel_clock_gettime"; \
+	const char* aarch_vdso_symbol3 = "__kernel_gettimeofday"; \
+	const char* aarch_vdso_symbol4 = "__kernel_rt_sigreturn";
 
-#define ARCH_VDSO_SYMBOLS			\
-	aarch_vdso_symbol1,			\
-	aarch_vdso_symbol2,			\
-	aarch_vdso_symbol3,			\
+#define ARCH_VDSO_SYMBOLS \
+	aarch_vdso_symbol1, \
+	aarch_vdso_symbol2, \
+	aarch_vdso_symbol3, \
 	aarch_vdso_symbol4
 
 extern void write_intraprocedure_branch(unsigned long to, unsigned long from);

--- a/criu/arch/arm/include/asm/vdso.h
+++ b/criu/arch/arm/include/asm/vdso.h
@@ -11,8 +11,11 @@
  */
 #define VDSO_SYMBOL_MAX		2
 #define VDSO_SYMBOL_GTOD	1
-#define ARCH_VDSO_SYMBOLS			\
-	"__vdso_clock_gettime",		\
-	"__vdso_gettimeofday"
+#define ARCH_VDSO_SYMBOLS_LIST \
+	const char* aarch_vdso_symbol1 = "__vdso_clock_gettime"; \
+	const char* aarch_vdso_symbol2 = "__vdso_gettimeofday";
+#define ARCH_VDSO_SYMBOLS \
+	aarch_vdso_symbol1, \
+	aarch_vdso_symbol2,
 
 #endif /* __CR_ASM_VDSO_H__ */

--- a/criu/arch/mips/include/asm/vdso.h
+++ b/criu/arch/mips/include/asm/vdso.h
@@ -14,10 +14,14 @@
  */
 #define VDSO_SYMBOL_MAX	3
 #define VDSO_SYMBOL_GTOD	0
-#define ARCH_VDSO_SYMBOLS			\
-	"__vdso_clock_gettime",			\
-	"__vdso_gettimeofday",			\
-	"__vdso_clock_getres"
+#define ARCH_VDSO_SYMBOLS_LIST \
+	const char* aarch_vdso_symbol1 = "__vdso_clock_gettime"; \
+	const char* aarch_vdso_symbol2 = "__vdso_gettimeofday"; \
+	const char* aarch_vdso_symbol3 = "__vdso_clock_getres";
+#define ARCH_VDSO_SYMBOLS \
+	aarch_vdso_symbol1, \
+	aarch_vdso_symbol2, \
+	aarch_vdso_symbol3,
 
 
 #endif /* __CR_ASM_VDSO_H__ */

--- a/criu/arch/ppc64/include/asm/vdso.h
+++ b/criu/arch/ppc64/include/asm/vdso.h
@@ -14,16 +14,28 @@
  */
 #define VDSO_SYMBOL_MAX		10
 #define VDSO_SYMBOL_GTOD	5
-#define ARCH_VDSO_SYMBOLS			\
-	"__kernel_clock_getres",		\
-	"__kernel_clock_gettime",		\
-	"__kernel_get_syscall_map",		\
-	"__kernel_get_tbfreq",			\
-	"__kernel_getcpu",			\
-	"__kernel_gettimeofday",		\
-	"__kernel_sigtramp_rt64",		\
-	"__kernel_sync_dicache",		\
-	"__kernel_sync_dicache_p5",		\
-	"__kernel_time"
+#define ARCH_VDSO_SYMBOLS_LIST \
+	const char* aarch_vdso_symbol1 = "__kernel_clock_getres"; \
+	const char* aarch_vdso_symbol2 = "__kernel_clock_gettime"; \
+	const char* aarch_vdso_symbol3 = "__kernel_get_syscall_map"; \
+	const char* aarch_vdso_symbol4 = "__kernel_get_tbfreq"; \
+	const char* aarch_vdso_symbol5 = "__kernel_getcpu"; \
+	const char* aarch_vdso_symbol6 = "__kernel_gettimeofday"; \
+	const char* aarch_vdso_symbol7 = "__kernel_sigtramp_rt64"; \
+	const char* aarch_vdso_symbol8 = "__kernel_sync_dicache"; \
+	const char* aarch_vdso_symbol9 = "__kernel_sync_dicache_p5"; \
+	const char* aarch_vdso_symbol10 = "__kernel_time";
+
+#define ARCH_VDSO_SYMBOLS \
+	aarch_vdso_symbol1, \
+	aarch_vdso_symbol2, \
+	aarch_vdso_symbol3, \
+	aarch_vdso_symbol4, \
+	aarch_vdso_symbol5, \
+	aarch_vdso_symbol6, \
+	aarch_vdso_symbol7, \
+	aarch_vdso_symbol8, \
+	aarch_vdso_symbol9, \
+	aarch_vdso_symbol10
 
 #endif /* __CR_ASM_VDSO_H__ */

--- a/criu/arch/s390/include/asm/vdso.h
+++ b/criu/arch/s390/include/asm/vdso.h
@@ -12,13 +12,18 @@
 #define VDSO_SYMBOL_GTOD	0
 
 /*
- * This definition is used in pie/util-vdso.c to initialize the vdso symbol
+ * These definitions are used in pie/util-vdso.c to initialize the vdso symbol
  * name string table 'vdso_symbols'
  */
-#define ARCH_VDSO_SYMBOLS				\
-	"__kernel_gettimeofday",			\
-	"__kernel_clock_gettime",			\
-	"__kernel_clock_getres",			\
-	"__kernel_getcpu"
+#define ARCH_VDSO_SYMBOLS_LIST \
+	const char* aarch_vdso_symbol1 = "__kernel_gettimeofday"; \
+	const char* aarch_vdso_symbol2 = "__kernel_clock_gettime"; \
+	const char* aarch_vdso_symbol3 = "__kernel_clock_getres"; \
+	const char* aarch_vdso_symbol4 = "__kernel_getcpu";
+#define ARCH_VDSO_SYMBOLS \
+	aarch_vdso_symbol1, \
+	aarch_vdso_symbol2, \
+	aarch_vdso_symbol3, \
+	aarch_vdso_symbol4
 
 #endif /* __CR_ASM_VDSO_H__ */

--- a/criu/arch/x86/include/asm/vdso.h
+++ b/criu/arch/x86/include/asm/vdso.h
@@ -35,13 +35,22 @@
  * vsyscall will be patched again when addressing:
  * https://github.com/checkpoint-restore/criu/issues/512
  */
-#define ARCH_VDSO_SYMBOLS			\
-	"__vdso_clock_gettime",			\
-	"__vdso_getcpu",			\
-	"__vdso_gettimeofday",			\
-	"__vdso_time",				\
-	"__kernel_sigreturn",			\
-	"__kernel_rt_sigreturn"
+
+#define ARCH_VDSO_SYMBOLS_LIST \
+	const char* aarch_vdso_symbol1 = "__vdso_clock_gettime"; \
+	const char* aarch_vdso_symbol2 = "__vdso_getcpu"; \
+	const char* aarch_vdso_symbol3 = "__vdso_gettimeofday"; \
+	const char* aarch_vdso_symbol4 = "__vdso_time"; \
+	const char* aarch_vdso_symbol5 = "__kernel_sigreturn"; \
+	const char* aarch_vdso_symbol6 = "__kernel_rt_sigreturn";
+
+#define ARCH_VDSO_SYMBOLS \
+	aarch_vdso_symbol1, \
+	aarch_vdso_symbol2, \
+	aarch_vdso_symbol3, \
+	aarch_vdso_symbol4, \
+	aarch_vdso_symbol5, \
+	aarch_vdso_symbol6
 
 /*	"__kernel_vsyscall",			*/
 

--- a/criu/pie/util-vdso.c
+++ b/criu/pie/util-vdso.c
@@ -219,6 +219,8 @@ static void parse_elf_symbols(uintptr_t mem, size_t size, Phdr_t *load,
 		struct vdso_symtable *t, uintptr_t dynsymbol_names,
 		Hash_t *hash, Dyn_t *dyn_symtab)
 {
+	ARCH_VDSO_SYMBOLS_LIST
+
 	const char *vdso_symbols[VDSO_SYMBOL_MAX] = {
 		ARCH_VDSO_SYMBOLS
 	};


### PR DESCRIPTION
I compile criu with the command "make DEBUG=1", and I use it to check/restore my program, it produces a segmentation fault(check the log at the bottom)

My running environment:
> Fedora 33
> Linux localhost.localdomain 5.8.15-301.fc33.aarch64 #1 SMP Thu Oct 15 15:56:58 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux

My test program:

`
#include <unistd.h>

int main()
{
	while(1)
	{
		sleep(10);
	}
	return 0;
}
`

This problem is caused by code in ./criu/pie/util-vdso.c, to be specific，by following codes:

`
const char * symbol = vdso_symbols[i];

k = elf_hash((const unsigned char *)symbol);
`

I try the same program in x86, it does not have such a problem, so I guess it is related to how the compiler handles the memory layout of the program since the execution code for pie is copied from somewhere.

I find two ways to solve this problem in my environment:

1.
change Makefile in the root directory
`
ifeq ($(DEBUG),1)
        DEFINES		+= -DCR_DEBUG
        CFLAGS		+= -O0 -ggdb3
`
to
`
ifeq ($(DEBUG),1)
        DEFINES		+= -DCR_DEBUG
        CFLAGS		+= -O2 -ggdb3
`

2.
put the content of the vdso_symbols in the stack(check the patch)

The complete running log:

**
[anatasluo@localhost criu]$ sudo /home/anatasluo/Git/criu/criu/criu dump -D /home/anatasluo/Tmp -t 323740 --file-locks --tcp-established --ext-unix-sk --shell-job -vv
[sudo] password for anatasluo: 
(00.000000) Will dump/restore TCP connections
(00.000020) Version: 3.15 (gitid v3.14-259-g11b3a1a75)
(00.000033) Running on localhost.localdomain Linux 5.8.15-301.fc33.aarch64 #1 SMP Thu Oct 15 15:56:58 UTC 2020 aarch64
(00.000058) Loaded kdat cache from /run/criu.kdat
(00.000066) ========================================
(00.000076) Dumping processes (pid: 323740)
(00.000079) ========================================
(00.000087) rlimit: RLIMIT_NOFILE unlimited for self
(00.000105) Running pre-dump scripts
(00.000140) irmap: Searching irmap cache in work dir
(00.000149) No irmap-cache image
(00.000158) irmap: Searching irmap cache in parent
(00.000163) irmap: No irmap cache
(00.000261) cg-prop: Parsing controller "cpu"
(00.000270) cg-prop: 	Strategy "replace"
(00.000274) cg-prop: 	Property "cpu.shares"
(00.000278) cg-prop: 	Property "cpu.cfs_period_us"
(00.000281) cg-prop: 	Property "cpu.cfs_quota_us"
(00.000283) cg-prop: 	Property "cpu.rt_period_us"
(00.000286) cg-prop: 	Property "cpu.rt_runtime_us"
(00.000291) cg-prop: Parsing controller "memory"
(00.000293) cg-prop: 	Strategy "replace"
(00.000296) cg-prop: 	Property "memory.limit_in_bytes"
(00.000298) cg-prop: 	Property "memory.memsw.limit_in_bytes"
(00.000300) cg-prop: 	Property "memory.swappiness"
(00.000302) cg-prop: 	Property "memory.soft_limit_in_bytes"
(00.000305) cg-prop: 	Property "memory.move_charge_at_immigrate"
(00.000307) cg-prop: 	Property "memory.oom_control"
(00.000309) cg-prop: 	Property "memory.use_hierarchy"
(00.000312) cg-prop: 	Property "memory.kmem.limit_in_bytes"
(00.000314) cg-prop: 	Property "memory.kmem.tcp.limit_in_bytes"
(00.000317) cg-prop: Parsing controller "cpuset"
(00.000319) cg-prop: 	Strategy "replace"
(00.000323) cg-prop: 	Property "cpuset.cpus"
(00.000327) cg-prop: 	Property "cpuset.mems"
(00.000330) cg-prop: 	Property "cpuset.memory_migrate"
(00.000333) cg-prop: 	Property "cpuset.cpu_exclusive"
(00.000338) cg-prop: 	Property "cpuset.mem_exclusive"
(00.000340) cg-prop: 	Property "cpuset.mem_hardwall"
(00.000345) cg-prop: 	Property "cpuset.memory_spread_page"
(00.000347) cg-prop: 	Property "cpuset.memory_spread_slab"
(00.000349) cg-prop: 	Property "cpuset.sched_load_balance"
(00.000351) cg-prop: 	Property "cpuset.sched_relax_domain_level"
(00.000354) cg-prop: Parsing controller "blkio"
(00.000356) cg-prop: 	Strategy "replace"
(00.000360) cg-prop: 	Property "blkio.weight"
(00.000362) cg-prop: Parsing controller "freezer"
(00.000364) cg-prop: 	Strategy "replace"
(00.000366) cg-prop: Parsing controller "perf_event"
(00.000368) cg-prop: 	Strategy "replace"
(00.000371) cg-prop: Parsing controller "net_cls"
(00.000373) cg-prop: 	Strategy "replace"
(00.000375) cg-prop: 	Property "net_cls.classid"
(00.000377) cg-prop: Parsing controller "net_prio"
(00.000379) cg-prop: 	Strategy "replace"
(00.000381) cg-prop: 	Property "net_prio.ifpriomap"
(00.000388) cg-prop: Parsing controller "pids"
(00.000393) cg-prop: 	Strategy "replace"
(00.000396) cg-prop: 	Property "pids.max"
(00.000403) cg-prop: Parsing controller "devices"
(00.000407) cg-prop: 	Strategy "replace"
(00.000412) cg-prop: 	Property "devices.list"
(00.000438) Preparing image inventory (version 1)
(00.000508) Add pid ns 1 pid 323748
(00.000528) Add net ns 2 pid 323748
(00.000542) Add ipc ns 3 pid 323748
(00.000554) Add uts ns 4 pid 323748
(00.000560) Add time ns 5 pid 323748
(00.000572) Add mnt ns 6 pid 323748
(00.000584) Add user ns 7 pid 323748
(00.000597) Add cgroup ns 8 pid 323748
(00.000600) cg: Dumping cgroups for 323748
(00.000619) cg:  `- New css ID 1
(00.000625) cg:     `- [] -> [/user.slice/user-1000.slice/session-13.scope] [0]
(00.000628) cg: Set 1 is criu one
(00.000653) Detected cgroup V1 freezer
(00.000771) Seized task 323740, state 1
(00.000781) seccomp: Collected tid_real 323740 mode 0
(00.000811) Collected (4 attempts, 0 in_progress)
(00.000837) Collected (4 attempts, 0 in_progress)
(00.000851) Collected 323740 in 1 state
(00.000912) Lock network
(00.000981) 	type sysfs source sysfs mnt_id 25 s_dev 0x18 / @ ./sys flags 0x30000e options seclabel
(00.000998) 	type proc source proc mnt_id 26 s_dev 0x19 / @ ./proc flags 0x30000e options 
(00.001010) 	type devtmpfs source devtmpfs mnt_id 27 s_dev 0x5 / @ ./dev flags 0x110000a options seclabel,size=8120380k,nr_inodes=2030095,mode=755
(00.001018) 	type securityfs source securityfs mnt_id 28 s_dev 0x7 / @ ./sys/kernel/security flags 0x30000e options 
(00.001024) 	type tmpfs source tmpfs mnt_id 29 s_dev 0x1a / @ ./dev/shm flags 0x1100006 options seclabel
(00.001034) 	type devpts source devpts mnt_id 30 s_dev 0x1b / @ ./dev/pts flags 0x30000a options seclabel,gid=5,mode=620,ptmxmode=000
(00.001127) 	type tmpfs source tmpfs mnt_id 31 s_dev 0x1c / @ ./run flags 0x1100006 options seclabel,size=3269116k,nr_inodes=819200,mode=755
(00.001140) 	type cgroup2 source cgroup2 mnt_id 32 s_dev 0x1d / @ ./sys/fs/cgroup flags 0x30000e options seclabel
(00.001147) 	type pstore source pstore mnt_id 33 s_dev 0x1e / @ ./sys/fs/pstore flags 0x30000e options seclabel
(00.001164) 	type efivarfs source efivarfs mnt_id 34 s_dev 0x1f / @ ./sys/firmware/efi/efivars flags 0x30000e options 
(00.001210) 	type bpf source none mnt_id 35 s_dev 0x20 / @ ./sys/fs/bpf flags 0x30000e options mode=700
(00.001224) 	type configfs source configfs mnt_id 62 s_dev 0x21 / @ ./sys/kernel/config flags 0x30000e options 
(00.001235) 	type xfs source /dev/mapper/fedora_fedora-root mnt_id 66 s_dev 0xfd00000 / @ ./ flags 0x300000 options seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota
(00.001244) 	type selinuxfs source selinuxfs mnt_id 37 s_dev 0x17 / @ ./sys/fs/selinux flags 0x30000a options 
(00.001252) 	type autofs source systemd-1 mnt_id 36 s_dev 0x23 / @ ./proc/sys/fs/binfmt_misc flags 0x300000 options fd=30,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=43012
(00.001262) 	type hugetlbfs source hugetlbfs mnt_id 38 s_dev 0x24 / @ ./dev/hugepages flags 0x300000 options seclabel,pagesize=2M
(00.001272) 	type mqueue source mqueue mnt_id 39 s_dev 0x16 / @ ./dev/mqueue flags 0x30000e options seclabel
(00.001283) 	type debugfs source debugfs mnt_id 40 s_dev 0x6 / @ ./sys/kernel/debug flags 0x30000e options seclabel
(00.001292) 	type tracefs source tracefs mnt_id 41 s_dev 0xb / @ ./sys/kernel/tracing flags 0x30000e options seclabel
(00.001298) 	skipping fs mounted at /sys/kernel/tracing
(00.001305) 	type xfs source /dev/sda2 mnt_id 87 s_dev 0x800002 / @ ./boot flags 0x300000 options seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota
(00.001330) 	type vfat source /dev/sda1 mnt_id 90 s_dev 0x800001 / @ ./boot/efi flags 0x300000 options fmask=0077,dmask=0077,codepage=437,iocharset=ascii,shortname=winnt,errors=remount-ro
(00.001340) 	type tmpfs source tmpfs mnt_id 93 s_dev 0x26 / @ ./tmp flags 0x1100006 options seclabel,size=8172788k,nr_inodes=409600
(00.001355) 	type rpc_pipefs source sunrpc mnt_id 177 s_dev 0x28 / @ ./var/lib/nfs/rpc_pipefs flags 0x300000 options 
(00.001368) 	type tmpfs source tmpfs mnt_id 718 s_dev 0x2b / @ ./run/user/1000 flags 0x300006 options seclabel,size=1634556k,nr_inodes=408639,mode=700,uid=1000,gid=1000
(00.001376) 	type tmpfs source tmpfs mnt_id 534 s_dev 0x2c / @ ./run/user/0 flags 0x300006 options seclabel,size=1634556k,nr_inodes=408639,mode=700
(00.001384) mnt: Building mountpoints tree
(00.001386) mnt: 	Building plain mount tree
(00.001388) mnt: 		Working on 534->31
(00.001391) mnt: 		Working on 718->31
(00.001393) mnt: 		Working on 177->66
(00.001401) mnt: 		Working on 93->66
(00.001407) mnt: 		Working on 90->87
(00.001409) mnt: 		Working on 87->66
(00.001411) mnt: 		Working on 40->25
(00.001413) mnt: 		Working on 39->27
(00.001422) mnt: 		Working on 38->27
(00.001428) mnt: 		Working on 36->26
(00.001435) mnt: 		Working on 37->25
(00.001440) mnt: 		Working on 66->1
(00.001445) mnt: 		Working on 62->25
(00.001449) mnt: 		Working on 35->25
(00.001452) mnt: 		Working on 34->25
(00.001456) mnt: 		Working on 33->25
(00.001462) mnt: 		Working on 32->25
(00.001467) mnt: 		Working on 31->66
(00.001475) mnt: 		Working on 30->27
(00.001480) mnt: 		Working on 29->27
(00.001486) mnt: 		Working on 28->25
(00.001488) mnt: 		Working on 27->66
(00.001497) mnt: 		Working on 26->66
(00.001502) mnt: 		Working on 25->66
(00.001507) mnt: 	Resorting children of 66 in mount order
(00.001515) mnt: 	Resorting children of 177 in mount order
(00.001520) mnt: 	Resorting children of 93 in mount order
(00.001524) mnt: 	Resorting children of 87 in mount order
(00.001529) mnt: 	Resorting children of 90 in mount order
(00.001534) mnt: 	Resorting children of 31 in mount order
(00.001541) mnt: 	Resorting children of 534 in mount order
(00.001546) mnt: 	Resorting children of 718 in mount order
(00.001553) mnt: 	Resorting children of 27 in mount order
(00.001557) mnt: 	Resorting children of 39 in mount order
(00.001562) mnt: 	Resorting children of 38 in mount order
(00.001566) mnt: 	Resorting children of 30 in mount order
(00.001568) mnt: 	Resorting children of 29 in mount order
(00.001573) mnt: 	Resorting children of 26 in mount order
(00.001575) mnt: 	Resorting children of 36 in mount order
(00.001579) mnt: 	Resorting children of 25 in mount order
(00.001585) mnt: 	Resorting children of 34 in mount order
(00.001587) mnt: 	Resorting children of 40 in mount order
(00.001589) mnt: 	Resorting children of 37 in mount order
(00.001594) mnt: 	Resorting children of 62 in mount order
(00.001603) mnt: 	Resorting children of 35 in mount order
(00.001608) mnt: 	Resorting children of 33 in mount order
(00.001615) mnt: 	Resorting children of 32 in mount order
(00.001621) mnt: 	Resorting children of 28 in mount order
(00.001625) mnt: Done:
(00.001627) mnt: [./](66->1)
(00.001629) mnt:  [./var/lib/nfs/rpc_pipefs](177->66)
(00.001631) mnt:  <--
(00.001632) mnt:  [./tmp](93->66)
(00.001634) mnt:  <--
(00.001636) mnt:  [./boot](87->66)
(00.001638) mnt:   [./boot/efi](90->87)
(00.001642) mnt:   <--
(00.001644) mnt:  <--
(00.001649) mnt:  [./run](31->66)
(00.001653) mnt:   [./run/user/0](534->31)
(00.001655) mnt:   <--
(00.001659) mnt:   [./run/user/1000](718->31)
(00.001662) mnt:   <--
(00.001666) mnt:  <--
(00.001668) mnt:  [./dev](27->66)
(00.001673) mnt:   [./dev/mqueue](39->27)
(00.001677) mnt:   <--
(00.001682) mnt:   [./dev/hugepages](38->27)
(00.001683) mnt:   <--
(00.001686) mnt:   [./dev/pts](30->27)
(00.001688) mnt:   <--
(00.001693) mnt:   [./dev/shm](29->27)
(00.001694) mnt:   <--
(00.001699) mnt:  <--
(00.001703) mnt:  [./proc](26->66)
(00.001705) mnt:   [./proc/sys/fs/binfmt_misc](36->26)
(00.001709) mnt:   <--
(00.001711) mnt:  <--
(00.001715) mnt:  [./sys](25->66)
(00.001717) mnt:   [./sys/firmware/efi/efivars](34->25)
(00.001722) mnt:   <--
(00.001723) mnt:   [./sys/kernel/debug](40->25)
(00.001725) mnt:   <--
(00.001728) mnt:   [./sys/fs/selinux](37->25)
(00.001730) mnt:   <--
(00.001735) mnt:   [./sys/kernel/config](62->25)
(00.001739) mnt:   <--
(00.001741) mnt:   [./sys/fs/bpf](35->25)
(00.001745) mnt:   <--
(00.001747) mnt:   [./sys/fs/pstore](33->25)
(00.001752) mnt:   <--
(00.001753) mnt:   [./sys/fs/cgroup](32->25)
(00.001758) mnt:   <--
(00.001759) mnt:   [./sys/kernel/security](28->25)
(00.001764) mnt:   <--
(00.001765) mnt:  <--
(00.001770) mnt: <--
(00.001782) Collecting netns 2/323748
(00.002531) unix: 	Collected: ino 43014 peer_ino 0 family    1 type    5 state 10 name /run/systemd/coredump
(00.002551) unix: 	Collected: ino 43018 peer_ino 0 family    1 type    5 state 10 name /run/udev/control
(00.002561) unix: 	Collected: ino 51211 peer_ino 0 family    1 type    1 state 10 name /run/dbus/system_bus_socket
(00.002570) unix: 	Collected: ino 43022 peer_ino 0 family    1 type    1 state 10 name /run/systemd/journal/io.systemd.journal
(00.002579) unix: 	Collected: ino 51217 peer_ino 0 family    1 type    1 state 10 name /run/pcscd/pcscd.comm
(00.002585) unix: 	Collected: ino 20672 peer_ino 0 family    1 type    1 state 10 name 
(00.002594) unix: 	Collected: ino 51221 peer_ino 0 family    1 type    1 state 10 name /run/.heim_org.h5l.kcm-socket
(00.002601) unix: 	Collected: ino 164886 peer_ino 0 family    1 type    2 state  7 name /run/user/0/systemd/notify
(00.002607) unix: 	Collected: ino 164890 peer_ino 0 family    1 type    1 state 10 name /run/user/0/systemd/private
(00.002614) unix: 	Collected: ino 164898 peer_ino 0 family    1 type    1 state 10 name /run/user/0/bus
(00.002620) unix: 	Collected: ino 1571 peer_ino 0 family    1 type    1 state 10 name /run/systemd/private
(00.002626) unix: 	Collected: ino 1574 peer_ino 0 family    1 type    1 state 10 name /run/systemd/userdb/io.systemd.DynamicUser
(00.002632) unix: 	Collected: ino 51216 peer_ino 0 family    1 type    1 state 10 name 
(00.002638) unix: 	Collected: ino 26205 peer_ino 0 family    1 type    2 state  7 name /run/user/1000/systemd/notify
(00.002642) unix: 	Collected: ino 26209 peer_ino 0 family    1 type    1 state 10 name /run/user/1000/systemd/private
(00.002646) unix: 	Collected: ino 26217 peer_ino 0 family    1 type    1 state 10 name /run/user/1000/bus
(00.002652) unix: 	Collected: ino 28784 peer_ino 0 family    1 type    2 state  7 name /run/chrony/chronyd.sock
(00.002658) unix: 	Collected: ino 43306 peer_ino 0 family    1 type    1 state 10 name /var/lib/sss/pipes/nss
(00.002664) unix: 	Collected: ino 22410 peer_ino 0 family    1 type    1 state 10 name /var/run/abrt/abrt.socket
(00.002667) unix: 	Collected: ino 20668 peer_ino 0 family    1 type    1 state 10 name /run/lvm/lvmpolld.socket
(00.002672) unix: 	Collected: ino 51215 peer_ino 0 family    1 type    1 state 10 name 
(00.002680) unix: 	Collected: ino 20674 peer_ino 0 family    1 type    1 state 10 name /run/systemd/userdb/io.systemd.Multiplexer
(00.002685) unix: 	Collected: ino 14280 peer_ino 0 family    1 type    2 state  7 name /run/systemd/notify
(00.002691) unix: 	Collected: ino 26057 peer_ino 0 family    1 type    2 state  7 name /run/systemd/home/notify
(00.002698) unix: 	Collected: ino 26061 peer_ino 0 family    1 type    1 state 10 name /run/systemd/userdb/io.systemd.Home
(00.002704) unix: 	Collected: ino 14297 peer_ino 0 family    1 type    2 state  7 name /run/systemd/journal/dev-log
(00.002710) unix: 	Collected: ino 14302 peer_ino 0 family    1 type    1 state 10 name /run/systemd/journal/stdout
(00.002716) unix: 	Collected: ino 14305 peer_ino 0 family    1 type    2 state  7 name /run/systemd/journal/socket
(00.002722) unix: 	Collected: ino 26087 peer_ino 0 family    1 type    1 state 10 name /run/gssproxy.sock
(00.002728) unix: 	Collected: ino 24050 peer_ino 0 family    1 type    1 state 10 name /run/irqbalance/irqbalance1095.sock
(00.002734) unix: 	Collected: ino 30760 peer_ino 0 family    1 type    1 state 10 name /var/lib/sss/pipes/private/sbus-monitor
(00.002740) unix: 	Collected: ino 42086 peer_ino 0 family    1 type    1 state 10 name /var/lib/sss/pipes/private/sbus-dp_implicit_files.1152
(00.002746) unix: 	Collected: ino 26086 peer_ino 0 family    1 type    1 state 10 name /var/lib/gssproxy/default.sock
(00.002752) unix: 	Collected: ino 26060 peer_ino 51306 family    1 type    1 state  1 name (null)
(00.002760) unix: 	Collected: ino 47302 peer_ino 47301 family    1 type    1 state  1 name (null)
(00.002763) unix: 	Collected: ino 164868 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.002767) unix: 	Collected: ino 158523 peer_ino 158524 family    1 type    1 state  1 name (null)
(00.002773) unix: 	Collected: ino 26084 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.002778) unix: 	Collected: ino 30755 peer_ino 51308 family    1 type    1 state  1 name (null)
(00.002784) unix: 	Collected: ino 386043 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002803) unix: 	Collected: ino 158572 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002811) unix: 	Collected: ino 24132 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002816) unix: 	Collected: ino 39366 peer_ino 51229 family    1 type    1 state  1 name (null)
(00.002822) unix: 	Collected: ino 272968 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002828) unix: 	Collected: ino 86191 peer_ino 86192 family    1 type    1 state  1 name (null)
(00.002831) unix: 	Collected: ino 135574 peer_ino 162105 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.002834) unix: 	Collected: ino 86192 peer_ino 86191 family    1 type    1 state  1 name (null)
(00.002837) unix: 	Collected: ino 24055 peer_ino 51310 family    1 type    1 state  1 name (null)
(00.002843) unix: 	Collected: ino 55633 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.002848) unix: 	Collected: ino 51328 peer_ino 30809 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.002854) unix: 	Collected: ino 272972 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002863) unix: 	Collected: ino 158617 peer_ino 158618 family    1 type    1 state  1 name (null)
(00.002870) unix: 	Collected: ino 158568 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002876) unix: 	Collected: ino 51306 peer_ino 26060 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.002882) unix: 	Collected: ino 155687 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002888) unix: 	Collected: ino 158486 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002890) unix: 	Collected: ino 30809 peer_ino 51328 family    1 type    1 state  1 name (null)
(00.002894) unix: 	Collected: ino 158482 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002901) unix: 	Collected: ino 375067 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.002906) unix: 	Collected: ino 47301 peer_ino 47302 family    1 type    1 state  1 name (null)
(00.002912) unix: 	Collected: ino 147656 peer_ino 164892 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.002918) unix: 	Collected: ino 51310 peer_ino 24055 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.002924) unix: 	Collected: ino 47304 peer_ino 47305 family    1 type    1 state  1 name (null)
(00.002930) unix: 	Collected: ino 86149 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002936) unix: 	Collected: ino 47303 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.002942) unix: 	Collected: ino 164865 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.002948) unix: 	Collected: ino 43052 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.002956) unix: 	Collected: ino 47305 peer_ino 47304 family    1 type    1 state  1 name (null)
(00.002963) unix: 	Collected: ino 55630 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.002968) unix: 	Collected: ino 51229 peer_ino 39366 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.002974) unix: 	Collected: ino 86154 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002977) unix: 	Collected: ino 55629 peer_ino 0 family    1 type    1 state  1 name (null)
(00.002986) unix: 	Collected: ino 155684 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.002991) unix: 	Collected: ino 158524 peer_ino 158523 family    1 type    1 state  1 name (null)
(00.002998) unix: 	Collected: ino 164889 peer_ino 164888 family    1 type    2 state  7 name (null)
(00.003003) unix: 	Collected: ino 162105 peer_ino 135574 family    1 type    1 state  1 name (null)
(00.003010) unix: 	Collected: ino 26056 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.003015) unix: 	Collected: ino 164888 peer_ino 164889 family    1 type    2 state  7 name (null)
(00.003023) unix: 	Collected: ino 26284 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003028) unix: 	Collected: ino 51308 peer_ino 30755 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.003037) unix: 	Collected: ino 164892 peer_ino 147656 family    1 type    1 state  1 name (null)
(00.003042) unix: 	Collected: ino 158618 peer_ino 158617 family    1 type    1 state  1 name (null)
(00.003050) unix: 	Collected: ino 162109 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003055) unix: 	Collected: ino 121822 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003063) unix: 	Collected: ino 52879 peer_ino 42192 family    1 type    1 state  1 name (null)
(00.003068) unix: 	Collected: ino 26255 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003076) unix: 	Collected: ino 52444 peer_ino 51316 family    1 type    1 state  1 name (null)
(00.003083) unix: 	Collected: ino 51263 peer_ino 22953 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003087) unix: 	Collected: ino 51320 peer_ino 24063 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.003094) unix: 	Collected: ino 304582 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003099) unix: 	Collected: ino 51259 peer_ino 21891 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003102) unix: 	Collected: ino 50538 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.003107) unix: 	Collected: ino 53348 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003115) unix: 	Collected: ino 55371 peer_ino 42550 family    1 type    1 state  1 name (null)
(00.003120) unix: 	Collected: ino 39402 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.003128) unix: 	Collected: ino 44468 peer_ino 1614 family    1 type    1 state  1 name (null)
(00.003136) unix: 	Collected: ino 51340 peer_ino 26211 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.003142) unix: 	Collected: ino 42122 peer_ino 52532 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003148) unix: 	Collected: ino 170039 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003154) unix: 	Collected: ino 307433 peer_ino 307432 family    1 type    1 state  1 name (null)
(00.003160) unix: 	Collected: ino 43304 peer_ino 0 family    1 type    2 state  7 name (null)
(00.003168) unix: 	Collected: ino 42056 peer_ino 52338 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003174) unix: 	Collected: ino 24156 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.003180) unix: 	Collected: ino 14673 peer_ino 14672 family    1 type    1 state  1 name (null)
(00.003185) unix: 	Collected: ino 30762 peer_ino 30761 family    1 type    1 state  1 name /var/lib/sss/pipes/private/sbus-monitor
(00.003191) unix: 	Collected: ino 86188 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003199) unix: 	Collected: ino 52425 peer_ino 42103 family    1 type    1 state  1 name (null)
(00.003204) unix: 	Collected: ino 43309 peer_ino 30770 family    1 type    1 state  1 name (null)
(00.003210) unix: 	Collected: ino 24054 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003216) unix: 	Collected: ino 154862 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003222) unix: 	Collected: ino 1614 peer_ino 44468 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003228) unix: 	Collected: ino 42054 peer_ino 52261 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003234) unix: 	Collected: ino 51256 peer_ino 50558 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.003242) unix: 	Collected: ino 53346 peer_ino 51314 family    1 type    1 state  1 name (null)
(00.003248) unix: 	Collected: ino 51261 peer_ino 14674 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.003251) unix: 	Collected: ino 14283 peer_ino 14282 family    1 type    2 state  7 name (null)
(00.003253) unix: 	Collected: ino 43305 peer_ino 42102 family    1 type    1 state  1 name (null)
(00.003256) unix: 	Collected: ino 50558 peer_ino 51256 family    1 type    1 state  1 name (null)
(00.003259) unix: 	Collected: ino 24086 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003264) unix: 	Collected: ino 52532 peer_ino 42122 family    1 type    1 state  1 name (null)
(00.003269) unix: 	Collected: ino 158520 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003275) unix: 	Collected: ino 30759 peer_ino 0 family    1 type    2 state  7 name (null)
(00.003282) unix: 	Collected: ino 42102 peer_ino 43305 family    1 type    1 state  1 name /var/lib/sss/pipes/private/sbus-dp_implicit_files.1152
(00.003285) unix: 	Collected: ino 51250 peer_ino 21817 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003289) unix: 	Collected: ino 14672 peer_ino 14673 family    1 type    1 state  1 name (null)
(00.003295) unix: 	Collected: ino 42052 peer_ino 22488 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003301) unix: 	Collected: ino 26250 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003308) unix: 	Collected: ino 22953 peer_ino 51263 family    1 type    1 state  1 name (null)
(00.003313) unix: 	Collected: ino 353782 peer_ino 0 family    1 type    5 state  7 name (null)
(00.003319) unix: 	Collected: ino 21891 peer_ino 51259 family    1 type    1 state  1 name (null)
(00.003328) unix: 	Collected: ino 29807 peer_ino 50485 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003334) unix: 	Collected: ino 386730 peer_ino 406535 family    1 type    1 state  1 name (null)
(00.003339) unix: 	Collected: ino 26207 peer_ino 26208 family    1 type    2 state  7 name (null)
(00.003346) unix: 	Collected: ino 52338 peer_ino 42056 family    1 type    1 state  1 name (null)
(00.003351) unix: 	Collected: ino 27768 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003357) unix: 	Collected: ino 50485 peer_ino 29807 family    1 type    1 state  1 name (null)
(00.003363) unix: 	Collected: ino 24113 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003368) unix: 	Collected: ino 24063 peer_ino 51320 family    1 type    1 state  1 name (null)
(00.003374) unix: 	Collected: ino 403319 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.003380) unix: 	Collected: ino 42550 peer_ino 55371 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003386) unix: 	Collected: ino 24049 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003392) unix: 	Collected: ino 121827 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003400) unix: 	Collected: ino 42103 peer_ino 52425 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003406) unix: 	Collected: ino 20758 peer_ino 51257 family    1 type    1 state  1 name (null)
(00.003412) unix: 	Collected: ino 307429 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003417) unix: 	Collected: ino 55614 peer_ino 42554 family    1 type    1 state  1 name (null)
(00.003423) unix: 	Collected: ino 30774 peer_ino 51318 family    1 type    1 state  1 name (null)
(00.003429) unix: 	Collected: ino 42187 peer_ino 52709 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003434) unix: 	Collected: ino 158614 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003437) unix: 	Collected: ino 21817 peer_ino 51250 family    1 type    1 state  1 name (null)
(00.003441) unix: 	Collected: ino 44480 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.003444) unix: 	Collected: ino 52709 peer_ino 42187 family    1 type    1 state  1 name (null)
(00.003450) unix: 	Collected: ino 51316 peer_ino 52444 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.003452) unix: 	Collected: ino 53353 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003458) unix: 	Collected: ino 143443 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003466) unix: 	Collected: ino 26208 peer_ino 26207 family    1 type    2 state  7 name (null)
(00.003472) unix: 	Collected: ino 42087 peer_ino 42088 family    1 type    1 state  1 name (null)
(00.003480) unix: 	Collected: ino 42192 peer_ino 52879 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003485) unix: 	Collected: ino 51314 peer_ino 53346 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.003491) unix: 	Collected: ino 42077 peer_ino 0 family    1 type    2 state  7 name (null)
(00.003499) unix: 	Collected: ino 22313 peer_ino 51275 family    1 type    1 state  1 name (null)
(00.003504) unix: 	Collected: ino 51257 peer_ino 20758 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.003513) unix: 	Collected: ino 30871 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003518) unix: 	Collected: ino 26287 peer_ino 26288 family    1 type    1 state  1 name (null)
(00.003524) unix: 	Collected: ino 52261 peer_ino 42054 family    1 type    1 state  1 name (null)
(00.003530) unix: 	Collected: ino 406535 peer_ino 386730 family    1 type    1 state  1 name /var/lib/sss/pipes/nss
(00.003536) unix: 	Collected: ino 386750 peer_ino 406537 family    1 type    1 state  1 name (null)
(00.003544) unix: 	Collected: ino 30873 peer_ino 30872 family    1 type    1 state  1 name (null)
(00.003550) unix: 	Collected: ino 51273 peer_ino 22242 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003556) unix: 	Collected: ino 403337 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.003562) unix: 	Collected: ino 253666 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003568) unix: 	Collected: ino 26211 peer_ino 51340 family    1 type    1 state  1 name (null)
(00.003573) unix: 	Collected: ino 42088 peer_ino 42087 family    1 type    1 state  1 name /var/lib/sss/pipes/private/sbus-dp_implicit_files.1152
(00.003579) unix: 	Collected: ino 30872 peer_ino 30873 family    1 type    1 state  1 name (null)
(00.003585) unix: 	Collected: ino 42093 peer_ino 30766 family    1 type    1 state  1 name (null)
(00.003590) unix: 	Collected: ino 22242 peer_ino 51273 family    1 type    1 state  1 name (null)
(00.003596) unix: 	Collected: ino 406537 peer_ino 386750 family    1 type    1 state  1 name /var/lib/sss/pipes/nss
(00.003602) unix: 	Collected: ino 42554 peer_ino 55614 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003607) unix: 	Collected: ino 30770 peer_ino 43309 family    1 type    1 state  1 name /var/lib/sss/pipes/private/sbus-monitor
(00.003613) unix: 	Collected: ino 30766 peer_ino 42093 family    1 type    1 state  1 name /var/lib/sss/pipes/private/sbus-monitor
(00.003619) unix: 	Collected: ino 51275 peer_ino 22313 family    1 type    1 state  1 name /run/systemd/journal/stdout
(00.003624) unix: 	Collected: ino 52439 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.003630) unix: 	Collected: ino 24062 peer_ino 0 family    1 type    2 state  7 name (null)
(00.003636) unix: 	Collected: ino 22488 peer_ino 42052 family    1 type    1 state  1 name (null)
(00.003641) unix: 	Collected: ino 14674 peer_ino 51261 family    1 type    1 state  1 name (null)
(00.003647) unix: 	Collected: ino 159026 peer_ino 0 family    1 type    1 state  1 name (null)
(00.003653) unix: 	Collected: ino 51318 peer_ino 30774 family    1 type    1 state  1 name /run/dbus/system_bus_socket
(00.003656) unix: 	Collected: ino 44484 peer_ino 44483 family    1 type    2 state  7 name (null)
(00.003659) unix: 	Collected: ino 307432 peer_ino 307433 family    1 type    1 state  1 name (null)
(00.003664) unix: 	Collected: ino 53347 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003669) unix: 	Collected: ino 28774 peer_ino 14297 family    1 type    2 state  7 name (null)
(00.003672) unix: 	Collected: ino 30761 peer_ino 30762 family    1 type    1 state  1 name (null)
(00.003677) unix: 	Collected: ino 44483 peer_ino 44484 family    1 type    2 state  7 name (null)
(00.003683) unix: 	Collected: ino 14282 peer_ino 14283 family    1 type    2 state  7 name (null)
(00.003689) unix: 	Collected: ino 26288 peer_ino 26287 family    1 type    1 state  1 name (null)
(00.003692) unix: 	Collected: ino 403375 peer_ino 14305 family    1 type    2 state  7 name (null)
(00.003696) unix: 	Collected: ino 43024 peer_ino 14280 family    1 type    2 state  7 name (null)
(00.004324) inet: 	Collected: ino  0x255c4 family AF_INET    type SOCK_STREAM    port       21 state TCP_LISTEN       src_addr 0.0.0.0
(00.004338) inet: 	Collected: ino   0xc578 family AF_INET    type SOCK_STREAM    port       53 state TCP_LISTEN       src_addr 127.0.0.53
(00.004342) inet: 	Collected: ino   0xd06d family AF_INET    type SOCK_STREAM    port       22 state TCP_LISTEN       src_addr 0.0.0.0
(00.004352) inet: 	Collected: ino   0xc571 family AF_INET    type SOCK_STREAM    port     5355 state TCP_LISTEN       src_addr 0.0.0.0
(00.004359) inet: 	Collected: ino  0x1db8d family AF_INET    type SOCK_STREAM    port       22 state TCP_ESTABLISHED  src_addr 192.168.122.102
(00.004365) inet: 	Collected: ino   0xd0ab family AF_INET    type SOCK_STREAM    port       22 state TCP_ESTABLISHED  src_addr 192.168.122.102
(00.004372) inet: 	Collected: ino  0x1db9c family AF_INET    type SOCK_STREAM    port       22 state TCP_ESTABLISHED  src_addr 192.168.122.102
(00.004378) inet: 	Collected: ino  0x2983c family AF_INET    type SOCK_STREAM    port    39358 state TCP_ESTABLISHED  src_addr 192.168.122.102
(00.004384) inet: 	Collected: ino  0x14fac family AF_INET    type SOCK_STREAM    port       22 state TCP_ESTABLISHED  src_addr 192.168.122.102
(00.004390) inet: 	Collected: ino  0x4a6ed family AF_INET    type SOCK_STREAM    port       22 state TCP_ESTABLISHED  src_addr 192.168.122.102
(00.004436) inet: 	Collected: ino   0xc570 family AF_INET    type SOCK_DGRAM     port     5355 state TCP_CLOSE        src_addr 0.0.0.0
(00.004443) inet: 	Collected: ino   0xc577 family AF_INET    type SOCK_DGRAM     port       53 state TCP_CLOSE        src_addr 127.0.0.53
(00.004452) inet: 	Collected: ino   0xb22e family AF_INET    type SOCK_DGRAM     port       68 state TCP_ESTABLISHED  src_addr 192.168.122.102
(00.004456) inet: 	Collected: ino   0x706e family AF_INET    type SOCK_DGRAM     port      323 state TCP_CLOSE        src_addr 127.0.0.1
(00.004969) inet: 	Collected: ino  0x255c5 family AF_INET6   type SOCK_STREAM    port       21 state TCP_LISTEN       src_addr ::
(00.004980) inet: 	Collected: ino   0xd06f family AF_INET6   type SOCK_STREAM    port       22 state TCP_LISTEN       src_addr ::
(00.004984) inet: 	Collected: ino   0x9942 family AF_INET6   type SOCK_STREAM    port     9090 state TCP_LISTEN       src_addr ::
(00.004987) inet: 	Collected: ino   0xc574 family AF_INET6   type SOCK_STREAM    port     5355 state TCP_LISTEN       src_addr ::
(00.005016) inet: 	Collected: ino   0xc573 family AF_INET6   type SOCK_DGRAM     port     5355 state TCP_CLOSE        src_addr ::
(00.005026) inet: 	Collected: ino   0x706f family AF_INET6   type SOCK_DGRAM     port      323 state TCP_CLOSE        src_addr ::1
(00.005054) inet: 	Collected: ino   0xb22a family AF_INET6   type SOCK_RAW       port       58 state TCP_CLOSE        src_addr ::
(00.005128) netlink: Collect netlink sock 0xc56f
(00.005138) netlink: Collect netlink sock 0x5e05
(00.005141) netlink: Collect netlink sock 0x782d
(00.005143) netlink: Collect netlink sock 0x14
(00.005148) netlink: Collect netlink sock 0x5e05
(00.005150) netlink: Collect netlink sock 0x782d
(00.005151) netlink: Collect netlink sock 0xc56f
(00.005156) netlink: Collect netlink sock 0x565f5
(00.005158) netlink: Collect netlink sock 0x3540
(00.005163) netlink: Collect netlink sock 0x3541
(00.005167) netlink: Collect netlink sock 0x34fa
(00.005172) netlink: Collect netlink sock 0x1509d
(00.005177) netlink: Collect netlink sock 0x4b0dd
(00.005182) netlink: Collect netlink sock 0x26b87
(00.005187) netlink: Collect netlink sock 0x26b2a
(00.005191) netlink: Collect netlink sock 0xa893
(00.005193) netlink: Collect netlink sock 0x6670
(00.005197) netlink: Collect netlink sock 0xc831
(00.005199) netlink: Collect netlink sock 0x28429
(00.005204) netlink: Collect netlink sock 0x66a2
(00.005209) netlink: Collect netlink sock 0x4b0dd
(00.005214) netlink: Collect netlink sock 0x26b87
(00.005219) netlink: Collect netlink sock 0x28429
(00.005223) netlink: Collect netlink sock 0x26b2a
(00.005228) netlink: Collect netlink sock 0x1509d
(00.005229) netlink: Collect netlink sock 0x66a2
(00.005234) netlink: Collect netlink sock 0x6670
(00.005237) netlink: Collect netlink sock 0xc831
(00.005242) netlink: Collect netlink sock 0xa893
(00.005246) netlink: Collect netlink sock 0x62c
(00.005248) netlink: Collect netlink sock 0xb8c3
(00.005252) netlink: Collect netlink sock 0x37d8
(00.005254) netlink: Collect netlink sock 0x19
(00.005259) netlink: Collect netlink sock 0x5e6b4
(00.005261) netlink: Collect netlink sock 0x37d8
(00.005266) netlink: Collect netlink sock 0x2ce7
(00.005270) netlink: Collect netlink sock 0x24
(00.005274) netlink: Collect netlink sock 0x7852
(00.005275) netlink: Collect netlink sock 0xb496
(00.005280) netlink: Collect netlink sock 0x1b
(00.005285) netlink: Collect netlink sock 0x50c1
(00.005289) netlink: Collect netlink sock 0xd960
(00.005293) netlink: Collect netlink sock 0x5e03
(00.005299) netlink: Collect netlink sock 0xccdb
(00.005303) netlink: Collect netlink sock 0xccd9
(00.005308) netlink: Collect netlink sock 0x28414
(00.005313) netlink: Collect netlink sock 0x6c81
(00.005314) netlink: Collect netlink sock 0x65cf
(00.005319) netlink: Collect netlink sock 0xb1f0
(00.005324) netlink: Collect netlink sock 0x50b8
(00.005328) netlink: Collect netlink sock 0xccd8
(00.005333) netlink: Collect netlink sock 0xccda
(00.005337) netlink: Collect netlink sock 0x28414
(00.005342) netlink: Collect netlink sock 0xd960
(00.005346) netlink: Collect netlink sock 0xb1f0
(00.005351) netlink: Collect netlink sock 0x5e03
(00.005355) netlink: Collect netlink sock 0xccdb
(00.005360) netlink: Collect netlink sock 0xccda
(00.005361) netlink: Collect netlink sock 0xccd9
(00.005366) netlink: Collect netlink sock 0xccd8
(00.005369) netlink: Collect netlink sock 0x6c81
(00.005373) netlink: Collect netlink sock 0x65cf
(00.005378) netlink: Collect netlink sock 0x50c1
(00.005383) netlink: Collect netlink sock 0x50b8
(00.005387) netlink: Collect netlink sock 0x5e04
(00.005392) netlink: Collect netlink sock 0x2f
(00.005394) netlink: Collect netlink sock 0x27
(00.005409) Collecting pidns 1/323748
(00.005518) ========================================
(00.005526) Dumping task (pid: 323740)
(00.005529) ========================================
(00.005536) Obtaining task stat ... 
(00.005577) 
(00.005583) Collecting mappings (pid: 323740)
(00.005585) ----------------------------------------
(00.005751) Dumping path for -3 fd via self 12 [/home/anatasluo/Git/code/main]
(00.005865) vma 41f000 borrows vfi from previous 400000
(00.005884) vma 420000 borrows vfi from previous 41f000
(00.005936) Dumping path for -3 fd via self 12 [/usr/lib64/libc-2.32.so]
(00.005992) vma ffff85de1000 borrows vfi from previous ffff85c7a000
(00.006082) vma ffff85df7000 borrows vfi from previous ffff85de1000
(00.006101) vma ffff85dfa000 borrows vfi from previous ffff85df7000
(00.006162) Dumping path for -3 fd via self 12 [/usr/lib64/ld-2.32.so]
(00.006280) vma ffff85e40000 borrows vfi from previous ffff85e3f000
(00.006306) Collected, longest area occupies 359 pages
(00.006318) 0x400000-0x401000 (4K) prot 0x5 flags 0x2 fdflags 0 st 0x41 off 0 reg fp  shmid: 0x1
(00.006325) 0x41f000-0x420000 (4K) prot 0x1 flags 0x2 fdflags 0 st 0x41 off 0xf000 reg fp  shmid: 0x1
(00.006331) 0x420000-0x421000 (4K) prot 0x3 flags 0x2 fdflags 0 st 0x41 off 0x10000 reg fp  shmid: 0x1
(00.006337) 0xffff85c7a000-0xffff85de1000 (1436K) prot 0x5 flags 0x2 fdflags 0 st 0x41 off 0 reg fp  shmid: 0x2
(00.006342) 0xffff85de1000-0xffff85df7000 (88K) prot 0 flags 0x2 fdflags 0 st 0x41 off 0x167000 reg fp  shmid: 0x2
(00.006348) 0xffff85df7000-0xffff85dfa000 (12K) prot 0x1 flags 0x2 fdflags 0 st 0x41 off 0x16d000 reg fp  shmid: 0x2
(00.006353) 0xffff85dfa000-0xffff85dfd000 (12K) prot 0x3 flags 0x2 fdflags 0 st 0x41 off 0x170000 reg fp  shmid: 0x2
(00.006358) 0xffff85dfd000-0xffff85e00000 (12K) prot 0x3 flags 0x22 fdflags 0 st 0x201 off 0 reg ap  shmid: 0
(00.006363) 0xffff85e00000-0xffff85e23000 (140K) prot 0x5 flags 0x2 fdflags 0 st 0x41 off 0 reg fp  shmid: 0x3
(00.006368) 0xffff85e30000-0xffff85e32000 (8K) prot 0x3 flags 0x22 fdflags 0 st 0x201 off 0 reg ap  shmid: 0
(00.006374) 0xffff85e3d000-0xffff85e3e000 (4K) prot 0x1 flags 0x22 fdflags 0 st 0x1201 off 0 reg vvar ap  shmid: 0
(00.006380) 0xffff85e3e000-0xffff85e3f000 (4K) prot 0x5 flags 0x22 fdflags 0 st 0x209 off 0 reg vdso ap  shmid: 0
(00.006386) 0xffff85e3f000-0xffff85e40000 (4K) prot 0x1 flags 0x2 fdflags 0 st 0x41 off 0x2f000 reg fp  shmid: 0x3
(00.006391) 0xffff85e40000-0xffff85e42000 (8K) prot 0x3 flags 0x2 fdflags 0 st 0x41 off 0x30000 reg fp  shmid: 0x3
(00.006396) 0xffffc39a4000-0xffffc39c5000 (132K) prot 0x3 flags 0x122 fdflags 0 st 0x201 off 0 reg ap  shmid: 0
(00.006402) ----------------------------------------
(00.006404) 
(00.006409) Collecting fds (pid: 323740)
(00.006413) ----------------------------------------
(00.006450) Found 3 file descriptors
(00.006454) ----------------------------------------
(00.006467) Dump private signals of 323740
(00.006481) Dump shared signals of 323740
(00.006492) Parasite syscall_ip at 0x400000
(00.006813) Set up parasite blob using memfd
(00.006826) Putting parasite blob into 0xffff9b601000->0xffff85c6b000
(00.006910) Dumping GP/FPU registers for 323740
(00.006927) Putting tsock into pid 323740
(00.007071) Wait for parasite being daemonized...
(00.007081) Wait for ack 2 on daemon socket
pie: 323740: Running daemon thread leader
pie: 323740: __sent ack msg: 2 2 0
(00.007104) Fetched ack: 2 2 0
pie: 323740: Daemon waits for command
(00.007107) Parasite 323740 has been switched to daemon mode
(00.007114) vdso: vDSO hint is reliable - omit checking
(00.007125) Sent msg to daemon 74 0 0
pie: 323740: __fetched msg: 74 0 0
(00.007130) Wait for ack 74 on daemon socket
pie: 323740: __sent ack msg: 74 74 0
(00.007134) Fetched ack: 74 74 0
pie: 323740: Daemon waits for command
(00.007142) Sent msg to daemon 70 0 0
pie: 323740: __fetched msg: 70 0 0
(00.007146) Wait for ack 70 on daemon socket
pie: 323740: __sent ack msg: 70 70 0
(00.007160) Fetched ack: 70 70 0
pie: 323740: Daemon waits for command
(00.007163) sid=-3 pgid=323740 pid=323740
(00.007255) 
(00.007260) Dumping opened files (pid: 323740)
(00.007261) ----------------------------------------
(00.007273) Sent msg to daemon 71 0 0
pie: 323740: __fetched msg: 71 0 0
pie: 323740: __sent ack msg: 71 71 0
pie: 323740: Daemon waits for command
(00.007310) Wait for ack 71 on daemon socket
(00.007317) Fetched ack: 71 71 0
(00.007353) 323740 fdinfo 0: pos:                0 flags:             2002/0
(00.007380) tty: Dumping tty 12 with id 0x4
(00.007392) Dumping path for 0 fd via self 12 [/dev/pts/0]
(00.007407) Sent msg to daemon 73 0 0
pie: 323740: __fetched msg: 73 0 0
(00.007412) Wait for ack 73 on daemon socket
pie: 323740: __sent ack msg: 73 73 0
(00.007426) Fetched ack: 73 73 0
pie: 323740: Daemon waits for command
(00.007543) 323740 fdinfo 1: pos:                0 flags:             2002/0
(00.007586) 323740 fdinfo 2: pos:                0 flags:             2002/0
(00.007604) ----------------------------------------
(00.007735) Sent msg to daemon 65 0 0
pie: 323740: __fetched msg: 65 0 0
(00.007743) Wait for ack 65 on daemon socket
pie: 323740: __sent ack msg: 65 65 0
pie: 323740: Daemon waits for command
(00.007758) Fetched ack: 65 65 0
(00.007764) 
(00.007769) Dumping pages (type: 58 pid: 323740)
(00.007775) ----------------------------------------
(00.007781)    Private vmas 359/468 pages
(00.007798) pagemap-cache: created for pid 323740 (takes 4096 bytes)
(00.007804) page-pipe: Create page pipe for 468 segs
(00.007811) page-pipe: Will grow page pipe (iov off is 0)
(00.007916) pagemap-cache: 323740: filling VMA 400000-401000 (4K) [l:400000 h:600000]
(00.007925) pagemap-cache: 	323740:           400000-401000           nr:1     cov:4096
(00.007934) pagemap-cache: 	323740:           41f000-420000           nr:2     cov:8192
(00.007940) pagemap-cache: 	323740:           420000-421000           nr:3     cov:12288
(00.007945) pagemap-cache: 	323740: cache  mode [l:400000 h:600000]
(00.007960) page-pipe: Add iov to page pipe (0 iovs, 0/468 total)
(00.007966) Pagemap generated: 1 pages (0 lazy) 0 holes
(00.007968) page-pipe: Add iov to page pipe (1 iovs, 1/468 total)
(00.007970) Pagemap generated: 1 pages (0 lazy) 0 holes
(00.007972) Pagemap generated: 1 pages (0 lazy) 0 holes
(00.007974) pagemap-cache: 323740: filling VMA ffff85c7a000-ffff85de1000 (1436K) [l:ffff85c00000 h:ffff85e00000]
(00.007980) pagemap-cache: 	323740:     ffff85c7a000-ffff85de1000     nr:1     cov:1470464
(00.008025) pagemap-cache: 	323740:     ffff85de1000-ffff85df7000     nr:2     cov:1560576
(00.008028) pagemap-cache: 	323740:     ffff85df7000-ffff85dfa000     nr:3     cov:1572864
(00.008031) pagemap-cache: 	323740:     ffff85dfa000-ffff85dfd000     nr:4     cov:1585152
(00.008033) pagemap-cache: 	323740:     ffff85dfd000-ffff85e00000     nr:5     cov:1597440
(00.008036) pagemap-cache: 	323740: cache  mode [l:ffff85c7a000 h:ffff85e00000]
(00.008052) Pagemap generated: 0 pages (0 lazy) 0 holes
(00.008057) Pagemap generated: 0 pages (0 lazy) 0 holes
(00.008060) page-pipe: Add iov to page pipe (2 iovs, 2/468 total)
(00.008062) Pagemap generated: 3 pages (0 lazy) 0 holes
(00.008064) Pagemap generated: 3 pages (0 lazy) 0 holes
(00.008066) page-pipe: Will grow page pipe (iov off is 3)
(00.008075) page-pipe: Add iov to page pipe (0 iovs, 3/468 total)
(00.008078) Pagemap generated: 2 pages (0 lazy) 0 holes
(00.008080) pagemap-cache: 323740: filling VMA ffff85e00000-ffff85e23000 (140K) [l:ffff85e00000 h:ffff86000000]
(00.008082) pagemap-cache: 	323740:     ffff85e00000-ffff85e23000     nr:1     cov:143360
(00.008085) pagemap-cache: 	323740:     ffff85e30000-ffff85e32000     nr:2     cov:151552
(00.008091) pagemap-cache: 	323740:     ffff85e3d000-ffff85e3e000     nr:3     cov:155648
(00.008096) pagemap-cache: 	323740:     ffff85e3e000-ffff85e3f000     nr:4     cov:159744
(00.008102) pagemap-cache: 	323740:     ffff85e3f000-ffff85e40000     nr:5     cov:163840
(00.008110) pagemap-cache: 	323740:     ffff85e40000-ffff85e42000     nr:6     cov:172032
(00.008116) pagemap-cache: 	323740: cache  mode [l:ffff85e00000 h:ffff86000000]
(00.008127) Pagemap generated: 0 pages (0 lazy) 0 holes
(00.008131) page-pipe: Add iov to page pipe (1 iovs, 4/468 total)
(00.008134) Pagemap generated: 2 pages (0 lazy) 0 holes
(00.008138) Pagemap generated: 0 pages (0 lazy) 0 holes
(00.008141) page-pipe: Will grow page pipe (iov off is 5)
(00.008149) page-pipe: Add iov to page pipe (0 iovs, 5/468 total)
(00.008154) Pagemap generated: 1 pages (0 lazy) 0 holes
(00.008156) Pagemap generated: 1 pages (0 lazy) 0 holes
(00.008158) Pagemap generated: 2 pages (0 lazy) 0 holes
(00.008160) pagemap-cache: 323740: filling VMA ffffc39a4000-ffffc39c5000 (132K) [l:ffffc3800000 h:ffffc3a00000]
(00.008168) page-pipe: Will grow page pipe (iov off is 6)
(00.008176) page-pipe: Add iov to page pipe (0 iovs, 6/468 total)
(00.008182) Pagemap generated: 3 pages (0 lazy) 0 holes
(00.008187) page-pipe: Page pipe:
(00.008191) page-pipe: * 4 pipes 7/468 iovs:
(00.008194) page-pipe: 	buf 9 pages, 3 iovs, flags: 0 pipe_off: 0 :
(00.008199) page-pipe: 		0x400000 1
(00.008203) page-pipe: 		0x41f000 2
(00.008208) page-pipe: 		0xffff85df7000 6
(00.008214) page-pipe: 	buf 4 pages, 2 iovs, flags: 1 pipe_off: 0 :
(00.008219) page-pipe: 		0xffff85dfe000 2
(00.008224) page-pipe: 		0xffff85e30000 2
(00.008232) page-pipe: 	buf 4 pages, 1 iovs, flags: 0 pipe_off: 0 :
(00.008236) page-pipe: 		0xffff85e3e000 4
(00.008241) page-pipe: 	buf 3 pages, 1 iovs, flags: 1 pipe_off: 0 :
(00.008246) page-pipe: 		0xffffc39c2000 3
(00.008251) page-pipe: * 0 holes:
(00.008258) PPB: 9 pages 3 segs 16 pipe 0 off
(00.008271) Sent msg to daemon 66 0 0
pie: 323740: __fetched msg: 66 0 0
(00.008281) Wait for ack 66 on daemon socket
pie: 323740: __sent ack msg: 66 66 0
pie: 323740: Daemon waits for command
(00.008310) Fetched ack: 66 66 0
(00.008312) PPB: 4 pages 2 segs 16 pipe 3 off
(00.008320) Sent msg to daemon 66 0 0
(00.008325) Wait for ack 66 on daemon socket
pie: 323740: __fetched msg: 66 0 0
pie: 323740: __sent ack msg: 66 66 0
(00.008350) Fetched ack: 66 66 0
pie: 323740: Daemon waits for command
(00.008353) PPB: 4 pages 1 segs 16 pipe 5 off
(00.008359) Sent msg to daemon 66 0 0
pie: 323740: __fetched msg: 66 0 0
(00.008363) Wait for ack 66 on daemon socket
pie: 323740: __sent ack msg: 66 66 0
(00.008391) Fetched ack: 66 66 0
pie: 323740: Daemon waits for command
(00.008393) PPB: 3 pages 1 segs 16 pipe 6 off
(00.008399) Sent msg to daemon 66 0 0
pie: 323740: __fetched msg: 66 0 0
(00.008406) Wait for ack 66 on daemon socket
pie: 323740: __sent ack msg: 66 66 0
pie: 323740: Daemon waits for command
(00.008419) Fetched ack: 66 66 0
(00.008422) page-xfer: Transferring pages:
(00.008428) page-xfer: 	buf 9/3
(00.008434) page-xfer: 	p 0x400000 [1]
(00.008460) page-xfer: 	p 0x41f000 [2]
(00.008478) page-xfer: 	p 0xffff85df7000 [6]
(00.008515) page-xfer: 	buf 4/2
(00.008521) page-xfer: 	p 0xffff85dfe000 [2]
(00.008533) page-xfer: 	p 0xffff85e30000 [2]
(00.008552) page-xfer: 	buf 4/1
(00.008557) page-xfer: 	p 0xffff85e3e000 [4]
(00.008577) page-xfer: 	buf 3/1
(00.008583) page-xfer: 	p 0xffffc39c2000 [3]
(00.008708) page-pipe: Killing page pipe
(00.008733) ----------------------------------------
(00.008747) Sent msg to daemon 65 0 0
(00.008749) Wait for ack 65 on daemon socket
pie: 323740: __fetched msg: 65 0 0
pie: 323740: __sent ack msg: 65 65 0
pie: 323740: Daemon waits for command
(00.008771) Fetched ack: 65 65 0
(00.008781) Sent msg to daemon 67 0 0
pie: 323740: __fetched msg: 67 0 0
(00.008786) Wait for ack 67 on daemon socket
pie: 323740: __sent ack msg: 67 67 0
(00.008809) Fetched ack: 67 67 0
pie: 323740: Daemon waits for command
(00.008822) Sent msg to daemon 68 0 0
pie: 323740: __fetched msg: 68 0 0
(00.008827) Wait for ack 68 on daemon socket
pie: 323740: __sent ack msg: 68 68 0
pie: 323740: Daemon waits for command
(00.008837) Fetched ack: 68 68 0
(00.008843) Sent msg to daemon 69 0 0
pie: 323740: __fetched msg: 69 0 0
(00.008848) Wait for ack 69 on daemon socket
pie: 323740: __sent ack msg: 69 69 0
(00.008851) Fetched ack: 69 69 0
pie: 323740: Daemon waits for command
(00.008856) 
(00.008861) Dumping core (pid: 323740)
(00.008863) ----------------------------------------
(00.008867) Obtaining personality ... 
(00.008896) Sent msg to daemon 64 0 0
(00.008902) Wait for ack 64 on daemon socket
pie: 323740: __fetched msg: 64 0 0
pie: 323740: __sent ack msg: 64 64 0
(00.008929) Fetched ack: 64 64 0
pie: 323740: Daemon waits for command
(00.008936) 323740 has 0 sched policy
(00.008943) 	dumping 0 nice for 323740
(00.008947) dumping /proc/323740/loginuid
(00.008998) dumping /proc/323740/oom_score_adj
(00.009025) Sent msg to daemon 76 0 0
(00.009031) Wait for ack 76 on daemon socket
pie: 323740: __fetched msg: 76 0 0
pie: 323740: __sent ack msg: 76 76 0
(00.009074) Fetched ack: 76 76 0
pie: 323740: Daemon waits for command
(00.009077) cg: Dumping cgroups for 323740
(00.009106) cg:  `- New css ID 2
(00.009113) cg:     `- [] -> [/user.slice/user-1000.slice/session-3.scope] [0]
(00.009246) cg: adding cgroup /proc/self/fd/15/user.slice/user-1000.slice/session-3.scope
(00.009268) cg: Couldn't open /proc/self/fd/15/user.slice/user-1000.slice/session-3.scope/cgroup.clone_children. This cgroup property may not exist on this kernel
(00.009282) cg: Couldn't open /proc/self/fd/15/user.slice/user-1000.slice/session-3.scope/notify_on_release. This cgroup property may not exist on this kernel
(00.009362) cg: Dumping value  from /proc/self/fd/15/user.slice/user-1000.slice/session-3.scope/cgroup.procs
(00.009379) cg: Couldn't open /proc/self/fd/15/user.slice/user-1000.slice/session-3.scope/tasks. This cgroup property may not exist on this kernel
(00.009606) cg: Set 2 is root one
(00.009687) ----------------------------------------
(00.009703) Waiting for 323740 to trap
(00.009719) Daemon 323740 exited trapping
(00.009730) Sent msg to daemon 3 0 0
(00.009740) Force no-breakpoints restore
(00.009760) 323740 was trapped
(00.009767) 323740 (native) is going to execute the syscall 207, required is 139
(00.009787) 323740 was trapped
(00.009793) `- Expecting exit
(00.009806) 323740 was trapped
(00.009813) 323740 (native) is going to execute the syscall 178, required is 139
(00.009828) 323740 was trapped
(00.009833) `- Expecting exit
(00.009846) 323740 was trapped
(00.009852) 323740 (native) is going to execute the syscall 64, required is 139
pie: 323740: __fetched msg: 3 0 0
(00.009869) 323740 was trapped
(00.009871) `- Expecting exit
(00.009884) 323740 was trapped
(00.009890) 323740 (native) is going to execute the syscall 178, required is 139
(00.009902) 323740 was trapped
(00.009905) `- Expecting exit
(00.009918) 323740 was trapped
(00.009924) 323740 (native) is going to execute the syscall 178, required is 139
(00.009939) 323740 was trapped
(00.009944) `- Expecting exit
(00.009958) 323740 was trapped
(00.009964) 323740 (native) is going to execute the syscall 64, required is 139
pie: 323740: 323740: new_sp=0xffff85c73f40 ip 0xffff85d1ffe8
(00.009981) 323740 was trapped
(00.009986) `- Expecting exit
(00.009998) 323740 was trapped
(00.010018) 323740 (native) is going to execute the syscall 57, required is 139
(00.010046) 323740 was trapped
(00.010051) `- Expecting exit
(00.010064) 323740 was trapped
(00.010071) 323740 (native) is going to execute the syscall 57, required is 139
(00.010083) 323740 was trapped
(00.010088) `- Expecting exit
(00.010101) 323740 was trapped
(00.010107) 323740 (native) is going to execute the syscall 139, required is 139
(00.010122) 323740 was stopped
(00.010202) 
(00.010208) Dumping mm (pid: 323740)
(00.010209) ----------------------------------------
(00.010214) 0x400000-0x401000 (4K) prot 0x5 flags 0x2 fdflags 0 st 0x41 off 0 reg fp  shmid: 0x1
(00.010220) 0x41f000-0x420000 (4K) prot 0x1 flags 0x2 fdflags 0 st 0x41 off 0xf000 reg fp  shmid: 0x1
(00.010226) 0x420000-0x421000 (4K) prot 0x3 flags 0x2 fdflags 0 st 0x41 off 0x10000 reg fp  shmid: 0x1
(00.010232) 0xffff85c7a000-0xffff85de1000 (1436K) prot 0x5 flags 0x2 fdflags 0 st 0x41 off 0 reg fp  shmid: 0x2
(00.010238) 0xffff85de1000-0xffff85df7000 (88K) prot 0 flags 0x2 fdflags 0 st 0x41 off 0x167000 reg fp  shmid: 0x2
(00.010245) 0xffff85df7000-0xffff85dfa000 (12K) prot 0x1 flags 0x2 fdflags 0 st 0x41 off 0x16d000 reg fp  shmid: 0x2
(00.010248) 0xffff85dfa000-0xffff85dfd000 (12K) prot 0x3 flags 0x2 fdflags 0 st 0x41 off 0x170000 reg fp  shmid: 0x2
(00.010250) 0xffff85dfd000-0xffff85e00000 (12K) prot 0x3 flags 0x22 fdflags 0 st 0x201 off 0 reg ap  shmid: 0
(00.010256) 0xffff85e00000-0xffff85e23000 (140K) prot 0x5 flags 0x2 fdflags 0 st 0x41 off 0 reg fp  shmid: 0x3
(00.010262) 0xffff85e30000-0xffff85e32000 (8K) prot 0x3 flags 0x22 fdflags 0 st 0x201 off 0 reg ap  shmid: 0
(00.010267) 0xffff85e3d000-0xffff85e3e000 (4K) prot 0x1 flags 0x22 fdflags 0 st 0x1201 off 0 reg vvar ap  shmid: 0
(00.010273) 0xffff85e3e000-0xffff85e3f000 (4K) prot 0x5 flags 0x22 fdflags 0 st 0x209 off 0 reg vdso ap  shmid: 0
(00.010279) 0xffff85e3f000-0xffff85e40000 (4K) prot 0x1 flags 0x2 fdflags 0 st 0x41 off 0x2f000 reg fp  shmid: 0x3
(00.010285) 0xffff85e40000-0xffff85e42000 (8K) prot 0x3 flags 0x2 fdflags 0 st 0x41 off 0x30000 reg fp  shmid: 0x3
(00.010291) 0xffffc39a4000-0xffffc39c5000 (132K) prot 0x3 flags 0x122 fdflags 0 st 0x201 off 0 reg ap  shmid: 0
(00.010296) Obtaining task auvx ...
(00.010441) Dumping path for -3 fd via self 15 [/home/anatasluo/Git/code]
(00.010484) Dumping path for -3 fd via self 15 [/]
(00.010495) Dumping task cwd id 0x6 root id 0x7
(00.010609) Dumping file-locks
(00.010619) 
(00.010625) Dumping pstree (pid: 323740)
(00.010630) ----------------------------------------
(00.010636) Process: 323740(323740)
(00.010673) ----------------------------------------
(00.010827) cg: Dumping 1 sets
(00.010839) cg:    `- Dumping  of /user.slice/user-1000.slice/session-3.scope
(00.010861) cg: Writing CG image
(00.010899) unix: Dumping external sockets
(00.010919) tty: Unpaired slave 0
(00.010926) Writing image inventory (version 1)
(00.011277) Running post-dump scripts
(00.011292) Unfreezing tasks into 2
(00.011295) 	Unseizing 323740 into 2
(00.011850) Writing stats
(00.011976) Dumping finished successfully
**

**
[anatasluo@localhost criu]$ sudo /home/anatasluo/Git/criu/criu/criu restore -D /home/anatasluo/Tmp --file-locks --tcp-established --ext-unix-sk --shell-job --daemon -vv
(00.000000) Will dump/restore TCP connections
(00.000019) Version: 3.15 (gitid v3.14-259-g11b3a1a75)
(00.000044) Running on localhost.localdomain Linux 5.8.15-301.fc33.aarch64 #1 SMP Thu Oct 15 15:56:58 UTC 2020 aarch64
(00.000171) Loaded kdat cache from /run/criu.kdat
(00.000188) rlimit: RLIMIT_NOFILE unlimited for self
(00.000379) kernel pid_max=4194304
(00.000391) Reading image tree
(00.000431) Add mnt ns 6 pid 323740
(00.000439) Add net ns 2 pid 323740
(00.000442) Add pid ns 1 pid 323740
(00.000450) pstree pid_max=-3
(00.000461) Migrating process tree (SID -3->85410)
(00.000464) Will restore in 0 namespaces
(00.000466) NS mask to use 0
(00.000504) Collecting 50/56 (flags 3)
(00.000514) No memfd.img image
(00.000517)  `- ... done
(00.000523) Collecting 40/54 (flags 2)
(00.000547) Collected [home/anatasluo/Git/code/main] ID 0x1
(00.000555) Collected [usr/lib64/libc-2.32.so] ID 0x2
(00.000558) Collected [usr/lib64/ld-2.32.so] ID 0x3
(00.000562) Collected [dev/pts/0] ID 0x5
(00.000569) Collected [home/anatasluo/Git/code] ID 0x6
(00.000577) Collected [.] ID 0x7
(00.000583)  `- ... done
(00.000588) Collecting 46/67 (flags 0)
(00.000594) No remap-fpath.img image
(00.000600)  `- ... done
(00.000644) cg: Preparing cgroups yard (cgroups restore mode 0x4)
(00.001190) cg: Opening .criu.cgyard.9YPqKX as cg yard
(00.001221) cg: 	Making controller dir .criu.cgyard.9YPqKX/unifie ()
(00.001276) cg: Determined cgroup dir unifie/user.slice/user-1000.slice/session-3.scope already exist
(00.001284) cg: Skip restoring properties on cgroup dir unifie/user.slice/user-1000.slice/session-3.scope
(00.001305) Running pre-restore scripts
(00.001355) No pidns-1.img image
(00.001429) Forking task with 323740 pid (flags 0x0)
(00.001439) Creating process using clone3()
(00.001552) PID: real 323740 virt 323740
(00.001863) 323740: cg: Move into 2
(00.002401) 323740: cg:   `-> unifie//user.slice/user-1000.slice/session-3.scope/cgroup.procs
(00.002513) 323740: Calling restore_sid() for init
(00.002566) 323740: Collecting 44/37 (flags 2)
(00.002718) 323740: tty: Collected tty ID 0x4 (pts)
(00.002753) 323740:  `- ... done
(00.002762) 323740: Collecting 45/51 (flags 0)
(00.002768) 323740: No tty-data.img image
(00.002772) 323740:  `- ... done
(00.002801) 323740: Restoring namespaces 323740 flags 0x0
(00.002823) 323740: Preparing info about shared resources
(00.002866) 323740: Collecting 48/38 (flags 0)
(00.002884) 323740: No filelocks.img image
(00.002886) 323740:  `- ... done
(00.002888) 323740: Collecting 42/27 (flags 0)
(00.002896) 323740: No pipes-data.img image
(00.002904) 323740:  `- ... done
(00.002906) 323740: Collecting 43/27 (flags 0)
(00.002911) 323740: No fifo-data.img image
(00.002919) 323740:  `- ... done
(00.002921) 323740: Collecting 41/68 (flags 0)
(00.002937) 323740: No sk-queues.img image
(00.002949) 323740:  `- ... done
(00.002996) 323740: Found 15 VMAs in image
(00.003012) 323740: vma 0x400000 0x401000
(00.003016) 323740: vma 0x41f000 0x420000
(00.003020) 323740: vma 0x420000 0x421000
(00.003031) 323740: vma 0xffff85c7a000 0xffff85de1000
(00.003042) 323740: vma 0xffff85de1000 0xffff85df7000
(00.003051) 323740: vma 0xffff85df7000 0xffff85dfa000
(00.003061) 323740: vma 0xffff85dfa000 0xffff85dfd000
(00.003063) 323740: vma 0xffff85dfd000 0xffff85e00000
(00.003073) 323740: vma 0xffff85e00000 0xffff85e23000
(00.003076) 323740: vma 0xffff85e30000 0xffff85e32000
(00.003085) 323740: vma 0xffff85e3d000 0xffff85e3e000
(00.003087) 323740: vma 0xffff85e3e000 0xffff85e3f000
(00.003096) 323740: vma 0xffff85e3f000 0xffff85e40000
(00.003099) 323740: vma 0xffff85e40000 0xffff85e42000
(00.003102) 323740: vma 0xffffc39a4000 0xffffc39c5000
(00.003127) 323740: Collect fdinfo pid=323740 fd=0 id=0x4
(00.003139) 323740: Collect fdinfo pid=323740 fd=1 id=0x4
(00.003142) 323740: Collect fdinfo pid=323740 fd=2 id=0x4
(00.003291) 323740: skqueue: Preparing SCMs
(00.003305) 323740: tty: Unpaired slave 0
(00.003308) 323740: tty: ctl tty leader 0x4
(00.003320) 323740: tty: Inherit terminal for id 0x4
(00.003331) 323740: tty: head driver pts id 0x4 index 0 (master 0 sid 1347 pgrp 323740 inherit 1)
(00.003342) 323740: tty: Found orphan slave fake leader (0x4)
(00.003346) 323740: unix: ghost: Resolving addresses
(00.003355) 323740: File descs:
(00.003358) 323740:  `- type 1 ID 0x1
(00.003367) 323740:  `- type 1 ID 0x2
(00.003369) 323740:  `- type 1 ID 0x3
(00.003377) 323740:  `- type 11 ID 0x4
(00.003387) 323740:    `- FD 0 pid 323740
(00.003397) 323740:    `- FD 1 pid 323740
(00.003404) 323740:    `- FD 2 pid 323740
(00.003414) 323740:  `- type 1 ID 0x5
(00.003423) 323740:  `- type 1 ID 0x6
(00.003425) 323740:  `- type 1 ID 0x7
(00.003663) 323740: Opened local page read 1 (parent 0)
(00.003686) 323740: Enqueue page-read
(00.003692) 323740: Enqueue page-read
(00.003704) 323740: Enqueue page-read
(00.003713) 323740: Enqueue page-read
(00.003722) 323740: Enqueue page-read
(00.003725) 323740: Enqueue page-read
(00.003731) 323740: Enqueue page-read
(00.003733) 323740: Enqueue page-read
(00.003735) 323740: Enqueue page-read
(00.003745) 323740: Enqueue page-read
(00.003754) 323740: Enqueue page-read
(00.003762) 323740: nr_restored_pages: 20
(00.003772) 323740: nr_shared_pages:   0
(00.003774) 323740: nr_dropped_pages:   0
(00.003780) 323740: nr_lazy:           0
(00.003800) 323740: Shrunk premap area to 0xffff898eb000(0)
(00.003810) 323740: Restore on-core sigactions for 323740
(00.003891) 323740: Restoring children in alien sessions:
(00.003902) 323740: Restoring children in our session:
(00.003915) 323740: Restoring 323740 to 323740 pgid
(00.003927) 323740: 	will call setpgid, mine pgid is 323752
(00.003945) 323740: Restoring resources
(00.003964) 323740: Opening fdinfo-s
(00.003977) 323740: tty: open driver pts id 0x4 index 0 (master 0 sid 1347 pgrp 323740 inherit 1)
(00.004006) 323740: tty: Migrated slave peer 0x4 -> to fd 0
(00.004054) 323740: 		Create fd for 0
(00.004064) 323740: 			Going to dup 0 into 1
(00.004068) 323740: 			Going to dup 0 into 2
(00.004071) 323740: 	Receive fd for 1
(00.004078) 323740: 	Receive fd for 2
(00.004090) 323740: Opening 0x00000000400000-0x00000000401000 0000000000000000 (41) vma
(00.004144) 323740: Opening 0x0000000041f000-0x00000000420000 0x0000000000f000 (41) vma
(00.004154) 323740: Opening 0x00000000420000-0x00000000421000 0x00000000010000 (41) vma
(00.004157) 323740: Opening 0x00ffff85c7a000-0x00ffff85de1000 0000000000000000 (20000041) vma
(00.004204) 323740: Opening 0x00ffff85de1000-0x00ffff85df7000 0x00000000167000 (41) vma
(00.004213) 323740: Opening 0x00ffff85df7000-0x00ffff85dfa000 0x0000000016d000 (41) vma
(00.004215) 323740: Opening 0x00ffff85dfa000-0x00ffff85dfd000 0x00000000170000 (41) vma
(00.004217) 323740: Opening 0x00ffff85e00000-0x00ffff85e23000 0000000000000000 (20000041) vma
(00.004253) 323740: Opening 0x00ffff85e3f000-0x00ffff85e40000 0x0000000002f000 (41) vma
(00.004264) 323740: Opening 0x00ffff85e40000-0x00ffff85e42000 0x00000000030000 (41) vma
(00.004334) 323740: `- render 7 iovs (0x400000:4096...)
(00.004347) 323740: Restore via sigreturn
(00.004416) 323740: Parsed 400000-587000 vma
(00.004428) 323740: Parsed 59f000-5a0000 vma
(00.004431) 323740: Parsed 59f000-5a7000 vma
(00.004441) 323740: Parsed 59f000-5b6000 vma
(00.004451) 323740: Parsed 17799000-177ba000 vma
(00.004465) 323740: Parsed ffff89abf000-ffff89acc000 vma
(00.004474) 323740: Parsed ffff89abf000-ffff89adc000 vma
(00.004477) 323740: Parsed ffff89abf000-ffff89af7000 vma
(00.004479) 323740: Parsed ffff89abf000-ffff89b0b000 vma
(00.004481) 323740: Parsed ffff89abf000-ffff89b0c000 vma
(00.004484) 323740: Parsed ffff89abf000-ffff89b0d000 vma
(00.004486) 323740: Parsed ffff89abf000-ffff89b11000 vma
(00.004488) 323740: Parsed ffff89abf000-ffff89c78000 vma
(00.004497) 323740: Parsed ffff89abf000-ffff89c8e000 vma
(00.004500) 323740: Parsed ffff89abf000-ffff89c91000 vma
(00.004502) 323740: Parsed ffff89abf000-ffff89c94000 vma
(00.004510) 323740: Parsed ffff89abf000-ffff89c97000 vma
(00.004513) 323740: Parsed ffff89abf000-ffff89caf000 vma
(00.004515) 323740: Parsed ffff89abf000-ffff89cc6000 vma
(00.004523) 323740: Parsed ffff89abf000-ffff89cc7000 vma
(00.004525) 323740: Parsed ffff89abf000-ffff89cca000 vma
(00.004528) 323740: Parsed ffff89abf000-ffff89ceb000 vma
(00.004530) 323740: Parsed ffff89abf000-ffff89d08000 vma
(00.004533) 323740: Parsed ffff89abf000-ffff89d0a000 vma
(00.004535) 323740: Parsed ffff89abf000-ffff89d0b000 vma
(00.004541) 323740: Parsed ffff89abf000-ffff89d0e000 vma
(00.004547) 323740: Parsed ffff89abf000-ffff89d2a000 vma
(00.004556) 323740: Parsed ffff89abf000-ffff89d2b000 vma
(00.004566) 323740: Parsed ffff89abf000-ffff89d2c000 vma
(00.004569) 323740: Parsed ffff89abf000-ffff89d34000 vma
(00.004577) 323740: Parsed ffff89abf000-ffff89d4b000 vma
(00.004584) 323740: Parsed ffff89abf000-ffff89d4c000 vma
(00.004587) 323740: Parsed ffff89abf000-ffff89d4d000 vma
(00.004589) 323740: Parsed ffff89abf000-ffff89d70000 vma
(00.004591) 323740: Parsed ffff89d7b000-ffff89d7f000 vma
(00.004599) 323740: Parsed ffff89d83000-ffff89d86000 vma
(00.004608) 323740: Parsed ffff89d83000-ffff89d88000 vma
(00.004617) 323740: Parsed ffff89d83000-ffff89d8a000 vma
(00.004626) 323740: Parsed ffff89d83000-ffff89d8b000 vma
(00.004628) 323740: Parsed ffff89d83000-ffff89d8c000 vma
(00.004631) 323740: Parsed ffff89d83000-ffff89d8d000 vma
(00.004633) 323740: Parsed ffff89d83000-ffff89d8f000 vma
(00.004635) 323740: Parsed ffffc4da5000-ffffc4dc6000 vma
(00.004648) 323740: 1 threads require 112K of memory
(00.004656) 323740: Found bootstrap VMA hint at: 0x10000 (needs ~120K)
(00.004717) 323740: 	call mremap(0xffff89d83000, 8192, 8192, MAYMOVE | FIXED, 0x28000)
(00.004732) 323740: 	call mremap(0xffff89d86000, 8192, 8192, MAYMOVE | FIXED, 0x2a000)
(00.004750) 323740: Thread    0 stack  0x1d080 rt_sigframe  0x25080
(00.004798) 323740: Going to chroot into /proc/self/fd/9
(00.004813) 323740: Restoring umask to 22
(00.004836) 323740: task_args: 0x27000
task_args->pid: 323740
task_args->nr_threads: 1
task_args->clone_restore_fn: 0x12574
task_args->thread_args: 0x27500
(00.004882) pie: 323740: Switched to the restorer 323740
(00.004907) pie: 323740: vdso: Remap rt-vdso 0xffff89d8b000 -> 0x2d000
(00.004926) pie: 323740: vdso: Remap rt-vvar 0xffff89d8a000 -> 0x2c000
(00.004940) pie: 323740: vdso: Using gettimeofday() on vdso at 0x2d560
(00.005234) pie: 323740: vdso: Using gettimeofday() on vdso at 0x2d560
(00.005258) pie: 323740: 	mmap(0x400000 -> 0x401000, 0x7 0x12 3)
(00.005272) pie: 323740: 	mmap(0x41f000 -> 0x420000, 0x3 0x12 3)
(00.005285) pie: 323740: 	mmap(0x420000 -> 0x421000, 0x3 0x12 3)
(00.005296) pie: 323740: 	mmap(0xffff85c7a000 -> 0xffff85de1000, 0x5 0x12 4)
(00.005301) pie: 323740: 	mmap(0xffff85de1000 -> 0xffff85df7000, 0x2 0x12 4)
(00.005314) pie: 323740: 	mmap(0xffff85df7000 -> 0xffff85dfa000, 0x3 0x12 4)
(00.005330) pie: 323740: 	mmap(0xffff85dfa000 -> 0xffff85dfd000, 0x3 0x12 4)
(00.005340) pie: 323740: 	mmap(0xffff85dfd000 -> 0xffff85e00000, 0x3 0x32 -1)
(00.005344) pie: 323740: 	mmap(0xffff85e00000 -> 0xffff85e23000, 0x5 0x12 5)
(00.005350) pie: 323740: 	mmap(0xffff85e30000 -> 0xffff85e32000, 0x3 0x32 -1)
(00.005353) pie: 323740: 	mmap(0xffff85e3d000 -> 0xffff85e3e000, 0x3 0x32 -1)
(00.005369) pie: 323740: 	mmap(0xffff85e3e000 -> 0xffff85e3f000, 0x7 0x32 -1)
(00.005382) pie: 323740: 	mmap(0xffff85e3f000 -> 0xffff85e40000, 0x3 0x12 5)
(00.005393) pie: 323740: 	mmap(0xffff85e40000 -> 0xffff85e42000, 0x3 0x12 5)
(00.005397) pie: 323740: 	mmap(0xffffc39a4000 -> 0xffffc39c5000, 0x3 0x132 -1)
(00.005402) pie: 323740: Preadv 0x400000:4096... (7 iovs)
(00.005556) pie: 323740: `- returned 81920
(00.005567) pie: 323740:    `- skip pagemap
(00.005569) pie: 323740:    `- skip pagemap
(00.005571) pie: 323740:    `- skip pagemap
(00.005573) pie: 323740:    `- skip pagemap
(00.005582) pie: 323740:    `- skip pagemap
(00.005589) pie: 323740:    `- skip pagemap
(00.005596) pie: 323740:    `- skip pagemap
(00.005603) pie: 323740: vdso: Parsing at 0xffff85e3e000 0xffff85e3f000
(00.005614) pie: 323740: vdso: PT_LOAD p_vaddr: 0x0
(00.005616) pie: 323740: vdso: DT_HASH: 0x120
(00.005624) pie: 323740: vdso: DT_STRTAB: 0x1e0
(00.005631) pie: 323740: vdso: DT_SYMTAB: 0x150
(00.005640) pie: 323740: vdso: DT_STRSZ: 0x77
(00.005642) pie: 323740: vdso: DT_SYMENT: 0x18
(00.005646) pie: 323740: vdso: nbucket 0x3 nchain 0x6 bucket 0xffff85e3e128 chain 0xffff85e3e134
(00.093308) Error (criu/cr-restore.c:1537): 323740 killed by signal 11: Segmentation fault
(00.094009) Error (criu/cr-restore.c:2514): Restoring FAILED.
**





