### PR TITLE
Tell podman to use vfs as storage-driver

### DIFF
--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -35,6 +35,7 @@ make install
 
 # overlaysfs behaves differently on Ubuntu and breaks CRIU
 # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1857257
+export STORAGE_DRIVER=vfs
 podman --storage-driver vfs info
 
 criu --version


### PR DESCRIPTION
Just saw that the podman test is failing. This is still caused by the broken overlayfs in the Ubuntu kernel. Hopefully this will be fixed at some point in the future.

It seems each podman command now needs to be told to use the storage-driver vfs