### PR TITLE
ci: fix syntax error in stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,4 +24,4 @@ jobs:
         days-before-close: 365
         remove-stale-when-updated: true
         exempt-pr-labels: 'no-auto-close'
-        exempt-issue-labels: 'no-auto-close', 'new feature', 'enhancement'
+        exempt-issue-labels: 'no-auto-close, new feature, enhancement'


### PR DESCRIPTION
The commas need to be inside of the quotes. Not on the outside.