### PR TITLE
Move the Fedora Rawhide tests away from Travis

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -63,3 +63,20 @@ steps:
   commands:
   - scripts/ci/apt-install make
   - make -C scripts/ci local CLANG=1
+
+---
+kind: pipeline
+type: docker
+name: aarch64 Fedora Rawhide
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: registry.fedoraproject.org/fedora:rawhide
+  commands:
+  - scripts/ci/prepare-for-fedora-rawhide.sh
+  - make -C scripts/ci/ local CC=gcc SKIP_CI_PREP=1 SKIP_CI_TEST=1 CD_TO_TOP=1
+  - make -C test/zdtm -j 4

--- a/.github/workflows/fedora-rawhide-test.yml
+++ b/.github/workflows/fedora-rawhide-test.yml
@@ -1,0 +1,12 @@
+name: Fedora Rawhide Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Fedora Rawhide Test
+      run: sudo -E make -C scripts/ci fedora-rawhide

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,6 @@ jobs:
       virt: vm
       dist: bionic
     - os: linux
-      arch: arm64
-      env: TR_ARCH=fedora-rawhide
-      dist: bionic
-    - os: linux
-      arch: amd64
-      env: TR_ARCH=fedora-rawhide
-      dist: bionic
-    - os: linux
       arch: amd64
       env: TR_ARCH=docker-test
       dist: bionic

--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -1,42 +1,8 @@
 ARG CC=gcc
 ARG ENV1=FOOBAR
 
-RUN dnf install -y \
-	ccache \
-	diffutils \
-	findutils \
-	gcc \
-	git \
-	gnutls-devel \
-	gzip \
-	iproute \
-	iptables \
-	nftables \
-	nftables-devel \
-	libaio-devel \
-	libasan \
-	libcap-devel \
-	libnet-devel \
-	libnl3-devel \
-	make \
-	procps-ng \
-	protobuf-c-devel \
-	protobuf-devel \
-	python3-flake8 \
-	python3-PyYAML \
-	python3-future \
-	python3-protobuf \
-	python3-junit_xml \
-	redhat-rpm-config \
-	sudo \
-	tar \
-	which \
-	e2fsprogs \
-	rubygem-asciidoctor \
-	kmod
-
-RUN ln -sf python3 /usr/bin/python
-ENV PYTHON=python3
+COPY scripts/ci/prepare-for-fedora-rawhide.sh /bin/prepare-for-fedora-rawhide.sh
+RUN /bin/prepare-for-fedora-rawhide.sh
 
 COPY . /criu
 WORKDIR /criu
@@ -49,4 +15,3 @@ RUN mv .ccache /tmp && make mrproper && ccache -sz  && \
 RUN adduser -u 1000 test
 
 RUN make -C test/zdtm -j $(nproc)
-

--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e -x
+
+dnf install -y \
+	ccache \
+	diffutils \
+	findutils \
+	gcc \
+	git \
+	gnutls-devel \
+	gzip \
+	iproute \
+	iptables \
+	nftables \
+	nftables-devel \
+	libaio-devel \
+	libasan \
+	libcap-devel \
+	libnet-devel \
+	libnl3-devel \
+	make \
+	procps-ng \
+	protobuf-c-devel \
+	protobuf-devel \
+	python3-flake8 \
+	python3-PyYAML \
+	python3-future \
+	python3-protobuf \
+	python3-junit_xml \
+	python-unversioned-command \
+	redhat-rpm-config \
+	sudo \
+	tar \
+	which \
+	e2fsprogs \
+	rubygem-asciidoctor \
+	kmod

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -138,6 +138,10 @@ print_env
 
 ci_prep
 
+if [ "${CD_TO_TOP}" = "1" ]; then
+	cd ../../
+fi
+
 if [ "$CLANG" = "1" ]; then
 	# Needed for clang on Circle CI
 	LDFLAGS="$LDFLAGS -Wl,-z,now"


### PR DESCRIPTION
This moves Fedora Rawhide aarch64 to Drone and Fedora Rawhide x86_64 to github actions.