### PR TITLE
dump: dump has to fail if there is locks and --file-locks isn't set

### DIFF
--- a/criu/file-lock.c
+++ b/criu/file-lock.c
@@ -108,6 +108,12 @@ int dump_file_locks(void)
 			continue;
 		}
 
+		if (!opts.handle_file_locks) {
+			pr_err("Some file locks are hold by dumping tasks!"
+					"You can try --" OPT_FILE_LOCKS " to dump them.\n");
+			return -1;
+		}
+
 		file_lock_entry__init(&fle);
 		fle.pid = fl->real_owner;
 		fle.fd = fl->owners_fd;

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -302,6 +302,7 @@ TST_FILE	=				\
 		file_lease03			\
 		file_lease04			\
 		file_locks00			\
+		file_locks00_fail		\
 		file_locks01			\
 		file_locks02			\
 		file_locks03			\

--- a/test/zdtm/static/file_locks00_fail.c
+++ b/test/zdtm/static/file_locks00_fail.c
@@ -1,0 +1,1 @@
+file_locks00.c

--- a/test/zdtm/static/file_locks00_fail.desc
+++ b/test/zdtm/static/file_locks00_fail.desc
@@ -1,0 +1,1 @@
+{'flags': 'excl crfail'}


### PR DESCRIPTION
If criu finds a file lock and the --file-locks option isn't set, it
stops dumping processes, resumes them and exits with an error.

Cc: @dracoding 