### PR TITLE
Use codecov.io

### DIFF
--- a/.github/workflows/gcov-test.yml
+++ b/.github/workflows/gcov-test.yml
@@ -1,0 +1,14 @@
+name: Coverage Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Coverage Tests
+      run: sudo -E make -C scripts/ci local GCOV=1
+    - name: Run Coverage Analysis
+      run: sudo -E make codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ jobs:
   allow_failures:
     - env: TR_ARCH=docker-test
     - env: TR_ARCH=docker-test DIST=xenial
-    - env: TR_ARCH=local       GCOV=1
 script:
   - sudo make CCACHE=1 -C scripts/ci $TR_ARCH
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,11 @@ lint:
 	shellcheck scripts/*.sh
 	shellcheck scripts/ci/*.sh scripts/ci/apt-install
 
+codecov: SHELL := $(shell which bash)
+codecov:
+	bash <(curl -s https://codecov.io/bash)
+.PHONY: codecov
+
 include Makefile.install
 
 .DEFAULT_GOAL := all

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -64,12 +64,6 @@ ci_prep () {
 	fi
 	CI_PKGS="$CI_PKGS $CC"
 
-	[ -n "$GCOV" ] && {
-		apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-		scripts/ci/apt-install --no-install-suggests g++-7
-		CC=gcc-7
-	}
-
 	# ccache support, only enable for non-GCOV case
 	if [ "$CCACHE" = "1" ] && [ -z "$GCOV" ]; then
 		# ccache is installed by default, need to set it up
@@ -290,6 +284,11 @@ make -C test/others/libcriu run
 
 # external namespace testing
 make -C test/others/ns_ext run
+
+# Skip all further tests when running with GCOV=1
+# The one test which currently cannot handle GCOV testing is compel/test
+# Probably because the GCOV Makefile infrastructure does not exist in compel
+[ -n "$GCOV" ] && exit 0
 
 # compel testing
 make -C compel/test


### PR DESCRIPTION
While moving CI jobs away from Travis I saw that we still have some GCOV based builds mentioned in the Travis configuration file.

This re-enables it (it was not running in Travis) and pushes the results to codecov.io.

See for results against my branch: https://codecov.io/gh/adrianreber/criu/tree/438efd3aedef9b38c545aca3be6117d7efb6c9ab

This would require integration of codecov.io into checkpoint-restore/criu.

This includes the changes from #1358 