### PR TITLE
ci: move asan and image streamer test to github

### DIFF
--- a/.github/workflows/fedora-asan-test.yml
+++ b/.github/workflows/fedora-asan-test.yml
@@ -1,0 +1,12 @@
+name: Fedora ASAN Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Fedora ASAN Test
+      run: sudo -E make -C scripts/ci fedora-asan

--- a/.github/workflows/stream-test.yml
+++ b/.github/workflows/stream-test.yml
@@ -1,0 +1,12 @@
+name: CRIU Image Streamer Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run CRIU Image Streamer Test
+      run: sudo -E make -C scripts/ci local STREAM_TEST=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,6 @@ jobs:
       # On xenial it should be possible to test overlayfs;
       # broken on the latest bionic kernel
       dist: xenial
-    - os: linux
-      arch: amd64
-      env: TR_ARCH=fedora-asan
-      dist: bionic
-    - env: TR_ARCH=local STREAM_TEST=1
   allow_failures:
     - env: TR_ARCH=docker-test
     - env: TR_ARCH=docker-test DIST=xenial

--- a/scripts/build/Dockerfile.fedora-asan.hdr
+++ b/scripts/build/Dockerfile.fedora-asan.hdr
@@ -1,2 +1,2 @@
-FROM fedora:29
+FROM registry.fedoraproject.org/fedora:latest
 ENV ASAN=1

--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -60,7 +60,7 @@ $(TARGETS): restart-docker
 
 fedora-asan: restart-docker
 	$(MAKE) -C ../build $@$(target-suffix)
-	docker run -it $(CONTAINER_OPTS) criu-$@ ./scripts/ci/asan.sh $(ZDTM_OPTIONS)
+	docker run $(CONTAINER_OPTS) criu-$@ ./scripts/ci/asan.sh $(ZDTM_OPTIONS)
 
 docker-test:
 	./docker-test.sh


### PR DESCRIPTION
This moves two more tests from Travis to GitHub Actions.

At Travis we now only have the aarch64 Graviton2, ppc64le and s390x tests remaining. As far as I know there is no CI system supporting those. We could, if we have access to any of those architectures, try to work with self-hosted GitHub Actions runners.

There are also still the Docker based tests. My last information was that Docker was broken. Not sure. @rst0git do you know if Docker works again with checkpoint/restore? Can you look into moving those tests to GitHub Actions?