### PR TITLE
seccomp: initialize seccomp_mode in all cases

### DIFF
--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -1056,6 +1056,7 @@ int parse_pid_status(pid_t pid, struct seize_task_status *ss, void *data)
 
 	cr->s.sigpnd = 0;
 	cr->s.shdpnd = 0;
+	cr->s.seccomp_mode = SECCOMP_MODE_DISABLED;
 
 	if (bfdopenr(&f))
 		return -1;


### PR DESCRIPTION
In parse_pid_status(), it is assumed that the seccomp field can be
missing from /proc/pid/status. When the field is missing, it is not
properly initialized, leading to bad behavior.

We initialize seccomp_mode to SECCOMP_MODE_DISABLED by default,
similarly to what is done in compel/src/lib/infect.c:parse_pid_status.

Signed-off-by: Nicolas Viennot <Nicolas.Viennot@twosigma.com>