### PR TITLE
test: fix test compilation on rawhide

### DIFF
--- a/test/zdtm/static/sigaltstack.c
+++ b/test/zdtm/static/sigaltstack.c
@@ -14,8 +14,10 @@
 const char *test_doc	= "Check for alternate signal stack";
 const char *test_author	= "Cyrill Gorcunov <gorcunov@openvz.org>";
 
-static char stack_thread[SIGSTKSZ + TEST_MSG_BUFFER_SIZE] __stack_aligned__;
-static char stack_main[SIGSTKSZ + TEST_MSG_BUFFER_SIZE] __stack_aligned__;
+#define TESTSIGSTKSZ 16384
+
+static char stack_thread[TESTSIGSTKSZ + TEST_MSG_BUFFER_SIZE] __stack_aligned__;
+static char stack_main[TESTSIGSTKSZ + TEST_MSG_BUFFER_SIZE] __stack_aligned__;
 
 enum {
 	SAS_MAIN_OLD,


### PR DESCRIPTION
The latest glibc has redefined SIGSTKSZ as 'sysconf (_SC_SIGSTKSZ)' and
this breaks a static char[] definition. According to the kernel
sources all for CRIU relevant architectures use 8192 except AARCH64.

Hardcode SIGSTKSZ in the test. This fixes:
```
 sigaltstack.c:17:13: error: variably modified 'stack_thread' at file scope
   17 | static char stack_thread[SIGSTKSZ + TEST_MSG_BUFFER_SIZE] __stack_aligned__;
      |             ^~~~~~~~~~~~
sigaltstack.c:18:13: error: variably modified 'stack_main' at file scope
   18 | static char stack_main[SIGSTKSZ + TEST_MSG_BUFFER_SIZE] __stack_aligned__;
      |             ^~~~~~~~~~
```