### PR TITLE
ci: use runc instead of crun for podman tests

### DIFF
--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -23,7 +23,10 @@ apt-get -y purge docker-ce || :
     curl \
     software-properties-common
 
-./apt-install podman containernetworking-plugins
+# explicitly install runc. crun is not compiled with criu support
+./apt-install cri-o-runc podman containernetworking-plugins
+
+echo -e '[engine]\nruntime="runc"' > /etc/containers/containers.conf
 
 export SKIP_CI_TEST=1
 


### PR DESCRIPTION
The latest podman pulls in crun instead of runc. Unfortunately crun is not built against libcriu and does not support checkpoint/restore. This switches the podman test back to runc.
