### PR TITLE
Fix java tests

### DIFF
--- a/criu/file-lock.c
+++ b/criu/file-lock.c
@@ -109,7 +109,7 @@ int dump_file_locks(void)
 		}
 
 		if (!opts.handle_file_locks) {
-			pr_err("Some file locks are hold by dumping tasks!"
+			pr_err("Some file locks are hold by dumping tasks! "
 					"You can try --" OPT_FILE_LOCKS " to dump them.\n");
 			return -1;
 		}
@@ -201,7 +201,7 @@ static int lock_check_fd(int lfd, struct file_lock *fl)
 	} else {
 		/*
 		 * The ret == 0 means, that new lock doesn't conflict
-		 * with any others on the file. But since we do know, 
+		 * with any others on the file. But since we do know,
 		 * that there should be some other one (file is found
 		 * in /proc/locks), it means that the lock is already
 		 * on file pointed by fd.

--- a/scripts/build/Dockerfile.openj9-alpine
+++ b/scripts/build/Dockerfile.openj9-alpine
@@ -26,5 +26,5 @@ WORKDIR /criu
 
 RUN make
 
-ENTRYPOINT mvn -f test/javaTests/pom.xml test
+ENTRYPOINT mvn -q -f test/javaTests/pom.xml test
 

--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -29,5 +29,5 @@ WORKDIR /criu
 
 RUN make
 
-ENTRYPOINT mvn -f test/javaTests/pom.xml test
+ENTRYPOINT mvn -q -f test/javaTests/pom.xml test
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -14,3 +14,5 @@
 /zdtm_mount_cgroups.lock
 /compel/handle_binary
 /umount2
+/javaTests/output/
+/javaTests/target/

--- a/test/javaTests/src/org/criu/java/tests/CheckpointRestore.java
+++ b/test/javaTests/src/org/criu/java/tests/CheckpointRestore.java
@@ -361,7 +361,7 @@ public class CheckpointRestore {
 	private void checkpoint(String pid, String checkpointOpt) throws IOException, InterruptedException {
 		ProcessBuilder builder;
 		System.out.println("Checkpointing process " + pid);
-		String command = "../../criu/criu dump --shell-job -t " + pid + " -vvv -D " + logFolder + " -o dump.log";
+		String command = "../../criu/criu dump --shell-job -t " + pid + " --file-locks -v4 -D " + logFolder + " -o dump.log";
 		if (0 == checkpointOpt.length()) {
 			String[] cmd = command.split(" ");
 			builder = new ProcessBuilder(cmd);
@@ -411,7 +411,7 @@ public class CheckpointRestore {
 	private void restore(String restoreOpt) throws IOException, InterruptedException {
 		ProcessBuilder builder;
 		System.out.println("Restoring process");
-		String command = "../../criu/criu restore -d -vvv --shell-job -D " + logFolder + " -o restore.log";
+		String command = "../../criu/criu restore -d --file-locks -v4 --shell-job -D " + logFolder + " -o restore.log";
 		if (0 == restoreOpt.length()) {
 			String[] cmd = command.split(" ");
 			builder = new ProcessBuilder(cmd);


### PR DESCRIPTION
The java tests are using file locks which results in the following error after https://github.com/checkpoint-restore/criu/pull/1357

> Error (criu/file-lock.c:112): Some file locks are hold by dumping tasks!You can try --file-locks to dump them.

Resolves #1370