### PR TITLE
namespaces: properly handle errors of snprintf

### DIFF
--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -1173,6 +1173,9 @@ static int write_id_map(pid_t pid, UidGidExtent **extents, int n, char *id_map)
 		if (len < 0) {
 			pr_perror("Unable to form the user/group mappings buffer");
 			return -1;
+		} else if (len >= sizeof(buf) - off) {
+			pr_err("The user/group mappings buffer truncated\n");
+			return -1;
 		}
 		off += len;
 	}


### PR DESCRIPTION
If snprintf was truncated we should probably know about it instead of
continuing to increase off, as snprintf returns number of characters
which would have been written and not the number which was actually
written.

Normally we check snprintf only for overflow not for error, some modern
compilers print warnings if truncation was not checked.

Probably it was the case why we implemented [1], the truncation happened
and on the next iteration of for loop we've hit negative size for
snprintf and got -1.

Fixes: 90f043dea ("namespaces: handle errors of snprintf") [1]
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>