### PR TITLE
plugin: check for plugin path truncation

### DIFF
--- a/criu/plugin.c
+++ b/criu/plugin.c
@@ -243,7 +243,11 @@ int cr_plugin_init(int stage)
 		if (len < 3 || strncmp(de->d_name + len - 3, ".so", 3))
 			continue;
 
-		snprintf(path, sizeof(path), "%s/%s", opts.libdir, de->d_name);
+		if (snprintf(path, sizeof(path), "%s/%s", opts.libdir, de->d_name) >=
+		    sizeof(path)) {
+			pr_err("Unable to build plugin path\n");
+			goto err;
+		}
 
 		if (cr_lib_load(stage, path))
 			goto err;


### PR DESCRIPTION
New compilators print warnings if snprintf return value is not checked
for truncation. Let's make them happy.

Fixes: #1372
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>