### PR TITLE
Ci/compat: check that test are 32bit ELFs

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -190,6 +190,11 @@ fi
 
 time make CC="$CC" -j4 -C test/zdtm V=1
 
+if [ "${COMPAT_TEST}x" = "yx" ] ; then
+	# Cross-verify that zdtm tests are 32-bit
+	file test/zdtm/static/env00 | grep 'ELF 32-bit' -q
+fi
+
 [ -f "$CCACHE_LOGFILE" ] && cat "$CCACHE_LOGFILE"
 
 # umask has to be called before a first criu run, so that .gcda (coverage data)


### PR DESCRIPTION
Just an additional check. I see that they are currently, but to be double sure that it starts to fail if they are 64-bit ELFs.