### PR TITLE
ci: Skip lazy-thp for remote pages over tls

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -221,8 +221,10 @@ LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $ZDTM_OPTS"
 ./test/zdtm.py run $LAZY_OPTS --lazy-pages
 # shellcheck disable=SC2086
 ./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages
+# FIXME: post-copy migration of THP over TLS (sometimes) fails with:
+#     Error (criu/tls.c:321): tls: Pull callback recv failed: Connection reset by peer
 # shellcheck disable=SC2086
-./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls
+./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls -x lazy-thp
 
 bash -x ./test/jenkins/criu-fault.sh
 if [ "$UNAME_M" == "x86_64" ]; then


### PR DESCRIPTION
Temporarily disable the lazy-thp test for remote lazy pages with enabled tls until #1380 is resolved.