### PR TITLE
ci: fix Fedora rawhide CI failures

### DIFF
--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -35,3 +35,6 @@ dnf install -y \
 	e2fsprogs \
 	rubygem-asciidoctor \
 	kmod
+
+# /tmp is no longer 755 in the rawhide container image and breaks CI - fix it
+chmod 1777 /tmp


### PR DESCRIPTION
It seems the Fedora rawhide /tmp is no longer 1777 but 755.

Change it back to 1777 to make our CI runs successful again.