### PR TITLE
lib/cli.py: Open out file as a binary

### DIFF
--- a/lib/py/cli.py
+++ b/lib/py/cli.py
@@ -16,7 +16,7 @@ def inf(opts):
 
 def outf(opts):
     if opts['out']:
-        return open(opts['out'], 'w+')
+        return open(opts['out'], 'wb+')
     else:
         return sys.stdout
 


### PR DESCRIPTION
python3 fails to encode image with the following:

> [dima@Mindolluin criu]$ ./crit/crit encode -i tmp -o tmp.1
> Traceback (most recent call last):
>   File "/home/dima/src/criu/./crit/crit", line 6, in <module>
>     cli.main()
>   File "/home/dima/src/criu/crit/pycriu/cli.py", line 410, in main
>     opts["func"](opts)
>   File "/home/dima/src/criu/crit/pycriu/cli.py", line 50, in encode
>     pycriu.images.dump(img, outf(opts))
>   File "/home/dima/src/criu/crit/pycriu/images/images.py", line 617, in dump
>     f.write(struct.pack('i', magic.by_name['IMG_COMMON']))
> TypeError: write() argument must be str, not bytes

Opening the output file as binary seems to help.

Signed-off-by: Dmitry Safonov <dima@arista.com>