### PR TITLE
Fix s390x Jenkins vt test failure

### DIFF
--- a/test/zdtm/static/vt.c
+++ b/test/zdtm/static/vt.c
@@ -16,7 +16,7 @@ char *filename;
 TEST_OPTION(filename, string, "file name", 1);
 
 #ifdef __s390x__
-#define MINOR	64 /* ttyS0 */
+#define MINOR	65 /* ttysclp0 */
 #else
 #define MINOR	5
 #endif

--- a/test/zdtm/static/vt.checkskip
+++ b/test/zdtm/static/vt.checkskip
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# This script checks if the device used in the actual test exists on this host
+
+import os
+import stat
+import errno
+import platform
+
+filename = 'vt.checker'
+minor = -1
+exists = True
+
+if platform.machine() == 's390x':
+    minor = 65
+else:
+    minor = 5
+
+try:
+    os.unlink(filename)
+except FileNotFoundError:
+    pass
+
+print("Running on %s with minor %d" % (platform.machine(), minor))
+os.mknod(filename, mode=0o640 | stat.S_IFCHR, device=os.makedev(4, minor))
+try:
+    os.open(filename, os.O_RDONLY)
+except OSError as e:
+    if e.errno == errno.ENXIO:
+        print("OS error({0}): {1}".format(e.errno, e.strerror))
+        exists = False
+
+os.unlink(filename)
+
+if exists:
+    exit(0)
+exit(1)


### PR DESCRIPTION
The new Jenkins s390x test host does not have `/dev/ttyS0` try `/dev/ttysclp0` which seems to exist on multiple hosts we checked.

Also add a checkskip for the vt test to not run it if the device used in the test does not exist.

@avagin : as discussed