### PR TITLE
ptrace-compat: Fix build error with musl

### DIFF
--- a/criu/include/ptrace-compat.h
+++ b/criu/include/ptrace-compat.h
@@ -6,11 +6,13 @@
 #include "common/config.h"
 
 #ifndef CONFIG_HAS_PTRACE_PEEKSIGINFO
+#ifndef _SYS_PTRACE_H
 struct ptrace_peeksiginfo_args {
 	__u64 off;	/* from which siginfo to start */
 	__u32 flags;
 	__u32 nr;	/* how may siginfos to take */
 };
+#endif
 #endif
 
 #endif /* __CR_PTRACE_H__ */


### PR DESCRIPTION
On Alpine (musl-1.1.19) `<sys/ptrace.h>` declares the struct `ptrace_peeksiginfo_args`. This results in the following compile-time error:
```
In file included from criu/cr-check.c:41:0:
criu/include/ptrace-compat.h:9:8: error: redefinition of 'struct ptrace_peeksiginfo_args'
 struct ptrace_peeksiginfo_args {
        ^~~~~~~~~~~~~~~~~~~~~~~
In file included from criu/cr-check.c:10:0:
/usr/include/sys/ptrace.h:89:8: note: originally defined here
 struct ptrace_peeksiginfo_args {
        ^~~~~~~~~~~~~~~~~~~~~~~
```
This problem has been mentioned previously in commit adaa7979 (compel: split sanitize ptrace.h).