### PR TITLE
ci: remove ccache setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c
 os: linux
 dist: bionic
-cache: ccache
 services:
   - docker
 jobs:
@@ -31,7 +30,6 @@ jobs:
       virt: vm
       dist: bionic
 script:
-  - sudo make CCACHE=1 -C scripts/ci $TR_ARCH
+  - sudo make -C scripts/ci $TR_ARCH
 after_success:
-  - ccache -s
   - make -C scripts/ci after_success

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -6,7 +6,6 @@ RUN apk update && apk add \
 	$CC \
 	bash \
 	build-base \
-	ccache \
 	coreutils \
 	git \
 	gnutls-dev \
@@ -26,9 +25,8 @@ RUN apk update && apk add \
 
 COPY . /criu
 WORKDIR /criu
-ENV CC="ccache $CC" CCACHE_DIR=/tmp/.ccache CCACHE_NOCOMPRESS=1 $ENV1=yes
-RUN mv .ccache /tmp && make mrproper && ccache -sz && \
-	date && make -j $(nproc) CC="$CC" && date && ccache -s
+ENV $ENV1=yes
+RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 
 RUN apk add \
 	ip6tables \

--- a/scripts/build/Dockerfile.centos7
+++ b/scripts/build/Dockerfile.centos7
@@ -5,7 +5,6 @@ ARG ENV1=FOOBAR
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum install -y \
-	ccache \
 	findutils \
 	gcc \
 	git \
@@ -39,9 +38,8 @@ RUN yum install -y \
 COPY . /criu
 WORKDIR /criu
 
-ENV CCACHE_DIR=/tmp/.ccache CCACHE_NOCOMPRESS=1 $ENV1=yes
-RUN mv .ccache /tmp && make mrproper && ccache -sz  && \
-	date && make -j $(nproc) CC="$CC" && date && ccache -s
+ENV $ENV1=yes
+RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 test

--- a/scripts/build/Dockerfile.centos8
+++ b/scripts/build/Dockerfile.centos8
@@ -7,7 +7,6 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 RUN yum config-manager --set-enabled powertools
 RUN yum install -y --allowerasing \
 	asciidoc \
-	ccache \
 	coreutils \
 	chkconfig \
 	diffutils \
@@ -44,9 +43,8 @@ ENV PYTHON=python3
 COPY . /criu
 WORKDIR /criu
 
-ENV CCACHE_DIR=/tmp/.ccache CCACHE_NOCOMPRESS=1 $ENV1=yes
-RUN mv .ccache /tmp && make mrproper && ccache -sz  && \
-	date && make -j $(nproc) CC="$CC" && date && ccache -s
+ENV $ENV1=yes
+RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 test

--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -7,9 +7,8 @@ RUN /bin/prepare-for-fedora-rawhide.sh
 COPY . /criu
 WORKDIR /criu
 
-ENV CCACHE_DIR=/tmp/.ccache CCACHE_NOCOMPRESS=1 $ENV1=yes
-RUN mv .ccache /tmp && make mrproper && ccache -sz  && \
-	date && make -j $(nproc) CC="$CC" && date && ccache -s
+ENV $ENV1=yes
+RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 test

--- a/scripts/build/Dockerfile.linux32.tmpl
+++ b/scripts/build/Dockerfile.linux32.tmpl
@@ -4,7 +4,6 @@ ARG ENV1=FOOBAR
 COPY scripts/ci/apt-install /bin/apt-install
 
 RUN apt-install \
-	ccache \
 	libnet-dev \
 	libnl-route-3-dev \
 	$CC \
@@ -28,12 +27,11 @@ RUN apt-install \
 
 COPY . /criu
 WORKDIR /criu
-ENV CC="ccache $CC" CCACHE_DIR=/tmp/.ccache CCACHE_NOCOMPRESS=1 $ENV1=yes
+ENV $ENV1=yes
 
 RUN uname -m && setarch linux32 uname -m && setarch --list
 
-RUN mv .ccache /tmp && make mrproper && ccache -s && \
-	date && \
+RUN make mrproper && date && \
 # Check single object build
 	setarch linux32 make -j $(nproc) CC="$CC" criu/parasite-syscall.o && \
 # Compile criu

--- a/scripts/build/Dockerfile.openj9-alpine
+++ b/scripts/build/Dockerfile.openj9-alpine
@@ -3,7 +3,6 @@ FROM adoptopenjdk/openjdk8-openj9:alpine
 RUN apk update && apk add \
 	bash \
 	build-base \
-	ccache \
 	coreutils \
 	git \
 	gnutls-dev \

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -4,7 +4,6 @@ ARG ENV1=FOOBAR
 COPY scripts/ci/apt-install /bin/apt-install
 
 RUN apt-install \
-	ccache \
 	libnet-dev \
 	libnl-route-3-dev \
 	$CC \
@@ -30,10 +29,9 @@ RUN apt-install \
 
 COPY . /criu
 WORKDIR /criu
-ENV CC="ccache $CC" CCACHE_DIR=/tmp/.ccache CCACHE_NOCOMPRESS=1 $ENV1=yes
+ENV $ENV1=yes
 
-RUN mv .ccache /tmp && make mrproper && ccache -s && \
-	date && \
+RUN make mrproper && date && \
 # Check single object build
 	make -j $(nproc) CC="$CC" criu/parasite-syscall.o && \
 # Compile criu

--- a/scripts/build/Makefile
+++ b/scripts/build/Makefile
@@ -19,10 +19,7 @@ Dockerfile.%: Dockerfile.%.hdr Dockerfile.%.tmpl
 	cat $^ > $@
 
 $(TARGETS):
-	mkdir -p $(HOME)/.ccache
-	mv $(HOME)/.ccache ../../
-	$(CONTAINER_RUNTIME) build  -t criu-$@ -f Dockerfile.$@ $(DB_CC) $(DB_ENV) ../..
-	$(CONTAINER_RUNTIME) run criu-$@ tar c -C /tmp .ccache | tar x -C $(HOME)
+	$(CONTAINER_RUNTIME) build  -t criu-$@ -f Dockerfile.$@ $(DB_CC) ../..
 .PHONY: $(TARGETS)
 
 # Clang builds add some Docker build env
@@ -32,6 +29,5 @@ endef
 $(foreach t,$(TARGETS),$(eval $(call CLANG_DEP,$(t))))
 
 %-clang:	DB_CC=--build-arg CC=clang
-%-clang:	DB_ENV=--build-arg ENV1=CCACHE_CPP2
 s390x-clang:	DB_CC=--build-arg CC=clang-3.8
 .PHONY: $(TARGETS_CLANG)

--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -2,7 +2,6 @@
 set -e -x
 
 dnf install -y \
-	ccache \
 	diffutils \
 	findutils \
 	gcc \

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -4,7 +4,7 @@ set -x -e
 CI_PKGS="protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
 		libgnutls30 libprotobuf-dev protobuf-compiler libcap-dev
 		libnl-3-dev gdb bash libnet-dev util-linux asciidoctor
-		libnl-route-3-dev time ccache flake8 libbsd-dev
+		libnl-route-3-dev time flake8 libbsd-dev
 		libperl-dev pkg-config"
 
 
@@ -63,16 +63,6 @@ ci_prep () {
 		CC=gcc
 	fi
 	CI_PKGS="$CI_PKGS $CC"
-
-	# ccache support, only enable for non-GCOV case
-	if [ "$CCACHE" = "1" ] && [ -z "$GCOV" ]; then
-		# ccache is installed by default, need to set it up
-		export CCACHE_DIR=$HOME/.ccache
-		[ "$CC" = "clang" ] && export CCACHE_CPP2=yes
-		# uncomment the following to get detailed ccache logs
-		#export CCACHE_LOGFILE=$HOME/ccache.log
-		CC="ccache $CC"
-	fi
 
 	# Do not install x86_64 specific packages on other architectures
 	if [ "$UNAME_M" = "x86_64" ]; then
@@ -194,8 +184,6 @@ if [ "${COMPAT_TEST}x" = "yx" ] ; then
 	# Cross-verify that zdtm tests are 32-bit
 	file test/zdtm/static/env00 | grep 'ELF 32-bit' -q
 fi
-
-[ -f "$CCACHE_LOGFILE" ] && cat "$CCACHE_LOGFILE"
 
 # umask has to be called before a first criu run, so that .gcda (coverage data)
 # files are created with read-write permissions for all.


### PR DESCRIPTION
ccache was set up in Travis to speed up compilation by re-using the .ccache directory from previous CI runs. As we are no longer using Travis we can remove all CI related ccache setup.