### PR TITLE
ci: fix recode errors seen in Jenkins

### DIFF
--- a/lib/py/images/images.py
+++ b/lib/py/images/images.py
@@ -284,9 +284,9 @@ class ghost_file_handler:
                 size = len(pb_str)
                 f.write(struct.pack('i', size))
                 f.write(pb_str)
-                f.write(base64.decodebytes(item['extra']))
+                f.write(base64.decodebytes(str.encode(item['extra'])))
         else:
-            f.write(base64.decodebytes(item['extra']))
+            f.write(base64.decodebytes(str.encode(item['extra'])))
 
     def dumps(self, entries):
         f = io.BytesIO('')

--- a/lib/py/images/pb2dict.py
+++ b/lib/py/images/pb2dict.py
@@ -246,11 +246,11 @@ def encode_dev(field, value):
 
 
 def encode_base64(value):
-    return base64.encodebytes(value)
+    return base64.encodebytes(value).decode()
 
 
 def decode_base64(value):
-    return base64.decodebytes(value)
+    return base64.decodebytes(str.encode(value))
 
 
 def encode_unix(value):

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -281,7 +281,7 @@ ip net add test
 
 ./test/zdtm.py run --empty-ns -T zdtm/static/socket-tcp*-local --iter 2
 
-./test/zdtm.py run -t zdtm/static/env00 -k always
+./test/zdtm.py run -t zdtm/static/env00 -t zdtm/transition/fork -t zdtm/static/ghost_holes00 -k always
 ./test/crit-recode.py
 
 # libcriu testing


### PR DESCRIPTION
Although we are running crit-recode.py also in all CI runs we never seen
following error except in Jenkins:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/base64.py", line 510, in _input_type_check
    m = memoryview(s)
TypeError: memoryview: a bytes-like object is required, not 'str'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "./test/crit-recode.py", line 25, in recode_and_check
    r_img = pycriu.images.dumps(pb)
  File "/var/lib/jenkins/workspace/Q/test/pycriu/images/images.py", line 635, in dumps
    dump(img, f)
  File "/var/lib/jenkins/workspace/Q/test/pycriu/images/images.py", line 626, in dump
    handler.dump(img['entries'], f)
  File "/var/lib/jenkins/workspace/Q/test/pycriu/images/images.py", line 289, in dump
    f.write(base64.decodebytes(item['extra']))
  File "/usr/lib/python3.8/base64.py", line 545, in decodebytes
    _input_type_check(s)
  File "/usr/lib/python3.8/base64.py", line 513, in _input_type_check
    raise TypeError(msg) from err
TypeError: expected bytes-like object, not str
```
This commit fixes this by encoding the string to bytes.