### PR TITLE
ci: remove '-Wl,-z,now' workaround

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -136,12 +136,6 @@ if [ "${CD_TO_TOP}" = "1" ]; then
 	cd ../../
 fi
 
-if [ "$CLANG" = "1" ]; then
-	# Needed for clang on Circle CI
-	LDFLAGS="$LDFLAGS -Wl,-z,now"
-	export LDFLAGS
-fi
-
 export GCOV CC
 $CC --version
 time make CC="$CC" -j4 V=1


### PR DESCRIPTION
This removes extending LDFLAGS with '-Wl,-z,now'. This was added as workaround but never really worked. It is correctly fixed with pull request #1379