### PR TITLE
ci: ignore taint in container based tests

### DIFF
--- a/scripts/ci/docker.env
+++ b/scripts/ci/docker.env
@@ -2,3 +2,6 @@ SKIP_CI_PREP=1
 ZDTM_OPTS=-x zdtm/static/binfmt_misc -x zdtm/static/sched_policy00
 CC=gcc
 SKIP_EXT_DEV_TEST=1
+# The Ubuntu kernel 5.4.0-1040-azure has a bug with CentOS 8 userspace
+# Without this flag the test will fail early because of being tainted (512 - warning)
+ZDTM_IGNORE_TAINT=1

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1961,8 +1961,9 @@ class Launcher:
         with open("/proc/sys/kernel/tainted") as taintfd:
             taint = taintfd.read()
         if self.__taint != taint:
-            raise Exception("The kernel is tainted: %r (%r)" %
-                            (taint, self.__taint))
+            if not opts["ignore_taint"]:
+                raise Exception("The kernel is tainted: %r (%r)" %
+                                (taint, self.__taint))
 
         if test_flag(desc, 'excl'):
             self.wait_all()

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -2672,6 +2672,13 @@ cp.set_defaults(action=clean_stuff)
 cp.add_argument("what", choices=['nsroot'])
 
 opts = vars(p.parse_args())
+
+try:
+    if os.environ["ZDTM_IGNORE_TAINT"] == "1":
+        opts["ignore_taint"] = True
+except KeyError:
+    pass
+
 if opts.get('sat', False):
     opts['keep_img'] = 'always'
 


### PR DESCRIPTION
Unfortunately the kernel in GitHub Actions has a bug (#1390) which breaks our CentOS 8 test run.

To avoid broken CI results this PR introduces a `ZDTM_IGNORE_TAINT` variable which is set in all container based runs.