### PR TITLE
criu: Throw error when parent path is provided but invalid

### DIFF
--- a/criu/include/image.h
+++ b/criu/include/image.h
@@ -147,6 +147,12 @@ extern off_t img_raw_size(struct cr_img *img);
 
 extern int open_image_dir(char *dir, int mode);
 extern void close_image_dir(void);
+/*
+ * Return -1 -- parent symlink points to invalid target
+ * Return 0 && pfd < 0 -- parent symlink does not exist
+ * Return 0 && pfd >= 0 -- opened
+ */
+extern int open_parent(int dfd, int *pfd);
 
 extern struct cr_img *open_image_at(int dfd, int type, unsigned long flags, ...);
 #define open_image(typ, flags, ...) open_image_at(-1, typ, flags, ##__VA_ARGS__)

--- a/criu/irmap.c
+++ b/criu/irmap.c
@@ -425,12 +425,10 @@ in:
 		close_image(*img);
 		if (dir == AT_FDCWD) {
 			pr_info("Searching irmap cache in parent\n");
-			dir = openat(get_service_fd(IMG_FD_OFF),
-					CR_PARENT_LINK, O_RDONLY);
+			if (open_parent(get_service_fd(IMG_FD_OFF), &dir))
+				return -1;
 			if (dir >= 0)
 				goto in;
-			if (errno != ENOENT)
-				return -1;
 		}
 
 		pr_info("No irmap cache\n");

--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -661,8 +661,9 @@ static int try_open_parent(int dfd, unsigned long id, struct page_read *pr, int 
 	if (opts.stream)
 		goto out;
 
-	pfd = openat(dfd, CR_PARENT_LINK, O_RDONLY);
-	if (pfd < 0 && errno == ENOENT)
+	if (open_parent(dfd, &pfd))
+		goto err;
+	if (pfd < 0)
 		goto out;
 
 	parent = xmalloc(sizeof(*parent));
@@ -687,6 +688,7 @@ err_free:
 	xfree(parent);
 err_cl:
 	close(pfd);
+err:
 	return -1;
 }
 


### PR DESCRIPTION
In image dump directory, there are 2 parent symlink error cases:
- Parent symlink does not exist
- Parent symlink exists but points to invalid target

At the moment, 2 cases are handled exactly the same (do full dump). However, while
the first case happen when parent path is not provided, the second one is likely
user's mistake when provides invalid parent path.

So we throw an error in the latter case instead of performing the full dump.

Fixes: #1387.