### PR TITLE
fix CRIU_REQ_TYPE__FEATURE_CHECK RPC request

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -1069,8 +1069,7 @@ static int handle_feature_check(int sk, CriuReq * msg)
 	}
 
 	if (pid == 0) {
-		/* kerndat_init() is called from setup_opts_from_req() */
-		if (setup_opts_from_req(sk, msg->opts))
+		if (kerndat_init())
 			exit(1);
 
 		setproctitle("feature-check --rpc");
@@ -1103,6 +1102,8 @@ static int handle_feature_check(int sk, CriuReq * msg)
 	}
 	if (status != 0)
 		goto out;
+
+	return 0;
 
 	/*
 	 * The child process was not able to send an answer. Tell


### PR DESCRIPTION
Closes: #1408

CRIU_REQ_TYPE__FEATURE_CHECK was failing, this was caused by two things in ```handle_feature_check()```:
	1. ```setup_opts_from_req()``` was used and it could be NULL (```kerndat_init()``` is enough for feature checking)
	2. ```resp.success``` was always set to false
