### PR TITLE
Use a real VM instead of a privileged container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,16 +1,20 @@
 environment:
+  HOME: "/root"
   CIRRUS_WORKING_DIR: "/tmp/criu"
-container:
-  # This test case does not work on focal, because the newer version
-  # of libvirt fails during 'vagrant up' with ip6tables errors.
-  image: ubuntu:bionic
-  kvm: true
+
+compute_engine_instance:
+  image_project: cirrus-images
+  image: family/docker-kvm
+  platform: linux
   cpu: 4
-  memory: 8G
+  memory: 16G
+  nested_virtualization: true
+
 task:
   name: Vagrant Fedora based test (no VDSO)
   setup_script: |
-    scripts/ci/apt-install make gcc pkg-config git perl-modules iproute2 kmod wget
+    scripts/ci/apt-install make gcc pkg-config git perl-modules iproute2 kmod wget cpu-checker
+    sudo kvm-ok
     ln -sf /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto
   build_script: |
     make -C scripts/ci vagrant-fedora-no-vdso

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -15,13 +15,6 @@ setup() {
 		# Load the kvm modules for vagrant to use qemu
 		modprobe kvm kvm_intel
 	fi
-	if [ -n "$CIRRUS_CI" ]; then
-		# Running modprobe is not possible on Cirrus, because
-		# we are running in a container with potentially other
-		# modules than the host.
-		# Vagrant can still use /dev/kvm later if we do
-		chmod 666 /dev/kvm
-	fi
 
 	# Tar up the git checkout to have vagrant rsync it to the VM
 	tar cf criu.tar ../../../criu
@@ -32,28 +25,13 @@ setup() {
 	./apt-install libvirt-clients libvirt-daemon-system libvirt-dev qemu-utils qemu \
 		ruby build-essential libxml2-dev qemu-kvm rsync ebtables dnsmasq-base \
 		openssh-client
-	if [ -n "$CIRRUS_CI" ]; then
-		# On Cirrus systemctl does not work, because we are running in
-		# a container without access to systemd
-		/usr/sbin/virtlogd -d
-		/usr/sbin/libvirtd -d
-	else
-		systemctl restart libvirtd
-	fi
+	systemctl restart libvirtd
 	vagrant plugin install vagrant-libvirt
 	vagrant init fedora/${FEDORA_VERSION}-cloud-base --box-version ${FEDORA_BOX_VERSION}
 	# The default libvirt Vagrant VM uses 512MB.
 	# Travis VMs should have around 7.5GB.
 	# Increasing it to 4GB should work.
 	sed -i Vagrantfile -e 's,^end$,  config.vm.provider :libvirt do |libvirt|'"\n"'    libvirt.memory = 4096;end'"\n"'end,g'
-	if [ -n "$CIRRUS_CI" ]; then
-		# Work around for:
-		# Error while activating network: Call to virNetworkCreate failed: internal error:
-		# Failed to apply firewall rules /usr/sbin/ip6tables --table filter --list-rules: modprobe: FATAL: Module ip6_tables not found in directory /lib/modules/5.4.0-1025-gcp
-		# On cirrus-ci.com. Running in a container without access to the host's kernel modules
-		rm -f /sbin/ip6tables
-		cp /bin/true /sbin/ip6tables
-	fi
 	vagrant up --provider=libvirt --no-tty
 	mkdir -p /root/.ssh
 	vagrant ssh-config >> /root/.ssh/config


### PR DESCRIPTION
It allows to remove the workarounds and performance is much better (13 mins build vs 20 mins).