### PR TITLE
ci: move CentOS 8 based test to Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,20 +1,53 @@
-environment:
-  HOME: "/root"
-  CIRRUS_WORKING_DIR: "/tmp/criu"
-
-compute_engine_instance:
-  image_project: cirrus-images
-  image: family/docker-kvm
-  platform: linux
-  cpu: 4
-  memory: 16G
-  nested_virtualization: true
-
 task:
   name: Vagrant Fedora based test (no VDSO)
+  environment:
+    HOME: "/root"
+    CIRRUS_WORKING_DIR: "/tmp/criu"
+
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-kvm
+    platform: linux
+    cpu: 4
+    memory: 16G
+    nested_virtualization: true
+
   setup_script: |
     scripts/ci/apt-install make gcc pkg-config git perl-modules iproute2 kmod wget cpu-checker
     sudo kvm-ok
     ln -sf /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto
   build_script: |
     make -C scripts/ci vagrant-fedora-no-vdso
+
+task:
+  name: CentOS 8 based test
+  environment:
+    HOME: "/root"
+    CIRRUS_WORKING_DIR: "/tmp/criu"
+
+  compute_engine_instance:
+    image_project: centos-cloud
+    image: family/centos-8
+    platform: linux
+    cpu: 4
+    memory: 8G
+
+  setup_script: |
+    ln -sf /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm dnf-plugins-core
+    yum config-manager --set-enabled powertools
+    yum install -y --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libselinux-devel make protobuf-c-devel protobuf-devel python3-devel python3-flake8 python3-PyYAML python3-future python3-protobuf xmlto
+    alternatives --set python /usr/bin/python3
+    systemctl stop sssd
+    # Even with selinux in permissive mode the selinux tests will be executed
+    # The Cirrus CI user runs as a service from selinux point of view and is
+    # much more restricted than a normal shell (system_u:system_r:unconfined_service_t:s0)
+    # The test case above (vagrant-fedora-no-vdso) should run selinux tests in enforcing mode
+    setenforce 0
+    # netns-nft fails with
+    # 4: FAIL: netns-nft.c:51: Can't get nft table (errno = 11 (Resource temporarily unavailable))
+    mv /usr/sbin/nft /usr/sbin/nft.away
+    pip3 install junit_xml
+
+  build_script: |
+    make -C scripts/ci local SKIP_CI_PREP=1 CC=gcc CD_TO_TOP=1

--- a/.github/workflows/centos-test.yml
+++ b/.github/workflows/centos-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        target: [centos7, centos8]
+        target: [centos7]
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/py/images/images.py
+++ b/lib/py/images/images.py
@@ -42,6 +42,7 @@ import base64
 import struct
 import os
 import array
+import sys
 
 from . import magic
 from . import pb
@@ -284,9 +285,15 @@ class ghost_file_handler:
                 size = len(pb_str)
                 f.write(struct.pack('i', size))
                 f.write(pb_str)
-                f.write(base64.decodebytes(str.encode(item['extra'])))
+                if (sys.version_info > (3, 0)):
+                    f.write(base64.decodebytes(str.encode(item['extra'])))
+                else:
+                    f.write(base64.decodebytes(item['extra']))
         else:
-            f.write(base64.decodebytes(str.encode(item['extra'])))
+            if (sys.version_info > (3, 0)):
+                f.write(base64.decodebytes(str.encode(item['extra'])))
+            else:
+                f.write(base64.decodebytes(item['extra']))
 
     def dumps(self, entries):
         f = io.BytesIO('')

--- a/lib/py/images/pb2dict.py
+++ b/lib/py/images/pb2dict.py
@@ -3,6 +3,7 @@ import collections
 import os
 import quopri
 import socket
+import sys
 from ipaddress import IPv4Address, IPv6Address, ip_address
 
 from google.protobuf.descriptor import FieldDescriptor as FD
@@ -246,11 +247,17 @@ def encode_dev(field, value):
 
 
 def encode_base64(value):
-    return base64.encodebytes(value).decode()
+    if (sys.version_info > (3, 0)):
+        return base64.encodebytes(value).decode()
+    else:
+        return base64.encodebytes(value)
 
 
 def decode_base64(value):
-    return base64.decodebytes(str.encode(value))
+    if (sys.version_info > (3, 0)):
+        return base64.decodebytes(str.encode(value))
+    else:
+        return base64.decodebytes(value)
 
 
 def encode_unix(value):

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -238,7 +238,7 @@ fi
 #make -C test/others/exec/ run
 make -C test/others/make/ run CC="$CC"
 if [ -n "$TRAVIS" ] || [ -n "$CIRCLECI" ]; then
-       # GitHub Actions does not provide a real TTY and CRIU will fail with:
+       # GitHub Actions (and Cirrus CI) does not provide a real TTY and CRIU will fail with:
        # Error (criu/tty.c:1014): tty: Don't have tty to inherit session from, aborting
        make -C test/others/shell-job/ run
 fi


### PR DESCRIPTION
The kernel on GitHub Actions has a bug

https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1919472

which breaks our CI. It works on Cirrus. Let's move it there.

Maybe this is a better solution than #1401. Just run the CentOS 8 tests on a CentOS 8 kernel instead in a container on Ubuntu.