### PR TITLE
test: fix for cgroup00 failures on cgroup2 systems

### DIFF
--- a/test/zdtm_mount_cgroups
+++ b/test/zdtm_mount_cgroups
@@ -4,8 +4,6 @@
 # Error (cgroup.c:768): cg: Set 3 is not subset of 2
 # so lets create all test controllers before executing tests.
 
-cat /proc/self/cgroup | grep -q zdtmtst.defaultroot && exit
-
 tdir=`mktemp -d zdtm.XXXXXX`
 for i in "zdtmtst" "zdtmtst.defaultroot"; do
 	mount -t cgroup -o none,name=$i zdtm $tdir &&

--- a/test/zdtm_umount_cgroups
+++ b/test/zdtm_umount_cgroups
@@ -2,8 +2,6 @@
 
 # Lets delete all test controllers after executing tests.
 
-cat /proc/self/cgroup | grep -q zdtmtst.defaultroot || exit 0
-
 tdir=`mktemp -d zdtm.XXXXXX`
 for i in "zdtmtst" "zdtmtst.defaultroot"; do
 	mount -t cgroup -o none,name=$i zdtm $tdir || { rmdir $tdir; exit 1; }


### PR DESCRIPTION
Jenkins on Fedora 31 using cgroup2 on PPC64LE kept reporting 50% of the time that it failed with:
```
  Run criu dump
  =[log]=> dump/zdtm/static/cgroup00/57/1/dump.log
  ------------------------ grep Error ------------------------
  b'(00.021407) cg:     `- [name=zdtmtst] -> [/subcg00/subsubcg] [0]'
  b'(00.021411) cg:     `- [name=zdtmtst.defaultroot] -> [/] [0]'
  b'(00.021444) cg: adding cgroup /proc/self/fd/15/system.slice/sshd.service'
  b'(00.021566) cg: adding cgroup /proc/self/fd/15/subcg00/subsubcg'
  b'(00.048042) Error (criu/cgroup.c:585): cg: Unable to create the cgroup (name=zdtmtst.defaultroot) file system: Device or resource busy'
  b'(00.048083) Error (criu/cgroup.c:713): cg: failed walking /proc/self/fd/-1/ for empty cgroups: No such file or directory'
  b'(00.048089) ----------------------------------------'
  b'(00.048093) Error (criu/cr-dump.c:1402): Dump core (pid: 59) failed with -1'
  b'(00.048555) Unfreezing tasks into 1'
  b'(00.048559) \tUnseizing 57 into 1'
  b'(00.048573) \tUnseizing 58 into 1'
  b'(00.048584) \tUnseizing 59 into 1'
  b'(00.048598) Error (criu/cr-dump.c:1780): Dumping FAILED.'
  ------------------------ ERROR OVER ------------------------
```
With the changes in this commit this error is no longer reproducible.



@avagin I was watching the ppc64le cgroup00 error for some time now and was also able to reproduce it on ppc64le. This fixes it but I do not really understand what the problem was. If I did the steps which are in the cleanup script (`test/zdtm_umount_cgroups`) manually it always removed everything correctly. It never worked in the existing script.

Not sure why it did not work, but with the changes from the PR I was no longer able to reproduce above error.