### PR TITLE
net: allow restoring of precreated veth devices

### DIFF
--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -373,6 +373,7 @@ usage:
 "                            veth[IFNAME]:OUTNAME{@BRIDGE}\n"
 "                            macvlan[IFNAME]:OUTNAME\n"
 "                            mnt[COOKIE]:ROOT\n"
+"                            netdev[IFNAME]:ORIGNAME\n"
 "\n"
 "* Special resources support:\n"
 "     --" SK_EST_PARAM "  checkpoint/restore established TCP connections\n"


### PR DESCRIPTION
This introduces a new option

--external netdev[IFNAME]:ORIGNAME

which informs CRIU that this is pre-created network device that it is
supposed to move into a target network namespace. The "netdev" name was
chosen to make it flexible enough to e.g. also cover physical devices if
that is desirable at some point. For example:

--external netdev[eth0]:vethA23adf3

would instruct CRIU to move the network device with the name
"vethA23adf3" into a target network namespace renaming it to "eth0"
while doing so.

In order to restore ip addresses and additional data correctly CRIU
needs to move the network device into the target netns with the recorded
ifindex. This requires a kernel patch as discussed in [1]. The patch has
been merged into net-next and is expected to show up in the v5.13
release (cf. [2])

The motivating use-case can be found in [1]. But I'm repeating it mostly
verbatim here:

Assume a container with a standard veth tunnel for an unprivileged container:
```
<veth-host> <-> <bridge-host> <-> <veth-container>
```

When LXD starts a container it will create the veth pair in the host
namespaces with random names, let's assume:
```
<veth-host> := vethHOST
<veth-container> := vethCONT
```

The LXD generates a config for the container and tells the container to
use vethCONT as network device and usually also tells it to rename that
device to something more sensible like eth3. The container will then use
netlink to move and rename the vethCONT device into it's network
namespace as eth3 during startup.

Users may use lxc snapshot --stateful to create a CRIU dump.
And they can restore via
lxc restore --stateful <container-name> <stateful-snapshot-name>

And this is where things get hairy currently. LXD's network models
requires it to always be in control of all network devices and so
similar to regular startup it will precreate the two veth devices
vethHOST and vethCONT and tell LXC about it.

What we would like CRIU to be able to do is to add a commandline option
to tell CRIU to not bother creating the veth device but instead to
simply assume that someone else will create, move, and rename it and
instead  just restore routes, iptables, addresses and so on.

With this kernel patch applied I can successfully dump and restore a
LXD containers:

```
ubuntu@f2-vm:~/src/bin$ lxc launch images:alpine/edge alp1
Creating alp1
Starting alp1

ubuntu@f2-vm:~/src/bin$ lxc snapshot --stateful alp1

ubuntu@f2-vm:~/src/bin$ lxc list
+------+---------+----------------------+-----------------------------------------------+-----------+-----------+
| NAME |  STATE  |         IPV4         |                     IPV6                      |   TYPE    | SNAPSHOTS |
+------+---------+----------------------+-----------------------------------------------+-----------+-----------+
| alp1 | RUNNING | 10.47.211.144 (eth0) | fd42:8722:277d:69cf:216:3eff:fe69:9b8b (eth0) | CONTAINER | 1         |
+------+---------+----------------------+-----------------------------------------------+-----------+-----------+

ubuntu@f2-vm:~/src/bin$ lxc restore --stateful alp1 snap0

ubuntu@f2-vm:~/src/bin$ lxc list
+------+---------+----------------------+-----------------------------------------------+-----------+-----------+
| NAME |  STATE  |         IPV4         |                     IPV6                      |   TYPE    | SNAPSHOTS |
+------+---------+----------------------+-----------------------------------------------+-----------+-----------+
| alp1 | RUNNING | 10.47.211.144 (eth0) | fd42:8722:277d:69cf:216:3eff:fe69:9b8b (eth0) | CONTAINER | 1         |
+------+---------+----------------------+-----------------------------------------------+-----------+-----------+

ubuntu@f2-vm:~/src/bin$ lxc exec alp1 -- sh
~ # ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
15: eth0@if18: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP qlen 1000
    link/ether 00:16:3e:69:9b:8b brd ff:ff:ff:ff:ff:ff
    inet 10.47.211.144/24 brd 10.47.211.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fd42:8722:277d:69cf:216:3eff:fe69:9b8b/64 scope global dynamic flags 100
       valid_lft 86355sec preferred_lft 86355sec
    inet6 fe80::216:3eff:fe69:9b8b/64 scope link
       valid_lft forever preferred_lft forever
```
```
[1]: https://github.com/checkpoint-restore/criu/issues/1421
[2]: https://patchwork.kernel.org/project/netdevbpf/patch/20210406075448.203816-1-avagin@gmail.com/
```
Fixes: #1421
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>