### PR TITLE
Makefile: fix docker-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,7 @@ docker-build:
 .PHONY: docker-build
 
 docker-test:
-	docker run --rm -it --privileged -v /lib/modules:/lib/modules --network=host --cgroupns=host criu-x86_64 \
+	docker run --rm --privileged -v /lib/modules:/lib/modules --network=host --cgroupns=host criu-x86_64 \
 		./test/zdtm.py run -a --keep-going --ignore-taint
 .PHONY: docker-test
 

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ docker-build:
 
 docker-test:
 	docker run --rm -it --privileged -v /lib/modules:/lib/modules --network=host --cgroupns=host criu-x86_64 \
-		./test/zdtm.py run -a -x tcp6 -x tcpbuf6 -x static/rtc -x cgroup
+		./test/zdtm.py run -a --keep-going --ignore-taint
 .PHONY: docker-test
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ ifeq ($(ARCH),x86)
 endif
 
 ifeq ($(ARCH),mips)
-        DEFINES		:= -DCONFIG_MIPS 
+        DEFINES		:= -DCONFIG_MIPS
 endif
 
 #
@@ -379,11 +379,11 @@ gcov:
 .PHONY: gcov
 
 docker-build:
-	$(MAKE) -C scripts/build/ x86_64 
+	$(MAKE) -C scripts/build/ x86_64
 .PHONY: docker-build
 
 docker-test:
-	docker run --rm -it --privileged criu-x86_64 ./test/zdtm.py run -a -x tcp6 -x tcpbuf6 -x static/rtc -x cgroup
+	docker run --rm -it --privileged -v /lib/modules:/lib/modules criu-x86_64 ./test/zdtm.py run -a -x tcp6 -x tcpbuf6 -x static/rtc -x cgroup
 .PHONY: docker-test
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,8 @@ docker-build:
 .PHONY: docker-build
 
 docker-test:
-	docker run --rm -it --privileged -v /lib/modules:/lib/modules criu-x86_64 ./test/zdtm.py run -a -x tcp6 -x tcpbuf6 -x static/rtc -x cgroup
+	docker run --rm -it --privileged -v /lib/modules:/lib/modules --network=host --cgroupns=host criu-x86_64 \
+		./test/zdtm.py run -a -x tcp6 -x tcpbuf6 -x static/rtc -x cgroup
 .PHONY: docker-test
 
 help:

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -31,7 +31,7 @@ COPY . /criu
 WORKDIR /criu
 ENV $ENV1=yes
 
-RUN make mrproper && date && \
+RUN git clean -dfx && date && \
 # Check single object build
 	make -j $(nproc) CC="$CC" criu/parasite-syscall.o && \
 # Compile criu

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -41,7 +41,8 @@ RUN git clean -dfx && date && \
 	make mrproper && ! git clean -ndx --exclude=scripts/build \
 	--exclude=.config --exclude=test | grep .
 
-# Compile tests
-RUN date && make -j $(nproc) CC="$CC" -C test/zdtm && date
+# Re-compile criu and compile tests for 'make docker-test'
+RUN make -j $(nproc) CC="$CC" && \
+	date &&  make -j $(nproc) CC="$CC" -C test/zdtm && date
 
 #RUN make test/compel/handle_binary && ./test/compel/handle_binary

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -3,6 +3,8 @@ ARG ENV1=FOOBAR
 
 COPY scripts/ci/apt-install /bin/apt-install
 
+# On Ubuntu, kernel modules such as ip_tables and xt_mark may not be loaded by default
+# We need to install kmod to enable iptables to load these modules for us.
 RUN apt-install \
 	libnet-dev \
 	libnl-route-3-dev \
@@ -21,10 +23,15 @@ RUN apt-install \
 	libprotobuf-c-dev \
 	libprotobuf-dev \
 	libselinux-dev \
+	iproute2 \
+	kmod \
 	pkg-config \
 	protobuf-c-compiler \
 	protobuf-compiler \
+	python-is-python3 \
 	python3-minimal \
+	python3-protobuf \
+	python3-yaml \
 	python3-future
 
 COPY . /criu


### PR DESCRIPTION
The `make docker-test` command was originally used with the shell-script version of zdtm, which was removed in commit https://github.com/checkpoint-restore/criu/commit/2cb4532e266d0c9f8e87839d5b5eb728a3e4d10d.

This pull request includes a number of updates to allow the container image build with `make docker-build` to run zdtm tests.