### PR TITLE
zdtm: netns-nft test checkskip fix

### DIFF
--- a/test/zdtm/static/netns-nft.checkskip
+++ b/test/zdtm/static/netns-nft.checkskip
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-test -f /usr/sbin/nft || exit 1
+pkg-config --libs libnftables


### PR DESCRIPTION
Let's check the nftables support basing on `pkg-config`.
On CentOS 8 we meet with the problem when the nft binary is
present, but there is no pkgconfig file for the nftables library.

See #1416

Signed-off-by: Alexander Mikhalitsyn <alexander.mikhalitsyn@virtuozzo.com>