### PR TITLE
scripts/build: drop obsolete ENV1 variable

### DIFF
--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -1,6 +1,5 @@
 FROM alpine
 ARG CC=gcc
-ARG ENV1=FOOBAR
 
 RUN apk update && apk add \
 	$CC \
@@ -25,7 +24,6 @@ RUN apk update && apk add \
 
 COPY . /criu
 WORKDIR /criu
-ENV $ENV1=yes
 RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 
 RUN apk add \

--- a/scripts/build/Dockerfile.centos7
+++ b/scripts/build/Dockerfile.centos7
@@ -1,7 +1,6 @@
 FROM centos:7
 
 ARG CC=gcc
-ARG ENV1=FOOBAR
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum install -y \
@@ -38,7 +37,6 @@ RUN yum install -y \
 COPY . /criu
 WORKDIR /criu
 
-ENV $ENV1=yes
 RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 
 # The rpc test cases are running as user #1000, let's add the user

--- a/scripts/build/Dockerfile.centos8
+++ b/scripts/build/Dockerfile.centos8
@@ -1,7 +1,6 @@
 FROM registry.centos.org/centos/centos:8
 
 ARG CC=gcc
-ARG ENV1=FOOBAR
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm dnf-plugins-core
 RUN yum config-manager --set-enabled powertools
@@ -43,7 +42,6 @@ ENV PYTHON=python3
 COPY . /criu
 WORKDIR /criu
 
-ENV $ENV1=yes
 RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 
 # The rpc test cases are running as user #1000, let's add the user

--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -1,5 +1,4 @@
 ARG CC=gcc
-ARG ENV1=FOOBAR
 
 COPY scripts/ci/prepare-for-fedora-rawhide.sh /bin/prepare-for-fedora-rawhide.sh
 RUN /bin/prepare-for-fedora-rawhide.sh
@@ -7,7 +6,6 @@ RUN /bin/prepare-for-fedora-rawhide.sh
 COPY . /criu
 WORKDIR /criu
 
-ENV $ENV1=yes
 RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 
 # The rpc test cases are running as user #1000, let's add the user

--- a/scripts/build/Dockerfile.linux32.tmpl
+++ b/scripts/build/Dockerfile.linux32.tmpl
@@ -1,5 +1,4 @@
 ARG CC=gcc
-ARG ENV1=FOOBAR
 
 COPY scripts/ci/apt-install /bin/apt-install
 
@@ -27,7 +26,6 @@ RUN apt-install \
 
 COPY . /criu
 WORKDIR /criu
-ENV $ENV1=yes
 
 RUN uname -m && setarch linux32 uname -m && setarch --list
 

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -1,5 +1,4 @@
 ARG CC=gcc
-ARG ENV1=FOOBAR
 
 COPY scripts/ci/apt-install /bin/apt-install
 
@@ -29,7 +28,6 @@ RUN apt-install \
 
 COPY . /criu
 WORKDIR /criu
-ENV $ENV1=yes
 
 RUN make mrproper && date && \
 # Check single object build


### PR DESCRIPTION
The ENV1 variable was first introduced with commit 7290de5 and it not used anymore.