### PR TITLE
tiny fix on dump_empty_fs

### DIFF
--- a/criu/filesystems.c
+++ b/criu/filesystems.c
@@ -656,12 +656,12 @@ static int dump_empty_fs(struct mount_info *pm)
 		return fd;
 
 	ret = is_empty_dir(fd);
-	if (ret < 0) {
+	if (ret == 0) {
 		pr_err("%s isn't empty\n", pm->fstype->name);
 		return -1;
 	}
 
-	return ret ? 0 : -1;
+	return ret == 1 ? 0 : -1;
 }
 
 /*

--- a/criu/util.c
+++ b/criu/util.c
@@ -731,7 +731,13 @@ int is_root_user(void)
 /*
  * is_empty_dir will always close the FD dirfd: either implicitly
  * via closedir or explicitly in case fdopendir had failed
+ *
+ * return values:
+ *   < 0 : open directory stream failed
+ *     0 : directory is not empty
+ *     1 : directory is empty
  */
+
 int is_empty_dir(int dirfd)
 {
 	int ret = 0;
@@ -740,6 +746,7 @@ int is_empty_dir(int dirfd)
 
 	fdir = fdopendir(dirfd);
 	if (!fdir) {
+		pr_perror("open directory stream by fd %d failed", dirfd);
 		close_safe(&dirfd);
 		return -1;
 	}


### PR DESCRIPTION
return value of is_empty_dir:
* -1 : open directory stream failed
*  0 : directory is not empty
*  1 : directory is empty

Signed-off-by: Liu Hua <weldonliu@tencent.com>