### PR TITLE
pr_* spring cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,13 @@ lint:
 	shellcheck scripts/*.sh
 	shellcheck scripts/ci/*.sh scripts/ci/apt-install
 	shellcheck test/others/crit/*.sh
+	# Do not append \n to pr_perror or fail
+	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*\\n"'
+	# Do not use %m with pr_perror or fail
+	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*%m'
+	# Do not use errno with pr_perror or fail
+	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>\(".*".*errno'
+.PHONY: lint
 
 codecov: SHELL := $(shell which bash)
 codecov:

--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,8 @@ lint:
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*%m'
 	# Do not use errno with pr_perror or fail
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>\(".*".*errno'
+	# End pr_(err|warn|msg|info|debug) with \n
+	! git --no-pager grep -En '^\s*\<pr_(err|warn|msg|info|debug)\>.*);$$' | grep -v '\\n'
 	# No EOL whitespace for C files
 	! git --no-pager grep -E '\s+$$' \*.c \*.h
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,8 @@ lint:
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*%m'
 	# Do not use errno with pr_perror or fail
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>\(".*".*errno'
+	# No EOL whitespace for C files
+	! git --no-pager grep -E '\s+$$' \*.c \*.h
 .PHONY: lint
 
 codecov: SHELL := $(shell which bash)

--- a/Makefile
+++ b/Makefile
@@ -411,6 +411,7 @@ lint:
 	flake8 --config=scripts/flake8.cfg test/inhfd/*.py
 	flake8 --config=scripts/flake8.cfg test/others/rpc/config_file.py
 	flake8 --config=scripts/flake8.cfg lib/py/images/pb2dict.py
+	shellcheck --version
 	shellcheck scripts/*.sh
 	shellcheck scripts/ci/*.sh scripts/ci/apt-install
 	shellcheck test/others/crit/*.sh

--- a/compel/arch/mips/src/lib/cpu.c
+++ b/compel/arch/mips/src/lib/cpu.c
@@ -17,11 +17,11 @@ void compel_set_cpu_cap(compel_cpuinfo_t *c, unsigned int feature){ }
 void compel_clear_cpu_cap(compel_cpuinfo_t *c, unsigned int feature){ }
 
 int compel_test_cpu_cap(compel_cpuinfo_t *c, unsigned int feature)
-{ 
+{
     return 0;
 }
 
-int compel_cpuid(compel_cpuinfo_t *c){	
+int compel_cpuid(compel_cpuinfo_t *c){
     return 0;
 }
 
@@ -31,6 +31,6 @@ bool compel_cpu_has_feature(unsigned int feature)
 	compel_cpuid(&rt_info);
 	rt_info_done = true;
     }
-    
+
     return compel_test_cpu_cap(&rt_info, feature);
 }

--- a/compel/arch/mips/src/lib/include/uapi/asm/infect-types.h
+++ b/compel/arch/mips/src/lib/include/uapi/asm/infect-types.h
@@ -41,8 +41,8 @@ typedef struct {
 
 #define MIPS_a0			regs[4] //arguments a0-a3
 #define MIPS_t0			regs[8] //temporaries t0-t7
-#define MIPS_v0			regs[2] 
-#define MIPS_v1			regs[3] 
+#define MIPS_v0			regs[2]
+#define MIPS_v1			regs[3]
 #define MIPS_sp			regs[29]
 #define MIPS_ra			regs[31]
 
@@ -59,10 +59,10 @@ static inline bool user_regs_native(user_regs_struct_t *pregs)
 #define compel_arch_get_tls_task(ctl, tls)
 #define compel_arch_get_tls_thread(tctl, tls)
 
-#define REG_RES(regs)		((regs).MIPS_v0) 
-#define REG_IP(regs)		((regs).cp0_epc) 
+#define REG_RES(regs)		((regs).MIPS_v0)
+#define REG_IP(regs)		((regs).cp0_epc)
 #define REG_SP(regs)		((regs).MIPS_sp)
-#define REG_SYSCALL_NR(regs)	((regs).MIPS_v0) 
+#define REG_SYSCALL_NR(regs)	((regs).MIPS_v0)
 
 //#define __NR(syscall, compat)	((compat) ? __NR32_##syscall : __NR_##syscall)
 #define __NR(syscall, compat)	__NR_##syscall

--- a/compel/arch/mips/src/lib/include/uapi/asm/sigframe.h
+++ b/compel/arch/mips/src/lib/include/uapi/asm/sigframe.h
@@ -36,8 +36,8 @@ struct rt_sigframe {
 
 #define RT_SIGFRAME_UC(rt_sigframe)		(&rt_sigframe->rs_uc)
 #define RT_SIGFRAME_UC_SIGMASK(rt_sigframe) 	((k_rtsigset_t *)(void *)&rt_sigframe->rs_uc.uc_sigmask)
-#define RT_SIGFRAME_REGIP(rt_sigframe)	((long unsigned int)0x00)   
-#define RT_SIGFRAME_FPU(rt_sigframe)		     
+#define RT_SIGFRAME_REGIP(rt_sigframe)	((long unsigned int)0x00)
+#define RT_SIGFRAME_FPU(rt_sigframe)
 #define RT_SIGFRAME_HAS_FPU(rt_sigframe) 1
 
 

--- a/compel/arch/mips/src/lib/infect.c
+++ b/compel/arch/mips/src/lib/infect.c
@@ -217,7 +217,7 @@ void *remote_mmap(struct parasite_ctl *ctl,
  * regs must be inited when calling this function from original context
  */
 void parasite_setup_regs(unsigned long new_ip, void *stack, user_regs_struct_t *regs)
-{  
+{
     regs->cp0_epc = new_ip;
     if (stack){
 	  /* regs[29] is sp */
@@ -286,7 +286,7 @@ void compel_relocs_apply_mips(void *mem, void *vbase, struct parasite_blob_desc 
        * mips rebasing :load time relocation
        * parasite.built-in.o and restorer.built-in.o is ELF 64-bit LSB relocatable for mips.
        * so we have to relocate some type for R_MIPS_26 R_MIPS_HIGHEST R_MIPS_HIGHER R_MIPS_HI16 and R_MIPS_LO16 in there.
-       * for mips64el .if toload/store data or jump instruct ,need to relocation R_TYPE 
+       * for mips64el .if toload/store data or jump instruct ,need to relocation R_TYPE
        */
     for (i = 0, j = 0; i < nr_relocs; i++) {
 	if (elf_relocs[i].type & COMPEL_TYPE_MIPS_26) {

--- a/compel/arch/s390/src/lib/infect.c
+++ b/compel/arch/s390/src/lib/infect.c
@@ -196,13 +196,13 @@ int get_vx_regs(pid_t pid, user_fpregs_struct_t *fpregs)
 			pr_debug("VXRS registers not supported\n");
 			return 0;
 		}
-		pr_perror("Couldn't get VXRS_LOW\n");
+		pr_perror("Couldn't get VXRS_LOW");
 		return -1;
 	}
 	iov.iov_base = &fpregs->vxrs_high;
 	iov.iov_len = sizeof(fpregs->vxrs_high);
 	if (ptrace(PTRACE_GETREGSET, pid, NT_S390_VXRS_HIGH, &iov) < 0) {
-		pr_perror("Couldn't get VXRS_HIGH\n");
+		pr_perror("Couldn't get VXRS_HIGH");
 		return -1;
 	}
 	fpregs->flags |= USER_FPREGS_VXRS;
@@ -243,7 +243,7 @@ int get_gs_cb(pid_t pid, user_fpregs_struct_t *fpregs)
 			pr_debug("GS_BC not set\n");
 			return 0;
 		}
-		pr_perror("Couldn't get GS_BC\n");
+		pr_perror("Couldn't get GS_BC");
 		return -1;
 	}
 	fpregs->flags |= USER_GS_BC;
@@ -274,7 +274,7 @@ int get_ri_cb(pid_t pid, user_fpregs_struct_t *fpregs)
 			pr_debug("RI_CB not set\n");
 			return 0;
 		default:
-			pr_perror("Couldn't get RI_CB\n");
+			pr_perror("Couldn't get RI_CB");
 			return -1;
 		}
 	}
@@ -386,14 +386,14 @@ int compel_set_task_ext_regs(pid_t pid, user_fpregs_struct_t *ext_regs)
 		iov.iov_base = &ext_regs->vxrs_low;
 		iov.iov_len = sizeof(ext_regs->vxrs_low);
 		if (ptrace(PTRACE_SETREGSET, pid, NT_S390_VXRS_LOW, &iov) < 0) {
-			pr_perror("Couldn't set VXRS_LOW\n");
+			pr_perror("Couldn't set VXRS_LOW");
 			ret = -1;
 		}
 
 		iov.iov_base = &ext_regs->vxrs_high;
 		iov.iov_len = sizeof(ext_regs->vxrs_high);
 		if (ptrace(PTRACE_SETREGSET, pid, NT_S390_VXRS_HIGH, &iov) < 0) {
-			pr_perror("Couldn't set VXRS_HIGH\n");
+			pr_perror("Couldn't set VXRS_HIGH");
 			ret = -1;
 		}
 	}
@@ -402,13 +402,13 @@ int compel_set_task_ext_regs(pid_t pid, user_fpregs_struct_t *ext_regs)
 		iov.iov_base = &ext_regs->gs_cb;
 		iov.iov_len = sizeof(ext_regs->gs_cb);
 		if (ptrace(PTRACE_SETREGSET, pid, NT_S390_GS_CB, &iov) < 0) {
-			pr_perror("Couldn't set GS_CB\n");
+			pr_perror("Couldn't set GS_CB");
 			ret = -1;
 		}
 		iov.iov_base = &ext_regs->gs_bc;
 		iov.iov_len = sizeof(ext_regs->gs_bc);
 		if (ptrace(PTRACE_SETREGSET, pid, NT_S390_GS_BC, &iov) < 0) {
-			pr_perror("Couldn't set GS_BC\n");
+			pr_perror("Couldn't set GS_BC");
 			ret = -1;
 		}
 	}
@@ -417,7 +417,7 @@ int compel_set_task_ext_regs(pid_t pid, user_fpregs_struct_t *ext_regs)
 		iov.iov_base = &ext_regs->ri_cb;
 		iov.iov_len = sizeof(ext_regs->ri_cb);
 		if (ptrace(PTRACE_SETREGSET, pid, NT_S390_RI_CB, &iov) < 0) {
-			pr_perror("Couldn't set RI_CB\n");
+			pr_perror("Couldn't set RI_CB");
 			ret = -1;
 		}
 	}

--- a/compel/arch/x86/src/lib/thread_area.c
+++ b/compel/arch/x86/src/lib/thread_area.c
@@ -64,7 +64,7 @@ int __compel_arch_fetch_thread_area(int tid, struct thread_ctx *th)
 		if (err == -EIO && native_mode)
 			return 0;
 		if (err) {
-			pr_perror("get_thread_area failed for %d\n", tid);
+			pr_perror("get_thread_area failed for %d", tid);
 			return err;
 		}
 	}

--- a/compel/src/lib/handle-elf.c
+++ b/compel/src/lib/handle-elf.c
@@ -201,7 +201,7 @@ int __handle_elf(void *mem, size_t size)
 		}
 #endif
 	}
-        
+
 	/* Calculate section addresses with proper alignment.
 	 * Note: some but not all linkers precalculate this information.
 	 */

--- a/criu/arch/mips/crtools.c
+++ b/criu/arch/mips/crtools.c
@@ -65,14 +65,14 @@ int save_task_regs(void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpre
     core->ti_mips->gpregs->r29 = regs->regs[29];
     core->ti_mips->gpregs->r30 = regs->regs[30];
     core->ti_mips->gpregs->r31 = regs->regs[31];
-    
+
     core->ti_mips->gpregs->lo = regs->lo;
     core->ti_mips->gpregs->hi = regs->hi;
     core->ti_mips->gpregs->cp0_epc = regs->cp0_epc;
     core->ti_mips->gpregs->cp0_badvaddr = regs->cp0_badvaddr;
     core->ti_mips->gpregs->cp0_status = regs->cp0_status;
     core->ti_mips->gpregs->cp0_cause = regs->cp0_cause;
-    
+
     core->ti_mips->fpregs->r0 = fpregs->regs[0];
     core->ti_mips->fpregs->r1 = fpregs->regs[1];
     core->ti_mips->fpregs->r2 = fpregs->regs[2];
@@ -107,7 +107,7 @@ int save_task_regs(void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpre
     core->ti_mips->fpregs->r31 = fpregs->regs[31];
     core->ti_mips->fpregs->fpu_fcr31 = fpregs->fpu_fcr31;
     core->ti_mips->fpregs->fpu_id = fpregs->fpu_id;
-    
+
     return 0;
 }
 
@@ -142,7 +142,7 @@ int arch_alloc_thread_info(CoreEntry *core)
 
     user_mips_fpregs_entry__init(fpregs);
     ti_mips->fpregs = fpregs;
-    
+
     return 0;
 err:
     return -1;
@@ -155,7 +155,7 @@ void arch_free_thread_info(CoreEntry *core)
 
     if (core->ti_mips->gpregs)
 	xfree(core->ti_mips->gpregs);
-    
+
     if (core->ti_mips->fpregs)
 	xfree(core->ti_mips->fpregs);
 

--- a/criu/arch/mips/include/asm/restorer.h
+++ b/criu/arch/mips/include/asm/restorer.h
@@ -7,13 +7,13 @@
 #include <compel/plugins/std/syscall-codes.h>
 #include <compel/asm/sigframe.h>
 
-static inline void restore_tls(tls_t *ptls) { 
-	asm volatile(							
-		     "move $4, %0				    \n"	
-		     "li $2,  "__stringify(__NR_set_thread_area)"  \n" 
-		     "syscall					    \n"	
-		     :							
-		     : "r"(*ptls)					
+static inline void restore_tls(tls_t *ptls) {
+	asm volatile(
+		     "move $4, %0				    \n"
+		     "li $2,  "__stringify(__NR_set_thread_area)"  \n"
+		     "syscall					    \n"
+		     :
+		     : "r"(*ptls)
 		     : "$4","$2","memory");
 }
 static inline int arch_compat_rt_sigaction(void *stack, int sig, void *act)

--- a/criu/arch/x86/kerndat.c
+++ b/criu/arch/x86/kerndat.c
@@ -224,7 +224,7 @@ int kdat_x86_has_ptrace_fpu_xsave_bug(void)
 		 * waitpid() may end with ECHILD if SIGCHLD == SIG_IGN,
 		 * and the child has stopped already.
 		 */
-		pr_perror("Failed to wait for %s() test\n", __func__);
+		pr_perror("Failed to wait for %s() test", __func__);
 		goto out_kill;
 	}
 

--- a/criu/arch/x86/kerndat.c
+++ b/criu/arch/x86/kerndat.c
@@ -110,7 +110,7 @@ static void mmap_bug_test(void)
 	}
 
 	if (munmap(map1, PAGE_SIZE)) {
-		pr_err("Failed to unmap() 32-bit mapping: %m\n");
+		pr_perror("Failed to unmap() 32-bit mapping");
 		exit(1);
 	}
 

--- a/criu/bpfmap.c
+++ b/criu/bpfmap.c
@@ -72,7 +72,7 @@ int restore_bpfmap_data(int map_fd, uint32_t map_id, struct bpfmap_data_rst **bp
 		.flags = 0,
 	);
 
-	for (map_data = bpf_hash_table[map_id & BPFMAP_DATA_HASH_MASK]; map_data != NULL; 
+	for (map_data = bpf_hash_table[map_id & BPFMAP_DATA_HASH_MASK]; map_data != NULL;
 		map_data = map_data->next) {
 
 		if (map_data->bde->map_id == map_id)
@@ -143,11 +143,11 @@ int dump_one_bpfmap_data(BpfmapFileEntry *bpf, int lfd, const struct fd_parms *p
 	 * by userspace if it's dealing with percpu maps. 'count' will contain the
 	 * number of keys/values successfully retrieved. Note that 'count' is an
 	 * input/output variable and it can contain a lower value after a call.
-	 * 
+	 *
 	 * If there's no more entries to retrieve, ENOENT will be returned. If error
 	 * is ENOENT, count might be > 0 in case it copied some values but there were
 	 * no more entries to retrieve.
-	 * 
+	 *
 	 * Note that if the return code is an error and not -EFAULT,
 	 * count indicates the number of elements successfully processed.
 	 */
@@ -270,7 +270,7 @@ static int dump_one_bpfmap(int lfd, u32 id, const struct fd_parms *p)
 	}
 
 	return ret;
-	
+
 }
 
 const struct fdtype_ops bpfmap_dump_ops = {

--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -311,7 +311,7 @@ static int read_cgroup_prop(struct cgroup_prop *property, const char *fullpath)
 
 	ret = read(fd, buf, sizeof(buf) - 1);
 	if (ret == -1) {
-		pr_err("Failed scanning %s\n", fullpath);
+		pr_perror("Failed scanning %s", fullpath);
 		close(fd);
 		return -1;
 	}

--- a/criu/config.c
+++ b/criu/config.c
@@ -187,7 +187,7 @@ static int next_config(char **argv, char ***_argv, bool no_default_config,
 				break;
 			home_dir = getenv("HOME");
 			if (!home_dir) {
-				pr_info("Unable to get $HOME directory, local configuration file will not be used.");
+				pr_info("Unable to get $HOME directory, local configuration file will not be used.\n");
 			} else {
 				snprintf(local_filepath, PATH_MAX, "%s/%s%s",
 						home_dir, USER_CONFIG_DIR, DEFAULT_CONFIG_FILENAME);
@@ -755,7 +755,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 			break;
 		case 1065:
 			if (!add_fsname_auto(optarg)) {
-				pr_err("Failed while parsing --enable-fs option: %s", optarg);
+				pr_err("Failed while parsing --enable-fs option: %s\n", optarg);
 				return 1;
 			}
 			break;
@@ -767,7 +767,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 			break;
 		case 1070:
 			if (irmap_scan_path_add(optarg)) {
-				pr_err("Failed while parsing --irmap-scan-path option: %s", optarg);
+				pr_err("Failed while parsing --irmap-scan-path option: %s\n", optarg);
 				return -1;
 			}
 			break;

--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -190,7 +190,7 @@ static int check_prctl_cat1(void)
 
 	ret = prctl(PR_GET_TID_ADDRESS, (unsigned long)&tid_addr, 0, 0, 0);
 	if (ret < 0) {
-		pr_msg("prctl: PR_GET_TID_ADDRESS is not supported: %m");
+		pr_perror("prctl: PR_GET_TID_ADDRESS is not supported");
 		return -1;
 	}
 
@@ -206,19 +206,19 @@ static int check_prctl_cat1(void)
 			if (errno == EPERM)
 				pr_msg("prctl: One needs CAP_SYS_RESOURCE capability to perform testing\n");
 			else
-				pr_msg("prctl: PR_SET_MM_BRK is not supported: %m\n");
+				pr_perror("prctl: PR_SET_MM_BRK is not supported");
 			return -1;
 		}
 
 		ret = prctl(PR_SET_MM, PR_SET_MM_EXE_FILE, -1, 0, 0);
 		if (ret < 0 && errno != EBADF) {
-			pr_msg("prctl: PR_SET_MM_EXE_FILE is not supported: %m\n");
+			pr_perror("prctl: PR_SET_MM_EXE_FILE is not supported");
 			return -1;
 		}
 
 		ret = prctl(PR_SET_MM, PR_SET_MM_AUXV, (long)&user_auxv, sizeof(user_auxv), 0);
 		if (ret < 0) {
-			pr_msg("prctl: PR_SET_MM_AUXV is not supported: %m\n");
+			pr_perror("prctl: PR_SET_MM_AUXV is not supported");
 			return -1;
 		}
 	}
@@ -908,7 +908,7 @@ static int check_aio_remap(void)
 	int r;
 
 	if (syscall(SYS_io_setup, 16, &ctx) < 0) {
-		pr_err("No AIO syscall: %m\n");
+		pr_perror("No AIO syscall");
 		return -1;
 	}
 
@@ -930,7 +930,7 @@ static int check_aio_remap(void)
 	ctx = (aio_context_t)naddr;
 	r = syscall(SYS_io_getevents, ctx, 0, 1, NULL, NULL);
 	if (r < 0) {
-		pr_err("AIO remap doesn't work properly: %m\n");
+		pr_perror("AIO remap doesn't work properly");
 		return -1;
 	}
 

--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1528,10 +1528,10 @@ void pr_check_features(const char *offset, const char *sep, int width)
 			pr_msg("\n%s", offset);
 			pos = offset_len;
 		}
-		pr_msg("%s", fl->name);
+		pr_msg("%s", fl->name); // no \n
 		pos += len;
 		if ((fl + 1)->name) { // not the last item
-			pr_msg("%s", sep);
+			pr_msg("%s", sep); // no \n
 			pos += sep_len;
 		}
 	}

--- a/criu/cr-dedup.c
+++ b/criu/cr-dedup.c
@@ -19,7 +19,7 @@ int cr_dedup(void)
 
 	dirp = opendir(CR_PARENT_LINK);
 	if (dirp == NULL) {
-		pr_perror("Can't enter previous snapshot folder, error=%d", errno);
+		pr_perror("Can't enter previous snapshot folder");
 		ret = -1;
 		goto err;
 	}
@@ -29,7 +29,7 @@ int cr_dedup(void)
 		ent = readdir(dirp);
 		if (ent == NULL) {
 			if (errno) {
-				pr_perror("Failed readdir, error=%d", errno);
+				pr_perror("Failed readdir");
 				ret = -1;
 				goto err;
 			}

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1462,7 +1462,7 @@ static inline int fork_with_pid(struct pstree_item *item)
 				ret = set_next_pid((void *)&pid);
 			}
 			if (ret != 0) {
-				pr_err("Setting PID failed");
+				pr_err("Setting PID failed\n");
 				goto err_unlock;
 			}
 		}

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3614,7 +3614,7 @@ static int sigreturn_restore(pid_t pid, struct task_restore_args *task_args, uns
 	/* VMA we need for stacks and sigframes for threads */
 	if (mmap(mem, memzone_size, PROT_READ | PROT_WRITE,
 			MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, 0, 0) != mem) {
-		pr_err("Can't mmap section for restore code\n");
+		pr_perror("Can't mmap section for restore code");
 		goto err;
 	}
 

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1224,7 +1224,7 @@ static int wait_exiting_children(void)
 	futex_dec_and_wake(&task_entries->nr_in_progress);
 
 	if (waitid(P_ALL, 0, &info, WEXITED | WNOWAIT)) {
-		pr_perror("Failed to wait\n");
+		pr_perror("Failed to wait");
 		return -1;
 	}
 

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -174,7 +174,7 @@ int main(int argc, char *argv[], char *envp[])
 	if (strcmp(argv[optind], "service")) {
 		ret = open_image_dir(opts.imgs_dir, image_dir_mode(argv, optind));
 		if (ret < 0) {
-			pr_err("Couldn't open image dir: %s", opts.imgs_dir);
+			pr_err("Couldn't open image dir %s\n", opts.imgs_dir);
 			return 1;
 		}
 	}

--- a/criu/fdstore.c
+++ b/criu/fdstore.c
@@ -93,7 +93,7 @@ int fdstore_add(int fd)
 
 	ret = send_fd(sk, NULL, 0, fd);
 	if (ret) {
-		pr_perror("Can't send fd %d into store\n", fd);
+		pr_perror("Can't send fd %d into store", fd);
 		mutex_unlock(&desc->lock);
 		return -1;
 	}

--- a/criu/file-lock.c
+++ b/criu/file-lock.c
@@ -479,7 +479,7 @@ static int open_break_cb(int ns_root_fd, struct reg_file_info *rfi, void *arg)
 		close(fd);
 		return -1;
 	} else if (errno != EWOULDBLOCK) {
-		pr_perror("Can't break lease\n");
+		pr_perror("Can't break lease");
 		return -1;
 	}
 	return 0;
@@ -512,7 +512,7 @@ static int set_file_lease(int fd, int type)
 	struct stat st;
 
 	if (fstat(fd, &st)) {
-		pr_perror("Can't get file stat (%i)\n", fd);
+		pr_perror("Can't get file stat (%i)", fd);
 		return -1;
 	}
 
@@ -524,7 +524,7 @@ static int set_file_lease(int fd, int type)
 
 	ret = fcntl(fd, F_SETLEASE, type);
 	if (ret < 0)
-		pr_perror("Can't set lease\n");
+		pr_perror("Can't set lease");
 
 	setfsuid(old_fsuid);
 	return ret;
@@ -589,20 +589,20 @@ static int restore_file_lease(FileLockEntry *fle)
 		signum_fcntl = fcntl(fle->fd, F_GETSIG);
 		signum = signum_fcntl ? signum_fcntl : SIGIO;
 		if (signum_fcntl < 0) {
-			pr_perror("Can't get file i/o signum\n");
+			pr_perror("Can't get file i/o signum");
 			return -1;
 		}
 		if (sigemptyset(&blockmask) ||
 			sigaddset(&blockmask, signum) ||
 			sigprocmask(SIG_BLOCK, &blockmask, &oldmask)) {
-			pr_perror("Can't block file i/o signal\n");
+			pr_perror("Can't block file i/o signal");
 			return -1;
 		}
 
 		ret = restore_breaking_file_lease(fle);
 
 		if (sigprocmask(SIG_SETMASK, &oldmask, NULL)) {
-			pr_perror("Can't restore sigmask\n");
+			pr_perror("Can't restore sigmask");
 			ret = -1;
 		}
 		return ret;

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1536,7 +1536,7 @@ static int get_build_id(const int fd, const struct stat *fd_status,
 	mapped_size = min_t(size_t, fd_status->st_size, BUILD_ID_MAP_SIZE);
 	start_addr = mmap(0, mapped_size, PROT_READ, MAP_PRIVATE | MAP_FILE, fd, 0);
 	if (start_addr == MAP_FAILED) {
-		pr_warn("Couldn't mmap file with fd %d", fd);
+		pr_warn("Couldn't mmap file with fd %d\n", fd);
 		return -1;
 	}
 

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1544,7 +1544,7 @@ static int get_build_id(const int fd, const struct stat *fd_status,
 		ret = get_build_id_32(start_addr, build_id, fd, mapped_size);
 	if (buf[EI_CLASS] == ELFCLASS64)
 		ret = get_build_id_64(start_addr, build_id, fd, mapped_size);
-	
+
 	munmap(start_addr, mapped_size);
 	return ret;
 }
@@ -2065,7 +2065,7 @@ int open_path(struct file_desc *d,
 		tmp = inherit_fd_lookup_id(rfi->rfe->name);
 		if (tmp >= 0) {
 			inh_fd = tmp;
-			/* 
+			/*
 			 * PROC_SELF isn't used, because only service
 			 * descriptors can be used here.
 			 */

--- a/criu/include/bpfmap.h
+++ b/criu/include/bpfmap.h
@@ -30,4 +30,4 @@ extern const struct fdtype_ops bpfmap_dump_ops;
 extern struct collect_image_info bpfmap_cinfo;
 extern struct collect_image_info bpfmap_data_cinfo;
 
-#endif /* __CR_BPFMAP_H__ */ 
+#endif /* __CR_BPFMAP_H__ */

--- a/criu/ipc_ns.c
+++ b/criu/ipc_ns.c
@@ -58,7 +58,7 @@ static void fill_ipc_desc(int id, IpcDescEntry *desc, const struct ipc_perm *ipc
 static void pr_ipc_sem_array(int nr, u16 *values)
 {
 	while (nr--)
-		pr_info("  %-5d", values[nr]);
+		pr_info("  %-5d", values[nr]); // no \n
 	pr_info("\n");
 }
 

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -417,7 +417,7 @@ static bool kerndat_has_memfd_create(void)
 	else if (ret == -1 && errno == EFAULT)
 		kdat.has_memfd = true;
 	else {
-		pr_err("Unexpected error from memfd_create(NULL, 0): %m\n");
+		pr_perror("Unexpected error from memfd_create(NULL, 0)");
 		return -1;
 	}
 

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1045,7 +1045,7 @@ static bool kerndat_has_clone3_set_tid(void)
 	if (pid == -1 && errno == EINVAL) {
 		kdat.has_clone3_set_tid = true;
 	} else {
-		pr_perror("Unexpected error from clone3\n");
+		pr_perror("Unexpected error from clone3");
 		return -1;
 	}
 

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -54,7 +54,7 @@ static int check_pagemap(void)
 	fd = __open_proc(PROC_SELF, EPERM, O_RDONLY, "pagemap");
 	if (fd < 0) {
 		if (errno == EPERM) {
-			pr_info("Pagemap disabled");
+			pr_info("Pagemap disabled\n");
 			kdat.pmap = PM_DISABLED;
 			return 0;
 		}

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -64,7 +64,7 @@ int do_task_reset_dirty_track(int pid)
 		if (errno == EINVAL) /* No clear-soft-dirty in kernel */
 			ret = 1;
 		else {
-			pr_perror("Can't reset %d's dirty memory tracker (%d)", pid, errno);
+			pr_perror("Can't reset %d's dirty memory tracker", pid);
 			ret = -1;
 		}
 	} else {

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -3832,7 +3832,7 @@ static int ns_remount_writable(void *arg)
 
 	if (do_restore_task_mnt_ns(ns))
 		return 1;
-	pr_debug("Switched to mntns %u:%u/n", ns->id, ns->kid);
+	pr_debug("Switched to mntns %u:%u\n", ns->id, ns->kid);
 
 	if (mount(NULL, mi->ns_mountpoint, NULL, MS_REMOUNT | MS_BIND |
 		  (mi->flags & ~(MS_PROPAGATE | MS_RDONLY)), NULL) == -1) {
@@ -3903,7 +3903,7 @@ static int __remount_readonly_mounts(struct ns_id *ns)
 			if (do_restore_task_mnt_ns(ns))
 				return -1;
 			mntns_set = true;
-			pr_debug("Switched to mntns %u:%u/n", ns->id, ns->kid);
+			pr_debug("Switched to mntns %u:%u\n", ns->id, ns->kid);
 		}
 
 		pr_info("Remount %d:%s back to readonly\n", mi->mnt_id, mi->mountpoint);

--- a/criu/net.c
+++ b/criu/net.c
@@ -2428,7 +2428,7 @@ static inline int restore_nftables(int pid)
 		return -1;
 	if (empty_image(img)) {
 		/* Backward compatibility */
-		pr_info("Skipping nft restore, no image");
+		pr_info("Skipping nft restore, no image\n");
 		ret = 0;
 		goto image_close_out;
 	}

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -1694,7 +1694,7 @@ static int parse_bpfmap(struct bfd *f, char *str, BpfmapFileEntry *bpf)
 {
 	/*
 	 * Format is:
-	 * 
+	 *
 	 * uint32_t map_type
 	 * uint32_t key_size
 	 * uint32_t value_size
@@ -1718,7 +1718,7 @@ static int parse_bpfmap(struct bfd *f, char *str, BpfmapFileEntry *bpf)
 
 	size_t n = sizeof(map) / sizeof(bpfmap_fmt);
 	int i;
-	
+
 	for (i = 0; i < n; i++) {
 		if (sscanf(str, map[i].fmt, map[i].value) != 1)
 			return -1;

--- a/criu/shmem.c
+++ b/criu/shmem.c
@@ -591,7 +591,7 @@ static int open_shmem(int pid, struct vma_area *vma)
 	 */
 	addr = mmap(NULL, si->size, PROT_WRITE | PROT_READ, flags, f, 0);
 	if (addr == MAP_FAILED) {
-		pr_err("Can't mmap shmid=0x%"PRIx64" size=%ld\n",
+		pr_perror("Can't mmap shmid=0x%"PRIx64" size=%ld",
 				vi->shmid, si->size);
 		goto err;
 	}

--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -665,7 +665,7 @@ static int unix_resolve_name(int lfd, uint32_t id, struct unix_sk_desc *d,
 
 	fd = ioctl(lfd, SIOCUNIXFILE);
 	if (fd < 0) {
-		pr_warn("Unable to get a socket file descriptor with SIOCUNIXFILE ioctl.");
+		pr_warn("Unable to get a socket file descriptor with SIOCUNIXFILE ioctl: %m\n");
 		goto fallback;
 	}
 
@@ -716,7 +716,7 @@ out:
 	return ret;
 
 fallback:
-	pr_warn("Trying to resolve unix socket with obsolete method");
+	pr_warn("Trying to resolve unix socket with obsolete method\n");
 	ret = unix_resolve_name_old(lfd, id, d, ue, p);
 	if (ret < 0)
 		pr_err("Unable to resolve unix socket name with obsolete method. Try a linux kernel newer than 4.10\n");

--- a/criu/vdso.c
+++ b/criu/vdso.c
@@ -471,12 +471,12 @@ static int vdso_mmap_compat(struct vdso_maps *native,
 		goto out_kill;
 
 	if (kill(pid, SIGCONT)) {
-		pr_perror("Failed to kill(SIGCONT) for compat vdso helper\n");
+		pr_perror("Failed to kill(SIGCONT) for compat vdso helper");
 		goto out_kill;
 	}
 	if (write(fds[1], &compat->vdso_start, sizeof(void *)) !=
 			sizeof(compat->vdso_start)) {
-		pr_perror("Failed write to pipe\n");
+		pr_perror("Failed write to pipe");
 		goto out_kill;
 	}
 	waitpid(pid, &status, WUNTRACED);

--- a/include/common/arch/mips/asm/linkage.h
+++ b/include/common/arch/mips/asm/linkage.h
@@ -6,7 +6,7 @@
 #define v0 	$2
 #define v1 	$3
 
-#define a0 	$4   
+#define a0 	$4
 #define a1      $5
 #define a2      $6
 #define a3      $7
@@ -18,7 +18,7 @@
 #define t1      $13
 #define t2      $14
 #define t3      $15
-	
+
 #define s0      $16     /* callee saved */
 #define s1      $17
 #define s2      $18

--- a/include/common/compiler.h
+++ b/include/common/compiler.h
@@ -44,7 +44,7 @@
 #define __aligned(x)		__attribute__((aligned(x)))
 
 /*
- * Macro to define stack alignment. 
+ * Macro to define stack alignment.
  * aarch64 requires stack to be aligned to 16 bytes.
  */
 #define __stack_aligned__	__attribute__((aligned(16)))

--- a/scripts/ci/apt-install
+++ b/scripts/ci/apt-install
@@ -12,7 +12,7 @@ max_apt_retries=5
 # hashsum mismatches, DNS errors and similar things
 while true; do
 	(( install_retry_counter+=1 ))
-	if [ ${install_retry_counter} -gt ${max_apt_retries} ]; then
+	if [ "${install_retry_counter}" -gt "${max_apt_retries}" ]; then
 		exit 1
 	fi
 	# shellcheck disable=SC2068
@@ -20,5 +20,5 @@ while true; do
 
 	# In case it is a network error let's wait a bit.
 	echo "Retrying attempt ${install_retry_counter}"
-	sleep ${install_retry_counter}
+	sleep "${install_retry_counter}"
 done

--- a/scripts/systemd-autofs-restart.sh
+++ b/scripts/systemd-autofs-restart.sh
@@ -45,8 +45,8 @@ bindmount=""
 
 function remove_bindmount {
 	if [ -n "$bindmount" ]; then
-		$JOIN_CT umount $bindmount
-		$JOIN_CT rm -rf $bindmount
+		$JOIN_CT umount "$bindmount"
+		$JOIN_CT rm -rf "$bindmount"
 		bindmount=""
 	fi
 }
@@ -107,7 +107,7 @@ function save_mountpoint {
 	# Nothing to do, if no file system is on top of autofs
 	[ "$top_mount_fs_type" = "autofs" ] && return
 
-	bindmount=$($JOIN_CT mktemp -d)
+	bindmount="$($JOIN_CT mktemp -d)"
 	if [ -z "$bindmount" ]; then
 		echo "Failed to create temporary directory"
 		return 1

--- a/scripts/tmp-files.sh
+++ b/scripts/tmp-files.sh
@@ -26,7 +26,7 @@ IMGFILE=$CRTOOLS_IMAGE_DIR"/tmpfiles.tar.gz"
 MY_NAME=$(basename "$0")
 
 case "$CRTOOLS_SCRIPT_ACTION" in
-	$POSTDUMP )
+	"$POSTDUMP")
 		if [ "$#" -lt 1 ]; then
 			echo "$MY_NAME: ERROR! No files are given."
 			exit 1
@@ -34,7 +34,7 @@ case "$CRTOOLS_SCRIPT_ACTION" in
 		tar "$DUMPARGS" "$IMGFILE" -- "$@"
 		exit $?
 		;;
-	$PRERESTORE )
+	"$PRERESTORE")
 		if [ "$#" -ne 0 ]; then
 			echo "$MY_NAME: ERROR! Not expected script args."
 			exit 1

--- a/soccr/soccr.h
+++ b/soccr/soccr.h
@@ -96,7 +96,7 @@ struct libsoccr_sk_data {
  * from the kernel and is required for restore. Not present data
  * is zeroified by the library.
  *
- * Ideally the caller should carry the whole _data structure between 
+ * Ideally the caller should carry the whole _data structure between
  * calls, but for optimization purposes it may analyze the flags
  * field and drop the unneeded bits.
  */
@@ -213,14 +213,14 @@ union libsoccr_addr *libsoccr_get_addr(struct libsoccr_sk *sk, int self, unsigne
 
 /*
  * Set a pointer on the send/recv queue data.
- * If flags have SOCCR_MEM_EXCL, the buffer is stolen by the library and is 
+ * If flags have SOCCR_MEM_EXCL, the buffer is stolen by the library and is
  * free()-ed after libsoccr_resume().
  */
 int libsoccr_set_queue_bytes(struct libsoccr_sk *sk, int queue_id, char *bytes, unsigned flags);
 
 /*
  * Set a pointer on the libsoccr_addr for src/dst.
- * If flags have SOCCR_MEM_EXCL, the buffer is stolen by the library and is 
+ * If flags have SOCCR_MEM_EXCL, the buffer is stolen by the library and is
  * fre()-ed after libsoccr_resume().
  */
 int libsoccr_set_addr(struct libsoccr_sk *sk, int self, union libsoccr_addr *, unsigned flags);

--- a/test/others/bers/bers.c
+++ b/test/others/bers/bers.c
@@ -366,7 +366,7 @@ int main(int argc, char *argv[])
 
 		pid = fork();
 		if (pid < 0) {
-			printf("Can't create fork: %m\n");
+			pr_perror("Can't fork");
 			exit(1);
 		} else if (pid == 0) {
 			work_on_fork(shared);

--- a/test/others/pipes/pipe.c
+++ b/test/others/pipes/pipe.c
@@ -10,7 +10,7 @@
  * Also note that changing the log file during restore has nothing to do
  * with the pipe.  It's just a nice feature for cases where it's desirable
  * to have a restored process use a different file then the original one.
- * 
+ *
  * The parent process spawns a child that will write messages to its
  * parent through a pipe.  After a couple of messages, parent invokes
  * criu to checkpoint the child.  Since the child exits after checkpoint,
@@ -377,7 +377,7 @@ void chld_handler(int signum)
 	if (pid == child_pid) {
 		if (!qflag) {
 			printf("%s %s exited with status %d\n", who(0),
-				who(pid), status); 
+				who(pid), status);
 		}
 		/* if child exited successfully, we're done */
 		if (status == 0)
@@ -528,7 +528,7 @@ char *pipe_name(int fd)
 }
 
 /*
- * Use two buffers to support two calls to 
+ * Use two buffers to support two calls to
  * this function in a printf argument list.
  */
 char *who(pid_t pid)

--- a/test/zdtm/lib/bpfmap_zdtm.c
+++ b/test/zdtm/lib/bpfmap_zdtm.c
@@ -123,4 +123,4 @@ int cmp_bpfmap_fdinfo(struct bpfmap_fdinfo_obj *old, struct bpfmap_fdinfo_obj *n
 		return -1;
 
 	return 0;
-} 
+}

--- a/test/zdtm/lib/tcp.c
+++ b/test/zdtm/lib/tcp.c
@@ -43,13 +43,13 @@ int tcp_init_server_with_opts(int family, int *port, struct zdtm_tcp_opts *opts)
 
 	if (opts->reuseport &&
 	    setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(int)) == -1) {
-		pr_perror("");
+		pr_perror("setsockopt(SO_REUSEPORT) failed");
 		return -1;
 	}
 
 	if (opts->reuseaddr &&
 	    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1 ) {
-		pr_perror("setsockopt() error");
+		pr_perror("setsockopt(SO_REUSEATTR) failed");
 		return -1;
 	}
 

--- a/test/zdtm/lib/test.c
+++ b/test/zdtm/lib/test.c
@@ -372,7 +372,7 @@ int test_wait_pre_dump(void)
 
 	if (read(criu_status_in, &ret, sizeof(ret)) != sizeof(ret)) {
 		if (errno != EBADF || !futex_get(&sig_received))
-			pr_perror("Can't wait pre-dump\n");
+			pr_perror("Can't wait pre-dump");
 		return -1;
 	}
 	pr_err("pre-dump\n");

--- a/test/zdtm/lib/zdtmtst.h
+++ b/test/zdtm/lib/zdtmtst.h
@@ -114,7 +114,7 @@ extern int write_pidfile(int pid);
 #define __stringify(x)          __stringify_1(x)
 
 /*
- * Macro to define stack alignment. 
+ * Macro to define stack alignment.
  * aarch64 requires stack to be aligned to 16 bytes.
  */
 #define __stack_aligned__	__attribute__((aligned(16)))

--- a/test/zdtm/static/apparmor.c
+++ b/test/zdtm/static/apparmor.c
@@ -22,13 +22,13 @@ int setprofile(void)
 
 	len = snprintf(profile, sizeof(profile), "changeprofile " PROFILE);
 	if (len < 0 || len >= sizeof(profile)) {
-		fail("bad sprintf\n");
+		fail("bad sprintf");
 		return -1;
 	}
 
 	fd = open("/proc/self/attr/current", O_WRONLY);
 	if (fd < 0) {
-		fail("couldn't open fd\n");
+		fail("couldn't open fd");
 		return -1;
 	}
 
@@ -38,7 +38,7 @@ int setprofile(void)
 	close(fd);
 
 	if (len < 0) {
-		fail("couldn't write profile\n");
+		fail("couldn't write profile");
 		return -1;
 	}
 
@@ -55,19 +55,19 @@ int checkprofile(void)
 
 	f = fopen(path, "r");
 	if (!f) {
-		fail("couldn't open lsm current\n");
+		fail("couldn't open lsm current");
 		return -1;
 	}
 
 	len = fscanf(f, "%[^ \n]s", profile);
 	fclose(f);
 	if (len != 1) {
-		fail("wrong number of items scanned %d\n", len);
+		fail("wrong number of items scanned %d", len);
 		return -1;
 	}
 
 	if (strcmp(profile, PROFILE) != 0) {
-		fail("bad profile .%s. expected .%s.\n", profile, PROFILE);
+		fail("bad profile .%s. expected .%s.", profile, PROFILE);
 		return -1;
 	}
 

--- a/test/zdtm/static/arm-neon00.c
+++ b/test/zdtm/static/arm-neon00.c
@@ -49,7 +49,7 @@ int main(int argc, char ** argv)
 	);
 
 	if (y1 != y2)
-		fail("VFP restoration failed: result = %d, expected = %d (a = %d, b = %d, c = %d)\n", y2, y1, a, b, c);
+		fail("VFP restoration failed: result = %d, expected = %d (a = %d, b = %d, c = %d)", y2, y1, a, b, c);
 	else
 		pass();
 

--- a/test/zdtm/static/autofs.c
+++ b/test/zdtm/static/autofs.c
@@ -437,11 +437,11 @@ static int automountd_serve(const char *mountpoint, struct autofs_params *p,
 			res = autofs_mount_direct(mountpoint, v5_packet);
 			break;
 		case autofs_ptype_expire_indirect:
-			pr_err("%d: expire request for indirect mount %s?",
+			pr_err("%d: expire request for indirect mount %s?\n",
 					getpid(), v5_packet->name);
 			return -EINVAL;
 		case autofs_ptype_expire_direct:
-			pr_err("%d: expire request for direct mount?",
+			pr_err("%d: expire request for direct mount?\n",
 					getpid());
 			return -EINVAL;
 		default:
@@ -507,7 +507,7 @@ static int automountd(struct autofs_params *p, int control_fd)
 
 	autofs_path = xsprintf("%s/%s", dirname, p->mountpoint);
 	if (!autofs_path) {
-		pr_err("failed to allocate autofs path");
+		pr_err("failed to allocate autofs path\n");
 		goto err;
 	}
 

--- a/test/zdtm/static/binfmt_misc.c
+++ b/test/zdtm/static/binfmt_misc.c
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
 	ssprintf(path, "%s/%s", dirname, NAME[0]);
 	fd = open(path, O_WRONLY);
 	if (fd < 0 || write(fd, "0", 1) != 1) {
-		fail("Can't disable %s\n", path);
+		fail("Can't disable %s", path);
 		exit(1);
 	}
 	close(fd);
@@ -170,7 +170,7 @@ int main(int argc, char **argv)
 			exit(1);
 
 		if (strcmp(tmp, dump[i])) {
-			fail("Content differs:\n%s\nand\n%s\n", tmp, dump[i]);
+			fail("Content differs:\n%s\nand\n%s", tmp, dump[i]);
 			exit(1);
 		}
 		free(dump[i]);

--- a/test/zdtm/static/bpf_array.c
+++ b/test/zdtm/static/bpf_array.c
@@ -77,13 +77,13 @@ int main(int argc, char **argv)
 		.flags = 0,
 	);
 
-	keys = mmap(NULL, max_entries * sizeof(int), 
-			PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, 0, 0);	
-	values = mmap(NULL, max_entries * sizeof(int), 
+	keys = mmap(NULL, max_entries * sizeof(int),
 			PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, 0, 0);
-	visited = mmap(NULL, max_entries * sizeof(int), 
+	values = mmap(NULL, max_entries * sizeof(int),
 			PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, 0, 0);
-	
+	visited = mmap(NULL, max_entries * sizeof(int),
+			PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, 0, 0);
+
 	if ((keys == MAP_FAILED) || (values == MAP_FAILED) || (visited == MAP_FAILED)) {
 		pr_perror("Can't mmap()");
 		goto err;
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 		pr_perror("Could not parse new map fdinfo from procfs");
 		goto err;
 	}
-	
+
 	if (cmp_bpf_map_info(&old_map_info, &new_map_info)) {
 		pr_err("bpf_map_info mismatch\n");
 		goto err;
@@ -167,7 +167,7 @@ err:
 	munmap(keys, max_entries * sizeof(int));
 	munmap(values, max_entries * sizeof(int));
 	munmap(visited, max_entries * sizeof(int));
-	
+
 	fail();
 	return 1;
 }

--- a/test/zdtm/static/bpf_hash.c
+++ b/test/zdtm/static/bpf_hash.c
@@ -34,7 +34,7 @@ static int map_batch_verify(int *visited, uint32_t max_entries, int *keys, int *
 {
 	memset(visited, 0, max_entries * sizeof(*visited));
 	for (int i = 0; i < max_entries; i++) {
-		
+
 		if (keys[i] + 1 != values[i]) {
 			pr_err("Key/value checking error: i=%d, key=%d, value=%d\n", i, keys[i], values[i]);
 			return -1;
@@ -76,13 +76,13 @@ int main(int argc, char **argv)
 		.flags = 0,
 	);
 
-	keys = mmap(NULL, max_entries * sizeof(int), 
-			PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, 0, 0);	
-	values = mmap(NULL, max_entries * sizeof(int), 
+	keys = mmap(NULL, max_entries * sizeof(int),
 			PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, 0, 0);
-	visited = mmap(NULL, max_entries * sizeof(int), 
+	values = mmap(NULL, max_entries * sizeof(int),
 			PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, 0, 0);
-	
+	visited = mmap(NULL, max_entries * sizeof(int),
+			PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, 0, 0);
+
 	if ((keys == MAP_FAILED) || (values == MAP_FAILED) || (visited == MAP_FAILED)) {
 		pr_perror("Can't mmap()");
 		goto err;
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
 		pr_perror("Could not parse new map fdinfo from procfs");
 		goto err;
 	}
-	
+
 	if (cmp_bpf_map_info(&old_map_info, &new_map_info)) {
 		pr_err("bpf_map_info mismatch\n");
 		goto err;
@@ -166,7 +166,7 @@ err:
 	munmap(keys, max_entries * sizeof(int));
 	munmap(values, max_entries * sizeof(int));
 	munmap(visited, max_entries * sizeof(int));
-	
+
 	fail();
 	return 1;
 }

--- a/test/zdtm/static/cgroup01.c
+++ b/test/zdtm/static/cgroup01.c
@@ -86,13 +86,13 @@ int main(int argc, char **argv)
 			ssprintf(paux, "%s/%s/%s.%d", aux, subname, empty, i);
 
 			if (stat(paux, &st)) {
-				fail("couldn't stat %s\n", paux);
+				fail("couldn't stat %s", paux);
 				ret = -1;
 				goto out_close;
 			}
 
 			if (!S_ISDIR(st.st_mode)) {
-				fail("%s is not a directory\n", paux);
+				fail("%s is not a directory", paux);
 				ret = -1;
 				goto out_close;
 			}
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
 		goto out_close;
 	}
 
-	fail("empty cgroup not found!\n");
+	fail("empty cgroup not found!");
 
 out_close:
 	fclose(cgf);

--- a/test/zdtm/static/cgroup02.c
+++ b/test/zdtm/static/cgroup02.c
@@ -148,12 +148,12 @@ int main(int argc, char **argv)
 	}
 
 	if (!found_zdtmtstroot) {
-		fail("oldroot not rewritten to zdtmtstroot!\n");
+		fail("oldroot not rewritten to zdtmtstroot!");
 		goto out_close;
 	}
 
 	if (!found_newroot) {
-		fail("oldroot not rewritten to newroot!\n");
+		fail("oldroot not rewritten to newroot!");
 		goto out_close;
 	}
 

--- a/test/zdtm/static/cgroup03.c
+++ b/test/zdtm/static/cgroup03.c
@@ -102,17 +102,17 @@ int checkperms(char *path)
 	}
 
 	if ((sb.st_mode & 0777) != 0777) {
-		fail("mode for %s doesn't match (%o)\n", path, sb.st_mode);
+		fail("mode for %s doesn't match (%o)", path, sb.st_mode);
 		return -1;
 	}
 
 	if (sb.st_uid != 1000) {
-		fail("uid for %s doesn't match (%d)\n", path, sb.st_uid);
+		fail("uid for %s doesn't match (%d)", path, sb.st_uid);
 		return -1;
 	}
 
 	if (sb.st_gid != 1000) {
-		fail("gid for %s doesn't match (%d)\n", path, sb.st_gid);
+		fail("gid for %s doesn't match (%d)", path, sb.st_gid);
 		return -1;
 	}
 

--- a/test/zdtm/static/cgroup_ifpriomap.c
+++ b/test/zdtm/static/cgroup_ifpriomap.c
@@ -105,7 +105,7 @@ static int read_one_priomap(char *prop_line, struct ifpriomap_t *out)
 
 	out->ifname = malloc(len + 1);
 	if (!out->ifname) {
-		pr_perror("malloc() failed\n");
+		pr_perror("malloc() failed");
 		return -1;
 	}
 

--- a/test/zdtm/static/cgroup_stray.c
+++ b/test/zdtm/static/cgroup_stray.c
@@ -97,7 +97,7 @@ static bool pid_in_cgroup(pid_t pid, const char *controller, const char *path) {
 		/* skip hierarchy no. */
 		pos = strstr(buf, ":");
 		if (!pos) {
-			pr_err("invalid /proc/pid/cgroups file");
+			pr_err("invalid /proc/pid/cgroups file\n");
 			goto out;
 		}
 		pos++;
@@ -105,7 +105,7 @@ static bool pid_in_cgroup(pid_t pid, const char *controller, const char *path) {
 
 		pos = strstr(pos, ":");
 		if (!pos) {
-			pr_err("invalid /proc/pid/cgroups file");
+			pr_err("invalid /proc/pid/cgroups file\n");
 			goto out;
 		}
 

--- a/test/zdtm/static/cgroup_stray.c
+++ b/test/zdtm/static/cgroup_stray.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 	}
 
 	if (!WIFEXITED(status) || WEXITSTATUS(status)) {
-		fail("exit status %d\n", status);
+		fail("exit status %d", status);
 		goto out_umount;
 	}
 

--- a/test/zdtm/static/cgroupns.c
+++ b/test/zdtm/static/cgroupns.c
@@ -95,7 +95,7 @@ static bool pid_in_cgroup(pid_t pid, const char *controller, const char *path) {
 		/* skip hierarchy no. */
 		pos = strstr(buf, ":");
 		if (!pos) {
-			pr_err("invalid /proc/pid/cgroups file");
+			pr_err("invalid /proc/pid/cgroups file\n");
 			goto out;
 		}
 		pos++;
@@ -103,7 +103,7 @@ static bool pid_in_cgroup(pid_t pid, const char *controller, const char *path) {
 
 		pos = strstr(pos, ":");
 		if (!pos) {
-			pr_err("invalid /proc/pid/cgroups file");
+			pr_err("invalid /proc/pid/cgroups file\n");
 			goto out;
 		}
 
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
 	}
 
 	if (pid != waitpid(pid, &status, 0)) {
-		pr_err("wrong pid");
+		pr_perror("wrong pid");
 		goto out;
 	}
 

--- a/test/zdtm/static/child_subreaper.c
+++ b/test/zdtm/static/child_subreaper.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
 	}
 
 	if (cs_before != cs_after)
-		fail("%d != %d\n", cs_before, cs_after);
+		fail("%d != %d", cs_before, cs_after);
 	else
 		pass();
 

--- a/test/zdtm/static/child_subreaper_existing_child.c
+++ b/test/zdtm/static/child_subreaper_existing_child.c
@@ -76,18 +76,18 @@ int subreaper(void)
 		pr_perror("Wrong exit status for HELPER: %d", status);
 		return 1;
 	}
-	
+
 	/* Give control to ORPHAN so it can check its parent */
 	futex_set_and_wake(&sh->fstate, TEST_CHECK);
 	futex_wait_until(&sh->fstate, TEST_EXIT);
-	
+
 	/* Cleanup: reap the ORPHAN */
 	wait(&status);
 	if (!WIFEXITED(status) || WEXITSTATUS(status)) {
 		pr_perror("Wrong exit status for ORPHAN: %d", status);
 		return 1;
 	}
-	
+
 	return 0;
 }
 

--- a/test/zdtm/static/cmdlinenv00.c
+++ b/test/zdtm/static/cmdlinenv00.c
@@ -26,7 +26,7 @@ static void read_from_proc(const char *path, char *buf, size_t size)
 
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
-		fail("Can't open cmdline\n");
+		fail("Can't open cmdline");
 		exit(1);
 	}
 

--- a/test/zdtm/static/cr_veth.c
+++ b/test/zdtm/static/cr_veth.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 	test_init(argc, argv);
 
 	if (!wait_for_veth()) {
-		fail("failed to inject veth device\n");
+		fail("failed to inject veth device");
 		return 1;
 	}
 

--- a/test/zdtm/static/criu-rtc.c
+++ b/test/zdtm/static/criu-rtc.c
@@ -96,7 +96,7 @@ int cr_plugin_restore_file(int id)
 
 	e = criu_rtc__unpack(NULL, len, buf);
 	if (e == NULL) {
-		pr_err("Unable to parse the RTC message %#x", id);
+		pr_err("Unable to parse the RTC message %#x\n", id);
 		return -1;
 	}
 

--- a/test/zdtm/static/cwd00.c
+++ b/test/zdtm/static/cwd00.c
@@ -46,12 +46,12 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (!getcwd(cwd2, sizeof(cwd2))) {
-		fail("can't get cwd: %m\n");
+		fail("can't get cwd: %m");
 		goto cleanup;
 	}
 
 	if (strcmp(cwd1, cwd2))
-		fail("%s != %s\n", cwd1, cwd2);
+		fail("%s != %s", cwd1, cwd2);
 	else
 		pass();
 cleanup:

--- a/test/zdtm/static/cwd00.c
+++ b/test/zdtm/static/cwd00.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (!getcwd(cwd2, sizeof(cwd2))) {
-		fail("can't get cwd: %m");
+		fail("can't get cwd");
 		goto cleanup;
 	}
 

--- a/test/zdtm/static/cwd01.c
+++ b/test/zdtm/static/cwd01.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 
 	aux2 = readlink("/proc/self/cwd", cwd2, sizeof(cwd2));
 	if (aux2 < 0) {
-		fail("can't get cwd: %m\n");
+		fail("can't get cwd: %m");
 		goto cleanup;
 	}
 	if (aux2 == sizeof(cwd2)) {
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
 
 	/* FIXME -- criu adds a suffix to removed cwd */
 	if (strncmp(cwd1, cwd2, aux))
-		fail("%s != %s\n", cwd1, cwd2);
+		fail("%s != %s", cwd1, cwd2);
 	else
 		pass();
 cleanup:

--- a/test/zdtm/static/cwd01.c
+++ b/test/zdtm/static/cwd01.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 
 	aux2 = readlink("/proc/self/cwd", cwd2, sizeof(cwd2));
 	if (aux2 < 0) {
-		fail("can't get cwd: %m");
+		fail("can't get cwd");
 		goto cleanup;
 	}
 	if (aux2 == sizeof(cwd2)) {

--- a/test/zdtm/static/cwd02.c
+++ b/test/zdtm/static/cwd02.c
@@ -63,18 +63,18 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (fstat(fd, &stf) < 0) {
-		fail("dir fd closed\n");
+		fail("dir fd closed");
 		goto cleanup;
 	}
 
 	if (stat("/proc/self/cwd", &std) < 0) {
-		fail("cwd is not OK\n");
+		fail("cwd is not OK");
 		goto cleanup;
 	}
 
 	if (stf.st_ino != std.st_ino ||
 			stf.st_dev != std.st_dev) {
-		fail("cwd and opened fd are not the same\n");
+		fail("cwd and opened fd are not the same");
 		goto cleanup;
 	}
 

--- a/test/zdtm/static/del_standalone_un.c
+++ b/test/zdtm/static/del_standalone_un.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
 	}
 
 	if (stat(addr.sun_path, &sb) != 0) {
-		fail("%s doesn't exist after restore\n", addr.sun_path);
+		fail("%s doesn't exist after restore", addr.sun_path);
 		goto out;
 	}
 

--- a/test/zdtm/static/deleted_dev.c
+++ b/test/zdtm/static/deleted_dev.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (fstat(fd, &st) < 0) {
-		fail("can't stat %s: %m", filename);
+		fail("can't stat %s", filename);
 		goto out;
 	}
 
@@ -59,12 +59,12 @@ int main(int argc, char **argv)
 	}
 
 	if (close(fd) < 0) {
-		fail("can't close %s: %m", filename);
+		fail("can't close %s", filename);
 		goto out;
 	}
 
 	if (unlink(filename) != -1 || errno != ENOENT) {
-		fail("file %s should have been deleted before migration: unlink: %m", filename);
+		fail("file %s should have been deleted before migration: unlink", filename);
 		goto out;
 	}
 

--- a/test/zdtm/static/deleted_dev.c
+++ b/test/zdtm/static/deleted_dev.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 	}
 
 	if (unlink(filename) != -1 || errno != ENOENT) {
-		fail("file %s should have been deleted before migration: unlink: %m\n", filename);
+		fail("file %s should have been deleted before migration: unlink: %m", filename);
 		goto out;
 	}
 

--- a/test/zdtm/static/deleted_unix_sock.c
+++ b/test/zdtm/static/deleted_unix_sock.c
@@ -125,12 +125,12 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (kill(pid, SIGTERM)) {
-		fail("terminating the child failed: %m");
+		fail("terminating the child failed");
 		goto out;
 	}
 
 	if (wait(&ret) != pid) {
-		fail("wait() returned wrong pid %d: %m", pid);
+		fail("wait() returned wrong pid %d", pid);
 		goto out;
 	}
 
@@ -147,7 +147,7 @@ int main(int argc, char ** argv)
 	}
 
 	if (read(sock, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m", filename);
+		fail("can't read %s", filename);
 		goto out;
 	}
 
@@ -159,12 +159,12 @@ int main(int argc, char ** argv)
 
 
 	if (close(sock)) {
-		fail("close failed: %m");
+		fail("close failed");
 		goto out;
 	}
 
 	if (unlink(filename) != -1 || errno != ENOENT) {
-		fail("file %s should have been deleted before migration: unlink: %m", filename);
+		fail("file %s should have been deleted before migration: unlink", filename);
 		goto out;
 	}
 

--- a/test/zdtm/static/deleted_unix_sock.c
+++ b/test/zdtm/static/deleted_unix_sock.c
@@ -125,46 +125,46 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (kill(pid, SIGTERM)) {
-		fail("terminating the child failed: %m\n");
+		fail("terminating the child failed: %m");
 		goto out;
 	}
 
 	if (wait(&ret) != pid) {
-		fail("wait() returned wrong pid %d: %m\n", pid);
+		fail("wait() returned wrong pid %d: %m", pid);
 		goto out;
 	}
 
 	if (WIFEXITED(ret)) {
 		ret = WEXITSTATUS(ret);
 		if (ret) {
-			fail("child exited with nonzero code %d (%s)\n", ret, strerror(ret));
+			fail("child exited with nonzero code %d (%s)", ret, strerror(ret));
 			goto out;
 		}
 	}
 	if (WIFSIGNALED(ret)) {
-		fail("child exited on unexpected signal %d\n", WTERMSIG(ret));
+		fail("child exited on unexpected signal %d", WTERMSIG(ret));
 		goto out;
 	}
 
 	if (read(sock, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m\n", filename);
+		fail("can't read %s: %m", filename);
 		goto out;
 	}
 
 	crc = ~0;
 	if (datachk(buf, sizeof(buf), &crc)) {
-		fail("CRC mismatch\n");
+		fail("CRC mismatch");
 		goto out;
 	}
 
 
 	if (close(sock)) {
-		fail("close failed: %m\n");
+		fail("close failed: %m");
 		goto out;
 	}
 
 	if (unlink(filename) != -1 || errno != ENOENT) {
-		fail("file %s should have been deleted before migration: unlink: %m\n", filename);
+		fail("file %s should have been deleted before migration: unlink: %m", filename);
 		goto out;
 	}
 

--- a/test/zdtm/static/dumpable02.c
+++ b/test/zdtm/static/dumpable02.c
@@ -44,13 +44,13 @@ int get_dumpable_from_pipes(int pipe_input, int pipe_output) {
 	buf[len] = 0;
 
 	if (memcmp(buf, "DUMPABLE:", 9) != 0) {
-		pr_perror("child returned [%s]", buf);
+		pr_err("child returned [%s]\n", buf);
 		return -1;
 	}
 
 	value = strtol(&buf[9], &endptr, 10);
 	if (!endptr || *endptr != '\n' || endptr != buf + len - 1) {
-		pr_perror("child returned [%s]", buf);
+		pr_err("child returned [%s]\n", buf);
 		return -1;
 	}
 
@@ -188,17 +188,17 @@ int main(int argc, char **argv)
 	}
 	errno = 0;
 	if (waited != pid) {
-		pr_perror("waited pid %d did not match child pid %d",
+		pr_err("waited pid %d did not match child pid %d\n",
 		    waited, pid);
 		return 1;
 	}
 	if (!WIFEXITED(status)) {
-		pr_perror("child dumpable server returned abnormally with status=%d",
+		pr_err("child dumpable server returned abnormally with status=%d\n",
 		    status);
 		return 1;
 	}
 	if (WEXITSTATUS(status) != 0) {
-		pr_perror("child dumpable server returned rc=%d",
+		pr_err("child dumpable server returned rc=%d\n",
 		    WEXITSTATUS(status));
 		return 1;
 	}

--- a/test/zdtm/static/dumpable02.c
+++ b/test/zdtm/static/dumpable02.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 	 */
 	ret = chmod(argv[0], 0111);
 	if (ret < 0) {
-		pr_perror("error chmodding %s", argv[0]);
+		pr_perror("chmod(%s) failed", argv[0]);
 		return 1;
 	}
 
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
 		}
 
 		execl(argv[0], "dumpable_server", NULL);
-		pr_perror("could not execv %s as a dumpable_server\nError No: %d", argv[0], errno);
+		pr_perror("could not execv %s as a dumpable_server", argv[0]);
 		return 1;
 	}
 

--- a/test/zdtm/static/env00.c
+++ b/test/zdtm/static/env00.c
@@ -26,12 +26,12 @@ int main(int argc, char **argv)
 
 	env = getenv(envname);
 	if (!env) {
-		fail("can't get env var \"%s\": %m\n", envname);
+		fail("can't get env var \"%s\": %m", envname);
 		goto out;
 	}
 
 	if (strcmp(env, test_author))
-		fail("%s != %s\n", env, test_author);
+		fail("%s != %s", env, test_author);
 	else
 		pass();
 out:

--- a/test/zdtm/static/env00.c
+++ b/test/zdtm/static/env00.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv)
 
 	env = getenv(envname);
 	if (!env) {
-		fail("can't get env var \"%s\": %m", envname);
+		fail("can't get env var \"%s\"", envname);
 		goto out;
 	}
 

--- a/test/zdtm/static/epoll.c
+++ b/test/zdtm/static/epoll.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
 
 	for (i = 0; i < ARRAY_SIZE(pipes); i++) {
 		if (pipe(pipes[i].pipefd)) {
-			pr_err("Can't create pipe %d\n", i);
+			pr_perror("Can't create pipe %d", i);
 			exit(1);
 		}
 
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
 
 			nfd = dup2(pipes[i].pipefd[0], i + 700);
 			if (nfd < 0) {
-				pr_err("dup2");
+				pr_perror("dup2");
 				exit(1);
 			}
 			close(pipes[i].pipefd[0]);

--- a/test/zdtm/static/epoll.c
+++ b/test/zdtm/static/epoll.c
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
 		uint8_t cw = 1, cr;
 
 		if (write(pipes[i].pipefd[1], &cw, sizeof(cw)) != sizeof(cw)) {
-			pr_perror("Unable to write into a pipe\n");
+			pr_perror("Unable to write into a pipe");
 			return 1;
 		}
 

--- a/test/zdtm/static/epoll01.c
+++ b/test/zdtm/static/epoll01.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 		uint8_t cw = 1, cr;
 
 		if (write(pipes[i].pipefd[1], &cw, sizeof(cw)) != sizeof(cw)) {
-			pr_perror("Unable to write into a pipe\n");
+			pr_perror("Unable to write into a pipe");
 			return 1;
 		}
 

--- a/test/zdtm/static/eventfs00.c
+++ b/test/zdtm/static/eventfs00.c
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (v != EVENTFD_FINAL) {
-		fail("EVENTFD_FINAL mismatch\n");
+		fail("EVENTFD_FINAL mismatch");
 		exit(1);
 	}
 

--- a/test/zdtm/static/fanotify00.c
+++ b/test/zdtm/static/fanotify00.c
@@ -284,25 +284,25 @@ int main (int argc, char *argv[])
 	close(fd);
 
 	if (unlink(fanotify_path)) {
-		fail("can't unlink %s\n", fanotify_path);
+		fail("can't unlink %s", fanotify_path);
 		exit(1);
 	}
 
 	if (parse_fanotify_fdinfo(fa_fd, &new, 3)) {
-		fail("parsing fanotify fdinfo failed\n");
+		fail("parsing fanotify fdinfo failed");
 		exit(1);
 	}
 
 	show_fanotify_obj(&new);
 
 	if (cmp_fanotify_obj(&old, &new)) {
-		fail("fanotify mismatch on fdinfo level\n");
+		fail("fanotify mismatch on fdinfo level");
 		exit(1);
 	}
 
 	length = read(fa_fd, buf, sizeof(buf));
 	if (length <= 0) {
-		fail("No events in fanotify queue\n");
+		fail("No events in fanotify queue");
 		exit(1);
 	}
 

--- a/test/zdtm/static/fd.c
+++ b/test/zdtm/static/fd.c
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
 			ret = 0;
 		}
 		pfd[ret] = '\0';
-		fail("Unexpected fd: %s -> %s\n", de->d_name, pfd);
+		fail("Unexpected fd: %s -> %s", de->d_name, pfd);
 		return 1;
 	}
 

--- a/test/zdtm/static/fdt_shared.c
+++ b/test/zdtm/static/fdt_shared.c
@@ -81,7 +81,7 @@ static int child3(void *_arg)
 	test_waitsig();
 
 	if (close(TEST_FD) != -1) {
-		fail("%d is exist\n", TEST_FD);
+		fail("%d is exist", TEST_FD);
 		return 1;
 	}
 
@@ -110,14 +110,14 @@ static int child(void *_arg)
 	waitpid(pid2, &status, 0);
 
 	if (status) {
-		fail("The child3 returned %d\n", status);
+		fail("The child3 returned %d", status);
 		return 1;
 	}
 
 	waitpid(pid, &status, 0);
 
 	if (status) {
-		fail("The child2 returned %d\n", status);
+		fail("The child2 returned %d", status);
 		return 1;
 	}
 
@@ -185,18 +185,18 @@ int main(int argc, char ** argv)
 	kill(pid, SIGTERM);
 
 	if (status) {
-		fail("The child returned %d\n", status);
+		fail("The child returned %d", status);
 		return 1;
 	}
 
 	waitpid(pid, &status, 0);
 	if (status) {
-		fail("The child returned %d\n", status);
+		fail("The child returned %d", status);
 		return 1;
 	}
 
 	if (close(TEST_FD) == 0) {
-		fail("%d was not closed\n", TEST_FD);
+		fail("%d was not closed", TEST_FD);
 		return 1;
 	}
 

--- a/test/zdtm/static/fifo-rowo-pair.c
+++ b/test/zdtm/static/fifo-rowo-pair.c
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
 
 	errno = WEXITSTATUS(status);
 	if (errno) {
-		fail("Child exited with error %m");
+		fail("Child exited with error");
 		exit(errno);
 	}
 

--- a/test/zdtm/static/fifo-rowo-pair.c
+++ b/test/zdtm/static/fifo-rowo-pair.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
 	task_waiter_complete_current(&t);
 
 	if (v != TEST_VALUE) {
-		fail("read data mismatch\n");
+		fail("read data mismatch");
 		exit_shot(pid, 1);
 	}
 
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
 		exit_shot(pid, 1);
 	}
 	if (v != TEST_VALUE) {
-		fail("read data mismatch\n");
+		fail("read data mismatch");
 		exit_shot(pid, 1);
 	}
 

--- a/test/zdtm/static/fifo.c
+++ b/test/zdtm/static/fifo.c
@@ -59,12 +59,12 @@ int main(int argc, char **argv)
 	}
 
 	if (close(fd) < 0) {
-		fail("can't close %s: %m", filename);
+		fail("can't close %s", filename);
 		return 1;
 	}
 
 	if (stat(filename, &st) < 0) {
-		fail("can't stat %s: %m", filename);
+		fail("can't stat %s", filename);
 		return 1;
 	}
 
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 	}
 
 	if (unlink(filename) < 0) {
-		fail("can't unlink %s: %m", filename);
+		fail("can't unlink %s", filename);
 		return 1;
 	}
 

--- a/test/zdtm/static/fifo.c
+++ b/test/zdtm/static/fifo.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
 
 	crc = ~0;
 	if (datachk(buf, BUF_SIZE, &crc)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		return 1;
 	}
 

--- a/test/zdtm/static/fifo_ro.c
+++ b/test/zdtm/static/fifo_ro.c
@@ -67,12 +67,12 @@ int main(int argc, char **argv)
 	}
 
 	if (close(fd_ro) < 0) {
-		fail("can't close %s: %m", filename);
+		fail("can't close %s", filename);
 		return 1;
 	}
 
 	if (stat(filename, &st) < 0) {
-		fail("can't stat %s: %m", filename);
+		fail("can't stat %s", filename);
 		return 1;
 	}
 
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
 	}
 
 	if (unlink(filename) < 0) {
-		fail("can't unlink %s: %m", filename);
+		fail("can't unlink %s", filename);
 		return 1;
 	}
 

--- a/test/zdtm/static/fifo_ro.c
+++ b/test/zdtm/static/fifo_ro.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
 
 	crc = ~0;
 	if (datachk(buf, BUF_SIZE, &crc)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		return 1;
 	}
 

--- a/test/zdtm/static/fifo_wronly.c
+++ b/test/zdtm/static/fifo_wronly.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
 			return 1;
 		}
 		if (close(fd1) < 0) {
-			fail("can't close %d, %s: %m", fd1, filename);
+			fail("can't close %d, %s", fd1, filename);
 			chret = errno;
 			return chret;
 		}
@@ -93,12 +93,12 @@ int main(int argc, char **argv)
 		}
 
 		if (close(fd) < 0) {
-			fail("can't close %d, %s: %m", fd, filename);
+			fail("can't close %d, %s", fd, filename);
 			return 1;
 		}
 
 		if (stat(filename, &st) < 0) {
-			fail("can't stat %s: %m", filename);
+			fail("can't stat %s", filename);
 			return 1;
 		}
 
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
 		}
 
 		if (unlink(filename) < 0) {
-			fail("can't unlink %s: %m", filename);
+			fail("can't unlink %s", filename);
 			return 1;
 		}
 	}

--- a/test/zdtm/static/fifo_wronly.c
+++ b/test/zdtm/static/fifo_wronly.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 		wait(&chret);
 		chret = WEXITSTATUS(chret);
 		if (chret) {
-			fail("child exited with non-zero code %d (%s)\n",
+			fail("child exited with non-zero code %d (%s)",
 				chret, strerror(chret));
 			return 1;
 		}

--- a/test/zdtm/static/file_attr.c
+++ b/test/zdtm/static/file_attr.c
@@ -72,12 +72,12 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (lseek(fd, 0, SEEK_SET) < 0) {
-		fail("lseeking to the beginning of file failed: %m");
+		fail("lseeking to the beginning of file failed");
 		goto out;
 	}
 
 	if (read(fd, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m", filename);
+		fail("can't read %s", filename);
 		goto out;
 	}
 
@@ -88,7 +88,7 @@ int main(int argc, char ** argv)
 	}
 
 	if (fstat(fd, &st) < 0) {
-		fail("can't fstat %s: %m", filename);
+		fail("can't fstat %s", filename);
 		goto out;
 	}
 
@@ -103,12 +103,12 @@ int main(int argc, char ** argv)
 	}
 
 	if (close(fd)) {
-		fail("close failed: %m");
+		fail("close failed");
 		goto out_noclose;
 	}
 
 	if (unlink(filename) != -1 || errno != ENOENT) {
-		fail("file %s should have been deleted before migration: unlink: %m", filename);
+		fail("file %s should have been deleted before migration: unlink", filename);
 		goto out_noclose;
 	}
 

--- a/test/zdtm/static/file_attr.c
+++ b/test/zdtm/static/file_attr.c
@@ -72,18 +72,18 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (lseek(fd, 0, SEEK_SET) < 0) {
-		fail("lseeking to the beginning of file failed: %m\n");
+		fail("lseeking to the beginning of file failed: %m");
 		goto out;
 	}
 
 	if (read(fd, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m\n", filename);
+		fail("can't read %s: %m", filename);
 		goto out;
 	}
 
 	crc = ~0;
 	if (datachk(buf, sizeof(buf), &crc)) {
-		fail("CRC mismatch\n");
+		fail("CRC mismatch");
 		goto out;
 	}
 
@@ -103,12 +103,12 @@ int main(int argc, char ** argv)
 	}
 
 	if (close(fd)) {
-		fail("close failed: %m\n");
+		fail("close failed: %m");
 		goto out_noclose;
 	}
 
 	if (unlink(filename) != -1 || errno != ENOENT) {
-		fail("file %s should have been deleted before migration: unlink: %m\n", filename);
+		fail("file %s should have been deleted before migration: unlink: %m", filename);
 		goto out_noclose;
 	}
 

--- a/test/zdtm/static/file_fown.c
+++ b/test/zdtm/static/file_fown.c
@@ -55,17 +55,17 @@ static int cmp_pipe_params(struct params *p1, struct params *p2)
 
 	for (i = 0; i < 2; i++) {
 		if (p1->pipe_flags[i] != p2->pipe_flags[i]) {
-			fail("pipe flags failed [%d] expected %08o got %08o\n",
+			fail("pipe flags failed [%d] expected %08o got %08o",
 			     i, p1->pipe_flags[i], p2->pipe_flags[i]);
 			return -1;
 		}
 		if (p1->pipe_pid[i] != p2->pipe_pid[i]) {
-			fail("pipe pid failed [%d] expected %d got %d\n",
+			fail("pipe pid failed [%d] expected %d got %d",
 			     i, p1->pipe_pid[i], p2->pipe_pid[i]);
 			return -1;
 		}
 		if (p1->pipe_sig[i] != p2->pipe_sig[i]) {
-			fail("pipe sig failed [%d] expected %d got %d\n",
+			fail("pipe sig failed [%d] expected %d got %d",
 			     i, p1->pipe_sig[i], p2->pipe_sig[i]);
 			return -1;
 		}
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (getresuid(&ruid, &euid, &suid)) {
-		fail("getresuid failed\n");
+		fail("getresuid failed");
 		exit(1);
 	}
 
@@ -103,12 +103,12 @@ int main(int argc, char *argv[])
 	saio.sa_handler	= (sig_t)signal_handler_io;
 	saio.sa_flags	= SA_RESTART;
 	if (sigaction(SIGIO, &saio, 0)) {
-		fail("sigaction failed\n");
+		fail("sigaction failed");
 		exit(1);
 	}
 
 	if (!getuid() && setresuid(-1, 1, -1)) {
-		fail("setresuid failed\n");
+		fail("setresuid failed");
 		exit(1);
 	}
 
@@ -118,14 +118,14 @@ int main(int argc, char *argv[])
 	    fcntl(pipes[1], F_SETSIG, SIGIO)					||
 	    fcntl(pipes[0], F_SETFL, fcntl(pipes[0], F_GETFL) | O_ASYNC)	||
 	    fcntl(pipes[1], F_SETFL, fcntl(pipes[1], F_GETFL) | O_ASYNC)) {
-		fail("fcntl failed\n");
+		fail("fcntl failed");
 		exit(1);
 	}
 
 	fill_pipe_params(shared, pipes);
 
 	if (setresuid(-1, euid, -1)) {
-		fail("setresuid failed\n");
+		fail("setresuid failed");
 		exit(1);
 	}
 
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
 		fill_pipe_params(&p, pipes);
 
 		if (write(pipes[1], &p, sizeof(p)) != sizeof(p)) {
-			fail("write failed\n");
+			fail("write failed");
 			exit(1);
 		}
 
@@ -156,24 +156,24 @@ int main(int argc, char *argv[])
 	kill(pid, SIGTERM);
 
 	if (waitpid(pid, &status, P_ALL) == -1) {
-		fail("waitpid failed\n");
+		fail("waitpid failed");
 		exit(1);
 	}
 
 	if (read(pipes[0], &obtained, sizeof(obtained)) != sizeof(obtained)) {
-		fail("read failed\n");
+		fail("read failed");
 		exit(1);
 	}
 
 	if (shared->sigio < 1) {
-		fail("shared->sigio = %d (> 0 expected)\n", shared->sigio);
+		fail("shared->sigio = %d (> 0 expected)", shared->sigio);
 		exit(1);
 	}
 
 	shared->pipe_pid[1] = pid;
 
 	if (cmp_pipe_params(shared, &obtained)) {
-		fail("params comparison failed\n");
+		fail("params comparison failed");
 		exit(1);
 	}
 

--- a/test/zdtm/static/file_lease00.c
+++ b/test/zdtm/static/file_lease00.c
@@ -41,7 +41,7 @@ static int check_lease_type(int fd, int expected_type)
 
 	if (lease_type != expected_type) {
 		if (lease_type < 0)
-			pr_perror("Can't acquire lease type\n");
+			pr_perror("Can't acquire lease type");
 		else
 			pr_err("Mismatched lease type: %i\n", lease_type);
 		return -1;
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 	}
 	if (fcntl(fd_rd, F_SETLEASE, F_RDLCK) < 0 ||
 		fcntl(fd_wr, F_SETLEASE, F_WRLCK) < 0) {
-		pr_perror("Can't set leases\n");
+		pr_perror("Can't set leases");
 		close_files(fd_rd, fd_wr);
 		return -1;
 	}

--- a/test/zdtm/static/file_lease00.c
+++ b/test/zdtm/static/file_lease00.c
@@ -73,9 +73,9 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (check_lease_type(fd_rd, F_RDLCK))
-		fail("Read lease check failed\n");
+		fail("Read lease check failed");
 	else if (check_lease_type(fd_wr, F_WRLCK))
-		fail("Write lease check failed\n");
+		fail("Write lease check failed");
 	else
 		pass();
 

--- a/test/zdtm/static/file_lease01.c
+++ b/test/zdtm/static/file_lease01.c
@@ -44,7 +44,7 @@ static int check_lease_type(int fd, int expected_type)
 
 	if (lease_type != expected_type) {
 		if (lease_type < 0)
-			pr_perror("Can't acquire lease type\n");
+			pr_perror("Can't acquire lease type");
 		else
 			pr_err("Mismatched lease type: %i\n", lease_type);
 		return -1;

--- a/test/zdtm/static/file_lease01.c
+++ b/test/zdtm/static/file_lease01.c
@@ -74,11 +74,11 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (check_lease_type(fds[FD_LEASE_FREE], F_UNLCK))
-		fail("Unexpected lease was found (%i)\n", fds[FD_LEASE_FREE]);
+		fail("Unexpected lease was found (%i)", fds[FD_LEASE_FREE]);
 	else if (check_lease_type(fds[FD_LEASED1], F_RDLCK))
-		fail("Lease isn't set (%i)\n", fds[FD_LEASED1]);
+		fail("Lease isn't set (%i)", fds[FD_LEASED1]);
 	else if (check_lease_type(fds[FD_LEASED2], F_RDLCK))
-		fail("Lease isn't set (%i)\n", fds[FD_LEASED2]);
+		fail("Lease isn't set (%i)", fds[FD_LEASED2]);
 	else
 		pass();
 

--- a/test/zdtm/static/file_lease02.c
+++ b/test/zdtm/static/file_lease02.c
@@ -39,7 +39,7 @@ static int check_lease_type(int fd, int expected_type)
 
 	if (lease_type != expected_type) {
 		if (lease_type < 0)
-			pr_perror("Can't acquire lease type\n");
+			pr_perror("Can't acquire lease type");
 		else
 			pr_err("Mismatched lease type: %i\n", lease_type);
 		return -1;
@@ -54,15 +54,15 @@ static int prepare_file(char *file, int file_type, int break_type)
 
 	fd = open(file, file_type | O_CREAT, 0666);
 	if (fd < 0) {
-		pr_perror("Can't open file (type %i)\n", file_type);
+		pr_perror("Can't open file (type %i)", file_type);
 		return fd;
 	}
 	if (fcntl(fd, F_SETLEASE, lease_type) < 0) {
-		pr_perror("Can't set exclusive lease\n");
+		pr_perror("Can't set exclusive lease");
 		goto err;
 	}
 	if (fcntl(fd, F_SETSIG, BREAK_SIGNUM) < 0) {
-		pr_perror("Can't set signum for file i/o\n");
+		pr_perror("Can't set signum for file i/o");
 		goto err;
 	}
 
@@ -74,7 +74,7 @@ static int prepare_file(char *file, int file_type, int break_type)
 		pr_err("Conflicting lease not found\n");
 		goto err;
 	} else if (errno != EWOULDBLOCK) {
-		pr_perror("Can't break lease\n");
+		pr_perror("Can't break lease");
 		goto err;
 	}
 	return fd;
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
 	if (sigemptyset(&act.sa_mask) ||
 		sigaddset(&act.sa_mask, BREAK_SIGNUM) ||
 		sigaction(BREAK_SIGNUM, &act, NULL)) {
-		pr_perror("Can't set signal action\n");
+		pr_perror("Can't set signal action");
 		fail();
 		return -1;
 	}

--- a/test/zdtm/static/file_lease02.c
+++ b/test/zdtm/static/file_lease02.c
@@ -131,11 +131,11 @@ int main(int argc, char **argv)
 
 	ret = 0;
 	if (sigaction_error)
-		fail("Ghost signal\n");
+		fail("Ghost signal");
 	else if (check_lease_type(fds[0], F_UNLCK) ||
 		check_lease_type(fds[1], F_RDLCK) ||
 		check_lease_type(fds[2], F_UNLCK))
-		fail("Lease type doesn't match\n");
+		fail("Lease type doesn't match");
 	else
 		pass();
 done:

--- a/test/zdtm/static/file_lease03.c
+++ b/test/zdtm/static/file_lease03.c
@@ -129,9 +129,9 @@ int main(int argc, char **argv)
 	if (ret < 0 || !WIFEXITED(status) || WEXITSTATUS(status))
 		fail();
 	if (sigaction_error)
-		fail("Ghost signal\n");
+		fail("Ghost signal");
 	else if (check_lease_type(fd, F_UNLCK))
-		fail("Lease type doesn't match\n");
+		fail("Lease type doesn't match");
 	else
 		pass();
 

--- a/test/zdtm/static/file_lease03.c
+++ b/test/zdtm/static/file_lease03.c
@@ -34,7 +34,7 @@ static int check_lease_type(int fd, int expected_type)
 
 	if (lease_type != expected_type) {
 		if (lease_type < 0)
-			pr_perror("Can't acquire lease type\n");
+			pr_perror("Can't acquire lease type");
 		else
 			pr_err("Mismatched lease type: %i\n", lease_type);
 		return -1;
@@ -49,15 +49,15 @@ static int prepare_file(char *file, int file_type, int break_type)
 
 	fd = open(file, file_type | O_CREAT, 0666);
 	if (fd < 0) {
-		pr_perror("Can't open file (type %i)\n", file_type);
+		pr_perror("Can't open file (type %i)", file_type);
 		return fd;
 	}
 	if (fcntl(fd, F_SETLEASE, lease_type) < 0) {
-		pr_perror("Can't set exclusive lease\n");
+		pr_perror("Can't set exclusive lease");
 		goto err;
 	}
 	if (fcntl(fd, F_SETSIG, BREAK_SIGNUM) < 0) {
-		pr_perror("Can't set signum for file i/o\n");
+		pr_perror("Can't set signum for file i/o");
 		goto err;
 	}
 
@@ -69,7 +69,7 @@ static int prepare_file(char *file, int file_type, int break_type)
 		pr_err("Conflicting lease not found\n");
 		goto err;
 	} else if (errno != EWOULDBLOCK) {
-		pr_perror("Can't break lease\n");
+		pr_perror("Can't break lease");
 		goto err;
 	}
 	return fd;
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
 	if (sigemptyset(&act.sa_mask) ||
 		sigaddset(&act.sa_mask, BREAK_SIGNUM) ||
 		sigaction(BREAK_SIGNUM, &act, NULL)) {
-		pr_perror("Can't set signal action\n");
+		pr_perror("Can't set signal action");
 		return -1;
 	}
 
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
 
 	ret = fd_dup = dup(fd);
 	if (fd_dup < 0) {
-		pr_perror("Can't dup fd\n");
+		pr_perror("Can't dup fd");
 		goto done;
 	}
 

--- a/test/zdtm/static/file_lease04.c
+++ b/test/zdtm/static/file_lease04.c
@@ -34,7 +34,7 @@ static int check_lease_type(int fd, int expected_type)
 
 	if (lease_type != expected_type) {
 		if (lease_type < 0)
-			pr_perror("Can't acquire lease type\n");
+			pr_perror("Can't acquire lease type");
 		else
 			pr_err("Mismatched lease type: %i\n", lease_type);
 		return -1;
@@ -49,15 +49,15 @@ static int prepare_file(char *file, int file_type, int break_type)
 
 	fd = open(file, file_type | O_CREAT, 0666);
 	if (fd < 0) {
-		pr_perror("Can't open file (type %i)\n", file_type);
+		pr_perror("Can't open file (type %i)", file_type);
 		return fd;
 	}
 	if (fcntl(fd, F_SETLEASE, lease_type) < 0) {
-		pr_perror("Can't set exclusive lease\n");
+		pr_perror("Can't set exclusive lease");
 		goto err;
 	}
 	if (fcntl(fd, F_SETSIG, BREAK_SIGNUM) < 0) {
-		pr_perror("Can't set signum for file i/o\n");
+		pr_perror("Can't set signum for file i/o");
 		goto err;
 	}
 
@@ -69,7 +69,7 @@ static int prepare_file(char *file, int file_type, int break_type)
 		pr_err("Conflicting lease not found\n");
 		goto err;
 	} else if (errno != EWOULDBLOCK) {
-		pr_perror("Can't break lease\n");
+		pr_perror("Can't break lease");
 		goto err;
 	}
 	return fd;
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
 	if (sigemptyset(&act.sa_mask) ||
 		sigaddset(&act.sa_mask, BREAK_SIGNUM) ||
 		sigaction(BREAK_SIGNUM, &act, NULL)) {
-		pr_perror("Can't set signal action\n");
+		pr_perror("Can't set signal action");
 		return -1;
 	}
 

--- a/test/zdtm/static/file_lease04.c
+++ b/test/zdtm/static/file_lease04.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
 	if (ret < 0 || !WIFEXITED(status) || WEXITSTATUS(status))
 		fail();
 	else if (sigaction_error)
-		fail("Ghost signal\n");
+		fail("Ghost signal");
 	else
 		pass();
 done:

--- a/test/zdtm/static/file_locks01.c
+++ b/test/zdtm/static/file_locks01.c
@@ -96,7 +96,7 @@ static int check_file_lock(int fd, char *expected_type,
 	snprintf(path, sizeof(path), "/proc/self/fdinfo/%d", fd);
 	fp_locks = fopen(path, "r");
 	if (!fp_locks) {
-		pr_err("Can't open %s\n", path);
+		pr_perror("Can't open %s", path);
 		return -1;
 	}
 
@@ -113,7 +113,7 @@ static int check_file_lock(int fd, char *expected_type,
 			     fl_flag, fl_type, fl_option, &fl_owner,
 			     &maj, &min, &i_no);
 		if (num < 7) {
-			pr_perror("Invalid lock info.");
+			pr_err("Invalid lock info\n");
 			break;
 		}
 

--- a/test/zdtm/static/file_locks05.c
+++ b/test/zdtm/static/file_locks05.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 	if (flock(fd2, LOCK_SH) == 0)
 		pass();
 	else
-		fail("Flock file locks check failed (%d)", errno);
+		fail("Flock file locks check failed");
 
 	close(fd);
 	close(fd2);

--- a/test/zdtm/static/file_locks06.c
+++ b/test/zdtm/static/file_locks06.c
@@ -36,10 +36,10 @@ int init_lock(int *fd, struct flock *lck)
 void cleanup(int *fd)
 {
 	if (close(*fd))
-		pr_perror("Can't close fd\n");
+		pr_perror("Can't close fd");
 
 	if (unlink(filename))
-		pr_perror("Can't unlink file\n");
+		pr_perror("Can't unlink file");
 }
 
 int main(int argc, char **argv)

--- a/test/zdtm/static/file_locks06.c
+++ b/test/zdtm/static/file_locks06.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 
 	if (check_file_lock_restored(getpid(), fd, &lck) ||
 		check_lock_exists(filename, &lck) < 0)
-		fail("OFD file locks check failed\n");
+		fail("OFD file locks check failed");
 	else
 		pass();
 

--- a/test/zdtm/static/file_locks07.c
+++ b/test/zdtm/static/file_locks07.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (check_file_locks_restored())
-		fail("OFD file locks check failed\n");
+		fail("OFD file locks check failed");
 	else
 		pass();
 

--- a/test/zdtm/static/file_locks07.c
+++ b/test/zdtm/static/file_locks07.c
@@ -59,10 +59,10 @@ void cleanup(void)
 
 	for (i = 0; i < FILE_NUM; ++i)
 		if (close(fds[i]))
-			pr_perror("Can't close fd\n");
+			pr_perror("Can't close fd");
 
 	if (unlink(filename))
-		pr_perror("Can't unlink file failed\n");
+		pr_perror("Can't unlink file failed");
 }
 
 int check_file_locks_restored(void)

--- a/test/zdtm/static/file_locks08.c
+++ b/test/zdtm/static/file_locks08.c
@@ -75,13 +75,13 @@ int main(int argc, char **argv)
 
 	if (check_file_lock_restored(getpid(), fd, &lck) ||
 		check_lock_exists(filename, &lck) < 0)
-		fail("OFD file locks check failed\n");
+		fail("OFD file locks check failed");
 
 	kill(pid, SIGTERM);
 	ret = waitpid(pid, &status, 0);
 
 	if (ret < 0 || !WIFEXITED(status) || WEXITSTATUS(status))
-		fail("OFD file locks check failed\n");
+		fail("OFD file locks check failed");
 	else
 		pass();
 

--- a/test/zdtm/static/file_locks08.c
+++ b/test/zdtm/static/file_locks08.c
@@ -38,10 +38,10 @@ int init_file_lock(int *fd, struct flock *lck)
 void cleanup(int *fd)
 {
 	if (close(*fd))
-		pr_perror("Can't close fd\n");
+		pr_perror("Can't close fd");
 
 	if (unlink(filename))
-		pr_perror("Can't unlink file\n");
+		pr_perror("Can't unlink file");
 }
 
 int main(int argc, char **argv)

--- a/test/zdtm/static/file_shared.c
+++ b/test/zdtm/static/file_shared.c
@@ -70,24 +70,24 @@ int main(int argc, char **argv)
 		}
 		off = lseek(fd2, 0, SEEK_CUR);
 		if (off != OFFSET) {
-			fail("offset1 fail\n");
+			fail("offset1 fail");
 			return 1;
 		}
 		off = lseek(fd3, 0, SEEK_CUR);
 		if (off != OFFSET2) {
-			fail("offset2 fail\n");
+			fail("offset2 fail");
 			return 1;
 		}
 
 		ret = fcntl(fd, F_GETFD, 0);
 		if (ret != 0) {
-			fail("fd cloexec broken\n");
+			fail("fd cloexec broken");
 			return 1;
 		}
 
 		ret = fcntl(fd2, F_GETFD, 0);
 		if (ret != 1) {
-			fail("fd2 cloexec broken\n");
+			fail("fd2 cloexec broken");
 			return 1;
 		}
 
@@ -95,17 +95,17 @@ int main(int argc, char **argv)
 		test_waitsig();
 		off = lseek(fd, 0, SEEK_CUR);
 		if (off != OFFSET) {
-			fail("offset3 fail\n");
+			fail("offset3 fail");
 			return 1;
 		}
 		off = lseek(fd2, 0, SEEK_CUR);
 		if (off != OFFSET) {
-			fail("offset4 fail\n");
+			fail("offset4 fail");
 			return 1;
 		}
 		off = lseek(fd3, 0, SEEK_CUR);
 		if (off != OFFSET2) {
-			fail("offset5 fail\n");
+			fail("offset5 fail");
 			return 1;
 		}
 		return 0;

--- a/test/zdtm/static/fpu00.c
+++ b/test/zdtm/static/fpu00.c
@@ -92,12 +92,12 @@ int main(int argc, char ** argv)
 		void *ret;
 
 		if (pthread_create(&child, NULL, &run_fpu_test, NULL)) {
-			pr_perror("Can't create pthread\n");
+			pr_perror("Can't create pthread");
 			exit(1);
 		}
 
 		if (pthread_join(child, &ret)) {
-			pr_perror("Can't join pthread\n");
+			pr_perror("Can't join pthread");
 			exit(1);
 		}
 

--- a/test/zdtm/static/fpu00.c
+++ b/test/zdtm/static/fpu00.c
@@ -68,7 +68,7 @@ void *run_fpu_test(void *unused)
 	res2 = finish();
 
 	if (res1 != res2)
-		fail("%f != %f\n", res1, res2);
+		fail("%f != %f", res1, res2);
 	else
 		pass();
 

--- a/test/zdtm/static/futex-rl.c
+++ b/test/zdtm/static/futex-rl.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
 
 	args = (struct args *)mmap(NULL, sizeof(*args), PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
 	if ((void *)args == MAP_FAILED) {
-		fail("mmap failed\n");
+		fail("mmap failed");
 		exit(1);
 	}
 
@@ -86,14 +86,14 @@ int main(int argc, char **argv)
 
 	test_msg("Creating thread\n");
 	if (pthread_create(&thread, NULL, thread_fn, (void *)args)) {
-		fail("Can't create thread\n");
+		fail("Can't create thread");
 		exit(1);
 	}
 
 	test_msg("Wait for thread work\n");
 	task_waiter_wait4(&args->waiter, 1);
 	if (args->result == -1) {
-		fail("thread failed\n");
+		fail("thread failed");
 		exit(1);
 	}
 

--- a/test/zdtm/static/futex.c
+++ b/test/zdtm/static/futex.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
 
 	sleep(1);
 	if (kid_passed != 0)
-		fail("some kids broke through\n");
+		fail("some kids broke through");
 
 	pthread_mutex_unlock(&m);
 	for (i = 0; i < num_threads; i++)
@@ -67,13 +67,13 @@ int main(int argc, char **argv)
 
 	if (pthread_mutex_trylock(&m)) {
 		if (errno == EBUSY)
-			fail("kids left my mutex locked\n");
+			fail("kids left my mutex locked");
 		else
 			pr_perror("kids spoiled my mutex");
 	}
 
 	if (kid_passed != num_threads)
-		fail("some kids died during migration\n");
+		fail("some kids died during migration");
 
 	pass();
 out:

--- a/test/zdtm/static/grow_map.c
+++ b/test/zdtm/static/grow_map.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
 
 	munmap(test_addr, PAGE_SIZE);
 	if (fake_grow_down[0] != 'c' || *(fake_grow_down - 1) != 'b') {
-		fail("%c %c\n", fake_grow_down[0], *(fake_grow_down - 1));
+		fail("%c %c", fake_grow_down[0], *(fake_grow_down - 1));
 		return 1;
 	}
 

--- a/test/zdtm/static/inotify02.c
+++ b/test/zdtm/static/inotify02.c
@@ -34,7 +34,7 @@ static int num_of_handles(int fd)
 	snprintf(path, sizeof(path), "/proc/self/fdinfo/%d", fd);
 	f = fopen(path, "r");
 	if (!f) {
-		pr_err("Can't open %s", path);
+		pr_perror("Can't open %s", path);
 		return -1;
 	}
 
@@ -59,13 +59,13 @@ int main (int argc, char *argv[])
 	test_init(argc, argv);
 
 	if (mkdir(dirname, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) {
-		pr_err("Can't create directory %s", dirname);
+		pr_perror("Can't create directory %s", dirname);
 		exit(1);
 	}
 
 	fd = inotify_init1(IN_NONBLOCK);
 	if (fd < 0) {
-		pr_err("inotify_init failed");
+		pr_perror("inotify_init failed");
 		exit(1);
 	}
 
@@ -73,12 +73,12 @@ int main (int argc, char *argv[])
 		snprintf(temp[i], sizeof(temp[0]), "d.%03d", i);
 		snprintf(path, sizeof(path), "%s/%s", dirname, temp[i]);
 		if (mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) {
-			pr_err("Can't create %s", path);
+			pr_perror("Can't create %s", path);
 			exit(1);
 		}
 
 		if (inotify_add_watch(fd, path, mask) < 0) {
-			pr_err("inotify_add_watch failed on %s", path);
+			pr_perror("inotify_add_watch failed on %s", path);
 			exit(1);
 		}
 	}

--- a/test/zdtm/static/inotify_system.c
+++ b/test/zdtm/static/inotify_system.c
@@ -257,7 +257,7 @@ int errors(int exp_len, int len, char *etalon_buf, char *buf) {
 			exp_event = (struct inotify_event *) &etalon_buf[marker];
 		else {
 			if (!harmless(event->mask)) {
-				fail("got unexpected event %s (%x mask)\n",
+				fail("got unexpected event %s (%x mask)",
 					handle_event(event->mask), event->mask);
 				error++;
 			}

--- a/test/zdtm/static/inotify_system.c
+++ b/test/zdtm/static/inotify_system.c
@@ -170,13 +170,13 @@ desc init_env(const char *dir, char *file_path, char *link_path) {
 	}
 
 	if (snprintf(file_path, BUF_SIZE, "%s/%s", dir, filename) >= BUF_SIZE) {
-		pr_perror("filename %s is too long", filename);
+		pr_err("filename %s is too long\n", filename);
 		rmdir(dir);
 		return in_desc;
 	}
 
 	if (snprintf(link_path, BUF_SIZE, "%s/%s", dir, linkname) >= BUF_SIZE) {
-		pr_perror("filename %s is too long", linkname);
+		pr_err("filename %s is too long\n", linkname);
 		rmdir(dir);
 		return in_desc;
 	}

--- a/test/zdtm/static/inotify_system.c
+++ b/test/zdtm/static/inotify_system.c
@@ -92,8 +92,8 @@ int addWatcher(int fd, const char *path) {
 	int wd;
 	wd = inotify_add_watch(fd, path, IN_ALL_EVENTS | IN_DONT_FOLLOW);
 	if (wd < 0) {
-		pr_perror("inotify_add_watch(%d, %s, IN_ALL_EVENTS) Failed, %s",
-			fd, path, strerror(errno));
+		pr_perror("inotify_add_watch(%d, %s, IN_ALL_EVENTS) failed",
+				fd, path);
 		return -1;
 	}
 	return wd;
@@ -101,8 +101,7 @@ int addWatcher(int fd, const char *path) {
 
 int fChmod(char *path) {
 	if (chmod(path, 0755) < 0) {
-		pr_perror("chmod(%s, 0755) Failed, %s",
-			path, strerror(errno));
+		pr_perror("chmod(%s, 0755) failed", path);
 		return -1;
 	}
 	return 0;
@@ -111,16 +110,15 @@ int fChmod(char *path) {
 int fWriteClose(char *path) {
 	int fd = open(path, O_RDWR | O_CREAT, 0700);
 	if (fd == -1) {
-		pr_perror("open(%s, O_RDWR|O_CREAT,0700) Failed, %s",
-			path, strerror(errno));
+		pr_perror("open(%s, O_RDWR|O_CREAT, 0700) failed", path);
 		return -1;
 	}
 	if (write(fd, "string", 7) == -1) {
-		pr_perror("write(%d, %s, 1) Failed, %s", fd, path, strerror(errno));
+		pr_perror("write(%d, %s, 1) failed", fd, path);
 		return -1;
 	}
 	if (close(fd) == -1) {
-		pr_perror("close(%s) Failed, %s", path, strerror(errno));
+		pr_perror("close(%s) failed", path);
 		return -1;
 	}
 	return 0;
@@ -130,17 +128,16 @@ int fNoWriteClose(char *path) {
 	char buf[BUF_SIZE];
 	int fd = open(path, O_RDONLY);
 	if ( fd < 0 ) {
-		pr_perror("open(%s, O_RDONLY) Failed, %s",
-			path, strerror(errno));
+		pr_perror("open(%s, O_RDONLY) failed", path);
 		return -1;
 	}
 	if (read(fd, buf, BUF_SIZE) == -1) {
-		pr_perror("read error: %s", strerror(errno));
+		pr_perror("read");
 		close(fd);
 		return -1;
 	}
 	if (close(fd) == -1) {
-		pr_perror("close(%s) Failed, %s", path, strerror(errno));
+		pr_perror("close(%s) failed", path);
 		return -1;
 	}
 	return 0;
@@ -148,8 +145,7 @@ int fNoWriteClose(char *path) {
 
 int fMove(char *from, char *to) {
 	if (rename(from, to) == -1) {
-		pr_perror("rename error (from: %s to: %s) : %s",
-			from, to, strerror(errno));
+		pr_perror("rename error (from: %s to: %s)", from, to);
 		return -1;
 	}
 	return 0;
@@ -158,13 +154,12 @@ int fMove(char *from, char *to) {
 desc init_env(const char *dir, char *file_path, char *link_path) {
 	desc in_desc = {-1, -1, -1, -1};
 	if (mkdir(dir, 0777) < 0) {
-		pr_perror("error in creating directory: %s, %s",
-			dir, strerror(errno));
+		pr_perror("mkdir(%s)", dir);
 		return in_desc;
 	}
 	in_desc.inot = inotify_init();
 	if (in_desc.inot < 0) {
-		pr_perror("inotify_init () Failed, %s", strerror(errno));
+		pr_perror("inotify_init() failed");
 		rmdir(dir);
 		return in_desc;
 	}
@@ -193,7 +188,7 @@ desc init_env(const char *dir, char *file_path, char *link_path) {
 
 int fDelete(char *path) {
 	if (unlink(path) != 0) {
-		pr_perror("unlink: (%s)", strerror(errno));
+		pr_perror("unlink(%s)", path);
 		return -1;
 	}
 	return 0;
@@ -201,7 +196,7 @@ int fDelete(char *path) {
 
 int fRemDir(const char *target) {
 	if(rmdir(target)) {
-		pr_perror("rmdir: (%s)", strerror(errno));
+		pr_perror("rmdir(%s)", target);
 		return -1;
 	}
 	return 0;
@@ -295,8 +290,8 @@ next_event:
 int read_set(int inot_fd, char *event_set) {
 	int len;
 	if ((len = read(inot_fd, event_set, EVENT_BUF_LEN)) < 0) {
-		pr_perror("read(%d, buf, %lu) Failed, errno=%d",
-			inot_fd, (unsigned long)EVENT_BUF_LEN, errno);
+		pr_perror("read(%d, buf, %lu) failed",
+			inot_fd, (unsigned long)EVENT_BUF_LEN);
 		return -1;
 	}
 	return len;

--- a/test/zdtm/static/ipc_namespace.c
+++ b/test/zdtm/static/ipc_namespace.c
@@ -199,19 +199,19 @@ int fill_ipc_ns(struct ipc_ns *ipc)
 
 	ret = get_messages_info(ipc);
 	if (ret < 0) {
-		pr_perror("Failed to collect messages");
+		pr_err("Failed to collect messages\n");
 		return ret;
 	}
 
 	ret = get_semaphores_info(ipc);
 	if (ret < 0) {
-		pr_perror("Failed to collect semaphores");
+		pr_err("Failed to collect semaphores\n");
 		return ret;
 	}
 
 	ret = get_shared_memory_info(ipc);
 	if (ret < 0) {
-		pr_perror("Failed to collect shared memory");
+		pr_err("Failed to collect shared memory\n");
 		return ret;
 	}
 	return 0;
@@ -304,7 +304,7 @@ static int rand_ipc_ns(void)
 		ret = rand_ipc_sysctl("/proc/sys/fs/mqueue/msgsize_default", ((unsigned)lrand48() & (8192 * 128 - 1)) | 128);
 
 	if (ret < 0)
-		pr_perror("Failed to randomize ipc namespace tunables");
+		pr_err("Failed to randomize ipc namespace tunables\n");
 
 	return ret;
 }
@@ -315,64 +315,64 @@ static void show_ipc_entry(struct ipc_ns *old, struct ipc_ns *new)
 
 	for (i = 0; i < 3; i++) {
 		if (old->ids[i].in_use != new->ids[i].in_use)
-			pr_perror("ids[%d].in_use differs: %d ---> %d", i,
+			pr_err("ids[%d].in_use differs: %d ---> %d\n", i,
 				old->ids[i].in_use, new->ids[i].in_use);
 
 	}
 	for (i = 0; i < 4; i++) {
 		if (old->sem_ctls[i] != new->sem_ctls[i])
-			pr_perror("sem_ctls[%d] differs: %d ---> %d", i,
+			pr_err("sem_ctls[%d] differs: %d ---> %d\n", i,
 				old->sem_ctls[i], new->sem_ctls[i]);
 
 	}
 
 	if (old->msg_ctlmax != new->msg_ctlmax)
-		pr_perror("msg_ctlmax differs: %d ---> %d",
+		pr_err("msg_ctlmax differs: %d ---> %d\n",
 			old->msg_ctlmax, new->msg_ctlmax);
 	if (old->msg_ctlmnb != new->msg_ctlmnb)
-		pr_perror("msg_ctlmnb differs: %d ---> %d",
+		pr_err("msg_ctlmnb differs: %d ---> %d\n",
 			old->msg_ctlmnb, new->msg_ctlmnb);
 	if (old->msg_ctlmni != new->msg_ctlmni)
-		pr_perror("msg_ctlmni differs: %d ---> %d",
+		pr_err("msg_ctlmni differs: %d ---> %d\n",
 			old->msg_ctlmni, new->msg_ctlmni);
 	if (old->auto_msgmni != new->auto_msgmni)
-		pr_perror("auto_msgmni differs: %d ---> %d",
+		pr_err("auto_msgmni differs: %d ---> %d\n",
 			old->auto_msgmni, new->auto_msgmni);
 	if (old->msg_next_id != new->msg_next_id)
-		pr_perror("msg_next_id differs: %d ---> %d",
+		pr_err("msg_next_id differs: %d ---> %d\n",
 			old->msg_next_id, new->msg_next_id);
 	if (old->sem_next_id != new->sem_next_id)
-		pr_perror("sem_next_id differs: %d ---> %d",
+		pr_err("sem_next_id differs: %d ---> %d\n",
 			old->sem_next_id, new->sem_next_id);
 	if (old->shm_next_id != new->shm_next_id)
-		pr_perror("shm_next_id differs: %d ---> %d",
+		pr_err("shm_next_id differs: %d ---> %d\n",
 			old->shm_next_id, new->shm_next_id);
 	if (old->shm_ctlmax != new->shm_ctlmax)
-		pr_perror("shm_ctlmax differs: %zu ---> %zu",
+		pr_err("shm_ctlmax differs: %zu ---> %zu\n",
 			old->shm_ctlmax, new->shm_ctlmax);
 	if (old->shm_ctlall != new->shm_ctlall)
-		pr_perror("shm_ctlall differs: %zu ---> %zu",
+		pr_err("shm_ctlall differs: %zu ---> %zu\n",
 			old->shm_ctlall, new->shm_ctlall);
 	if (old->shm_ctlmni != new->shm_ctlmni)
-		pr_perror("shm_ctlmni differs: %d ---> %d",
+		pr_err("shm_ctlmni differs: %d ---> %d\n",
 			old->shm_ctlmni, new->shm_ctlmni);
 	if (old->shm_rmid_forced != new->shm_rmid_forced)
-		pr_perror("shm_rmid_forced differs: %d ---> %d",
+		pr_err("shm_rmid_forced differs: %d ---> %d\n",
 			old->shm_rmid_forced, new->shm_rmid_forced);
 	if (old->mq_queues_max != new->mq_queues_max)
-		pr_perror("mq_queues_max differs: %d ---> %d",
+		pr_err("mq_queues_max differs: %d ---> %d\n",
 			old->mq_queues_max, new->mq_queues_max);
 	if (old->mq_msg_max != new->mq_msg_max)
-		pr_perror("mq_msg_max differs: %d ---> %d",
+		pr_err("mq_msg_max differs: %d ---> %d\n",
 			old->mq_msg_max, new->mq_msg_max);
 	if (old->mq_msgsize_max != new->mq_msgsize_max)
-		pr_perror("mq_msgsize_max differs: %d ---> %d",
+		pr_err("mq_msgsize_max differs: %d ---> %d\n",
 			old->mq_msgsize_max, new->mq_msgsize_max);
 	if (old->mq_msg_default != new->mq_msg_default)
-		pr_perror("mq_msg_default differs: %d ---> %d",
+		pr_err("mq_msg_default differs: %d ---> %d\n",
 			old->mq_msg_default, new->mq_msg_default);
 	if (old->mq_msgsize_default != new->mq_msgsize_default)
-		pr_perror("mq_msgsize_default differs: %d ---> %d",
+		pr_err("mq_msgsize_default differs: %d ---> %d\n",
 			old->mq_msgsize_default, new->mq_msgsize_default);
 }
 
@@ -384,13 +384,13 @@ int main(int argc, char **argv)
 
 	ret = rand_ipc_ns();
 	if (ret) {
-		pr_perror("Failed to randomize ipc ns before migration");
+		pr_err("Failed to randomize ipc ns before migration\n");
 		return -1;
 	}
 
 	ret = fill_ipc_ns(&ipc_before);
 	if (ret) {
-		pr_perror("Failed to collect ipc ns before migration");
+		pr_err("Failed to collect ipc ns before migration\n");
 		return ret;
 	}
 
@@ -399,12 +399,12 @@ int main(int argc, char **argv)
 
 	ret = fill_ipc_ns(&ipc_after);
 	if (ret) {
-		pr_perror("Failed to collect ipc ns after migration");
+		pr_err("Failed to collect ipc ns after migration\n");
 		return ret;
 	}
 
 	if (memcmp(&ipc_before, &ipc_after, sizeof(ipc_after))) {
-		pr_perror("IPC's differ");
+		pr_err("IPCs differ\n");
 		show_ipc_entry(&ipc_before, &ipc_after);
 		return -EINVAL;
 	}

--- a/test/zdtm/static/ipc_namespace.c
+++ b/test/zdtm/static/ipc_namespace.c
@@ -100,7 +100,7 @@ static int get_messages_info(struct ipc_ns *ipc)
 
 	ret = msgctl(0, MSG_INFO, (struct msqid_ds *)&info);
 	if (ret < 0) {
-		pr_perror("msgctl failed with %d", errno);
+		pr_perror("msgctl failed");
 		return ret;
 	}
 
@@ -149,7 +149,7 @@ static int get_semaphores_info(struct ipc_ns *ipc)
 
 	err = semctl(0, 0, SEM_INFO, &info);
 	if (err < 0)
-		pr_perror("semctl failed with %d", errno);
+		pr_perror("semctl failed");
 
 	ipc->sem_ctls[0] = info.semmsl;
 	ipc->sem_ctls[1] = info.semmns;
@@ -172,7 +172,7 @@ static int get_shared_memory_info(struct ipc_ns *ipc)
 
 	ret = shmctl(0, IPC_INFO, &u.shmid);
 	if (ret < 0)
-		pr_perror("semctl failed with %d", errno);
+		pr_perror("semctl failed");
 
 	ipc->shm_ctlmax = u.shminfo64.shmmax;
 	ipc->shm_ctlall = u.shminfo64.shmall;
@@ -180,7 +180,7 @@ static int get_shared_memory_info(struct ipc_ns *ipc)
 
 	ret = shmctl(0, SHM_INFO, &u.shmid);
 	if (ret < 0)
-		pr_perror("semctl failed with %d", errno);
+		pr_perror("semctl failed");
 
 	ipc->shm_tot = u.shminfo.shm_tot;
 	ipc->ids[IPC_SHM_IDS].in_use = u.shminfo.used_ids;
@@ -256,7 +256,7 @@ static int rand_ipc_sem(void)
 				      (unsigned) lrand48(), (unsigned) lrand48() % MAX_MNI);
 	ret = write(fd, buf, 128);
 	if (ret < 0) {
-		pr_perror("Can't write %s: %d", name, errno);
+		pr_perror("Can't write %s", name);
 		return -errno;
 	}
 	close(fd);

--- a/test/zdtm/static/jobctl00.c
+++ b/test/zdtm/static/jobctl00.c
@@ -75,7 +75,7 @@ static int reader(int sig)
 static int post_reader(int fd)
 {
 	if (write(fd, rd_string, sizeof(rd_string) - 1) < 0) {
-		fail("write failed: %m");
+		fail("write failed");
 		return -1;
 	}
 	return 0;
@@ -90,7 +90,7 @@ static int post_writer(int fd)
 {
 	char str[sizeof(wr_string) + 1];
 	if (read(0, str, sizeof(str)) < 0) {
-		fail("read failed: %m");
+		fail("read failed");
 		return -1;
 	}
 	/*
@@ -241,7 +241,7 @@ int finish_jobs(pid_t *jobs, int njobs, int fdmaster, int fdslave)
 		int jtno = i % (sizeof(job_types) / sizeof(job_types[0]));
 
 		if (tcsetpgrp(fdslave, jobs[i]) < 0) {
-			fail("can't bring a job into foreground: %m");
+			fail("can't bring a job into foreground");
 			goto killout;
 		}
 

--- a/test/zdtm/static/link10.c
+++ b/test/zdtm/static/link10.c
@@ -53,7 +53,7 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (fstat(fd, &stat) < 0 || fstat(fd2, &stat2) < 0) {
-		fail("fstat failed: %m");
+		fail("fstat failed");
 		goto out;
 	}
 

--- a/test/zdtm/static/loginuid.c
+++ b/test/zdtm/static/loginuid.c
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
 		return -1;
 
 	if (new_loginuid != test_value) {
-		fail("loginuid value %d is different after restore: %d\n",
+		fail("loginuid value %d is different after restore: %d",
 				test_value, new_loginuid);
 		return -1;
 	}

--- a/test/zdtm/static/macvlan.c
+++ b/test/zdtm/static/macvlan.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 	test_init(argc, argv);
 
 	if (!wait_for_macvlan()) {
-		fail("failed to inject macvlan device\n");
+		fail("failed to inject macvlan device");
 		return 1;
 	}
 

--- a/test/zdtm/static/maps00.c
+++ b/test/zdtm/static/maps00.c
@@ -133,7 +133,7 @@ static int check_map(struct map *map)
 
 	if (signal(SIGSEGV, segfault) == SIG_ERR)
 	{
-		fail("setting SIGSEGV handler failed: %m");
+		fail("setting SIGSEGV handler failed");
 		return -1;
 	}
 	if (!sigsetjmp(segv_ret, 1))
@@ -154,7 +154,7 @@ static int check_map(struct map *map)
 
 	if (signal(SIGSEGV, segfault) == SIG_ERR)
 	{
-		fail("setting SIGSEGV handler failed: %m");
+		fail("setting SIGSEGV handler failed");
 		return -1;
 	}
 
@@ -166,7 +166,7 @@ static int check_map(struct map *map)
 
 	if (signal(SIGSEGV, segfault) == SIG_ERR)
 	{
-		fail("restoring SIGSEGV handler failed: %m");
+		fail("restoring SIGSEGV handler failed");
 		return -1;
 	}
 
@@ -197,7 +197,7 @@ static int check_map(struct map *map)
 
 	if (signal(SIGSEGV, SIG_DFL) == SIG_ERR)
 	{
-		fail("restoring SIGSEGV handler failed: %m");
+		fail("restoring SIGSEGV handler failed");
 		return -1;
 	}
 

--- a/test/zdtm/static/maps00.c
+++ b/test/zdtm/static/maps00.c
@@ -133,7 +133,7 @@ static int check_map(struct map *map)
 
 	if (signal(SIGSEGV, segfault) == SIG_ERR)
 	{
-		fail("setting SIGSEGV handler failed: %m\n");
+		fail("setting SIGSEGV handler failed: %m");
 		return -1;
 	}
 	if (!sigsetjmp(segv_ret, 1))
@@ -142,7 +142,7 @@ static int check_map(struct map *map)
 		if (datachk(map->ptr, ONE_MAP_SIZE, &crc))	/* perform read access */
 			if (!(map->flag & MAP_ANONYMOUS) ||
 					(map->prot & PROT_WRITE)) {	/* anon maps could only be filled when r/w */
-				fail("CRC mismatch: ptr %p flag %8x prot %8x\n",
+				fail("CRC mismatch: ptr %p flag %8x prot %8x",
 				     map->ptr, map->flag, map->prot);
 				return -1;
 			}
@@ -154,7 +154,7 @@ static int check_map(struct map *map)
 
 	if (signal(SIGSEGV, segfault) == SIG_ERR)
 	{
-		fail("setting SIGSEGV handler failed: %m\n");
+		fail("setting SIGSEGV handler failed: %m");
 		return -1;
 	}
 
@@ -166,7 +166,7 @@ static int check_map(struct map *map)
 
 	if (signal(SIGSEGV, segfault) == SIG_ERR)
 	{
-		fail("restoring SIGSEGV handler failed: %m\n");
+		fail("restoring SIGSEGV handler failed: %m");
 		return -1;
 	}
 
@@ -197,7 +197,7 @@ static int check_map(struct map *map)
 
 	if (signal(SIGSEGV, SIG_DFL) == SIG_ERR)
 	{
-		fail("restoring SIGSEGV handler failed: %m\n");
+		fail("restoring SIGSEGV handler failed: %m");
 		return -1;
 	}
 

--- a/test/zdtm/static/maps01.c
+++ b/test/zdtm/static/maps01.c
@@ -36,7 +36,7 @@ int main(int argc, char ** argv)
 				MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
 	if (m == MAP_FAILED) {
-		pr_err("Failed to mmap %lu Mb shared anonymous R/W memory\n",
+		pr_perror("Failed to mmap %lu Mb shared anonymous R/W memory",
 				MEM_SIZE >> 20);
 		goto err;
 	}
@@ -45,14 +45,14 @@ int main(int argc, char ** argv)
 				MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
 	if (p == MAP_FAILED) {
-		pr_err("Failed to mmap %ld Mb shared anonymous R/W memory\n",
+		pr_perror("Failed to mmap %ld Mb shared anonymous R/W memory",
 				MEM_SIZE >> 20);
 		goto err;
 	}
 
 	p2 = mmap(NULL, MEM_OFFSET, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 	if (p2 == MAP_FAILED) {
-		pr_err("Failed to mmap %lu Mb anonymous memory\n",
+		pr_perror("Failed to mmap %lu Mb anonymous memory",
 				MEM_OFFSET >> 20);
 		goto err;
 	}
@@ -67,7 +67,7 @@ int main(int argc, char ** argv)
 		p3 = mmap(NULL, MEM_OFFSET3, PROT_READ | PROT_WRITE,
 					MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 		if (p3 == MAP_FAILED) {
-			pr_err("Failed to mmap %lu Mb anonymous R/W memory\n",
+			pr_perror("Failed to mmap %lu Mb anonymous R/W memory",
 					MEM_OFFSET3 >> 20);
 			goto err;
 		}

--- a/test/zdtm/static/maps03.c
+++ b/test/zdtm/static/maps03.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
 	test_msg("Testing restored data\n");
 
 	if (mem[4L << 30] != 1 || mem[8L << 30] != 2) {
-		fail("Data corrupted!\n");
+		fail("Data corrupted!");
 		exit(1);
 	}
 

--- a/test/zdtm/static/mem-touch.c
+++ b/test/zdtm/static/mem-touch.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
 			test_msg("Page %u matches %u\n", i, backup[i]);
 
 	if (fail)
-		fail("Memory corruption\n");
+		fail("Memory corruption");
 	else
 		pass();
 

--- a/test/zdtm/static/mlock_setuid.c
+++ b/test/zdtm/static/mlock_setuid.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 	if (new_flags & MAP_LOCKED) {
 		pass();
 	} else {
-		fail("Vma is not locked after c/r\n");
+		fail("Vma is not locked after c/r");
 		return -1;
 	}
 

--- a/test/zdtm/static/mmx00.c
+++ b/test/zdtm/static/mmx00.c
@@ -87,9 +87,9 @@ int main(int argc, char **argv)
 	finish(resbytes2, reswords2);
 
 	if (memcmp((uint8_t *) resbytes1, (uint8_t *) resbytes2, sizeof(resbytes1)))
-		fail("byte op mismatch\n");
+		fail("byte op mismatch");
 	else if (memcmp((uint8_t *) reswords1, (uint8_t *) reswords2, sizeof(reswords2)))
-		fail("word op mismatch\n");
+		fail("word op mismatch");
 	else
 		pass();
 #else

--- a/test/zdtm/static/mprotect00.c
+++ b/test/zdtm/static/mprotect00.c
@@ -31,7 +31,7 @@ static void segfault(int signo)
 static int check_prot(char *ptr, int prot)
 {
 	if (signal(SIGSEGV, segfault) == SIG_ERR) {
-		fail("setting SIGSEGV handler failed: %m\n");
+		fail("setting SIGSEGV handler failed: %m");
 		return -1;
 	}
 
@@ -41,32 +41,32 @@ static int check_prot(char *ptr, int prot)
 			return -1;
 		}
 		if (!(prot & PROT_READ)) {
-			fail("PROT_READ bypassed\n");
+			fail("PROT_READ bypassed");
 			return -1;
 		}
 	}
 	else		/* we come here on return from SIGSEGV handler */
 		if (prot & PROT_READ) {
-			fail("PROT_READ rejected\n");
+			fail("PROT_READ rejected");
 			return -1;
 		}
 
 	if (!sigsetjmp(segv_ret, 1)) {
 		ptr[20] = 67;
 		if (!(prot & PROT_WRITE)) {
-			fail("PROT_WRITE bypassed\n");
+			fail("PROT_WRITE bypassed");
 			return -1;
 		}
 	}
 	else		/* we come here on return from SIGSEGV handler */
 		if (prot & PROT_WRITE) {
-			fail("PROT_WRITE rejected\n");
+			fail("PROT_WRITE rejected");
 			return -1;
 		}
 
 
 	if (signal(SIGSEGV, SIG_DFL) == SIG_ERR) {
-		fail("restoring SIGSEGV handler failed: %m\n");
+		fail("restoring SIGSEGV handler failed: %m");
 		return -1;
 	}
 

--- a/test/zdtm/static/mprotect00.c
+++ b/test/zdtm/static/mprotect00.c
@@ -31,7 +31,7 @@ static void segfault(int signo)
 static int check_prot(char *ptr, int prot)
 {
 	if (signal(SIGSEGV, segfault) == SIG_ERR) {
-		fail("setting SIGSEGV handler failed: %m");
+		fail("setting SIGSEGV handler failed");
 		return -1;
 	}
 
@@ -66,7 +66,7 @@ static int check_prot(char *ptr, int prot)
 
 
 	if (signal(SIGSEGV, SIG_DFL) == SIG_ERR) {
-		fail("restoring SIGSEGV handler failed: %m");
+		fail("restoring SIGSEGV handler failed");
 		return -1;
 	}
 

--- a/test/zdtm/static/msgque.c
+++ b/test/zdtm/static/msgque.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
 		test_waitsig();
 
 		if (msgrcv(msg, &msgbuf, sizeof(TEST_STRING), MSG_TYPE, IPC_NOWAIT) == -1) {
-			fail("Child: msgrcv failed (%m)");
+			fail("Child: msgrcv failed");
 			return -errno;
 		}
 
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 		msgbuf.mtype = ANOTHER_MSG_TYPE;
 		memcpy(msgbuf.mtext, ANOTHER_TEST_STRING, sizeof(ANOTHER_TEST_STRING));
 		if (msgsnd(msg, &msgbuf, sizeof(ANOTHER_TEST_STRING), IPC_NOWAIT) != 0) {
-			fail("Child: msgsnd failed (%m)");
+			fail("Child: msgsnd failed");
 			return -errno;
 		};
 		pass();
@@ -83,14 +83,14 @@ int main(int argc, char **argv)
 		msgbuf.mtype = MSG_TYPE;
 		memcpy(msgbuf.mtext, TEST_STRING, sizeof(TEST_STRING));
 		if (msgsnd(msg, &msgbuf, sizeof(TEST_STRING), IPC_NOWAIT) != 0) {
-			fail("Parent: msgsnd failed (%m)");
+			fail("Parent: msgsnd failed");
 			goto err_kill;
 		};
 
 		msgbuf.mtype = ANOTHER_MSG_TYPE;
 		memcpy(msgbuf.mtext, ANOTHER_TEST_STRING, sizeof(ANOTHER_TEST_STRING));
 		if (msgsnd(msg, &msgbuf, sizeof(ANOTHER_TEST_STRING), IPC_NOWAIT) != 0) {
-			fail("child: msgsnd (2) failed (%m)");
+			fail("child: msgsnd (2) failed");
 			return -errno;
 		};
 
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
 		}
 
 		if (msgrcv(msg, &msgbuf, sizeof(ANOTHER_TEST_STRING), ANOTHER_MSG_TYPE, IPC_NOWAIT) == -1) {
-			fail("Parent: msgrcv failed (%m)");
+			fail("Parent: msgrcv failed");
 			goto err;
 		}
 

--- a/test/zdtm/static/msgque.c
+++ b/test/zdtm/static/msgque.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 		wait(&chret);
 		chret = WEXITSTATUS(chret);
 		if (chret) {
-			fail("Parent: child exited with non-zero code %d (%s)\n",
+			fail("Parent: child exited with non-zero code %d (%s)",
 			     chret, strerror(chret));
 			goto out;
 		}
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
 out:
 	if (msgctl(msg, IPC_RMID, 0)) {
-		fail("Failed to destroy message queue: %d\n", -errno);
+		fail("Failed to destroy message queue: %d", -errno);
 		return -errno;
 	}
 	return chret;

--- a/test/zdtm/static/msgque.c
+++ b/test/zdtm/static/msgque.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
 out:
 	if (msgctl(msg, IPC_RMID, 0)) {
-		fail("Failed to destroy message queue: %d", -errno);
+		fail("Failed to destroy message queue");
 		return -errno;
 	}
 	return chret;

--- a/test/zdtm/static/mtime_mmap.c
+++ b/test/zdtm/static/mtime_mmap.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 	ctime_new = fst.st_ctime;
 	/* time of last status change */
 	if (ctime_new <= ctime_old) {
-		fail("time of last status change of %s file wasn't changed\n",
+		fail("time of last status change of %s file wasn't changed",
 			filename);
 		goto failed;
 	}

--- a/test/zdtm/static/mtime_mmap.c
+++ b/test/zdtm/static/mtime_mmap.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
 	ptr = (char *)mmap(NULL, count, PROT_READ | PROT_WRITE,
 			MAP_SHARED, fd, 0);
 	if (ptr == MAP_FAILED) {
-		pr_perror("mmap() Failed, errno=%d : %s", errno, strerror(errno));
+		pr_perror("mmap() failed");
 		goto failed;
 	}
 
@@ -66,12 +66,12 @@ int main(int argc, char **argv)
 		ptr[i]++;
 
 	if (munmap(ptr, count)) {
-		pr_perror("munmap Failed, errno=%d : %s", errno, strerror(errno));
+		pr_perror("munmap failed");
 		goto failed;
 	}
 
 	if (fstat(fd, &fst) < 0) {
-		pr_perror("can't get %s file info", filename);
+		pr_perror("fstat(%s) failed", filename);
 		goto failed;
 	}
 

--- a/test/zdtm/static/netns_sub_veth.c
+++ b/test/zdtm/static/netns_sub_veth.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
 	ret = nl_connect(sk, NETLINK_ROUTE);
 	if (ret < 0) {
 		nl_socket_free(sk);
-		pr_err("Unable to connect socket: %s", nl_geterror(ret));
+		pr_err("Unable to connect socket: %s\n", nl_geterror(ret));
 		return -1;
 	}
 

--- a/test/zdtm/static/oom_score_adj.c
+++ b/test/zdtm/static/oom_score_adj.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 		return -1;
 
 	if (new_oom_score_adj != test_value) {
-		fail("OOM score value %d is different after restore: %d\n",
+		fail("OOM score value %d is different after restore: %d",
 				test_value, new_oom_score_adj);
 		return -1;
 	}

--- a/test/zdtm/static/opath_file.c
+++ b/test/zdtm/static/opath_file.c
@@ -37,7 +37,7 @@ static int parse_self_fdinfo(int fd, struct fdinfo *fi)
 	while (fgets(line, sizeof(line), file)) {
 		if (fdinfo_field(line, "flags")) {
 			if (sscanf(line, "%*s %llo", &val) != 1) {
-				pr_err("failed to read flags: %s", line);
+				pr_err("failed to read flags: %s\n", line);
 				goto fail;
 			}
 			pr_debug("Open flags = %llu\n", val);

--- a/test/zdtm/static/overmount_dev.c
+++ b/test/zdtm/static/overmount_dev.c
@@ -57,17 +57,17 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (umount(dirname) < 0) {
-		fail("can't umount %s: %m", dirname);
+		fail("can't umount %s", dirname);
 		goto cleanup;
 	}
 
 	if (close(fd) < 0) {
-		fail("can't close %s: %m", path);
+		fail("can't close %s", path);
 		goto unlink;
 	}
 
 	if (stat(path, &st) < 0) {
-		fail("can't stat %s: %m", path);
+		fail("can't stat %s", path);
 		goto unlink;
 	}
 
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
 	}
 
 	if (unlink(path) < 0) {
-		fail("can't unlink %s: %m", path);
+		fail("can't unlink %s", path);
 		goto rmdir;
 	}
 

--- a/test/zdtm/static/overmount_fifo.c
+++ b/test/zdtm/static/overmount_fifo.c
@@ -54,17 +54,17 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (umount(dirname) < 0) {
-		fail("can't umount %s: %m", dirname);
+		fail("can't umount %s", dirname);
 		goto cleanup;
 	}
 
 	if (close(fd) < 0) {
-		fail("can't close %s: %m", path);
+		fail("can't close %s", path);
 		goto unlink;
 	}
 
 	if (stat(path, &st) < 0) {
-		fail("can't stat %s: %m", path);
+		fail("can't stat %s", path);
 		goto unlink;
 	}
 
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 	}
 
 	if (unlink(path) < 0) {
-		fail("can't unlink %s: %m", path);
+		fail("can't unlink %s", path);
 		goto rmdir;
 	}
 

--- a/test/zdtm/static/overmount_file.c
+++ b/test/zdtm/static/overmount_file.c
@@ -47,17 +47,17 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (umount(dirname) < 0) {
-		fail("can't umount %s: %m", dirname);
+		fail("can't umount %s", dirname);
 		goto cleanup;
 	}
 
 	if (close(fd) < 0) {
-		fail("can't close %s: %m", path);
+		fail("can't close %s", path);
 		goto unlink;
 	}
 
 	if (unlink(path) < 0) {
-		fail("can't unlink %s: %m", path);
+		fail("can't unlink %s", path);
 		goto rmdir;
 	}
 

--- a/test/zdtm/static/overmount_sock.c
+++ b/test/zdtm/static/overmount_sock.c
@@ -147,36 +147,36 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (kill(pid, SIGTERM)) {
-		fail("terminating the child failed: %m\n");
+		fail("terminating the child failed: %m");
 		goto out;
 	}
 
 	if (wait(&ret) != pid) {
-		fail("wait() returned wrong pid %d: %m\n", pid);
+		fail("wait() returned wrong pid %d: %m", pid);
 		goto out;
 	}
 
 	if (WIFEXITED(ret)) {
 		ret = WEXITSTATUS(ret);
 		if (ret) {
-			fail("child exited with nonzero code %d (%s)\n", ret,
+			fail("child exited with nonzero code %d (%s)", ret,
 				strerror(ret));
 			goto out;
 		}
 	}
 	if (WIFSIGNALED(ret)) {
-		fail("child exited on unexpected signal %d\n", WTERMSIG(ret));
+		fail("child exited on unexpected signal %d", WTERMSIG(ret));
 		goto out;
 	}
 
 	if (read(sock, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m\n", path);
+		fail("can't read %s: %m", path);
 		goto out;
 	}
 
 	crc = ~0;
 	if (datachk(buf, sizeof(buf), &crc)) {
-		fail("CRC mismatch\n");
+		fail("CRC mismatch");
 		goto out;
 	}
 

--- a/test/zdtm/static/overmount_sock.c
+++ b/test/zdtm/static/overmount_sock.c
@@ -147,12 +147,12 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (kill(pid, SIGTERM)) {
-		fail("terminating the child failed: %m");
+		fail("terminating the child failed");
 		goto out;
 	}
 
 	if (wait(&ret) != pid) {
-		fail("wait() returned wrong pid %d: %m", pid);
+		fail("wait() returned wrong pid %d", pid);
 		goto out;
 	}
 
@@ -170,7 +170,7 @@ int main(int argc, char ** argv)
 	}
 
 	if (read(sock, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m", path);
+		fail("can't read %s", path);
 		goto out;
 	}
 
@@ -181,17 +181,17 @@ int main(int argc, char ** argv)
 	}
 
 	if (umount(dirname) < 0) {
-		fail("can't umount %s: %m", dirname);
+		fail("can't umount %s", dirname);
 		goto out;
 	}
 
 	if (close(sock) < 0) {
-		fail("can't close %s: %m", path);
+		fail("can't close %s", path);
 		goto out;
 	}
 
 	if (unlink(path) < 0) {
-		fail("can't unlink %s: %m", path);
+		fail("can't unlink %s", path);
 		goto out;
 	}
 

--- a/test/zdtm/static/packet_sock.c
+++ b/test/zdtm/static/packet_sock.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 
 	alen = sizeof(ver);
 	if (getsockopt(sk1, SOL_PACKET, PACKET_VERSION, &ver, &alen) < 0) {
-		fail("Can't get sockopt ver %m");
+		fail("Can't get sockopt ver");
 		return 1;
 	}
 
@@ -217,7 +217,7 @@ int main(int argc, char **argv)
 
 	alen = sizeof(yes);
 	if (getsockopt(sk1, SOL_PACKET, PACKET_AUXDATA, &yes, &alen) < 0) {
-		fail("Can't get sockopt auxdata %m");
+		fail("Can't get sockopt auxdata");
 		return 1;
 	}
 
@@ -236,7 +236,7 @@ int main(int argc, char **argv)
 
 	alen = sizeof(yes);
 	if (getsockopt(sk1, SOL_PACKET, PACKET_FANOUT, &yes, &alen) < 0) {
-		fail("Can't read fanout back %m");
+		fail("Can't read fanout back");
 		return 1;
 	}
 
@@ -256,13 +256,13 @@ int main(int argc, char **argv)
 
 	alen = sizeof(rsv);
 	if (getsockopt(sk2, SOL_PACKET, PACKET_RESERVE, &rsv, &alen) < 0) {
-		fail("Can't get sockopt rsv %m");
+		fail("Can't get sockopt rsv");
 		return 1;
 	}
 
 	alen = sizeof(yes);
 	if (getsockopt(sk2, SOL_PACKET, PACKET_ORIGDEV, &yes, &alen) < 0) {
-		fail("Can't get sockopt origdev %m");
+		fail("Can't get sockopt origdev");
 		return 1;
 	}
 
@@ -287,7 +287,7 @@ int main(int argc, char **argv)
 
 	alen = sizeof(yes);
 	if (getsockopt(sk2, SOL_PACKET, PACKET_FANOUT, &yes, &alen) < 0) {
-		fail("Can't read fanout2 back %m");
+		fail("Can't read fanout2 back");
 		return 1;
 	}
 

--- a/test/zdtm/static/packet_sock.c
+++ b/test/zdtm/static/packet_sock.c
@@ -211,7 +211,7 @@ int main(int argc, char **argv)
 	}
 
 	if (ver != TPACKET_V2) {
-		fail("Version mismatch have %d, want %d\n", ver, TPACKET_V2);
+		fail("Version mismatch have %d, want %d", ver, TPACKET_V2);
 		return 1;
 	}
 
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
 	}
 
 	if (rsv != SK_RESERVE) {
-		fail("Reserve mismatch have %d, want %d\n", rsv, SK_RESERVE);
+		fail("Reserve mismatch have %d, want %d", rsv, SK_RESERVE);
 		return 1;
 	}
 

--- a/test/zdtm/static/pipe01.c
+++ b/test/zdtm/static/pipe01.c
@@ -116,7 +116,7 @@ int main(int argc, char ** argv)
 		crc = ~0;
 		ret = datachk(buf, sizeof(buf), &crc);
 		if (ret) {
-			fail("CRC mismatch\n");
+			fail("CRC mismatch");
 			goto err;
 		}
 	}

--- a/test/zdtm/static/posix_timers.c
+++ b/test/zdtm/static/posix_timers.c
@@ -122,32 +122,32 @@ static int check_handler_status(struct posix_timers_info *info,
 	int timer_ms;
 
 	if (!info->handler_cnt && !info->oneshot) {
-		fail("%s: Signal handler wasn't called\n", info->name);
+		fail("%s: Signal handler wasn't called", info->name);
 		return -EINVAL;
 	}
 
 	if (info->handler_status) {
 		if (info->handler_status & WRONG_SIGNAL)
-			fail("%s: Handler: wrong signal received\n", info->name);
+			fail("%s: Handler: wrong signal received", info->name);
 		if (info->handler_status & WRONG_SI_PTR)
-			fail("%s: Handler: wrong timer address\n", info->name);
+			fail("%s: Handler: wrong timer address", info->name);
 		if (info->handler_status & FAIL_OVERRUN)
-			fail("%s: Handler: failed to get overrun count\n", info->name);
+			fail("%s: Handler: failed to get overrun count", info->name);
 		return -1;
 	}
 
 	if (!info->oneshot && !its->it_value.tv_sec && !its->it_value.tv_nsec) {
-		fail("%s: timer became unset\n", info->name);
+		fail("%s: timer became unset", info->name);
 		return -EFAULT;
 	}
 
 	if (info->oneshot && (its->it_interval.tv_sec || its->it_interval.tv_nsec)) {
-		fail("%s: timer became periodic\n", info->name);
+		fail("%s: timer became periodic", info->name);
 		return -EFAULT;
 	}
 
 	if (!info->oneshot && !its->it_interval.tv_sec && !its->it_interval.tv_nsec) {
-		fail("%s: timer became oneshot\n", info->name);
+		fail("%s: timer became oneshot", info->name);
 		return -EFAULT;
 	}
 
@@ -155,15 +155,15 @@ static int check_handler_status(struct posix_timers_info *info,
 		int val = its->it_value.tv_sec * 1000 + its->it_value.tv_nsec / 1000 / 1000;
 		if (info->handler_cnt) {
 			if (val != 0) {
-				fail("%s: timer continues ticking after expiration\n", info->name);
+				fail("%s: timer continues ticking after expiration", info->name);
 				return -EFAULT;
 			}
 			if (info->handler_cnt > 1) {
-				fail("%s: timer expired %d times\n", info->name, info->handler_cnt);
+				fail("%s: timer expired %d times", info->name, info->handler_cnt);
 				return -EFAULT;
 			}
 			if (info->ms_int > ms_passed) {
-				fail("%s: timer expired too early\n", info->name);
+				fail("%s: timer expired too early", info->name);
 				return -EFAULT;
 			}
 			return 0;
@@ -179,7 +179,7 @@ static int check_handler_status(struct posix_timers_info *info,
 	test_msg("%20s: Handler count    : %d\n", info->name, info->handler_cnt);
 
 	if (displacement > MAX_TIMER_DISPLACEMENT) {
-		fail("%32s: Time displacement: %d%% (max alloved: %d%%)\n", info->name, displacement, MAX_TIMER_DISPLACEMENT);
+		fail("%32s: Time displacement: %d%% (max alloved: %d%%)", info->name, displacement, MAX_TIMER_DISPLACEMENT);
 		return -EFAULT;
 	}
 	return 0;
@@ -193,19 +193,19 @@ static int check_timers(int delta, struct timespec *sleep_start, struct timespec
 	struct itimerspec val, oldval;
 
 	if (sigprocmask(SIG_UNBLOCK, &mask, NULL) == -1) {
-		fail("Failed to unlock signal\n");
+		fail("Failed to unlock signal");
 		return -errno;
 	}
 
 	while (info->handler) {
 		memset(&val, 0, sizeof(val));
 		if (timer_settime(info->timerid, 0, &val, &oldval) == -1) {
-			fail("%s: failed to reset timer\n", info->name);
+			fail("%s: failed to reset timer", info->name);
 			return -errno;
 		}
 
 		if (clock_gettime(info->clock, &info->end) == -1) {
-			fail("Can't get %s end time\n", info->name);
+			fail("Can't get %s end time", info->name);
 			return -errno;
 		}
 

--- a/test/zdtm/static/proc-self.c
+++ b/test/zdtm/static/proc-self.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (memcmp(path_orig, path_new, sizeof(path_orig))) {
-		fail("Paths mismatch %s %s\n", path_orig, path_new);
+		fail("Paths mismatch %s %s", path_orig, path_new);
 		return -1;
 	}
 

--- a/test/zdtm/static/pthread00.c
+++ b/test/zdtm/static/pthread00.c
@@ -89,7 +89,7 @@ static void *thread_func_1(void *map)
 
 	pid = test_fork();
 	if (pid < 0) {
-		fail("Failed to test_fork()\n");
+		fail("Failed to test_fork()");
 		exit_group(1);
 	} else if (pid == 0) {
 		passage(2);
@@ -115,7 +115,7 @@ static void *thread_func_2(void *map)
 
 	pid = test_fork();
 	if (pid < 0) {
-		fail("Failed to test_fork()\n");
+		fail("Failed to test_fork()");
 		exit_group(1);
 	} else if (pid == 0) {
 		passage(4);

--- a/test/zdtm/static/pty00.c
+++ b/test/zdtm/static/pty00.c
@@ -38,7 +38,7 @@ int main(int argc, char ** argv)
 	 * receive SIGHUP, so make sure it's delivered.
 	 */
 	if (sigaction(SIGHUP, &sa, 0)) {
-		fail("sigaction failed\n");
+		fail("sigaction failed");
 		return 1;
 	}
 

--- a/test/zdtm/static/rmdir_open.c
+++ b/test/zdtm/static/rmdir_open.c
@@ -49,17 +49,17 @@ int main(int argc, char **argv)
 	 * still points to some removed directory.
 	 */
 	if (fstat(fd, &st)) {
-		fail("Can't stat fd\n");
+		fail("Can't stat fd");
 		goto out;
 	}
 
 	if (!S_ISDIR(st.st_mode)) {
-		fail("Fd is no longer directory\n");
+		fail("Fd is no longer directory");
 		goto out;
 	}
 
 	if (st.st_nlink != 0) {
-		fail("Directory is not removed\n");
+		fail("Directory is not removed");
 		goto out;
 	}
 

--- a/test/zdtm/static/s390x_gs_threads.c
+++ b/test/zdtm/static/s390x_gs_threads.c
@@ -118,7 +118,7 @@ static void *thread_run(void *param)
 	gs_epl = malloc(sizeof(unsigned long) * 6);
 	gs_cb = malloc(sizeof(*gs_cb));
 	if (gs_epl == NULL || gs_cb == NULL) {
-		fail("Error allocating memory\n");
+		fail("Error allocating memory");
 		exit(1);
 	}
 	gs_cb->gsd = 0x1234000000UL | 26;

--- a/test/zdtm/static/s390x_mmap_high.c
+++ b/test/zdtm/static/s390x_mmap_high.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
 	for (i = 0; i < MAP_SIZE; i++) {
 		if (buf[i] == VAL)
 			continue;
-		fail("%d: %d != %d\n", i, buf[i], VAL);
+		fail("%d: %d != %d", i, buf[i], VAL);
 		goto out;
 	}
 	pass();

--- a/test/zdtm/static/s390x_runtime_instr.c
+++ b/test/zdtm/static/s390x_runtime_instr.c
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
 			free(buf);
 			return 0;
 		}
-		fail("Fail with error %d", errno);
+		fail("syscall(s390_runtime_instr) failed");
 		free(buf);
 		return -1;
 	}

--- a/test/zdtm/static/seccomp_filter.c
+++ b/test/zdtm/static/seccomp_filter.c
@@ -180,7 +180,7 @@ int main(int argc, char ** argv)
 	}
 
 	if (mode != SECCOMP_MODE_FILTER) {
-		fail("seccomp mode mismatch %d\n", mode);
+		fail("seccomp mode mismatch %d", mode);
 		return 1;
 	}
 

--- a/test/zdtm/static/seccomp_filter_inheritance.c
+++ b/test/zdtm/static/seccomp_filter_inheritance.c
@@ -159,7 +159,7 @@ int main(int argc, char ** argv)
 	}
 
 	if (mode != SECCOMP_MODE_FILTER) {
-		fail("seccomp mode mismatch %d\n", mode);
+		fail("seccomp mode mismatch %d", mode);
 		return 1;
 	}
 

--- a/test/zdtm/static/seccomp_filter_threads.c
+++ b/test/zdtm/static/seccomp_filter_threads.c
@@ -206,7 +206,7 @@ int main(int argc, char ** argv)
 	mode = get_seccomp_mode(pid);
 
 	if (mode != SECCOMP_MODE_DISABLED) {
-		fail("seccomp mode mismatch %d\n", mode);
+		fail("seccomp mode mismatch %d", mode);
 		return 1;
 	}
 
@@ -217,7 +217,7 @@ int main(int argc, char ** argv)
 	}
 
 	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-		fail("expected 0 exit, got %d\n", WEXITSTATUS(status));
+		fail("expected 0 exit, got %d", WEXITSTATUS(status));
 		exit(1);
 	}
 

--- a/test/zdtm/static/seccomp_filter_threads.c
+++ b/test/zdtm/static/seccomp_filter_threads.c
@@ -153,7 +153,7 @@ int main(int argc, char ** argv)
 			MAP_ANONYMOUS | MAP_SHARED, -1, 0);
 
 	if (wait_rdy == MAP_FAILED || wait_run == MAP_FAILED) {
-		pr_perror("mmap failed\n");
+		pr_perror("mmap failed");
 		exit(1);
 	}
 

--- a/test/zdtm/static/seccomp_filter_tsync.c
+++ b/test/zdtm/static/seccomp_filter_tsync.c
@@ -196,7 +196,7 @@ int main(int argc, char ** argv)
 	}
 
 	if (mode != SECCOMP_MODE_FILTER) {
-		fail("seccomp mode mismatch %d\n", mode);
+		fail("seccomp mode mismatch %d", mode);
 		return 1;
 	}
 

--- a/test/zdtm/static/seccomp_strict.c
+++ b/test/zdtm/static/seccomp_strict.c
@@ -115,7 +115,7 @@ int main(int argc, char ** argv)
 		exit(1);
 	}
 	if (mode != SECCOMP_MODE_STRICT) {
-		fail("seccomp mode mismatch %d\n", mode);
+		fail("seccomp mode mismatch %d", mode);
 		return 1;
 	}
 

--- a/test/zdtm/static/selinux00.c
+++ b/test/zdtm/static/selinux00.c
@@ -39,7 +39,7 @@ int setprofile(void)
 
 	fd = open("/proc/self/attr/current", O_WRONLY);
 	if (fd < 0) {
-		fail("Could not open /proc/self/attr/current\n");
+		fail("Could not open /proc/self/attr/current");
 		return -1;
 	}
 
@@ -47,7 +47,7 @@ int setprofile(void)
 	close(fd);
 
 	if (len < 0) {
-		fail("Could not write context\n");
+		fail("Could not write context");
 		return -1;
 	}
 
@@ -63,20 +63,20 @@ int checkprofile(void)
 
 	fd = open("/proc/self/attr/current", O_RDONLY);
 	if (fd < 0) {
-		fail("Could not open /proc/self/attr/current\n");
+		fail("Could not open /proc/self/attr/current");
 		return -1;
 	}
 
 	len = read(fd, context, strlen(CONTEXT));
 	close(fd);
 	if (len != strlen(CONTEXT)) {
-		fail("SELinux context has unexpected length %d, expected %zd\n",
+		fail("SELinux context has unexpected length %d, expected %zd",
 			len, strlen(CONTEXT));
 		return -1;
 	}
 
 	if (strncmp(context, CONTEXT, strlen(CONTEXT)) != 0) {
-		fail("Wrong SELinux context %s expected %s\n", context, CONTEXT);
+		fail("Wrong SELinux context %s expected %s", context, CONTEXT);
 		return -1;
 	}
 
@@ -94,14 +94,14 @@ int check_sockcreate(void)
 		free(output);
 		/* sockcreate should be empty, if fscanf found something
 		 * it is wrong.*/
-		fail("sockcreate should be empty\n");
+		fail("sockcreate should be empty");
 		return -1;
 	}
 
 	if (output) {
 		free(output);
 		/* Same here, output should still be NULL. */
-		fail("sockcreate should be empty\n");
+		fail("sockcreate should be empty");
 		return -1;
 	}
 

--- a/test/zdtm/static/selinux01.c
+++ b/test/zdtm/static/selinux01.c
@@ -41,7 +41,7 @@ int setprofile(void)
 
 	fd = open("/proc/self/attr/current", O_WRONLY);
 	if (fd < 0) {
-		fail("Could not open /proc/self/attr/current\n");
+		fail("Could not open /proc/self/attr/current");
 		return -1;
 	}
 
@@ -49,7 +49,7 @@ int setprofile(void)
 	close(fd);
 
 	if (len < 0) {
-		fail("Could not write context\n");
+		fail("Could not write context");
 		return -1;
 	}
 
@@ -62,7 +62,7 @@ int set_sockcreate(void)
 
 	fd = open("/proc/self/attr/sockcreate", O_WRONLY);
 	if (fd < 0) {
-		fail("Could not open /proc/self/attr/sockcreate\n");
+		fail("Could not open /proc/self/attr/sockcreate");
 		return -1;
 	}
 
@@ -70,7 +70,7 @@ int set_sockcreate(void)
 	close(fd);
 
 	if (len < 0) {
-		fail("Could not write context\n");
+		fail("Could not write context");
 		return -1;
 	}
 
@@ -86,20 +86,20 @@ int check_sockcreate(void)
 
 	fd = open("/proc/self/attr/sockcreate", O_RDONLY);
 	if (fd < 0) {
-		fail("Could not open /proc/self/attr/sockcreate\n");
+		fail("Could not open /proc/self/attr/sockcreate");
 		return -1;
 	}
 
 	len = read(fd, context, strlen(CONTEXT));
 	close(fd);
 	if (len != strlen(CONTEXT)) {
-		fail("SELinux context has unexpected length %d, expected %zd\n",
+		fail("SELinux context has unexpected length %d, expected %zd",
 			len, strlen(CONTEXT));
 		return -1;
 	}
 
 	if (strncmp(context, CONTEXT, strlen(CONTEXT)) != 0) {
-		fail("Wrong SELinux context %s expected %s\n", context, CONTEXT);
+		fail("Wrong SELinux context %s expected %s", context, CONTEXT);
 		return -1;
 	}
 
@@ -117,14 +117,14 @@ int check_sockcreate_empty(void)
 		free(output);
 		/* sockcreate should be empty, if fscanf found something
 		 * it is wrong.*/
-		fail("sockcreate should be empty\n");
+		fail("sockcreate should be empty");
 		return -1;
 	}
 
 	if (output) {
 		free(output);
 		/* Same here, output should still be NULL. */
-		fail("sockcreate should be empty\n");
+		fail("sockcreate should be empty");
 		return -1;
 	}
 
@@ -164,11 +164,11 @@ int main(int argc, char **argv)
 	memset(ctx, 0, 1024);
 	/* Read out the socket label */
 	if (fgetxattr(sk, "security.selinux", ctx, 1024) == -1) {
-		fail("Reading xattr 'security.selinux' failed.\n");
+		fail("Reading xattr 'security.selinux' failed.");
 		return -1;
 	}
 	if (strncmp(ctx, CONTEXT, strlen(CONTEXT)) != 0) {
-		fail("Wrong SELinux context %s expected %s\n", ctx, CONTEXT);
+		fail("Wrong SELinux context %s expected %s", ctx, CONTEXT);
 		return -1;
 	}
 	memset(ctx, 0, 1024);
@@ -179,11 +179,11 @@ int main(int argc, char **argv)
 	/* Read out the socket label again */
 
 	if (fgetxattr(sk, "security.selinux", ctx, 1024) == -1) {
-		fail("Reading xattr 'security.selinux' failed.\n");
+		fail("Reading xattr 'security.selinux' failed.");
 		return -1;
 	}
 	if (strncmp(ctx, CONTEXT, strlen(CONTEXT)) != 0) {
-		fail("Wrong SELinux context %s expected %s\n", ctx, CONTEXT);
+		fail("Wrong SELinux context %s expected %s", ctx, CONTEXT);
 		return -1;
 	}
 

--- a/test/zdtm/static/sem.c
+++ b/test/zdtm/static/sem.c
@@ -98,7 +98,7 @@ static int check_sem_by_id(int id, int num, int val)
 		return -errno;
 	}
 	if (curr != val) {
-		fail("Sem has wrong value: %d instead of %d\n", curr, val);
+		fail("Sem has wrong value: %d instead of %d", curr, val);
 		return -EFAULT;
 	}
 	return sem_test(id, lock, unlock,

--- a/test/zdtm/static/session00.c
+++ b/test/zdtm/static/session00.c
@@ -217,7 +217,7 @@ int main(int argc, char ** argv)
 				err++;
 			}
 			if (!WIFEXITED(status) || WEXITSTATUS(status)) {
-				fail("The process with pid %d returns %d\n", pid, status);
+				fail("The process with pid %d returns %d", pid, status);
 				err++;
 			}
 		}

--- a/test/zdtm/static/shm-mp.c
+++ b/test/zdtm/static/shm-mp.c
@@ -20,7 +20,7 @@ static void segfault(int signo)
 static int check_prot(char *ptr, char val, int prot)
 {
 	if (signal(SIGSEGV, segfault) == SIG_ERR) {
-		fail("setting SIGSEGV handler failed: %m\n");
+		fail("setting SIGSEGV handler failed: %m");
 		return -1;
 	}
 
@@ -30,29 +30,29 @@ static int check_prot(char *ptr, char val, int prot)
 			return -1;
 		}
 		if (!(prot & PROT_READ)) {
-			fail("PROT_READ bypassed\n");
+			fail("PROT_READ bypassed");
 			return -1;
 		}
 	} else		/* we come here on return from SIGSEGV handler */
 		if (prot & PROT_READ) {
-			fail("PROT_READ rejected\n");
+			fail("PROT_READ rejected");
 			return -1;
 		}
 
 	if (!sigsetjmp(segv_ret, 1)) {
 		*ptr = val;
 		if (!(prot & PROT_WRITE)) {
-			fail("PROT_WRITE bypassed\n");
+			fail("PROT_WRITE bypassed");
 			return -1;
 		}
 	} else		/* we come here on return from SIGSEGV handler */
 		if (prot & PROT_WRITE) {
-			fail("PROT_WRITE rejected\n");
+			fail("PROT_WRITE rejected");
 			return -1;
 		}
 
 	if (signal(SIGSEGV, SIG_DFL) == SIG_ERR) {
-		fail("restoring SIGSEGV handler failed: %m\n");
+		fail("restoring SIGSEGV handler failed: %m");
 		return -1;
 	}
 

--- a/test/zdtm/static/shm-mp.c
+++ b/test/zdtm/static/shm-mp.c
@@ -20,7 +20,7 @@ static void segfault(int signo)
 static int check_prot(char *ptr, char val, int prot)
 {
 	if (signal(SIGSEGV, segfault) == SIG_ERR) {
-		fail("setting SIGSEGV handler failed: %m");
+		fail("setting SIGSEGV handler failed");
 		return -1;
 	}
 
@@ -52,7 +52,7 @@ static int check_prot(char *ptr, char val, int prot)
 		}
 
 	if (signal(SIGSEGV, SIG_DFL) == SIG_ERR) {
-		fail("restoring SIGSEGV handler failed: %m");
+		fail("restoring SIGSEGV handler failed");
 		return -1;
 	}
 

--- a/test/zdtm/static/shm.c
+++ b/test/zdtm/static/shm.c
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
 
 	ret = shmctl(shm, IPC_RMID, NULL);
 	if (ret < 0) {
-		fail("Failed (1) to destroy segment: %d", -errno);
+		fail("Failed (1) to destroy segment");
 		fail_count++;
 		goto out_shm;
 	}
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
 out_shm:
 	ret = shmctl(shm, IPC_RMID, NULL);
 	if (ret < 0) {
-		fail("Failed (2) to destroy segment: %d", -errno);
+		fail("Failed (2) to destroy segment");
 		fail_count++;
 	}
 	if (fail_count == 0)

--- a/test/zdtm/static/shm.c
+++ b/test/zdtm/static/shm.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
 	shm = prepare_shm(key, shmem_size);
 	if (shm == -1) {
-		pr_perror("Can't prepare shm (1)");
+		pr_err("Can't prepare shm (1)\n");
 		goto out;
 	}
 

--- a/test/zdtm/static/shm.c
+++ b/test/zdtm/static/shm.c
@@ -138,14 +138,14 @@ int main(int argc, char **argv)
 
 	ret = check_shm_id(shm, shmem_size);
 	if (ret < 0) {
-		fail("ID check (1) failed\n");
+		fail("ID check (1) failed");
 		fail_count++;
 		goto out_shm;
 	}
 
 	ret = check_shm_key(key, shmem_size);
 	if (ret < 0) {
-		fail("KEY check failed\n");
+		fail("KEY check failed");
 		fail_count++;
 		goto out_shm;
 	}
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
 
 	ret = shmctl(shm, IPC_RMID, NULL);
 	if (ret < 0) {
-		fail("Failed (1) to destroy segment: %d\n", -errno);
+		fail("Failed (1) to destroy segment: %d", -errno);
 		fail_count++;
 		goto out_shm;
 	}
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
 
 	ret = check_shm_id(shm, shmem_size);
 	if (ret < 0) {
-		fail("ID check (2) failed\n");
+		fail("ID check (2) failed");
 		fail_count++;
 		goto out_shm;
 	}
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
 out_shm:
 	ret = shmctl(shm, IPC_RMID, NULL);
 	if (ret < 0) {
-		fail("Failed (2) to destroy segment: %d\n", -errno);
+		fail("Failed (2) to destroy segment: %d", -errno);
 		fail_count++;
 	}
 	if (fail_count == 0)

--- a/test/zdtm/static/shm.c
+++ b/test/zdtm/static/shm.c
@@ -29,14 +29,14 @@ static int fill_shm_seg(int id, size_t size)
 
 	mem = shmat(id, NULL, 0);
 	if (mem == (void *)-1) {
-		pr_perror("Can't attach shm: %d", -errno);
+		pr_perror("Can't attach shm");
 		return -1;
 	}
 
 	datagen(mem, size, &crc);
 
 	if (shmdt(mem) < 0) {
-		pr_perror("Can't detach shm: %d", -errno);
+		pr_perror("Can't detach shm");
 		return -1;
 	}
 	return 0;
@@ -48,7 +48,7 @@ static int get_shm_seg(int key, size_t size, unsigned int flags)
 
 	id = shmget(key, size, 0777 | flags);
 	if (id == -1) {
-		pr_perror("Can't get shm: %d", -errno);
+		pr_perror("Can't get shm");
 		return -1;
 	}
 	return id;
@@ -74,7 +74,7 @@ static int check_shm_id(int id, size_t size)
 
 	mem = shmat(id, NULL, 0);
 	if (mem == (void *)-1) {
-		pr_perror("Can't attach shm: %d", -errno);
+		pr_perror("Can't attach shm");
 		return -1;
 	}
 	crc = INIT_CRC;
@@ -83,7 +83,7 @@ static int check_shm_id(int id, size_t size)
 		return -1;
 	}
 	if (shmdt(mem) < 0) {
-		pr_perror("Can't detach shm: %d", -errno);
+		pr_perror("Can't detach shm");
 		return -1;
 	}
 	return 0;

--- a/test/zdtm/static/sigpending.c
+++ b/test/zdtm/static/sigpending.c
@@ -105,12 +105,12 @@ static void sig_handler(int signal, siginfo_t *info, void *data)
 
 		crc = ~0;
 		if (datachk((uint8_t *) siginf_body(info), _si_fields_sz, &crc)) {
-			fail("CRC mismatch\n");
+			fail("CRC mismatch");
 			return;
 		}
 
 		 if (memcmp(info, src, siginfo_filled)) {
-			fail("Source and received info are differ\n");
+			fail("Source and received info are differ");
 			return;
 		}
 

--- a/test/zdtm/static/sk-unix-mntns.c
+++ b/test/zdtm/static/sk-unix-mntns.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 	task_waiter_init(&t);
 	cwd = get_current_dir_name();
 	if (!cwd) {
-		fail("getcwd\n");
+		fail("getcwd");
 		exit(1);
 	}
 
@@ -89,12 +89,12 @@ int main(int argc, char *argv[])
 
 	ret = bind(sk, (struct sockaddr *) &addr, addrlen);
 	if (ret) {
-		fail("bind\n");
+		fail("bind");
 		exit(1);
 	}
 
 	if (connect(csk, (struct sockaddr *) &addr, addrlen)) {
-		fail("connect\n");
+		fail("connect");
 		exit(1);
 	}
 
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
 		}
 
 		if (strncmp(rbuf, sbuf, len)) {
-			fail("data corrupted\n");
+			fail("data corrupted");
 			exit(1);
 		}
 

--- a/test/zdtm/static/sk-unix-mntns.c
+++ b/test/zdtm/static/sk-unix-mntns.c
@@ -78,12 +78,12 @@ int main(int argc, char *argv[])
 
 	sk = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0);
 	if (sk < 0) {
-		pr_perror("socket\n");
+		pr_perror("socket");
 		exit(1);
 	}
 	csk = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0);
 	if (csk < 0) {
-		pr_perror("socket\n");
+		pr_perror("socket");
 		exit(1);
 	}
 
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
 		close(csk);
 		csk = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0);
 		if (csk < 0) {
-			pr_perror("socket\n");
+			pr_perror("socket");
 			exit(1);
 		}
 		if (connect(csk, (struct sockaddr *) &addr, addrlen)) {

--- a/test/zdtm/static/sk-unix-rel.c
+++ b/test/zdtm/static/sk-unix-rel.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 
 	cwd = get_current_dir_name();
 	if (!cwd) {
-		fail("getcwd\n");
+		fail("getcwd");
 		exit(1);
 	}
 
@@ -57,25 +57,25 @@ int main(int argc, char *argv[])
 	sock[0] = socket(AF_UNIX, SOCK_STREAM, 0);
 	sock[1] = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (sock[0] < 0 || sock[1] < 0) {
-		fail("socket\n");
+		fail("socket");
 		exit(1);
 	}
 
 	if (setsockopt(sock[0], SOL_SOCKET, SO_REUSEADDR, &(int){ 1 }, sizeof(int)) < 0 ||
 	    setsockopt(sock[1], SOL_SOCKET, SO_REUSEADDR, &(int){ 1 }, sizeof(int)) < 0) {
-		fail("setsockopt\n");
+		fail("setsockopt");
 		exit(1);
 	}
 
 	ret = bind(sock[0], (struct sockaddr *) &addr, addrlen);
 	if (ret) {
-		fail("bind\n");
+		fail("bind");
 		exit(1);
 	}
 
 	ret = listen(sock[0], 16);
 	if (ret) {
-		fail("bind\n");
+		fail("bind");
 		exit(1);
 	}
 
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
 	test_waitsig();
 
 	if (connect(sock[1], (struct sockaddr *) &addr, addrlen)) {
-		fail("connect\n");
+		fail("connect");
 		exit(1);
 	}
 
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
 	read(ret, &buf, sizeof(buf));
 
 	if (strcmp(buf, SK_DATA)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("stream            : '%s'\n", buf);

--- a/test/zdtm/static/sk-unix-unconn.c
+++ b/test/zdtm/static/sk-unix-unconn.c
@@ -45,7 +45,7 @@ int main(int argc, char ** argv)
 
 	ret = bind(sk, (struct sockaddr *) &addr, addrlen);
 	if (ret) {
-		fail("bind\n");
+		fail("bind");
 		return 1;
 	}
 

--- a/test/zdtm/static/sock_peercred.c
+++ b/test/zdtm/static/sock_peercred.c
@@ -53,7 +53,7 @@ static int child_func(void *fd_p)
 
 	/* If sks[1] == fd, the below closes it, but we don't care */
 	if (dup2(sks[0], fd) == -1) {
-		pr_perror("Can't dup fd\n");
+		pr_perror("Can't dup fd");
 		return 1;
 	}
 
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
 	}
 
 	if (wait(&status) == -1 || status) {
-		pr_perror("wait error: status=%d\n", status);
+		pr_perror("wait error: status=%d", status);
 		goto out;
 	}
 

--- a/test/zdtm/static/sock_peercred.c
+++ b/test/zdtm/static/sock_peercred.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 
 	if (ucred.pid != pid || ucred.gid != getuid() + UID_INC ||
 			        ucred.gid != getgid() + GID_INC) {
-		fail("Wrong pid, uid or gid\n");
+		fail("Wrong pid, uid or gid");
 		goto out;
 	}
 

--- a/test/zdtm/static/socket-ext.c
+++ b/test/zdtm/static/socket-ext.c
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 	test_waitsig();
 
 	if (unlink(path)) {
-		pr_perror("Unable to remove %s\n", path);
+		pr_perror("Unable to remove %s", path);
 		return 1;
 	}
 	if (rmdir(dir)) {

--- a/test/zdtm/static/socket-raw.c
+++ b/test/zdtm/static/socket-raw.c
@@ -383,7 +383,7 @@ int main(int argc, char *argv[])
 	ret = wait(&status);
 	if (ret == -1 || !WIFEXITED(status) || WEXITSTATUS(status)) {
 		kill(pid, SIGKILL);
-		fail("Failed waiting server\n");
+		fail("Failed waiting server");
 		exit(1);
 	}
 

--- a/test/zdtm/static/socket-tcp-close-wait.c
+++ b/test/zdtm/static/socket-tcp-close-wait.c
@@ -37,11 +37,11 @@ int fill_sock_buf(int fd)
 
 	flags = fcntl(fd, F_GETFL, 0);
 	if (flags == -1) {
-		pr_err("Can't get flags");
+		pr_perror("Can't get flags");
 		return -1;
 	}
 	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
-		pr_err("Can't set flags");
+		pr_perror("Can't set flags");
 		return -1;
 	}
 
@@ -52,14 +52,14 @@ int fill_sock_buf(int fd)
 		if (ret == -1) {
 			if (errno == EAGAIN)
 				break;
-			pr_err("write");
+			pr_perror("write");
 			return -1;
 		}
 		size += ret;
 	}
 
 	if (fcntl(fd, F_SETFL, flags) == -1) {
-		pr_err("Can't set flags");
+		pr_perror("Can't set flags");
 		return -1;
 	}
 
@@ -77,7 +77,7 @@ static int clean_sk_buf(int fd)
 	while (1) {
 		ret = read(fd, buf, sizeof(buf));
 		if (ret == -1) {
-			pr_err("read");
+			pr_perror("read");
 			return -11;
 		}
 
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
 		test_init(argc, argv);
 
 	if ((fd_s = tcp_init_server(ZDTM_SRV_FAMILY, &port)) < 0) {
-		pr_err("initializing server failed");
+		pr_err("initializing server failed\n");
 		return 1;
 	}
 
@@ -208,13 +208,13 @@ int main(int argc, char **argv)
 	 */
 	fd = tcp_accept_server(fd_s);
 	if (fd < 0) {
-		pr_err("can't accept client connection");
+		pr_err("can't accept client connection\n");
 		return 1;
 	}
 
 	ctl_fd = tcp_accept_server(fd_s);
 	if (ctl_fd < 0) {
-		pr_err("can't accept client connection");
+		pr_err("can't accept client connection\n");
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp-close-wait.c
+++ b/test/zdtm/static/socket-tcp-close-wait.c
@@ -267,7 +267,7 @@ int main(int argc, char **argv)
 	rcv_size = clean_sk_buf(fd);
 
 	if (ret != rcv_size) {
-		fail("The child sent %d bytes, but the parent received %d bytes\n", ret, rcv_size);
+		fail("The child sent %d bytes, but the parent received %d bytes", ret, rcv_size);
 		return 1;
 	}
 
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
 	/* == End of the final stage == */
 
 	if (ret != snd_size) {
-		fail("The parent sent %d bytes, but the child received %d bytes\n", snd_size, ret);
+		fail("The parent sent %d bytes, but the child received %d bytes", snd_size, ret);
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp-close-wait.c
+++ b/test/zdtm/static/socket-tcp-close-wait.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
 
 		close(pfd[1]);
 		if (read(pfd[0], &port, sizeof(port)) != sizeof(port)) {
-			pr_perror("Can't read port\n");
+			pr_perror("Can't read port");
 			return 1;
 		}
 		close(pfd[0]);

--- a/test/zdtm/static/socket-tcp-close0.c
+++ b/test/zdtm/static/socket-tcp-close0.c
@@ -28,7 +28,7 @@ static int check_socket_closed(int sk)
 		pr_perror("Can't get socket state");
 		return -1;
 	} else if (info.tcpi_state != TCP_CLOSE) {
-		pr_err("Invalid socket state (%i)", (int)info.tcpi_state);
+		pr_err("Invalid socket state (%i)\n", (int)info.tcpi_state);
 		return -1;
 	}
 

--- a/test/zdtm/static/socket-tcp-close0.c
+++ b/test/zdtm/static/socket-tcp-close0.c
@@ -25,7 +25,7 @@ static int check_socket_closed(int sk)
 
 	err = getsockopt(sk, IPPROTO_TCP, TCP_INFO, (void *)&info, &len);
 	if (err != 0) {
-		pr_perror("Can't get socket state\n");
+		pr_perror("Can't get socket state");
 		return -1;
 	} else if (info.tcpi_state != TCP_CLOSE) {
 		pr_err("Invalid socket state (%i)", (int)info.tcpi_state);

--- a/test/zdtm/static/socket-tcp-close0.c
+++ b/test/zdtm/static/socket-tcp-close0.c
@@ -56,7 +56,7 @@ static int check_socket_closed(int sk)
 	}
 
 	if (errno != EPIPE) {
-		fail("errno is %d (%s) (expected EPIPE)", errno, strerror(errno));
+		fail("wrong errno (expected EPIPE)");
 		return 1;
 	}
 	return 0;

--- a/test/zdtm/static/socket-tcp-close1.c
+++ b/test/zdtm/static/socket-tcp-close1.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (check_socket_state(fd_s, TCP_LISTEN)) {
-		fail("Listen socket state is changed\n");
+		fail("Listen socket state is changed");
 		close(fd_s);
 		return 1;
 	}

--- a/test/zdtm/static/socket-tcp-close1.c
+++ b/test/zdtm/static/socket-tcp-close1.c
@@ -21,7 +21,7 @@ static int check_socket_state(int sk, int state)
 
 	err = getsockopt(sk, IPPROTO_TCP, TCP_INFO, (void *)&info, &len);
 	if (err != 0) {
-		pr_perror("Can't get socket state\n");
+		pr_perror("Can't get socket state");
 		return -1;
 	}
 	return info.tcpi_state == state ? 0 : -1;

--- a/test/zdtm/static/socket-tcp-closed.c
+++ b/test/zdtm/static/socket-tcp-closed.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 	if (memcmp(&addr, &dst_addr, aux)) {
-		pr_err("A destination address mismatch");
+		pr_err("A destination address mismatch\n");
 		return 1;
 	}
 
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 	if (memcmp(&addr, &src_addr, aux)) {
-		pr_err("A source address mismatch");
+		pr_err("A source address mismatch\n");
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp-closing.c
+++ b/test/zdtm/static/socket-tcp-closing.c
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
 	rcv_size = clean_sk_buf(fd);
 
 	if (ret != rcv_size) {
-		fail("The child sent %d bytes, but the parent received %d bytes\n", ret, rcv_size);
+		fail("The child sent %d bytes, but the parent received %d bytes", ret, rcv_size);
 		return 1;
 	}
 
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
 	}
 
 	if (ret != snd_size) {
-		fail("The parent sent %d bytes, but the child received %d bytes\n", snd_size, ret);
+		fail("The parent sent %d bytes, but the child received %d bytes", snd_size, ret);
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp-closing.c
+++ b/test/zdtm/static/socket-tcp-closing.c
@@ -37,11 +37,11 @@ int fill_sock_buf(int fd)
 
 	flags = fcntl(fd, F_GETFL, 0);
 	if (flags == -1) {
-		pr_err("Can't get flags");
+		pr_perror("Can't get flags");
 		return -1;
 	}
 	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
-		pr_err("Can't set flags");
+		pr_perror("Can't set flags");
 		return -1;
 	}
 
@@ -52,14 +52,14 @@ int fill_sock_buf(int fd)
 		if (ret == -1) {
 			if (errno == EAGAIN)
 				break;
-			pr_err("write");
+			pr_perror("write");
 			return -1;
 		}
 		size += ret;
 	}
 
 	if (fcntl(fd, F_SETFL, flags) == -1) {
-		pr_err("Can't set flags");
+		pr_perror("Can't set flags");
 		return -1;
 	}
 
@@ -77,7 +77,7 @@ static int clean_sk_buf(int fd)
 	while (1) {
 		ret = read(fd, buf, sizeof(buf));
 		if (ret == -1) {
-			pr_err("read");
+			pr_perror("read");
 			return -11;
 		}
 
@@ -104,13 +104,13 @@ int main(int argc, char **argv)
 		test_init(argc, argv);
 
 	if (pipe(pfd)) {
-		pr_err("pipe() failed");
+		pr_perror("pipe() failed");
 		return 1;
 	}
 
 	extpid = fork();
 	if (extpid < 0) {
-		pr_err("fork() failed");
+		pr_perror("fork() failed");
 		return 1;
 	} else if (extpid == 0) {
 		int size = 0;
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
 
 		close(pfd[1]);
 		if (read(pfd[0], &port, sizeof(port)) != sizeof(port)) {
-			pr_err("Can't read port\n");
+			pr_perror("Can't read port");
 			return 1;
 		}
 
@@ -138,17 +138,17 @@ int main(int argc, char **argv)
 			return 1;
 
 		if (shutdown(fd, SHUT_WR) == -1) {
-			pr_err("shutdown");
+			pr_perror("shutdown");
 			return 1;
 		}
 
 		if (write(ctl_fd, &size, sizeof(size)) != sizeof(size)) {
-			pr_err("write");
+			pr_perror("write");
 			return 1;
 		}
 
 		if (read(ctl_fd, &c, 1) != 0) {
-			pr_err("read");
+			pr_perror("read");
 			return 1;
 		}
 
@@ -166,13 +166,13 @@ int main(int argc, char **argv)
 		test_init(argc, argv);
 
 	if ((fd_s = tcp_init_server(ZDTM_SRV_FAMILY, &port)) < 0) {
-		pr_err("initializing server failed");
+		pr_err("initializing server failed\n");
 		return 1;
 	}
 
 	close(pfd[0]);
 	if (write(pfd[1], &port, sizeof(port)) != sizeof(port)) {
-		pr_err("Can't send port");
+		pr_perror("Can't send port");
 		return 1;
 	}
 	close(pfd[1]);
@@ -182,13 +182,13 @@ int main(int argc, char **argv)
 	 */
 	fd = tcp_accept_server(fd_s);
 	if (fd < 0) {
-		pr_err("can't accept client connection %m");
+		pr_err("can't accept client connection\n");
 		return 1;
 	}
 
 	ctl_fd = tcp_accept_server(fd_s);
 	if (ctl_fd < 0) {
-		pr_err("can't accept client connection %m");
+		pr_err("can't accept client connection\n");
 		return 1;
 	}
 
@@ -197,12 +197,12 @@ int main(int argc, char **argv)
 		return 1;
 
 	if (shutdown(fd, SHUT_WR) == -1) {
-		pr_err("shutdown");
+		pr_perror("shutdown");
 		return 1;
 	}
 
 	if (read(ctl_fd, &ret, sizeof(ret)) != sizeof(ret)) {
-		pr_err("read");
+		pr_perror("read");
 		return 1;
 	}
 
@@ -224,12 +224,12 @@ int main(int argc, char **argv)
 	}
 
 	if (shutdown(ctl_fd, SHUT_WR) == -1) {
-		pr_err("shutdown");
+		pr_perror("shutdown");
 		return 1;
 	}
 
 	if (read(ctl_fd, &ret, sizeof(ret)) != sizeof(ret)) {
-		pr_err("read");
+		pr_perror("read");
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp-fin-wait1.c
+++ b/test/zdtm/static/socket-tcp-fin-wait1.c
@@ -38,11 +38,11 @@ int fill_sock_buf(int fd)
 
 	flags = fcntl(fd, F_GETFL, 0);
 	if (flags == -1) {
-		pr_err("Can't get flags");
+		pr_perror("Can't get flags");
 		return -1;
 	}
 	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
-		pr_err("Can't set flags");
+		pr_perror("Can't set flags");
 		return -1;
 	}
 
@@ -53,14 +53,14 @@ int fill_sock_buf(int fd)
 		if (ret == -1) {
 			if (errno == EAGAIN)
 				break;
-			pr_err("write");
+			pr_perror("write");
 			return -1;
 		}
 		size += ret;
 	}
 
 	if (fcntl(fd, F_SETFL, flags) == -1) {
-		pr_err("Can't set flags");
+		pr_perror("Can't set flags");
 		return -1;
 	}
 
@@ -78,7 +78,7 @@ static int clean_sk_buf(int fd)
 	while (1) {
 		ret = read(fd, buf, sizeof(buf));
 		if (ret == -1) {
-			pr_err("read");
+			pr_perror("read");
 			return -11;
 		}
 
@@ -106,13 +106,13 @@ int main(int argc, char **argv)
 		test_init(argc, argv);
 
 	if (pipe(pfd)) {
-		pr_err("pipe() failed");
+		pr_perror("pipe() failed");
 		return 1;
 	}
 
 	extpid = fork();
 	if (extpid < 0) {
-		pr_err("fork() failed");
+		pr_perror("fork() failed");
 		return 1;
 	} else if (extpid == 0) {
 		int size = 0;
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
 		close(pfd[1]);
 		if (read(pfd[0], &port, sizeof(port)) != sizeof(port)) {
-			pr_err("Can't read port\n");
+			pr_perror("Can't read port");
 			return 1;
 		}
 
@@ -137,17 +137,17 @@ int main(int argc, char **argv)
 			return 1;
 
 		if (read(ctl_fd, &c, 1) != 0) {
-			pr_err("read");
+			pr_perror("read");
 			return 1;
 		}
 
 		if (write(fd, &TEST_MSG[2], sizeof(TEST_MSG) - 2) != sizeof(TEST_MSG) - 2) {
-			pr_err("write");
+			pr_perror("write");
 			return 1;
 		}
 
 		if (shutdown(fd, SHUT_WR) == -1) {
-			pr_err("shutdown");
+			pr_perror("shutdown");
 			return 1;
 		}
 
@@ -165,13 +165,13 @@ int main(int argc, char **argv)
 		test_init(argc, argv);
 
 	if ((fd_s = tcp_init_server(ZDTM_SRV_FAMILY, &port)) < 0) {
-		pr_err("initializing server failed");
+		pr_err("initializing server failed\n");
 		return 1;
 	}
 
 	close(pfd[0]);
 	if (write(pfd[1], &port, sizeof(port)) != sizeof(port)) {
-		pr_err("Can't send port");
+		pr_perror("Can't send port");
 		return 1;
 	}
 	close(pfd[1]);
@@ -181,13 +181,13 @@ int main(int argc, char **argv)
 	 */
 	fd = tcp_accept_server(fd_s);
 	if (fd < 0) {
-		pr_err("can't accept client connection %m");
+		pr_err("can't accept client connection\n");
 		return 1;
 	}
 
 	ctl_fd = tcp_accept_server(fd_s);
 	if (ctl_fd < 0) {
-		pr_err("can't accept client connection %m");
+		pr_err("can't accept client connection\n");
 		return 1;
 	}
 
@@ -198,7 +198,7 @@ int main(int argc, char **argv)
 #endif
 
 	if (shutdown(fd, SHUT_WR) == -1) {
-		pr_err("shutdown");
+		pr_perror("shutdown");
 		return 1;
 	}
 
@@ -207,18 +207,18 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (shutdown(ctl_fd, SHUT_WR) == -1) {
-		pr_err("shutdown");
+		pr_perror("shutdown");
 		return 1;
 	}
 
 	if (recv(fd, buf, sizeof(buf), MSG_WAITALL) != sizeof(TEST_MSG) ||
 	    strncmp(buf, TEST_MSG, sizeof(TEST_MSG))) {
-		pr_err("read");
+		pr_perror("recv: expected %s, got %s", TEST_MSG, buf);
 		return 1;
 	}
 
 	if (read(ctl_fd, &ret, sizeof(ret)) != sizeof(ret)) {
-		pr_err("read");
+		pr_perror("read");
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp-fin-wait1.c
+++ b/test/zdtm/static/socket-tcp-fin-wait1.c
@@ -223,7 +223,7 @@ int main(int argc, char **argv)
 	}
 
 	if (ret != snd_size) {
-		fail("The parent sent %d bytes, but the child received %d bytes\n", snd_size, ret);
+		fail("The parent sent %d bytes, but the child received %d bytes", snd_size, ret);
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp-listen.c
+++ b/test/zdtm/static/socket-tcp-listen.c
@@ -140,7 +140,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 	if (val != 1) {
-		fail("SO_REUSEADDR are not set for %d\n", fd);
+		fail("SO_REUSEADDR are not set for %d", fd);
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp-reuseport.c
+++ b/test/zdtm/static/socket-tcp-reuseport.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 	if (val == 1) {
-		fail("SO_REUSEPORT is set for %d\n", fd);
+		fail("SO_REUSEPORT is set for %d", fd);
 		return 1;
 	}
 	optlen = sizeof(val);
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 	if (val != 1) {
-		fail("SO_REUSEPORT is not set for %d\n", fd);
+		fail("SO_REUSEPORT is not set for %d", fd);
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp-unconn.c
+++ b/test/zdtm/static/socket-tcp-unconn.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 	if (memcmp(&addr, &src_addr, aux)) {
-		pr_err("A source address mismatch");
+		pr_err("A source address mismatch\n");
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcp.c
+++ b/test/zdtm/static/socket-tcp.c
@@ -210,7 +210,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 	if (val != 1) {
-		fail("SO_REUSEADDR are not set for %d\n", fd);
+		fail("SO_REUSEADDR are not set for %d", fd);
 		return 1;
 	}
 

--- a/test/zdtm/static/socket-tcpbuf.c
+++ b/test/zdtm/static/socket-tcpbuf.c
@@ -196,7 +196,7 @@ int main(int argc, char **argv)
 			return 1;
 
 		if (size != rcv_buf_size) {
-			fail("the received buffer contains only %d bytes (%d)\n", size, rcv_buf_size);
+			fail("the received buffer contains only %d bytes (%d)", size, rcv_buf_size);
 		}
 
 		rcv_size += size;
@@ -300,19 +300,19 @@ int main(int argc, char **argv)
 
 	ret = clean_sk_buf(fd, 0);
 	if (ret != rcv_buf_size) {
-		fail("the received buffer contains only %d bytes (%d)\n", ret, rcv_buf_size);
+		fail("the received buffer contains only %d bytes (%d)", ret, rcv_buf_size);
 	}
 	rcv_size += ret;
 
 	if (snd != rcv_size) {
-		fail("The child sent %d bytes, but the parent received %d bytes\n", rcv_buf_size, rcv_size);
+		fail("The child sent %d bytes, but the parent received %d bytes", rcv_buf_size, rcv_size);
 		return 1;
 	}
 
 	read_safe(ctl_fd, &ret, sizeof(ret));
 
 	if (ret != snd_size) {
-		fail("The parent sent %d bytes, but the child received %d bytes\n", snd_size, ret);
+		fail("The parent sent %d bytes, but the child received %d bytes", snd_size, ret);
 		return 1;
 	}
 

--- a/test/zdtm/static/socket_dgram_data.c
+++ b/test/zdtm/static/socket_dgram_data.c
@@ -43,15 +43,15 @@ int main(int argc, char **argv)
 	addrlen = sizeof(addr.sun_family) + sizeof(SK_SRV);
 
 	if (bind(srv, (struct sockaddr *) &addr, addrlen)) {
-		fail("bind\n");
+		fail("bind");
 		exit(1);
 	}
 	if (connect(clnt1, (struct sockaddr *) &addr, addrlen)) {
-		fail("connect\n");
+		fail("connect");
 		exit(1);
 	}
 	if (connect(clnt2, (struct sockaddr *) &addr, addrlen)) {
-		fail("connect\n");
+		fail("connect");
 		exit(1);
 	}
 

--- a/test/zdtm/static/socket_queues.c
+++ b/test/zdtm/static/socket_queues.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
 	test_init(argc, argv);
 
 	if (socketpair(AF_UNIX, SOCK_STREAM, 0, ssk_pair_s) == -1) {
-		fail("socketpair\n");
+		fail("socketpair");
 		exit(1);
 	}
 
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 	write(ssk_pair_s[1], SK_DATA_S1, sizeof(SK_DATA_S1));
 
 	if (socketpair(AF_UNIX, SOCK_DGRAM, 0, ssk_pair_d) == -1) {
-		fail("socketpair\n");
+		fail("socketpair");
 		exit(1);
 	}
 
@@ -57,48 +57,48 @@ int main(int argc, char *argv[])
 
 	read(ssk_pair_s[1], buf_left, strlen(SK_DATA_S1) + 1);
 	if (strcmp(buf_left, SK_DATA_S1)) {
-		fail("SK_DATA_S2: '%s\n", SK_DATA_S1);
+		fail("SK_DATA_S2: '%s", SK_DATA_S1);
 		exit(1);
 	}
 	read(ssk_pair_s[1], buf_right, strlen(SK_DATA_S2) + 1);
 	if (strcmp(buf_right, SK_DATA_S2)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("stream1            : '%s' '%s'\n", buf_left, buf_right);
 
 	read(ssk_pair_s[0], buf_left, strlen(SK_DATA_S2) + 1);
 	if (strcmp(buf_left, SK_DATA_S2)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	read(ssk_pair_s[0], buf_right, strlen(SK_DATA_S1) + 1);
 	if (strcmp(buf_right, SK_DATA_S1)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("stream2            : '%s' '%s'\n", buf_left, buf_right);
 
 	read(ssk_pair_d[1], buf_left, strlen(SK_DATA_D1) + 1);
 	if (strcmp(buf_left, SK_DATA_D1)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	read(ssk_pair_d[1], buf_right, strlen(SK_DATA_D2) + 1);
 	if (strcmp(buf_right, SK_DATA_D2)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("dgram1            : '%s' '%s'\n", buf_left, buf_right);
 
 	read(ssk_pair_d[0], buf_left, strlen(SK_DATA_D2) + 1);
 	if (strcmp(buf_left, SK_DATA_D2)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	read(ssk_pair_d[0], buf_right,strlen(SK_DATA_D1) + 1);
 	if (strcmp(buf_right, SK_DATA_D1)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("dgram2            : '%s' '%s'\n", buf_left, buf_right);

--- a/test/zdtm/static/socket_snd_addr.c
+++ b/test/zdtm/static/socket_snd_addr.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
 	addrlen = sizeof(addr.sun_family) + sizeof(SK_SRV);
 
 	if (bind(srv, (struct sockaddr *) &addr, addrlen)) {
-		fail("bind\n");
+		fail("bind");
 		exit(1);
 	}
 
@@ -59,14 +59,14 @@ int main(int argc, char **argv)
 		addrlen = sizeof(addr.sun_family) + sizeof(SK_NAME);
 
 		if (bind(clnt, (struct sockaddr *) &addr, addrlen)) {
-			fail("bind\n");
+			fail("bind");
 			exit(1);
 		}
 
 		memcpy(addr.sun_path, SK_SRV, sizeof(SK_SRV));
 		addrlen = sizeof(addr.sun_family) + sizeof(SK_SRV);
 		if (connect(clnt, (struct sockaddr *) &addr, addrlen)) {
-			fail("connect\n");
+			fail("connect");
 			exit(1);
 		}
 

--- a/test/zdtm/static/socket_udp_shutdown.c
+++ b/test/zdtm/static/socket_udp_shutdown.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
 	sk1 = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	sk2 = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	if (sk1 < 0 || sk2 < 0) {
-		pr_err("Can't create socket");
+		pr_perror("Can't create socket");
 		exit(1);
 		return 1;
 	}
@@ -49,19 +49,19 @@ int main(int argc, char **argv)
 
 	if (bind(sk1, (struct sockaddr *)&addr1, len) < 0 ||
 	    bind(sk2, (struct sockaddr *)&addr2, len) < 0) {
-		pr_err("Can't bind socket");
+		pr_perror("Can't bind socket");
 		return 1;
 	}
 
 	if (connect(sk1, (struct sockaddr *)&addr2, len) ||
 	    connect(sk2, (struct sockaddr *)&addr1, len)) {
-		pr_err("Can't connect");
+		pr_perror("Can't connect");
 		return 1;
 	}
 
 	if (shutdown(sk1, SHUT_WR) ||
 	    shutdown(sk2, SHUT_RD)) {
-		pr_err("Can't shutdown\n");
+		pr_perror("Can't shutdown");
 		return 1;
 	}
 
@@ -75,17 +75,17 @@ int main(int argc, char **argv)
 	ret = recvfrom(sk1, buf, sizeof(buf), 0,
 		       (struct sockaddr *)&addr, &len);
 	if (ret <= 0) {
-		pr_err("Can't receive data");
+		pr_perror("Can't receive data");
 		return 1;
 	}
 
 	if (len != sizeof(struct sockaddr_in) || memcmp(&addr2, &addr, len)) {
-		pr_err("Data received from wrong peer");
+		pr_err("Data received from wrong peer\n");
 		return 1;
 	}
 
 	if (ret != sizeof(MSG1) || memcmp(buf, MSG1, ret)) {
-		pr_err("Wrong message received");
+		pr_err("Wrong message received\n");
 		return 1;
 	}
 
@@ -102,17 +102,17 @@ int main(int argc, char **argv)
 	ret = recvfrom(sk1, buf, sizeof(buf), 0,
 		       (struct sockaddr *)&addr, &len);
 	if (ret <= 0) {
-		pr_err("Can't receive data");
+		pr_perror("Can't receive data");
 		return 1;
 	}
 
 	if (len != sizeof(struct sockaddr_in) || memcmp(&addr2, &addr, len)) {
-		pr_err("Data received from wrong peer");
+		pr_err("Data received from wrong peer\n");
 		return 1;
 	}
 
 	if (ret != sizeof(MSG1) || memcmp(buf, MSG1, ret)) {
-		pr_err("Wrong message received");
+		pr_err("Wrong message received\n");
 		return 1;
 	}
 

--- a/test/zdtm/static/sockets00.c
+++ b/test/zdtm/static/sockets00.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 
 	cwd = get_current_dir_name();
 	if (!cwd) {
-		fail("getcwd\n");
+		fail("getcwd");
 		exit(1);
 	}
 
@@ -62,13 +62,13 @@ int main(int argc, char *argv[])
 	ssk_icon[1] = socket(AF_UNIX, SOCK_STREAM, 0);
 	ssk_icon[2] = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (ssk_icon[0] < 0 || ssk_icon[1] < 0 || ssk_icon[2] < 0) {
-		fail("socket\n");
+		fail("socket");
 		exit(1);
 	}
 
 	ret = bind(ssk_icon[0], (struct sockaddr *) &addr, addrlen);
 	if (ret) {
-		fail("bind\n");
+		fail("bind");
 		exit(1);
 	}
 
@@ -86,13 +86,13 @@ int main(int argc, char *argv[])
 
 	ret = listen(ssk_icon[0], 16);
 	if (ret) {
-		fail("bind\n");
+		fail("bind");
 		exit(1);
 	}
 
 	ret = connect(ssk_icon[2], (struct sockaddr *) &addr, addrlen);
 	if (ret) {
-		fail("connect\n");
+		fail("connect");
 		exit(1);
 	}
 
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 
 	ret = connect(ssk_icon[1], (struct sockaddr *) &addr, addrlen);
 	if (ret) {
-		fail("connect\n");
+		fail("connect");
 		exit(1);
 	}
 
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (st_b.st_mode != st_a.st_mode) {
-		fail("The file permissions for %s were changed %o %o\n",
+		fail("The file permissions for %s were changed %o %o",
 					path, st_b.st_mode, st_a.st_mode);
 		exit(1);
 	}
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 
 	ret = accept(ssk_icon[0], NULL, NULL);
 	if (ret < 0) {
-		fail("accept\n");
+		fail("accept");
 		exit(1);
 	}
 
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
 	write(ssk_icon[1], SK_DATA, sizeof(SK_DATA));
 	read(ret, &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("stream1           : '%s'\n", buf);
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
 	write(ssk_icon[2], SK_DATA, sizeof(SK_DATA));
 	read(ssk_icon[3], &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("stream2           : '%s'\n", buf);

--- a/test/zdtm/static/sockets02.c
+++ b/test/zdtm/static/sockets02.c
@@ -26,12 +26,12 @@ int main(int argc, char *argv[])
 	data = (char)lrand48();
 
 	if (socketpair(AF_UNIX, SOCK_STREAM, 0, ssk_pair) == -1) {
-		fail("socketpair\n");
+		fail("socketpair");
 		exit(1);
 	}
 
 	if (write(ssk_pair[1], &data, sizeof(data)) != sizeof(data)) {
-		fail("write\n");
+		fail("write");
 		exit(1);
 	}
 

--- a/test/zdtm/static/sockets02.c
+++ b/test/zdtm/static/sockets02.c
@@ -49,14 +49,14 @@ int main(int argc, char *argv[])
 	errno = 0;
 	ret = read(ssk_pair[0], &aux, sizeof(aux));
 	if (ret != 0 || errno != 0) {
-		fail("Opened end in wrong state (%d/%d)", ret, errno);
+		fail("Opened end in wrong state (ret=%d)", ret);
 		return 0;
 	}
 
 	errno = 0;
 	ret = read(ssk_pair[1], &aux, sizeof(aux));
 	if (ret != -1 || errno != EBADF) {
-		fail("Closed end in wrong state (%d/%d)", ret, errno);
+		fail("Closed end in wrong state (ret=%d)", ret);
 		return 0;
 	}
 

--- a/test/zdtm/static/sockets03.c
+++ b/test/zdtm/static/sockets03.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
 	int ret;
 
 	test_init(argc, argv);
-    
+
 	signal(SIGPIPE, SIG_IGN);
 
 	cwd = get_current_dir_name();

--- a/test/zdtm/static/sockets03.c
+++ b/test/zdtm/static/sockets03.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
 
 	cwd = get_current_dir_name();
 	if (!cwd) {
-		fail("getcwd\n");
+		fail("getcwd");
 		exit(1);
 	}
 
@@ -55,31 +55,31 @@ int main(int argc, char *argv[])
 	sk[0] = socket(AF_UNIX, SOCK_STREAM, 0);
 	sk[1] = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (sk[0] < 0 || sk[1] < 0) {
-		fail("socket\n");
+		fail("socket");
 		exit(1);
 	}
 
 	ret = bind(sk[0], (struct sockaddr *) &addr, addrlen);
 	if (ret) {
-		fail("bind\n");
+		fail("bind");
 		exit(1);
 	}
 
 	ret = listen(sk[0], 16);
 	if (ret) {
-		fail("listen\n");
+		fail("listen");
 		exit(1);
 	}
 
 	ret = shutdown(sk[1], SHUT_RD);
 	if (ret) {
-		fail("shutdown\n");
+		fail("shutdown");
 		exit(1);
 	}
 
 	ret = connect(sk[1], (struct sockaddr *) &addr, addrlen);
 	if (ret) {
-		fail("connect\n");
+		fail("connect");
 		exit(1);
 	}
 
@@ -93,22 +93,22 @@ int main(int argc, char *argv[])
 	test_waitsig();
 
 	if (write(sk[1], SK_DATA, sizeof(SK_DATA)) < 0) {
-		fail("write\n");
+		fail("write");
 		exit(1);
 	}
 
 	if (read(sk[2], &buf, sizeof(buf)) < 0) {
-		fail("read\n");
+		fail("read");
 		exit(1);
 	}
 
 	if (strncmp(buf, SK_DATA, sizeof(SK_DATA))) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 
 	if (write(sk[2], SK_DATA, sizeof(SK_DATA)) >= 0) {
-		fail("successful write to shutdown receiver\n");
+		fail("successful write to shutdown receiver");
 		exit(1);
 	}
 

--- a/test/zdtm/static/sockets_dgram.c
+++ b/test/zdtm/static/sockets_dgram.c
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
 	       (struct sockaddr *) &name_bound, sizeof(name_bound));
 	read(sk_dgram_bound_server, &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA_BOUND)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("dgram-bound       : '%s'\n", buf);
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
 	write(sk_dgram_conn_client, SK_DATA_CONN, sizeof(SK_DATA_CONN));
 	read(sk_dgram_conn_server, &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA_CONN)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("dgram-conn        : '%s'\n", buf);
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
 	write(sk_dgram_bound_conn, SK_DATA_BOUND_CONN, sizeof(SK_DATA_BOUND_CONN));
 	read(sk_dgram_bound_conn, &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA_BOUND_CONN)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("dgram-bound-conn  : '%s'\n", buf);
@@ -175,7 +175,7 @@ int main(int argc, char *argv[])
 	       (struct sockaddr *) &name_bound, sizeof(name_bound));
 	read(sk_dgram_bound_server, &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA_BOUND)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("dgram-bound       : '%s'\n", buf);
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
 	write(sk_dgram_conn_client, SK_DATA_CONN, sizeof(SK_DATA_CONN));
 	read(sk_dgram_conn_server, &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA_CONN)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("dgram-conn        : '%s'\n", buf);
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
 	write(sk_dgram_bound_conn, SK_DATA_BOUND_CONN, sizeof(SK_DATA_BOUND_CONN));
 	read(sk_dgram_bound_conn, &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA_BOUND_CONN)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("dgram-bound-conn  : '%s'\n", buf);

--- a/test/zdtm/static/sockets_spair.c
+++ b/test/zdtm/static/sockets_spair.c
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
 	test_init(argc, argv);
 
 	if (socketpair(AF_UNIX, SOCK_STREAM, 0, ssk_pair) == -1) {
-		fail("socketpair\n");
+		fail("socketpair");
 		exit(1);
 	}
 
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 	write(ssk_pair[0], SK_DATA, sizeof(SK_DATA));
 	read(ssk_pair[1], &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("stream            : '%s'\n", buf);
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 	write(ssk_pair[0], SK_DATA, sizeof(SK_DATA));
 	read(ssk_pair[1], &buf, sizeof(buf));
 	if (strcmp(buf, SK_DATA)) {
-		fail("data corrupted\n");
+		fail("data corrupted");
 		exit(1);
 	}
 	test_msg("stream            : '%s'\n", buf);

--- a/test/zdtm/static/sse00.c
+++ b/test/zdtm/static/sse00.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
 	finish(res2);
 
 	if (memcmp((uint8_t *) res1, (uint8_t *) res2, sizeof(res1)))
-		fail("results differ\n");
+		fail("results differ");
 	else
 		pass();
 #else

--- a/test/zdtm/static/sse20.c
+++ b/test/zdtm/static/sse20.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
 	finish(res2);
 
 	if (memcmp((uint8_t *) res1, (uint8_t *) res2, sizeof(res1)))
-		fail("results differ\n");
+		fail("results differ");
 	else
 		pass();
 #else

--- a/test/zdtm/static/tempfs_overmounted.c
+++ b/test/zdtm/static/tempfs_overmounted.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (umount("a/b") || umount("a") || umount("a") || umount("a/b/c") || umount("a/b") || umount("a/b")) {
-		pr_err("umount");
+		pr_perror("umount");
 		return 1;
 	}
 

--- a/test/zdtm/static/tempfs_overmounted01.c
+++ b/test/zdtm/static/tempfs_overmounted01.c
@@ -34,11 +34,11 @@ int main(int argc, char **argv)
 	}
 	if (pid == 0) {
 		if (mount("zdtm", dirname, "tmpfs", 0, "") < 0) {
-			pr_err("Can't mount tmpfs");
+			pr_perror("Can't mount tmpfs");
 			return 1;
 		}
 		if (chdir(dirname)) {
-			pr_err("chdir");
+			pr_perror("chdir");
 			return 1;
 		}
 

--- a/test/zdtm/static/thread_different_uid_gid.c
+++ b/test/zdtm/static/thread_different_uid_gid.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
 	task_waiter_init(&t);
 
 	if (getuid() != 0) {
-		fail("Test is expected to be run with root privileges\n");
+		fail("Test is expected to be run with root privileges");
 		exit(1);
 	}
 

--- a/test/zdtm/static/thread_different_uid_gid.c
+++ b/test/zdtm/static/thread_different_uid_gid.c
@@ -39,19 +39,19 @@ void *chg_uid_gid(void *arg)
 
 	newcaps = cap_from_text("cap_setgid,cap_setuid=+eip");
 	if (!newcaps) {
-		pr_perror("Failed to get capability struct\n");
+		pr_perror("Failed to get capability struct");
 		exit(1);
 	}
 
 	ret = cap_set_proc(newcaps);
 	if (ret) {
-		pr_perror("Failed to set capabilities for the process\n");
+		pr_perror("Failed to set capabilities for the process");
 		exit(1);
 	}
 
 	mycaps = cap_get_proc();
 	if (!mycaps) {
-		pr_perror("Failed to get child thread capabilities\n");
+		pr_perror("Failed to get child thread capabilities");
 		exit_group(2);
 	}
 
@@ -62,7 +62,7 @@ void *chg_uid_gid(void *arg)
 	if (ret >= 0) {
 		syscall(SYS_setresuid, uid, uid, uid);
 	} else if (ret < 0) {
-		pr_perror("Failed to change UID/GID\n");
+		pr_perror("Failed to change UID/GID");
 		exit_group(2);
 	}
 
@@ -103,17 +103,17 @@ int main(int argc, char **argv)
 
 	newcaps = cap_from_text("cap_setgid,cap_setuid=+eip");
 	if (!newcaps) {
-		pr_perror("Failed to get capability struct\n");
+		pr_perror("Failed to get capability struct");
 		exit(1);
 	}
 	ret = cap_set_proc(newcaps);
 	if (ret) {
-		pr_perror("Failed to set capabilities for the process\n");
+		pr_perror("Failed to set capabilities for the process");
 		exit(1);
 	}
 	ret = prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0);
 	if (ret) {
-		pr_perror("Unable to set KEEPCAPS\n");
+		pr_perror("Unable to set KEEPCAPS");
 		exit(1);
 	}
 
@@ -132,12 +132,12 @@ int main(int argc, char **argv)
 	if (ret >= 0) {
 		ret = syscall(SYS_setresuid, mainuser, mainuser, mainuser);
 	} else if (ret < 0) {
-		pr_perror("Failed to drop privileges\n");
+		pr_perror("Failed to drop privileges");
 		exit(1);
 	}
 	test_msg("Now main thread runs as UID: %d; GID: %d\n", getuid(), getgid());
 	if (gid == getgid() || uid == getuid()) {
-		pr_perror("Thread credentials match\n");
+		pr_perror("Thread credentials match");
 		exit(1);
 	}
 	test_msg("Main thread is waiting for signal\n");
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (gid == getgid() || uid == getuid()) {
-		pr_perror("Thread credentials match after restore\n");
+		pr_perror("Thread credentials match after restore");
 		exit(1);
 	}
 

--- a/test/zdtm/static/umask00.c
+++ b/test/zdtm/static/umask00.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
 
 	mask2 = umask(0);
 	if (mask != mask2)
-		fail("mask changed: %o != %o\n", mask, mask2);
+		fail("mask changed: %o != %o", mask, mask2);
 	else
 		pass();
 

--- a/test/zdtm/static/unbound_sock.c
+++ b/test/zdtm/static/unbound_sock.c
@@ -33,7 +33,7 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (bind(sock, (struct sockaddr *) &name, sizeof(name)) < 0)
-		fail("can't bind to a socket: %m");
+		fail("can't bind to a socket");
 	else
 		pass();
 

--- a/test/zdtm/static/unhashed_proc.c
+++ b/test/zdtm/static/unhashed_proc.c
@@ -58,16 +58,16 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (getcwd(cwd2, sizeof(cwd2))) {
-		fail("successful getcwd: %s\n", cwd2);
+		fail("successful getcwd: %s", cwd2);
 		exit(1);
 	} else if (errno != ENOENT) {
-		fail("wrong errno: %m\n");
+		fail("wrong errno: %m");
 		exit(1);
 	}
 
 	len = readlink("/proc/self/cwd", cwd2, sizeof(cwd2)-1);
 	if (len < 0) {
-		fail("can't read cwd symlink %m\n");
+		fail("can't read cwd symlink %m");
 		exit(1);
 	}
 	cwd2[len] = 0;

--- a/test/zdtm/static/unhashed_proc.c
+++ b/test/zdtm/static/unhashed_proc.c
@@ -61,13 +61,13 @@ int main(int argc, char ** argv)
 		fail("successful getcwd: %s", cwd2);
 		exit(1);
 	} else if (errno != ENOENT) {
-		fail("wrong errno: %m");
+		fail("wrong errno");
 		exit(1);
 	}
 
 	len = readlink("/proc/self/cwd", cwd2, sizeof(cwd2)-1);
 	if (len < 0) {
-		fail("can't read cwd symlink %m");
+		fail("can't read cwd symlink");
 		exit(1);
 	}
 	cwd2[len] = 0;

--- a/test/zdtm/static/unlink_fifo.c
+++ b/test/zdtm/static/unlink_fifo.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (close(fd) < 0) {
-		fail("can't close %s: %m", filename);
+		fail("can't close %s", filename);
 		return 1;
 	}
 

--- a/test/zdtm/static/unlink_fifo_wronly.c
+++ b/test/zdtm/static/unlink_fifo_wronly.c
@@ -46,12 +46,12 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	if (close(fd) < 0) {
-		fail("can't close (O_RDONLY | O_NONBLOCK) %s: %m", filename);
+		fail("can't close (O_RDONLY | O_NONBLOCK) %s", filename);
 		return 1;
 	}
 
 	if (close(fd1) < 0) {
-		fail("can't close (O_WRONLY) %s: %m", filename);
+		fail("can't close (O_WRONLY) %s", filename);
 		return 1;
 	}
 

--- a/test/zdtm/static/unlink_fstat00.c
+++ b/test/zdtm/static/unlink_fstat00.c
@@ -152,7 +152,7 @@ int main(int argc, char ** argv)
 		goto failed;
 	}
 	if (read(fd, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m", filename);
+		fail("can't read %s", filename);
 		goto failed;
 	}
 

--- a/test/zdtm/static/unlink_fstat00.c
+++ b/test/zdtm/static/unlink_fstat00.c
@@ -152,13 +152,13 @@ int main(int argc, char ** argv)
 		goto failed;
 	}
 	if (read(fd, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m\n", filename);
+		fail("can't read %s: %m", filename);
 		goto failed;
 	}
 
 	crc = ~0;
 	if (datachk(buf, sizeof(buf), &crc)) {
-		fail("CRC mismatch\n");
+		fail("CRC mismatch");
 		goto failed;
 	}
 

--- a/test/zdtm/static/unlink_fstat02.c
+++ b/test/zdtm/static/unlink_fstat02.c
@@ -82,7 +82,7 @@ int main(int argc, char ** argv)
 	}
 
 	if ((fst.st_dev != fst2.st_dev) || (fst.st_ino != fst2.st_ino)) {
-		fail("files differ after restore\n");
+		fail("files differ after restore");
 		goto failed;
 	}
 

--- a/test/zdtm/static/unlink_fstat03.c
+++ b/test/zdtm/static/unlink_fstat03.c
@@ -75,12 +75,12 @@ int main(int argc, char ** argv)
 
 	/* An NFS mount is restored with another st_dev */
 	if (fsst.f_type != NFS_SUPER_MAGIC && fst.st_dev != fst2.st_dev) {
-		fail("files differ after restore\n");
+		fail("files differ after restore");
 		goto failed;
 	}
 
 	if (fst.st_ino != fst2.st_ino) {
-		fail("files differ after restore\n");
+		fail("files differ after restore");
 		goto failed;
 	}
 

--- a/test/zdtm/static/uptime_grow.c
+++ b/test/zdtm/static/uptime_grow.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
 		if (!tv_ge(&tm, &tm_old)) {
 			diff_nsec = (tm_old.tv_sec - tm.tv_sec) * 1.0E9 +\
 				(tm_old.tv_nsec - tm.tv_nsec);
-			fail("clock step backward for %e nsec\n", diff_nsec);
+			fail("clock step backward for %e nsec", diff_nsec);
 			exit(1);
 		}
 		tm_old = tm;

--- a/test/zdtm/static/vdso-proxy.c
+++ b/test/zdtm/static/vdso-proxy.c
@@ -42,7 +42,7 @@ static int parse_maps(struct vm_area *vmas)
 
 	maps = fopen("/proc/self/maps", "r");
 	if (maps == NULL) {
-		pr_err("Failed to open maps file: %m\n");
+		pr_perror("Failed to open maps file");
 		return -1;
 	}
 
@@ -74,7 +74,7 @@ static int parse_maps(struct vm_area *vmas)
 	}
 
 	if (fclose(maps)) {
-		pr_err("Failed to close maps file: %m\n");
+		pr_perror("Failed to close maps file");
 		return -1;
 	}
 
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
 	test_msg("[NOTE]\tMappings before:\n");
 	nr_before = parse_maps(vmas_before);
 	if (nr_before < 0) {
-		pr_perror("Failed to parse maps");
+		pr_err("Failed to parse maps\n");
 		return -1;
 	}
 
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
 	test_msg("[NOTE]\tMappings after:\n");
 	nr_after = parse_maps(vmas_after);
 	if (nr_after < 0) {
-		pr_perror("Failed to parse maps");
+		pr_err("Failed to parse maps\n");
 		return -1;
 	}
 

--- a/test/zdtm/static/vfork00.c
+++ b/test/zdtm/static/vfork00.c
@@ -23,7 +23,7 @@ int main(int argc, char ** argv)
 	 * in the child */
 	pid = fork();
 	if (pid < 0) {
-		pr_err("fork failed: %m");
+		pr_perror("fork failed");
 		exit(1);
 	}
 

--- a/test/zdtm/static/vfork00.c
+++ b/test/zdtm/static/vfork00.c
@@ -54,12 +54,12 @@ int main(int argc, char ** argv)
 	 * the grand-child has exec()-ed, but we don't know the pid of the
 	 * latter */
 	if (kill(0, SIGTERM)) {
-		fail("terminating the children failed: %m");
+		fail("terminating the children failed");
 		exit(1);
 	}
 
 	if (wait(&ret) != pid) {
-		fail("wait() returned wrong pid: %m");
+		fail("wait() returned wrong pid");
 		exit(1);
 	}
 

--- a/test/zdtm/static/wait00.c
+++ b/test/zdtm/static/wait00.c
@@ -33,12 +33,12 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (kill(pid, SIGTERM)) {
-		fail("terminating the child failed: %m");
+		fail("terminating the child failed");
 		goto out;
 	}
 
 	if (wait(&ret) != pid) {
-		fail("wait() returned wrong pid: %m");
+		fail("wait() returned wrong pid");
 		goto out;
 	}
 

--- a/test/zdtm/static/wait00.c
+++ b/test/zdtm/static/wait00.c
@@ -33,24 +33,24 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (kill(pid, SIGTERM)) {
-		fail("terminating the child failed: %m\n");
+		fail("terminating the child failed: %m");
 		goto out;
 	}
 
 	if (wait(&ret) != pid) {
-		fail("wait() returned wrong pid: %m\n");
+		fail("wait() returned wrong pid: %m");
 		goto out;
 	}
 
 	if (WIFEXITED(ret)) {
 		ret = WEXITSTATUS(ret);
 		if (ret) {
-			fail("child exited with nonzero code %d (%s)\n", ret, strerror(ret));
+			fail("child exited with nonzero code %d (%s)", ret, strerror(ret));
 			goto out;
 		}
 	}
 	if (WIFSIGNALED(ret)) {
-		fail("child exited on unexpected signal %d\n", WTERMSIG(ret));
+		fail("child exited on unexpected signal %d", WTERMSIG(ret));
 		goto out;
 	}
 

--- a/test/zdtm/static/write_read00.c
+++ b/test/zdtm/static/write_read00.c
@@ -39,18 +39,18 @@ int main(int argc, char ** argv)
 
 	fd = open(filename, O_RDONLY);
 	if (fd < 0) {
-		fail("can't open %s: %m\n", filename);
+		fail("can't open %s: %m", filename);
 		exit(1);
 	}
 
 	if (read(fd, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m\n", filename);
+		fail("can't read %s: %m", filename);
 		goto out;
 	}
 
 	crc = ~0;
 	if (datachk(buf, sizeof(buf), &crc)) {
-		fail("CRC mismatch\n");
+		fail("CRC mismatch");
 		goto out;
 	}
 

--- a/test/zdtm/static/write_read00.c
+++ b/test/zdtm/static/write_read00.c
@@ -39,12 +39,12 @@ int main(int argc, char ** argv)
 
 	fd = open(filename, O_RDONLY);
 	if (fd < 0) {
-		fail("can't open %s: %m", filename);
+		fail("can't open %s", filename);
 		exit(1);
 	}
 
 	if (read(fd, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m", filename);
+		fail("can't read %s", filename);
 		goto out;
 	}
 

--- a/test/zdtm/static/write_read01.c
+++ b/test/zdtm/static/write_read01.c
@@ -52,13 +52,13 @@ int main(int argc, char ** argv)
 
 	/* recover reading */
 	if (read(fd, buf + len, sizeof(buf) - len) != (sizeof(buf) - len)) {
-		fail("can't read %s: %m\n", filename);
+		fail("can't read %s: %m", filename);
 		goto out;
 	}
 
 	crc = ~0;
 	if (datachk(buf, sizeof(buf), &crc)) {
-		fail("CRC mismatch\n");
+		fail("CRC mismatch");
 		goto out;
 	}
 

--- a/test/zdtm/static/write_read01.c
+++ b/test/zdtm/static/write_read01.c
@@ -52,7 +52,7 @@ int main(int argc, char ** argv)
 
 	/* recover reading */
 	if (read(fd, buf + len, sizeof(buf) - len) != (sizeof(buf) - len)) {
-		fail("can't read %s: %m", filename);
+		fail("can't read %s", filename);
 		goto out;
 	}
 

--- a/test/zdtm/static/write_read02.c
+++ b/test/zdtm/static/write_read02.c
@@ -50,7 +50,7 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (write(fd, buf + len, sizeof(buf) - len) != (sizeof(buf) - len)) {
-		fail("can't write %s: %m", filename);
+		fail("can't write %s", filename);
 		goto out;
 	}
 
@@ -58,12 +58,12 @@ int main(int argc, char ** argv)
 
 	fd = open(filename, O_RDONLY);
 	if (fd < 0) {
-		fail("can't open %s: %m", filename);
+		fail("can't open %s", filename);
 		return 1;
 	}
 
 	if (read(fd, buf, full_len) != full_len) {
-		fail("can't read %s: %m", filename);
+		fail("can't read %s", filename);
 		return 1;
 	}
 

--- a/test/zdtm/static/write_read02.c
+++ b/test/zdtm/static/write_read02.c
@@ -50,7 +50,7 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (write(fd, buf + len, sizeof(buf) - len) != (sizeof(buf) - len)) {
-		fail("can't write %s: %m\n", filename);
+		fail("can't write %s: %m", filename);
 		goto out;
 	}
 
@@ -58,18 +58,18 @@ int main(int argc, char ** argv)
 
 	fd = open(filename, O_RDONLY);
 	if (fd < 0) {
-		fail("can't open %s: %m\n", filename);
+		fail("can't open %s: %m", filename);
 		return 1;
 	}
 
 	if (read(fd, buf, full_len) != full_len) {
-		fail("can't read %s: %m\n", filename);
+		fail("can't read %s: %m", filename);
 		return 1;
 	}
 
 	crc = ~0;
 	if (datachk(buf, full_len, &crc)) {
-		fail("CRC mismatch\n");
+		fail("CRC mismatch");
 		return 1;
 	}
 

--- a/test/zdtm/static/write_read10.c
+++ b/test/zdtm/static/write_read10.c
@@ -72,51 +72,51 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (kill(pid, SIGTERM)) {
-		fail("terminating the child failed: %m\n");
+		fail("terminating the child failed: %m");
 		goto out;
 	}
 
 	if (wait(&ret) != pid) {
-		fail("wait() returned wrong pid %d: %m\n", pid);
+		fail("wait() returned wrong pid %d: %m", pid);
 		goto out;
 	}
 
 	if (WIFEXITED(ret)) {
 		ret = WEXITSTATUS(ret);
 		if (ret) {
-			fail("child exited with nonzero code %d (%s)\n", ret, strerror(ret));
+			fail("child exited with nonzero code %d (%s)", ret, strerror(ret));
 			goto out;
 		}
 	}
 	if (WIFSIGNALED(ret)) {
-		fail("child exited on unexpected signal %d\n", WTERMSIG(ret));
+		fail("child exited on unexpected signal %d", WTERMSIG(ret));
 		goto out;
 	}
 
 	if (lseek(fd, 0, SEEK_SET) < 0) {
-		fail("lseeking to the beginning of file failed: %m\n");
+		fail("lseeking to the beginning of file failed: %m");
 		goto out;
 	}
 
 	if (read(fd, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m\n", filename);
+		fail("can't read %s: %m", filename);
 		goto out;
 	}
 
 	crc = ~0;
 	if (datachk(buf, sizeof(buf), &crc)) {
-		fail("CRC mismatch\n");
+		fail("CRC mismatch");
 		goto out;
 	}
 
 
 	if (close(fd)) {
-		fail("close failed: %m\n");
+		fail("close failed: %m");
 		goto out_noclose;
 	}
 
 	if (unlink(filename) != -1 || errno != ENOENT) {
-		fail("file %s should have been deleted before migration: unlink: %m\n",
+		fail("file %s should have been deleted before migration: unlink: %m",
 				filename);
 		goto out_noclose;
 	}

--- a/test/zdtm/static/write_read10.c
+++ b/test/zdtm/static/write_read10.c
@@ -72,12 +72,12 @@ int main(int argc, char ** argv)
 	test_waitsig();
 
 	if (kill(pid, SIGTERM)) {
-		fail("terminating the child failed: %m");
+		fail("terminating the child failed");
 		goto out;
 	}
 
 	if (wait(&ret) != pid) {
-		fail("wait() returned wrong pid %d: %m", pid);
+		fail("wait() returned wrong pid %d", pid);
 		goto out;
 	}
 
@@ -94,12 +94,12 @@ int main(int argc, char ** argv)
 	}
 
 	if (lseek(fd, 0, SEEK_SET) < 0) {
-		fail("lseeking to the beginning of file failed: %m");
+		fail("lseeking to the beginning of file failed");
 		goto out;
 	}
 
 	if (read(fd, buf, sizeof(buf)) != sizeof(buf)) {
-		fail("can't read %s: %m", filename);
+		fail("can't read %s", filename);
 		goto out;
 	}
 
@@ -111,12 +111,12 @@ int main(int argc, char ** argv)
 
 
 	if (close(fd)) {
-		fail("close failed: %m");
+		fail("close failed");
 		goto out_noclose;
 	}
 
 	if (unlink(filename) != -1 || errno != ENOENT) {
-		fail("file %s should have been deleted before migration: unlink: %m",
+		fail("file %s should have been deleted before migration: unlink",
 				filename);
 		goto out_noclose;
 	}

--- a/test/zdtm/static/zombie00.c
+++ b/test/zdtm/static/zombie00.c
@@ -78,28 +78,28 @@ int main(int argc, char ** argv)
 
 	for (i = 0; i < NR_ZOMBIES; i++) {
 		if (waitpid(zombie[i].pid, &status, 0) != zombie[i].pid) {
-			fail("Exit with wrong pid\n");
+			fail("Exit with wrong pid");
 			exit(1);
 		}
 
 		if (zombie[i].exited) {
 			if (!WIFEXITED(status)) {
-				fail("Not exited, but should (%d)\n", zombie[i].pid);
+				fail("Not exited, but should (%d)", zombie[i].pid);
 				exit(1);
 			}
 
 			if (WEXITSTATUS(status) != zombie[i].exitcode) {
-				fail("Exit with wrong status (%d)\n", zombie[i].pid);
+				fail("Exit with wrong status (%d)", zombie[i].pid);
 				exit(1);
 			}
 		} else {
 			if (!WIFSIGNALED(status)) {
-				fail("Not killed, but should (%d)\n", zombie[i].pid);
+				fail("Not killed, but should (%d)", zombie[i].pid);
 				exit(1);
 			}
 
 			if (WTERMSIG(status) != zombie[i].exitcode) {
-				fail("Killed with wrong signal (%d)\n", zombie[i].pid);
+				fail("Killed with wrong signal (%d)", zombie[i].pid);
 				exit(1);
 			}
 		}

--- a/test/zdtm/static/zombie_leader.c
+++ b/test/zdtm/static/zombie_leader.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
 	}
 
 	if (!*cpid) {
-		pr_err("Don't know grand child's pid");
+		pr_err("Don't know grand child's pid\n");
 		goto err;
 	}
 

--- a/test/zdtm/transition/epoll.c
+++ b/test/zdtm/transition/epoll.c
@@ -82,7 +82,7 @@ static void run_child(int num)
 		if (write(fd, buf, buf_size) < 0 &&
 			(!stop /* signal SIGUSR2 NOT received */ ||
 				(errno != EINTR && errno != EPIPE))) {
-			fail("child write: %m\n");
+			fail("child write: %m");
 			rv = WRITEERROR;
 			goto out;
 		}
@@ -178,17 +178,17 @@ int main(int argc, char **argv)
 	for (i = 0; i < scale; i++) {
 		kill(pids[i], SIGUSR2);
 		if (waitpid(pids[i], &rv, 0) < 0) {
-			fail("waitpid error: %m\n");
+			fail("waitpid error: %m");
 			counter++;
 			continue;
 		} else {
 			rv = WEXITSTATUS(rv);
 			if (rv < MAX_EXIT_CODE && rv > SUCCESS) {
-				fail("Child failed: %s (%d)\n",
+				fail("Child failed: %s (%d)",
 						child_fail_reason[rv], rv);
 				counter++;
 			} else if (rv != SUCCESS) {
-				fail("Unknown exitcode from child: %d\n", rv);
+				fail("Unknown exitcode from child: %d", rv);
 				counter++;
 			}
 		}

--- a/test/zdtm/transition/epoll.c
+++ b/test/zdtm/transition/epoll.c
@@ -82,7 +82,7 @@ static void run_child(int num)
 		if (write(fd, buf, buf_size) < 0 &&
 			(!stop /* signal SIGUSR2 NOT received */ ||
 				(errno != EINTR && errno != EPIPE))) {
-			fail("child write: %m");
+			fail("child write");
 			rv = WRITEERROR;
 			goto out;
 		}
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 	for (i = 0; i < scale; i++) {
 		kill(pids[i], SIGUSR2);
 		if (waitpid(pids[i], &rv, 0) < 0) {
-			fail("waitpid error: %m");
+			fail("waitpid error");
 			counter++;
 			continue;
 		} else {

--- a/test/zdtm/transition/fifo_dyn.c
+++ b/test/zdtm/transition/fifo_dyn.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 			if (errno == EINTR)
 				continue;
 			else {
-				fail("write failed: %m");
+				fail("write failed");
 				ret = 1;
 				break;
 			}
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 			continue;
 
 		if (len > 0) {
-			fail("read failed: %m");
+			fail("read failed");
 			ret = 1;
 			break;
 		}

--- a/test/zdtm/transition/fifo_dyn.c
+++ b/test/zdtm/transition/fifo_dyn.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 			if (errno == EINTR)
 				continue;
 			else {
-				fail("write failed: %m\n");
+				fail("write failed: %m");
 				ret = 1;
 				break;
 			}
@@ -120,13 +120,13 @@ int main(int argc, char **argv)
 			continue;
 
 		if (len > 0) {
-			fail("read failed: %m\n");
+			fail("read failed: %m");
 			ret = 1;
 			break;
 		}
 
 		if (memcmp(buf, rbuf, wlen)) {
-			fail("data mismatch\n");
+			fail("data mismatch");
 			ret = 1;
 			break;
 		}
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
 	wait(&chret);
 	chret = WEXITSTATUS(chret);
 	if (chret) {
-		fail("child exited with non-zero code %d (%s)\n",
+		fail("child exited with non-zero code %d (%s)",
 			chret, strerror(chret));
 		return 1;
 	}

--- a/test/zdtm/transition/fifo_loop.c
+++ b/test/zdtm/transition/fifo_loop.c
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
 			if (errno == EINTR)
 				continue;
 			else {
-				fail("write failed: %m\n");
+				fail("write failed: %m");
 				ret = 1;
 				break;
 			}
@@ -163,13 +163,13 @@ int main(int argc, char **argv)
 		}
 
 		if (len > 0) {
-			fail("read failed: %m\n");
+			fail("read failed: %m");
 			ret = 1;
 			break;
 		}
 
 		if (memcmp(buf, rbuf, wlen)) {
-			fail("data mismatch\n");
+			fail("data mismatch");
 			ret = 1;
 			break;
 		}
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
 	test_waitsig(); /* even if failed, wait for migration to complete */
 
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m\n");
+		fail("failed to send SIGTERM to my process group: %m");
 		return 1;	/* shouldn't wait() in this case */
 	}
 	close(readfd);
@@ -188,14 +188,14 @@ int main(int argc, char **argv)
 	for (i = 1; i < num_procs; i++) {	/* i = 0 - parent */
 		int chret;
 		if (waitpid(pids[i], &chret, 0) < 0) {
-			fail("waitpid error: %m\n");
+			fail("waitpid error: %m");
 			ret = 1;
 			continue;
 		}
 
 		chret = WEXITSTATUS(chret);
 		if (chret) {
-			fail("child %d exited with non-zero code %d (%s)\n",
+			fail("child %d exited with non-zero code %d (%s)",
 				i, chret, strerror(chret));
 			ret = 1;
 			continue;

--- a/test/zdtm/transition/fifo_loop.c
+++ b/test/zdtm/transition/fifo_loop.c
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
 			if (errno == EINTR)
 				continue;
 			else {
-				fail("write failed: %m");
+				fail("write failed");
 				ret = 1;
 				break;
 			}
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
 		}
 
 		if (len > 0) {
-			fail("read failed: %m");
+			fail("read failed");
 			ret = 1;
 			break;
 		}
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
 	test_waitsig(); /* even if failed, wait for migration to complete */
 
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m");
+		fail("failed to send SIGTERM to my process group");
 		return 1;	/* shouldn't wait() in this case */
 	}
 	close(readfd);
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
 	for (i = 1; i < num_procs; i++) {	/* i = 0 - parent */
 		int chret;
 		if (waitpid(pids[i], &chret, 0) < 0) {
-			fail("waitpid error: %m");
+			fail("waitpid error");
 			ret = 1;
 			continue;
 		}

--- a/test/zdtm/transition/file_read.c
+++ b/test/zdtm/transition/file_read.c
@@ -217,21 +217,21 @@ int main(int argc, char **argv)
 	killall();
 	for (i = 0; i < scale; i++) {
 		if (waitpid(pids[i], &rv, 0) == -1) {
-			fail("Can't wipe up the kid\n");
+			fail("Can't wipe up the kid");
 			counter++;
 			continue;
 		}
 		if (!WIFEXITED(rv)) {
-			fail("Kid was killed\n");
+			fail("Kid was killed");
 			counter++;
 		} else {
 			rv = WEXITSTATUS(rv);
 			if (rv < MAX_EXIT_CODE_VAL && rv > SUCCESS) {
-				fail("Kid failed: %s (%d)\n",
+				fail("Kid failed: %s (%d)",
 						kids_fail_reasons[rv], rv);
 				counter++;
 			} else if (rv != SUCCESS) {
-				fail("Unknown exitcode from kid: %d\n", rv);
+				fail("Unknown exitcode from kid: %d", rv);
 				counter++;
 			}
 		}

--- a/test/zdtm/transition/lazy-thp.c
+++ b/test/zdtm/transition/lazy-thp.c
@@ -29,7 +29,7 @@ int main(int argc, char ** argv)
 	mem = malloc(PAGE_SIZE * N_PAGES);
 	org = malloc(PAGE_SIZE);
 	if (!mem || !org) {
-		fail("malloc failed\n");
+		fail("malloc failed");
 		exit(1);
 	}
 
@@ -48,7 +48,7 @@ int main(int argc, char ** argv)
 			org[128] = (count % 2 == 0) ? count : 0x42;
 
 			if (memcmp(org, m, PAGE_SIZE)) {
-				fail("memory corruption\n");
+				fail("memory corruption");
 				return 1;
 			}
 		}

--- a/test/zdtm/transition/maps008.c
+++ b/test/zdtm/transition/maps008.c
@@ -109,7 +109,7 @@ static void check_mem_eq(void *addr1, size_t size1, void *addr2, size_t size2)
 static void xmunmap(void *map, size_t size)
 {
 	if (munmap(map, size)) {
-		pr_err("xmunmap");
+		pr_perror("xmunmap");
 		exit(1);
 	}
 }
@@ -507,7 +507,7 @@ int main(int argc, char **argv)
 	};
 
 	if (atexit(kill_pstree_from_root)) {
-		pr_err("Can't setup atexit cleanup func");
+		pr_err("Can't setup atexit cleanup func\n");
 		exit(1);
 	}
 	return proc1_func();

--- a/test/zdtm/transition/netlink00.c
+++ b/test/zdtm/transition/netlink00.c
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 				goto out;
 			};
 			if (recv_reply() < 0){
-				fail("RTNETLINK answers: %m");
+				fail("RTNETLINK answers");
 				goto out;
 			};
 

--- a/test/zdtm/transition/pipe_loop00.c
+++ b/test/zdtm/transition/pipe_loop00.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
 			if (errno == EINTR)
 				continue;
 			else {
-				fail("write failed\n");
+				fail("write failed");
 				ret = 1;
 				break;
 			}
@@ -129,13 +129,13 @@ int main(int argc, char **argv)
 			continue;
 
 		if (len > 0) {
-			fail("read failed: %m\n");
+			fail("read failed: %m");
 			ret = 1;
 			break;
 		}
 
 		if (memcmp(buf, rbuf, wlen)) {
-			fail("data mismatch\n");
+			fail("data mismatch");
 			ret = 1;
 			break;
 		}
@@ -146,21 +146,21 @@ int main(int argc, char **argv)
 	test_waitsig();	/* even if failed, wait for migration to complete */
 
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m\n");
+		fail("failed to send SIGTERM to my process group: %m");
 		goto out;	/* shouldn't wait() in this case */
 	}
 
 	for (i = 1; i < num_procs; i++) {	/* i = 0 - parent */
 		int chret;
 		if (wait(&chret) < 0) {
-			fail("can't wait for a child: %m\n");
+			fail("can't wait for a child: %m");
 			ret = 1;
 			continue;
 		}
 
 		chret = WEXITSTATUS(chret);
 		if (chret) {
-			fail("child %d exited with non-zero code %d (%s)\n",
+			fail("child %d exited with non-zero code %d (%s)",
 			     i, chret, strerror(chret));
 			ret = 1;
 			continue;

--- a/test/zdtm/transition/pipe_loop00.c
+++ b/test/zdtm/transition/pipe_loop00.c
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
 			continue;
 
 		if (len > 0) {
-			fail("read failed: %m");
+			fail("read failed");
 			ret = 1;
 			break;
 		}
@@ -146,14 +146,14 @@ int main(int argc, char **argv)
 	test_waitsig();	/* even if failed, wait for migration to complete */
 
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m");
+		fail("failed to send SIGTERM to my process group");
 		goto out;	/* shouldn't wait() in this case */
 	}
 
 	for (i = 1; i < num_procs; i++) {	/* i = 0 - parent */
 		int chret;
 		if (wait(&chret) < 0) {
-			fail("can't wait for a child: %m");
+			fail("can't wait for a child");
 			ret = 1;
 			continue;
 		}

--- a/test/zdtm/transition/pipe_shared00.c
+++ b/test/zdtm/transition/pipe_shared00.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 	while(test_go())
 		if (write(pipes[1], buf, sizeof(buf)) < 0 &&
 		    (errno != EINTR || test_go())) {	/* only SIGTERM may stop us */
-			fail("write failed: %m");
+			fail("write failed");
 			ret = 1;
 			break;
 		}
@@ -111,14 +111,14 @@ int main(int argc, char **argv)
 	test_waitsig();	/* even if failed, wait for migration to complete */
 
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m");
+		fail("failed to send SIGTERM to my process group");
 		goto out;	/* shouldn't wait() in this case */
 	}
 
 	for (i = 1; i < num_procs; i++) {	/* i = 0 - parent */
 		int chret;
 		if (wait(&chret) < 0) {
-			fail("can't wait for a child: %m");
+			fail("can't wait for a child");
 			ret = 1;
 			continue;
 		}

--- a/test/zdtm/transition/pipe_shared00.c
+++ b/test/zdtm/transition/pipe_shared00.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 	while(test_go())
 		if (write(pipes[1], buf, sizeof(buf)) < 0 &&
 		    (errno != EINTR || test_go())) {	/* only SIGTERM may stop us */
-			fail("write failed: %m\n");
+			fail("write failed: %m");
 			ret = 1;
 			break;
 		}
@@ -111,21 +111,21 @@ int main(int argc, char **argv)
 	test_waitsig();	/* even if failed, wait for migration to complete */
 
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m\n");
+		fail("failed to send SIGTERM to my process group: %m");
 		goto out;	/* shouldn't wait() in this case */
 	}
 
 	for (i = 1; i < num_procs; i++) {	/* i = 0 - parent */
 		int chret;
 		if (wait(&chret) < 0) {
-			fail("can't wait for a child: %m\n");
+			fail("can't wait for a child: %m");
 			ret = 1;
 			continue;
 		}
 
 		chret = WEXITSTATUS(chret);
 		if (chret) {
-			fail("child exited with non-zero code %d (%s)\n",
+			fail("child exited with non-zero code %d (%s)",
 			     chret, strerror(chret));
 			ret = 1;
 			continue;

--- a/test/zdtm/transition/shmem.c
+++ b/test/zdtm/transition/shmem.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
 	}
 
 	if (status != *sum) {
-		fail("checksum mismatch: %x %x\n", status, *sum);
+		fail("checksum mismatch: %x %x", status, *sum);
 		return 1;
 	}
 

--- a/test/zdtm/transition/socket_loop00.c
+++ b/test/zdtm/transition/socket_loop00.c
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
 			continue;
 
 		if (len > 0) {
-			fail("read failed: %m");
+			fail("read failed");
 			ret = 1;
 			break;
 		}
@@ -150,22 +150,22 @@ int main(int argc, char **argv)
 	 * has been received. Thus, send signal before closing parent fds.
 	 */
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m");
+		fail("failed to send SIGTERM to my process group");
 		goto out;	/* shouldn't wait() in this case */
 	}
 	if (close(out))
-		fail("Failed to close parent fd 'out': %m");
+		fail("Failed to close parent fd 'out'");
 	/* If last child in the chain (from whom we read data) receives signal
 	 * after parent has finished reading but before calling write(2), this
 	 * child can block forever.  To avoid this, close 'in' fd.
 	 */
 	if (close(in))
-		fail("failed to close parent fd 'in': %m");
+		fail("failed to close parent fd 'in'");
 
 	for (i = 1; i < num_procs; i++) {	/* i = 0 - parent */
 		int chret;
 		if (wait(&chret) < 0) {
-			fail("can't wait for a child: %m");
+			fail("can't wait for a child");
 			ret = 1;
 			continue;
 		}

--- a/test/zdtm/transition/socket_loop00.c
+++ b/test/zdtm/transition/socket_loop00.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 			if (errno == EINTR)
 				continue;
 			else {
-				fail("write failed\n");
+				fail("write failed");
 				ret = 1;
 				break;
 			}
@@ -131,13 +131,13 @@ int main(int argc, char **argv)
 			continue;
 
 		if (len > 0) {
-			fail("read failed: %m\n");
+			fail("read failed: %m");
 			ret = 1;
 			break;
 		}
 
 		if (memcmp(buf, rbuf, wlen)) {
-			fail("data mismatch\n");
+			fail("data mismatch");
 			ret = 1;
 			break;
 		}
@@ -150,29 +150,29 @@ int main(int argc, char **argv)
 	 * has been received. Thus, send signal before closing parent fds.
 	 */
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m\n");
+		fail("failed to send SIGTERM to my process group: %m");
 		goto out;	/* shouldn't wait() in this case */
 	}
 	if (close(out))
-		fail("Failed to close parent fd 'out': %m\n");
+		fail("Failed to close parent fd 'out': %m");
 	/* If last child in the chain (from whom we read data) receives signal
 	 * after parent has finished reading but before calling write(2), this
 	 * child can block forever.  To avoid this, close 'in' fd.
 	 */
 	if (close(in))
-		fail("failed to close parent fd 'in': %m\n");
+		fail("failed to close parent fd 'in': %m");
 
 	for (i = 1; i < num_procs; i++) {	/* i = 0 - parent */
 		int chret;
 		if (wait(&chret) < 0) {
-			fail("can't wait for a child: %m\n");
+			fail("can't wait for a child: %m");
 			ret = 1;
 			continue;
 		}
 
 		chret = WEXITSTATUS(chret);
 		if (chret) {
-			fail("child %d exited with non-zero code %d (%s)\n",
+			fail("child %d exited with non-zero code %d (%s)",
 			     i, chret, strerror(chret));
 			ret = 1;
 			continue;

--- a/test/zdtm/transition/unix_sock.c
+++ b/test/zdtm/transition/unix_sock.c
@@ -155,7 +155,7 @@ static int child(void)
 				(errno != EINTR && errno != EPIPE && \
 					errno != ECONNRESET))) {
 			ret = errno;
-			fail("child write: %m");
+			fail("child write");
 			goto out;
 		}
 	}
@@ -219,7 +219,7 @@ int main(int argc, char **argv)
 		read_fds = active_fds;
 		if (select(FD_SETSIZE, &read_fds, NULL, NULL, NULL) < 0 &&
 		    errno != EINTR) {
-			fail("error waiting for data: %m");
+			fail("error waiting for data");
 			goto out;
 		}
 
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
 					if(errno == EINTR)	/* we're asked to stop */
 						break;
 					else {
-						fail("error reading data from socket: %m");
+						fail("error reading data from socket");
 						goto out;
 					}
 				}
@@ -246,7 +246,7 @@ out:
 	test_waitsig();
 
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m");
+		fail("failed to send SIGTERM to my process group");
 		goto cleanup;	/* shouldn't wait() in this case */
 	}
 
@@ -259,10 +259,10 @@ out:
 		 * (not yet delivered), then called write(), blocking forever.
 		 */
 		if(close(child_desc[nproc].sock))
-			fail("Can't close server socket: %m");
+			fail("Can't close server socket");
 
 		if (wait(&chret) < 0) {
-			fail("can't wait for a child: %m");
+			fail("can't wait for a child");
 			goto cleanup;
 		}
 

--- a/test/zdtm/transition/unix_sock.c
+++ b/test/zdtm/transition/unix_sock.c
@@ -155,7 +155,7 @@ static int child(void)
 				(errno != EINTR && errno != EPIPE && \
 					errno != ECONNRESET))) {
 			ret = errno;
-			fail("child write: %m\n");
+			fail("child write: %m");
 			goto out;
 		}
 	}
@@ -246,7 +246,7 @@ out:
 	test_waitsig();
 
 	if (kill(0, SIGTERM)) {
-		fail("failed to send SIGTERM to my process group: %m\n");
+		fail("failed to send SIGTERM to my process group: %m");
 		goto cleanup;	/* shouldn't wait() in this case */
 	}
 
@@ -259,16 +259,16 @@ out:
 		 * (not yet delivered), then called write(), blocking forever.
 		 */
 		if(close(child_desc[nproc].sock))
-			fail("Can't close server socket: %m\n");
+			fail("Can't close server socket: %m");
 
 		if (wait(&chret) < 0) {
-			fail("can't wait for a child: %m\n");
+			fail("can't wait for a child: %m");
 			goto cleanup;
 		}
 
 		chret = WEXITSTATUS(chret);
 		if (chret) {
-			fail("child exited with non-zero code %d (%s)\n",
+			fail("child exited with non-zero code %d (%s)",
 			     chret, strerror(chret));
 			goto cleanup;
 		}


### PR DESCRIPTION
This series fixes some uses of `pr_*` macros, mostly with regards to whether to use `\n` or not.

In addition, it amends top Makefile's `linter` target to do some sanity checks for `pr_*` macros usage. These checks do not and can not catch 100% of the misuse cases, but they catch quite a lot. Hopefully this will prevent some mis-use of `pr_*` in the future.

Do the same about whitespace at EOL.

Please review commit-by-commit, and see individual commit messages for more details.