### PR TITLE
logging: pr_perror() -> pr_msg() when execvp fails in action scripts and others

### DIFF
--- a/criu/util.c
+++ b/criu/util.c
@@ -626,7 +626,9 @@ int cr_system_userns(int in, int out, int err, char *cmd,
 
 		execvp(cmd, argv);
 
-		pr_perror("exec(%s, ...) failed", cmd);
+		/* We can't use pr_error() as log file fd is closed. */
+		fprintf(stderr, "Error (%s:%d): " LOG_PREFIX "execvp(\"%s\", ...) failed: %s\n",
+		       __FILE__, __LINE__, cmd, strerror(errno));
 out_chld:
 		_exit(1);
 	}


### PR DESCRIPTION
When invoking an action-script, all file descriptors >= 3 are closed.
If execvp() fails, we can only log the error on stderr. pr_msg() outputs
on stderr, so we use this as opposed to pr_perror().