### PR TITLE
pstree: when computing pid_max, disregard pgid and sid

### DIFF
--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -557,11 +557,7 @@ static int read_one_pstree_item(struct cr_img *img, pid_t *pid_max)
 	if (e->pid > *pid_max)
 		*pid_max = e->pid;
 	pi->pgid = e->pgid;
-	if (e->pgid > *pid_max)
-		*pid_max = e->pgid;
 	pi->sid = e->sid;
-	if (e->sid > *pid_max)
-		*pid_max = e->sid;
 	pi->pid->state = TASK_ALIVE;
 
 	if (e->ppid == 0) {


### PR DESCRIPTION
computing pid_max is useful when creating new processes (they have pids
we want to control). pgid and sid are related, but not relevent. In
fact, if the sid is outside of our application tree, then we should not
care. This is the case when using --shell-job. pgid/sid is should not
influence the adjustment of /proc/sys/kernel/pid_max