### PR TITLE
Add annotations for code analyzers to ignore false positives

### DIFF
--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -355,6 +355,7 @@ static int gen_parasite_saddr(struct sockaddr_un *saddr, int key)
 	int sun_len;
 
 	saddr->sun_family = AF_UNIX;
+	/* cppcheck-suppress nullPointer */
 	snprintf(saddr->sun_path, UNIX_PATH_MAX,
 			"X/crtools-pr-%d", key);
 

--- a/criu/autofs.c
+++ b/criu/autofs.c
@@ -1114,6 +1114,7 @@ close_pipe:
 free_info:
 	free(info);
 umount:
+	/* coverity[toctou] */
 	if (umount(mi->mountpoint) < 0)
 		pr_perror("Failed to umount %s", mi->mountpoint);
 	goto close_pipe;

--- a/criu/cgroup-props.c
+++ b/criu/cgroup-props.c
@@ -395,6 +395,7 @@ static int cgp_parse_file(char *path)
 	ret = 0;
 err:
 	if (mem != MAP_FAILED)
+		/* coverity[uninit_use_in_call] */
 		munmap(mem, st.st_size);
 	close_safe(&fd);
 	return ret;

--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -1809,6 +1809,7 @@ static int prepare_cgroup_sfd(CgroupEntry *ce)
 				fstype = "cgroup2";
 
 			pr_debug("\tMaking controller dir %s (%s)\n", paux, opt);
+			/* coverity[toctou] */
 			if (mkdir(paux, 0700)) {
 				pr_perror("\tCan't make controller dir %s", paux);
 				goto err;

--- a/criu/config.c
+++ b/criu/config.c
@@ -872,6 +872,7 @@ int parse_options(int argc, char **argv, bool *usage_error,
 			break;
 		case 'V':
 			pr_msg("Version: %s\n", CRIU_VERSION);
+			/* coverity[pointless_string_compare] */
 			if (strcmp(CRIU_GITID, "0"))
 				pr_msg("GitID: %s\n", CRIU_GITID);
 			exit(0);

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -1019,6 +1019,7 @@ static int handle_version(int sk, CriuReq * msg)
 	/* This assumes we will always have a major and minor version */
 	version.major_number = CRIU_VERSION_MAJOR;
 	version.minor_number = CRIU_VERSION_MINOR;
+	/* coverity[pointless_string_compare] */
 	if (strcmp(CRIU_GITID, "0")) {
 		version.gitid = CRIU_GITID;
 	}

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -341,6 +341,7 @@ static int kerndat_get_dirty_track(void)
 
 	map[0] = '\0';
 
+	/* coverity[check_return] */
 	lseek(pm2, (unsigned long)map / PAGE_SIZE * sizeof(u64), SEEK_SET);
 	ret = read(pm2, &pmap, sizeof(pmap));
 	if (ret < 0)

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -2854,6 +2854,7 @@ static int create_mnt_roots(void)
 		mnt_roots = NULL;
 		goto out;
 	}
+	/* coverity[check_return] */
 	chmod(mnt_roots, 0777);
 
 	exit_code = 0;

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -2782,6 +2782,7 @@ err_tmpfs:
 	}
 
 err_root:
+	/* coverity[toctou] */
 	if (tmp_dir && rmdir(put_root)) {
 		pr_perror("Can't remove the directory %s", put_root);
 		return -1;

--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -151,6 +151,7 @@ static void skip_pagemap_pages(struct page_read *pr, unsigned long len)
 static int seek_pagemap(struct page_read *pr, unsigned long vaddr)
 {
 	if (!pr->pe)
+		/* coverity[branch_past_initialization] */
 		goto adv;
 
 	do {

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -755,6 +755,7 @@ int parse_smaps(pid_t pid, struct vm_area_list *vma_area_list,
 		if (!eof && !__is_vma_range_fmt(str)) {
 			if (!strncmp(str, "Nonlinear", 9)) {
 				BUG_ON(!vma_area);
+				/* coverity[var_deref_op] */
 				pr_err("Nonlinear mapping found %016"PRIx64"-%016"PRIx64"\n",
 				       vma_area->e->start, vma_area->e->end);
 				/*
@@ -765,6 +766,7 @@ int parse_smaps(pid_t pid, struct vm_area_list *vma_area_list,
 				goto err;
 			} else if (!strncmp(str, "VmFlags: ", 9)) {
 				BUG_ON(!vma_area);
+				/* coverity[var_deref_model] */
 				parse_vma_vmflags(&str[9], vma_area);
 				continue;
 			} else

--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -284,6 +284,7 @@ int uffd_open(int flags, unsigned long *features)
 	}
 
 	if (uffdio_api.api != UFFD_API) {
+		/* coverity[format_error] */
 		pr_err("Incompatible uffd API: expected %Lu, got %Lu\n",
 		       UFFD_API, uffdio_api.api);
 		goto err;


### PR DESCRIPTION
I have taken the commits from #1235 which only add annotations to tell code analyzers about false positives and collected them all in this PR.

This PR only adds comments.