### PR TITLE
Allow systemcfg proc file to be dumped

### DIFF
--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -173,7 +173,8 @@ static void parse_vma_vmflags(char *buf, struct vma_area *vma_area)
 	 * only exception is VVAR area that mapped by the kernel as
 	 * VM_IO | VM_PFNMAP | VM_DONTEXPAND | VM_DONTDUMP
 	 */
-	if (io_pf && !vma_area_is(vma_area, VMA_AREA_VVAR))
+	if (io_pf && !vma_area_is(vma_area, VMA_AREA_VVAR) &&
+	    !vma_entry_is(vma_area->e, VMA_FILE_SHARED))
 		vma_area->e->status |= VMA_UNSUPP;
 
 	if (vma_area->e->madv)


### PR DESCRIPTION
Currently, it cannot be check-pointed, because that type of file is on UNSUPP list.

Signed-off-by: zl-wang <zlwang@ca.ibm.com>