### PR TITLE
SIGTRAP missed in restored process' caught sigset

### DIFF
--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -447,6 +447,13 @@ static int parasite_run(pid_t pid, int cmd, unsigned long ip, void *stack,
 	k_rtsigset_t block;
 
 	ksigfillset(&block);
+
+	/* This meant to be a work-around for the existing bug that the restored
+	 * process' caught sigset is not equal to the checkpoint process'. It was
+	 * noticed that SIGTRAP is missing there outstandingly.
+	 */
+	block.sig[0] = block.sig[0] & ~(1<<(SIGTRAP - 1));
+
 	if (ptrace(PTRACE_SETSIGMASK, pid, sizeof(k_rtsigset_t), &block)) {
 		pr_perror("Can't block signals for %d", pid);
 		goto err_sig;

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -173,7 +173,8 @@ static void parse_vma_vmflags(char *buf, struct vma_area *vma_area)
 	 * only exception is VVAR area that mapped by the kernel as
 	 * VM_IO | VM_PFNMAP | VM_DONTEXPAND | VM_DONTDUMP
 	 */
-	if (io_pf && !vma_area_is(vma_area, VMA_AREA_VVAR))
+	if (io_pf && !vma_area_is(vma_area, VMA_AREA_VVAR) &&
+	    !vma_entry_is(vma_area->e, VMA_FILE_SHARED))
 		vma_area->e->status |= VMA_UNSUPP;
 
 	if (vma_area->e->madv)


### PR DESCRIPTION
    When checkpoint is restored, SIGTRAP is missed from the sigset
    which are in the original caught set. If the checkpoint was using
    SIGTRAP, the restored process just died silently. This fix
    adds it back into the caught set.

criu #1429 