### PR TITLE
dayatsin/recreate-shm

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -13,6 +13,7 @@ endif
 FOOTER		:= footer.txt
 SRC1		+= crit.txt
 SRC1		+= compel.txt
+SRC1		+= amdgpu_plugin.txt
 SRC8		+= criu.txt
 SRC		:= $(SRC1) $(SRC8)
 XMLS		:= $(patsubst %.txt,%.xml,$(SRC))

--- a/Documentation/amdgpu_plugin.txt
+++ b/Documentation/amdgpu_plugin.txt
@@ -9,7 +9,7 @@ userspace for AMD GPUs.
 
 CURRENT SUPPORT
 ---------------
-Single GPU systems (Gfx9)
+Single and Multi GPU systems (Gfx9)
 Checkpoint / Restore on same system
 Checkpoint / Restore inside a docker container
 Pytorch

--- a/Documentation/amdgpu_plugin.txt
+++ b/Documentation/amdgpu_plugin.txt
@@ -35,6 +35,82 @@ Dependencies
     This work is rebased on latest criu release available at this time.
 
 
+OPTIONS
+-------
+Optional parameters can be passed in as environment variables before
+executing criu command.
+
+*KFD_DESTINATION_GPUS*::
+    Override GPUs on local restore node. GPUs can be specified as gpu_id
+    (hex or decimal) or minor number. Default:<None>
+
+    E.g:
+
+    KFD_DESTINATION_GPUS=0xff31,0x90db
+
+    KFD_DESTINATION_GPUS=65329,37083
+
+    KFD_DESTINATION_GPUS=renderD129,renderD128
+
+
+*KFD_TOPOLOGY_CHECK*::
+    Enable or disable topology check.
+    If enabled, amggpu_plugin will check whether the destination GPU has
+    sufficient capabilities to run checkpointed application. This option is
+    only valid if KFD_DESTINATION_GPUS is used. Default:Enabled
+
+    E.g:
+    KFD_TOPOLOGY_CHECK=0
+
+*KFD_FW_VER_CHECK*::
+    Enable or disable firmware version check.
+    If enabled, firmware version on restored gpu needs to be greater than or
+    equal firmware version on checkpointed GPU. Default:Enabled
+
+    E.g:
+    KFD_FW_VER_CHECK=0
+
+*KFD_SDMA_FW_VER_CHECK*::
+    Enable or disable SDMA firmware version check.
+    If enabled, SDMA firmware version on restored gpu needs to be greater than or
+    equal firmware version on checkpointed GPU. Default:Enabled
+
+    E.g:
+    KFD_SDMA_FW_VER_CHECK=0
+
+*KFD_CACHES_COUNT_CHECK*::
+    Enable or disable caches count check. If enabled, the caches count on
+    restored GPU needs to be greater than or equal caches count on checkpointed
+    GPU. Default:Enabled
+
+    E.g:
+    KFD_CACHES_COUNT_CHECK=0
+
+*KFD_NUM_GWS_CHECK*::
+    Enable or disable num_gws check. If enabled, the num_gws on
+    restored GPU needs to be greater than or equal num_gws on checkpointed
+    GPU. Default:Enabled
+
+    E.g:
+    KFD_NUM_GWS_CHECK=0
+
+*KFD_VRAM_SIZE_CHECK*::
+    Enable or disable VRAM size check. If enabled, the VRAM size on
+    restored GPU needs to be greater than or equal VRAM size on checkpointed
+    GPU. Default:Enabled
+
+    E.g:
+    KFD_VRAM_SIZE_CHECK=0
+
+*KFD_IGNORE_NUMA*::
+    Enable or disable NUMA CPU region check. If enabled, the plugin will restore
+    GPUs that belong to one CPU NUMA region to the same CPU NUMA region.
+    Default:Enabled
+
+    E.g:
+    KFD_IGNORE_NUMA=1
+
+
 AUTHOR
 ------
 The AMDKFD team.

--- a/Documentation/amdgpu_plugin.txt
+++ b/Documentation/amdgpu_plugin.txt
@@ -1,0 +1,45 @@
+ROCM Support(1)
+===============
+
+NAME
+----
+amdgpu_plugin - A plugin extention to CRIU to support checkpoint/restore in
+userspace for AMD GPUs.
+
+
+CURRENT SUPPORT
+---------------
+Single GPU systems (Gfx9)
+Checkpoint / Restore on same system
+Checkpoint / Restore inside a docker container
+Pytorch
+
+DESCRIPTION
+-----------
+Though *criu* is a great tool for checkpointing and restoring running
+applications, it has certain limitations such as it cannot handle
+applications that have device files open. In order to support *ROCm* based
+workloads with *criu* we need to augment criu's core functionality with a
+plugin based extention mechanism. *amdgpu_plugin* provides the necessary support
+to criu to allow Checkpoint / Restore with ROCm.
+
+
+Dependencies
+~~~~~~~~~~~~~~
+*amdkfd support*::
+    In order to snapshot the *VRAM* and other *GPU* device states, we require
+    an updated version of amdkfd(amdgpu) driver. The kernel patches are under
+    review currently.
+
+*criu 3.15*::
+    This work is rebased on latest criu release available at this time.
+
+
+AUTHOR
+------
+The AMDKFD team.
+
+
+COPYRIGHT
+---------
+Copyright \(C) 2020-2021, Advanced Micro Devices, Inc. (AMD)

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ HOSTCFLAGS		+= $(WARNINGS) $(DEFINES) -iquote include/
 export AFLAGS CFLAGS USERCLFAGS HOSTCFLAGS
 
 # Default target
-all: flog criu lib crit
+all: flog criu lib crit amdgpu_plugin
 .PHONY: all
 
 #
@@ -290,15 +290,19 @@ clean mrproper:
 	$(Q) $(MAKE) $(build)=crit $@
 .PHONY: clean mrproper
 
+clean-amdgpu_plugin:
+	$(Q) $(MAKE) -C plugins/amdgpu clean
+.PHONY: clean-amdgpu_plugin
+
 clean-top:
 	$(Q) $(MAKE) -C Documentation clean
 	$(Q) $(MAKE) $(build)=test/compel clean
 	$(Q) $(RM) .gitid
 .PHONY: clean-top
 
-clean: clean-top
+clean: clean-top clean-amdgpu_plugin
 
-mrproper-top: clean-top
+mrproper-top: clean-top clean-amdgpu_plugin
 	$(Q) $(RM) $(CONFIG_HEADER)
 	$(Q) $(RM) $(VERSION_HEADER)
 	$(Q) $(RM) $(COMPEL_VERSION_HEADER)
@@ -325,6 +329,10 @@ zdtm: all
 test: zdtm
 	$(Q) $(MAKE) -C test
 .PHONY: test
+
+amdgpu_plugin:
+	$(Q) $(MAKE) -C plugins/amdgpu all
+.PHONY: amdgpu_plugin
 
 #
 # Generating tar requires tag matched CRIU_VERSION.
@@ -403,6 +411,7 @@ help:
 	@echo '      cscope          - Generate cscope database'
 	@echo '      test            - Run zdtm test-suite'
 	@echo '      gcov            - Make code coverage report'
+	@echo '      amdgpu_plugin   - Make AMD GPU plugin'
 .PHONY: help
 
 lint:

--- a/Makefile.install
+++ b/Makefile.install
@@ -7,6 +7,7 @@ MANDIR		?= $(PREFIX)/share/man
 INCLUDEDIR	?= $(PREFIX)/include
 LIBEXECDIR	?= $(PREFIX)/libexec
 RUNDIR		?= /run
+PLUGINDIR	?= /var/lib/criu
 
 #
 # For recent Debian/Ubuntu with multiarch support.
@@ -26,7 +27,7 @@ endif
 LIBDIR ?= $(PREFIX)/lib
 
 export PREFIX BINDIR SBINDIR MANDIR RUNDIR
-export LIBDIR INCLUDEDIR LIBEXECDIR
+export LIBDIR INCLUDEDIR LIBEXECDIR PLUGINDIR
 
 install-man:
 	$(Q) $(MAKE) -C Documentation install
@@ -40,12 +41,16 @@ install-criu: criu
 	$(Q) $(MAKE) $(build)=criu install
 .PHONY: install-criu
 
+install-amdgpu_plugin: amdgpu_plugin
+	$(Q) $(MAKE) -C plugins/amdgpu install
+.PHONY: install-amdgpu_plugin
+
 install-compel: $(compel-install-targets)
 	$(Q) $(MAKE) $(build)=compel install
 	$(Q) $(MAKE) $(build)=compel/plugins install
 .PHONY: install-compel
 
-install: install-man install-lib install-criu install-compel ;
+install: install-man install-lib install-criu install-compel install-amdgpu_plugin ;
 .PHONY: install
 
 uninstall:
@@ -54,4 +59,5 @@ uninstall:
 	$(Q) $(MAKE) $(build)=criu $@
 	$(Q) $(MAKE) $(build)=compel $@
 	$(Q) $(MAKE) $(build)=compel/plugins $@
+	$(Q) $(MAKE) -C plugins/amdgpu uninstall
 .PHONY: uninstall

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2451,6 +2451,21 @@ skip_ns_bouncing:
 		pr_err("Unable to flush breakpoints\n");
 
 	finalize_restore();
+	/*
+	 * Some external devices such as GPUs might need a very late
+	 * trigger to kick-off some events, memory notifiers and for
+	 * restarting the previously restored queues during criu restore
+	 * stage. This is needed since criu pie code may shuffle VMAs
+	 * around so things such as registering MMU notifiers (for GPU
+	 * mapped memory) could be done sanely once the pie code hands
+	 * over the control to master process.
+	 */
+	for_each_pstree_item(item) {
+		pr_info("Run late stage hook from criu master for external devices\n");
+		ret = run_plugins(RESUME_DEVICES_LATE, item->pid->real);
+		if (ret < 0)
+			pr_err("criu: restore late stage hook for external plugin failed\n");
+	}
 
 	ret = run_scripts(ACT_PRE_RESUME);
 	if (ret)

--- a/criu/file-ids.c
+++ b/criu/file-ids.c
@@ -77,11 +77,18 @@ int fd_id_generate_special(struct fd_parms *p, u32 *id)
 {
 	if (p) {
 		struct fd_id *fi;
+		struct stat st_kfd;
 
 		fi = fd_id_cache_lookup(p);
 		if (fi) {
-			*id = fi->id;
-			return 0;
+			if (stat("/dev/kfd", &st_kfd) == -1) {
+				*id = fi->id;
+				return 0;
+			} else {
+				/* Don't cache the id */
+				*id = fd_tree.subid++;
+				return 1;
+			}
 		}
 	}
 

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -2314,6 +2314,23 @@ static int open_filemap(int pid, struct vma_area *vma)
 	BUG_ON((vma->vmfd == NULL) || !vma->e->has_fdflags);
 	flags = vma->e->fdflags;
 
+	/* update the new device file page offsets and file paths set during restore */
+	if (vma->e->status & VMA_UNSUPP) {
+		uint64_t new_pgoff;
+		char new_path[PATH_MAX];
+		int ret;
+
+		struct reg_file_info *rfi = container_of(vma->vmfd, struct reg_file_info, d);
+		ret = run_plugins(UPDATE_VMA_MAP, rfi->rfe->name, new_path, vma->e->start,
+					vma->e->pgoff, &new_pgoff);
+		if (ret == 1) {
+			pr_info("New mmap %#016"PRIx64"->%#016"PRIx64" path %s\n", vma->e->pgoff,
+					new_pgoff, new_path);
+			vma->e->pgoff = new_pgoff;
+			strcpy(rfi->path, new_path);
+		}
+	}
+
 	if (ctx.flags != flags || ctx.desc != vma->vmfd) {
 		if (vma->e->status & VMA_AREA_MEMFD)
 			ret = memfd_open(vma->vmfd, &flags);
@@ -2331,6 +2348,7 @@ static int open_filemap(int pid, struct vma_area *vma)
 
 	ctx.vma = vma;
 	vma->e->fd = ctx.fd;
+
 	return 0;
 }
 

--- a/criu/include/criu-plugin.h
+++ b/criu/include/criu-plugin.h
@@ -53,6 +53,8 @@ enum {
 
 	CR_PLUGIN_HOOK__UPDATE_VMA_MAP		= 7,
 
+	CR_PLUGIN_HOOK__RESUME_DEVICES_LATE	= 8,
+
 	CR_PLUGIN_HOOK__MAX
 };
 
@@ -68,6 +70,7 @@ DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESTORE_EXT_MOUNT, int id, char *mountp
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__DUMP_EXT_LINK, int index, int type, char *kind);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, const char* old_path, char *new_path,
                                const uint64_t addr, const uint64_t old_pgoff, uint64_t *new_pgoff);
+DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESUME_DEVICES_LATE, int pid);
 
 enum {
 	CR_PLUGIN_STAGE__DUMP,
@@ -136,5 +139,6 @@ typedef int (cr_plugin_dump_ext_link_t)(int index, int type, char *kind);
 typedef int (cr_plugin_update_vma_offset_t)(const char* old_path, char *new_path,
 					    const uint64_t addr, const uint64_t old_pgoff,
 					    uint64_t *new_pgoff);
+typedef int (cr_plugin_resume_devices_late_t)(int pid);
 
 #endif /* __CRIU_PLUGIN_H__ */

--- a/criu/include/criu-plugin.h
+++ b/criu/include/criu-plugin.h
@@ -22,6 +22,7 @@
 
 #include <limits.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #define CRIU_PLUGIN_GEN_VERSION(a,b,c)	(((a) << 16) + ((b) << 8) + (c))
 #define CRIU_PLUGIN_VERSION_MAJOR	0
@@ -50,6 +51,8 @@ enum {
 
 	CR_PLUGIN_HOOK__DUMP_EXT_LINK		= 6,
 
+	CR_PLUGIN_HOOK__UPDATE_VMA_MAP		= 7,
+
 	CR_PLUGIN_HOOK__MAX
 };
 
@@ -63,6 +66,8 @@ DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESTORE_EXT_FILE, int id);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__DUMP_EXT_MOUNT, char *mountpoint, int id);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESTORE_EXT_MOUNT, int id, char *mountpoint, char *old_root, int *is_file);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__DUMP_EXT_LINK, int index, int type, char *kind);
+DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, const char* old_path, char *new_path,
+                               const uint64_t addr, const uint64_t old_pgoff, uint64_t *new_pgoff);
 
 enum {
 	CR_PLUGIN_STAGE__DUMP,
@@ -128,5 +133,8 @@ typedef int (cr_plugin_restore_file_t)(int id);
 typedef int (cr_plugin_dump_ext_mount_t)(char *mountpoint, int id);
 typedef int (cr_plugin_restore_ext_mount_t)(int id, char *mountpoint, char *old_root, int *is_file);
 typedef int (cr_plugin_dump_ext_link_t)(int index, int type, char *kind);
+typedef int (cr_plugin_update_vma_offset_t)(const char* old_path, char *new_path,
+					    const uint64_t addr, const uint64_t old_pgoff,
+					    uint64_t *new_pgoff);
 
 #endif /* __CRIU_PLUGIN_H__ */

--- a/criu/include/proc_parse.h
+++ b/criu/include/proc_parse.h
@@ -8,6 +8,9 @@
 #define PROC_TASK_COMM_LEN	32
 #define PROC_TASK_COMM_LEN_FMT	"(%31s"
 
+#define DRM_FIRST_RENDER_NODE 128
+#define DRM_LAST_RENDER_NODE 255
+
 struct proc_pid_stat {
 	int			pid;
 	char			comm[PROC_TASK_COMM_LEN];

--- a/criu/plugin.c
+++ b/criu/plugin.c
@@ -54,6 +54,7 @@ static cr_plugin_desc_t *cr_gen_plugin_desc(void *h, char *path)
 	__assign_hook(RESTORE_EXT_MOUNT,	"cr_plugin_restore_ext_mount");
 	__assign_hook(DUMP_EXT_LINK,		"cr_plugin_dump_ext_link");
 	__assign_hook(UPDATE_VMA_MAP,		"cr_plugin_update_vma_map");
+	__assign_hook(RESUME_DEVICES_LATE,	"cr_plugin_resume_devices_late");
 
 #undef __assign_hook
 

--- a/criu/plugin.c
+++ b/criu/plugin.c
@@ -53,6 +53,7 @@ static cr_plugin_desc_t *cr_gen_plugin_desc(void *h, char *path)
 	__assign_hook(DUMP_EXT_MOUNT,		"cr_plugin_dump_ext_mount");
 	__assign_hook(RESTORE_EXT_MOUNT,	"cr_plugin_restore_ext_mount");
 	__assign_hook(DUMP_EXT_LINK,		"cr_plugin_dump_ext_link");
+	__assign_hook(UPDATE_VMA_MAP,		"cr_plugin_update_vma_map");
 
 #undef __assign_hook
 

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -173,8 +173,7 @@ static void parse_vma_vmflags(char *buf, struct vma_area *vma_area)
 	 * only exception is VVAR area that mapped by the kernel as
 	 * VM_IO | VM_PFNMAP | VM_DONTEXPAND | VM_DONTDUMP
 	 */
-	if (io_pf && !vma_area_is(vma_area, VMA_AREA_VVAR) &&
-	    !vma_entry_is(vma_area->e, VMA_FILE_SHARED))
+	if (io_pf && !vma_area_is(vma_area, VMA_AREA_VVAR))
 		vma_area->e->status |= VMA_UNSUPP;
 
 	if (vma_area->e->madv)

--- a/plugins/amdgpu/Dockerfile
+++ b/plugins/amdgpu/Dockerfile
@@ -1,0 +1,95 @@
+FROM rocm/pytorch:rocm4.0.1_ubuntu18.04_py3.6_pytorch
+
+ARG CC=gcc
+
+#
+# Environment
+#
+ENV \
+DEBIAN_FRONTEND=noninteractive \
+LC_ALL=en_US.UTF-8 \
+LANG=en_US.UTF-8 \
+LANGUAGE=en_US.UTF-8 \
+.=.
+
+#
+# Package installation
+#
+RUN apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-install-recommends \
+	--no-upgrade -yq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	apt-utils \
+	apt-transport-https\
+	gnupg \
+	gnupg2 \
+	gettext \
+	locales \
+	iproute2 \
+	iputils-ping \
+	moreutils \
+	net-tools \
+	psmisc\
+	supervisor \
+	cifs-utils \
+	nfs-common \
+	systemd \
+	fuse \
+	xmlto \
+	autossh \
+	netbase \
+	libnet-dev \
+	libnl-route-3-dev \
+	$CC \
+	bsdmainutils \
+	ca-certificates \
+	build-essential \
+	git-core \
+	iptables \
+	libaio-dev \
+	libbsd-dev \
+	libcap-dev \
+	libgnutls28-dev \
+	libgnutls30 \
+	libnl-3-dev \
+	libprotobuf-c-dev \
+	libprotobuf-dev \
+	libselinux-dev \
+	pkg-config \
+	protobuf-c-compiler \
+	protobuf-compiler \
+	python-protobuf \
+	python3-minimal \
+	python3-future \
+	python-ipaddress \
+	curl \
+	wget \
+	vim \
+	openssl \
+	openssh-server \
+	python \
+	sudo \
+	libnuma1 \
+	libdrm-dev \
+	libdrm-amdgpu1 \
+	asciidoc \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	apt-get purge --auto-remove && \
+	apt-get clean
+
+# Clone latest criu code
+#RUN mkdir -p /home/criu_build_dir
+WORKDIR /root/criu_build_dir
+#RUN cd /home/criu_build_dir
+RUN git clone https://github.com/checkpoint-restore/criu.git
+#RUN cd /criu
+WORKDIR /root/criu_build_dir/criu
+
+RUN make mrproper && date && \
+# Check single object build
+	make -j $(nproc) CC="$CC" criu/parasite-syscall.o && \
+# Compile criu
+	make -j $(nproc) CC="$CC" && \
+	date && echo BUILD_OK && \
+# Install criu
+	make -j $(nproc) install && \
+	date && echo INSTALL_OK

--- a/plugins/amdgpu/Dockerfile.AMD
+++ b/plugins/amdgpu/Dockerfile.AMD
@@ -1,0 +1,109 @@
+FROM rocm/pytorch:rocm4.0.1_ubuntu18.04_py3.6_pytorch
+
+ARG CC=gcc
+ARG TOKEN
+ARG BRANCH=criu-dev
+
+# Environment
+ENV BRANCH=$BRANCH
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
+#
+# Package installation
+#
+RUN apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-install-recommends \
+	--no-upgrade -yq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	apt-utils \
+	apt-transport-https\
+	gnupg \
+	gnupg2 \
+	gettext \
+	locales \
+	iproute2 \
+	iputils-ping \
+	moreutils \
+	net-tools \
+	psmisc\
+	supervisor \
+	cifs-utils \
+	nfs-common \
+	systemd \
+	fuse \
+	xmlto \
+	autossh \
+	netbase \
+	libnet-dev \
+	libnl-route-3-dev \
+	$CC \
+	bsdmainutils \
+	ca-certificates \
+	build-essential \
+	git-core \
+	iptables \
+	libaio-dev \
+	libbsd-dev \
+	libcap-dev \
+	libgnutls28-dev \
+	libgnutls30 \
+	libnl-3-dev \
+	libprotobuf-c-dev \
+	libprotobuf-dev \
+	libselinux-dev \
+	pkg-config \
+	protobuf-c-compiler \
+	protobuf-compiler \
+	python-protobuf \
+	python3-minimal \
+	python3-future \
+	python-ipaddress \
+	curl \
+	wget \
+	vim \
+	openssl \
+	openssh-server \
+	python \
+	sudo \
+	libnuma1 \
+	libdrm-dev \
+	libdrm-amdgpu1 \
+	asciidoc \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	apt-get purge --auto-remove && \
+	apt-get clean
+
+# Clone latest criu code
+#RUN mkdir -p /home/criu_build_dir
+WORKDIR /root/criu_build_dir
+#RUN cd /home/criu_build_dir
+#RUN git clone https://github.com/checkpoint-restore/criu.git
+RUN if [ "x${TOKEN}" != "x" ]; then \
+	git clone https://${TOKEN}@github.com/RadeonOpenCompute/criu.git -b $BRANCH; \
+	else git clone https://github.com/checkpoint-restore/criu.git; \
+    fi
+
+#RUN cd /criu
+WORKDIR /root/criu_build_dir/criu
+
+RUN make mrproper && date && \
+# Check single object build
+	make -j $(nproc) CC="$CC" criu/parasite-syscall.o && \
+# Compile criu
+	make -j $(nproc) CC="$CC" && \
+	date && echo BUILD_OK && \
+# Install criu
+	make -j $(nproc) install && \
+	date && echo INSTALL_OK
+
+WORKDIR /root/criu_build_dir
+RUN	git clone --recursive -b  cl/rocm-transformers https://github.com/lcskrishna/transformers.git && \
+	cd transformers && wget https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json && \
+	wget https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json && \
+	wget https://github.com/allenai/bi-att-flow/blob/master/squad/evaluate-v1.1.py
+ENV SQUAD_DIR=/root/criu_build_dir/transformers
+WORKDIR /root/criu_build_dir/transformers
+RUN pip3 install tensorboard tensorboardX && pip3 install .
+

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -15,7 +15,7 @@ all: amdgpu_plugin.so
 criu-amdgpu.pb-c.c: criu-amdgpu.proto
 		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
 
-amdgpu_plugin.so: amdgpu_plugin.c criu-amdgpu.pb-c.c
+amdgpu_plugin.so: amdgpu_plugin.c amdgpu_plugin_topology.c criu-amdgpu.pb-c.c
 	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE)
 
 amdgpu_plugin_clean:

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -9,6 +9,7 @@ include $(__nmk_dir)msg.mk
 
 CC      		:= gcc
 PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
+PLUGIN_LDFLAGS		:= -lrt -lpthread
 
 all: amdgpu_plugin.so amdgpu_plugin_test
 
@@ -16,7 +17,7 @@ criu-amdgpu.pb-c.c: criu-amdgpu.proto
 		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
 
 amdgpu_plugin.so: amdgpu_plugin.c amdgpu_plugin_topology.c criu-amdgpu.pb-c.c
-	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE)
+	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS)
 
 amdgpu_plugin_clean:
 	$(call msg-clean, $@)

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -10,7 +10,7 @@ include $(__nmk_dir)msg.mk
 CC      		:= gcc
 PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
 
-all: amdgpu_plugin.so
+all: amdgpu_plugin.so amdgpu_plugin_test
 
 criu-amdgpu.pb-c.c: criu-amdgpu.proto
 		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
@@ -22,7 +22,17 @@ amdgpu_plugin_clean:
 	$(call msg-clean, $@)
 	$(Q) $(RM) amdgpu_plugin.so criu-amdgpu.pb-c*
 .PHONY: amdgpu_plugin_clean
-clean: amdgpu_plugin_clean
+
+test_topology_remap: amdgpu_plugin_topology.c tests/test_topology_remap.c
+	$(CC) $^ -o $@ -DCOMPILE_TESTS $(PLUGIN_INCLUDE) -I .
+
+amdgpu_plugin_test:  test_topology_remap
+
+amdgpu_plugin_test_clean:
+	$(Q) $(RM) test_topology_remap
+.PHONY: amdgpu_plugin_test_clean
+
+clean: amdgpu_plugin_clean amdgpu_plugin_test_clean
 
 mrproper: clean
 

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -1,0 +1,38 @@
+PLUGIN_NAME		:= amdgpu_plugin
+PLUGIN_SOBJ		:= amdgpu_plugin.so
+
+PLUGIN_INC		:= ../../../criu/include
+PLUGIN_INC_EXTRA	:= ../../criu/include
+PLUGIN_INCLUDE		:= -iquote$(PLUGIN_INC) -iquote $(PLUGIN_INC_EXTRA)
+
+include $(__nmk_dir)msg.mk
+
+CC      		:= gcc
+PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
+
+all: amdgpu_plugin.so
+
+criu-amdgpu.pb-c.c: criu-amdgpu.proto
+		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
+
+amdgpu_plugin.so: amdgpu_plugin.c criu-amdgpu.pb-c.c
+	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE)
+
+amdgpu_plugin_clean:
+	$(call msg-clean, $@)
+	$(Q) $(RM) amdgpu_plugin.so criu-amdgpu.pb-c*
+.PHONY: amdgpu_plugin_clean
+clean: amdgpu_plugin_clean
+
+mrproper: clean
+
+install:
+	$(E) "  INSTALL " $(PLUGIN_NAME)
+	$(Q) mkdir -p $(PLUGINDIR)
+	$(Q) install -m 644 $(PLUGIN_SOBJ) $(PLUGINDIR)
+.PHONY: install
+
+uninstall:
+	$(E) " UNINSTALL" $(PLUGIN_NAME)
+	$(Q) $(RM) $(PLUGINDIR)/$(PLUGIN_SOBJ)
+.PHONY: uninstall

--- a/plugins/amdgpu/README.md
+++ b/plugins/amdgpu/README.md
@@ -1,0 +1,275 @@
+Supporting ROCm with CRIU
+=========================
+
+_Felix Kuehling <Felix.Kuehling@amd.com>_<br>
+_Rajneesh Bardwaj <Rajneesh.Bhardwaj@amd.com>_<br>
+_David Yat Sin <David.YatSin@amd.com>_
+
+# Introduction
+
+ROCm is the Radeon Open Compute Platform developed by AMD to support
+high-performance computing and machine learning on AMD GPUs. It is a nearly
+fully open-source software stack starting from the kernel mode GPU driver,
+including compilers and language runtimes, all the way up to optimized
+mathematics libraries, machine learning frameworks and communication libraries.
+
+Documentation for the ROCm platform can be found here:
+https://rocmdocs.amd.com/en/latest/
+
+CRIU is a tool for freezing and checkpointing running applications or
+containers and later restoring them on the same or a different system. The
+process is transparent to the application being checkpointed. It is mostly
+implemented in user mode and relies heavily on Linux kernel features, e.g.
+cgroups, ptrace, vmsplice, and more. It can checkpoint and restore most
+applications relying on standard libraries. However, it is not able to
+checkpoint and restore applications using device drivers, with their own
+per-application kernel mode state, out of the box. This includes ROCm
+applications using the KFD device driver to access GPU hardware resources. CRIU
+includes some plugin hooks to allow extending it to add such support in the
+future.
+
+A common environment for ROCm applications is in data centers and compute
+clusters. In this environment, migrating applications using CRIU would be
+beneficial and desirable. This paper outlines AMDs plans for adding ROCm
+support to CRIU.
+
+# State associated with ROCm applications
+
+ROCm applications communicate with the kernel mode driver “amdgpu.ko” through
+the Thunk library “libhsakmt.so” to enumerate available GPUs, manage
+GPU-accessible memory, user mode queues for submitting work to the GPUs, and
+events for synchronizing with GPUs. Many of those APIs create and manipulate
+state maintained in the kernel mode driver that would need to be saved and
+restored by CRIU.
+
+## Memory
+
+ROCm manages memory in the form of buffer objects (BOs). We are also working on
+a new memory management API that will be based on virtual address ranges. For
+now, we are focusing on the buffer-object based memory management.
+
+There are different types of buffer objects supported:
+
+* VRAM (device memory managed by the kernel mode driver)
+* GTT (system memory managed by the kernel mode driver)
+* Userptr (normal system memory managed by user mode driver or application)
+* Doorbell (special aperture for sending signals to the GPU for user mode command submissions)
+* MMIO (special aperture for accessing GPU control registers, used for certain cache flushing operations)
+
+All these BOs are typically mapped into the GPU page tables for access by GPUs.
+Most of them are also mapped for CPU access. The following BO properties need
+to be saved and restored for CRIU to work with ROCm applications:
+
+* Buffer type
+* Buffer handle
+* Buffer size (page aligned)
+* Virtual address for GPU mapping (page aligned)
+* Device file offset for CPU mapping (for VRAM and GTT BOs)
+* Memory contents (for VRAM and GTT BOs)
+
+## Queues
+
+ROCm uses user mode queues to submit work to the GPUs. There are several memory
+buffers associated with queues. At the language runtime or application level,
+they expose the ring buffer as well as a signal object to tell the GPU about
+new commands added to the queue. The signal is mapped to a doorbell (a 64-bit
+entry in the doorbell aperture mapped by the doorbell BO). Internally there are
+other buffers needed for dispatch completion tracking, shader state saving
+during queue preemption and the queue state itself. Some of these buffers are
+managed in user mode, others are managed in kernel mode.
+
+When an application is checkpointed, we need to preempt all user mode queues
+belonging to the process, and then save their state, including:
+
+* Queue type (compute or DMA)
+* MQD (memory queue descriptor managed in kernel mode), with state such as
+  * ring buffer address
+  * read and write pointers
+  * doorbell offset
+  * pointer to AQL queue data structure
+* Control stack (kernel-managed piece of state needed for resuming preempted queue)
+
+The rest of the queue state is contained in user-managed buffer objects that
+will be saved by the memory state handling described above:
+
+* Ring buffer (userptr BO containing commands sent to the GPU)
+* AQL queue data structure (userptr BO containing `struct hsa_queue_t`)
+* EOP buffer (VRAM BO used for dispatch completion tracking by the command processor)
+* Context save area (userptr BO for saving shader state of preempted wavefronts)
+
+## Events
+
+Events are used to implement interrupt-based sleeping/waiting for signals sent
+from the GPU to the host. Signals are represented by some data structures in
+KFD and an entry in a user-allocated, GPU-accessible BO with event slots. We
+need to save the allocated set of event IDs and each event’s signaling state.
+The contents of the event slots will be saved by the memory state handling
+described above.
+
+## Topology
+
+When ROCm applications are started, they enumerate the device topology to find
+available GPUs, their capabilities and connectivity. An application can be
+checkpointed at any time, so it will not be at a safe place to re-enumerate the
+topology when it is restored. Therefore, we can only support restoring
+applications on systems with a very similar topology:
+
+* Same number of GPUs
+* Same type of GPUs (i.e. instruction set, cache sizes, number of compute units, etc.)
+* Same or larger memory size
+* Same VRAM accessibility by the host
+* Same connectivity and P2P memory support between GPUs
+
+At the KFD ioctl level, GPUs are identified by GPUIDs, which are unique
+identifiers created by hashing various GPU properties. That way a GPUID will
+not change during the lifetime of a process, even in a future where GPUs may be
+added or removed dynamically. When restoring a process on a different system,
+the GPUID may have changed. Or it may be desirable to restore a process using a
+different subset of GPUs on the same system (using cgroups). Therefore, we will
+need a translation of GPUIDs for restored processes that applies to all KFD
+ioctl calls after an application was restored.
+
+# CRIU plugins
+
+CRIU provides plugin hooks for device files:
+
+    int cr_plugin_dump_file(int fd, int id);
+    int cr_plugin_restore_file(int id);
+
+In a ROCm process, it will be invoked for `/dev/kfd` and `/dev/dri/renderD*`
+device nodes. `/dev/kfd` is used for KFD ioctl calls to manage memory, queues,
+signals and other functionality for all GPUs through a single device file
+descriptor. `/dev/dri/renderD*` are per GPU device files, called render nodes,
+that are used mostly for CPU mapping of VRAM and GTT BOs. Each BO is given a
+unique offset in the render node of the corresponding GPU at allocation time.
+
+Render nodes are also used for memory management and command submission by the
+Mesa user mode driver for video decoding and post processing. These use cases
+are relevant even in data centers. Support for this is not an immediate
+priority but planned for the future. This will require saving additional state
+as well as synchronization with any outstanding jobs. For now, there is no
+kernel-mode state associated with `/dev/renderD*`.
+
+The two existing plugins can be used for saving and restoring most state
+associated with ROCm applications. We are planning to add new ioctl calls to
+`/dev/kfd` to help with this.
+
+## Dumping
+
+At the “dump” stage, the ioctl will execute in the context of the CRIU dumper
+process. But the file descriptor (fd) is “drained” from the process being saved
+by the parasite code that CRIU injects into its target. This allows the plugin
+to make an ioctl call with enough context to allow KFD to access all the kernel
+mode state associated with the target process. CRIU is ptrace attached to the
+target process. KFD can use that fact to authorize access to the target
+process' information.
+
+The contents of GTT and VRAM BOs are not automatically saved by CRIU. CRIU can
+only support saving the contents of normal pageable mappings. GTT and VRAM BOs
+are special device file IO mappings. Therefore, our dumper plugin will need to
+save the contents of these BOs. In the initial implementaiton they can be
+accessed through `/proc/<pid>/mem`. For better performance we can use a DMA
+engine in the GPU to copy the data to system memory.
+
+## Restoring
+
+At the “restore” stage we first need to ensure that the topology of visible
+devices (in the cgroup) is compatible with the topology that was saved. Once
+this is confirmed, we can use a new ioctl to load the saved state back into
+KFD. This ioctl will run in the context of the process being restored, so no
+special authorization is needed. However, some of the data being copied back
+into kernel mode could have been tampered with. MQDs and control stacks provide
+access to privileged GPU registers. Therefore, the restore ioctl will only be
+allowed to run with root privileges.
+
+## Remapping render nodes and mmap offsets
+
+BOs are mapped for CPU access by mmapping the GPU's render node at a specific
+offset. The offset within the render node device file identifies the BO.
+However, when we recreate the BOs, we cannot guarantee that they will be
+restored with the same mmap offset that was saved, because the mmap offset
+address space per device is shared system wide.
+
+When a process is restored on a different GPU, it will need to map the BOs from
+a different render node device file altogether.
+
+A new plugin call will be needed to translate device file names and mmap
+offsets to the newly allocated ones, before CRIU's PIE code restores the VMA
+mappings. Fortunately, ROCm user mode does not remember the file names and mmap
+offsets after establishing the mappings, so changing the device files and mmap
+offsets under the hood will not be noticed by ROCm user mode.
+
+*This new plugin is enabled by the new hook `__UPDATE_VMA_MAP` in our RFC patch
+series.*
+
+## Resuming GPU execution
+
+At the time of running the `cr_plugin_restore_file` plugin, it is too early to
+restore userptr GPU page table mappings and their MMU notifiers. These mappings
+mirror CPU page tables into GPU page tables using the HMM mirror API in the
+kernel. The MMU notifiers notify the driver when the virtual address mapping
+changes so that the GPU mapping can be updated.
+
+This needs to happen after the restorer PIE code has restored all the VMAs at
+their correct virtual addresses. Otherwise, the HMM mirroring will simply fail.
+Before all the GPU memory mappings are in place, it is also too early to resume
+the user mode queue execution on the GPUs.
+
+Therefore, a new plugin is needed that runs in the context of the master
+restore process after the restorer PIE code has restored all the VMAs and
+returned control to all the restored processes via sigreturn. It needs to be
+called once for each restored target process to finalize userptr mappings and
+to resume execution on the GPUs.
+
+*This new plugin is enabled by the new hook `__RESUME_DEVICES_LATE` in our RFC
+patch series.*
+
+## Other CRIU changes
+
+In addition to the new plugins, we need to make some changes to CRIU itself to
+support device file VMAs. Currently CRIU will simply fail to dump a process
+that has such PFN or IO memory mappings. While CRIU will not need to save the
+contents of those VMAs, we do need CRIU to save and restore the VMAs
+themselves, with translated mmap offsets (see “Remapping mmap offsets” above).
+
+## Security considerations
+
+The new “dump” ioctl we are adding to `/dev/kfd` will expose information about
+remote processes. This is a potential security threat. CRIU will be
+ptrace-attached to the target process, which gives it full access to the state
+of the process being dumped. KFD can use ptrace attachment to authorize the use
+of the new ioctl on a specific target process.
+
+The new “restore” ioctl will load privileged information from user mode back
+into the kernel driver and the hardware. This includes MQD contents, which will
+eventually be loaded into HQD registers, as well as a control stack, which is a
+series of low-level commands that will be executed by the command processor.
+Therefore, we are limiting this ioctl to the root user. If CRIU restore must be
+possible for non-root users, we need to sanitize the privileged state to ensure
+it cannot be used to circumvent system security policies (e.g. arbitrary code
+execution in privileged contexts with access to page tables etc.).
+
+Modified mmap offsets could potentially be used to access BOs belonging to
+different processes. This potential threat is not new with CRIU. `amdgpu.ko`
+already implements checking of mmap offsets to ensure a context (represented by
+a render node file descriptor) is only allowed access to its own BOs.
+
+# Glossary
+
+Term | Definition
+--- | ---
+CRIU | Checkpoint/Restore In Userspace
+ROCm | Radeon Open Compute Platform
+Thunk | User-mode API interface  to interact with amdgpu.ko
+KFD | AMD Kernel Fusion Driver
+Mesa | Open source OpenGL implementation
+GTT | Graphis Translation Table, also used to denote kernel-managed system memory for GPU access
+VRAM | Video RAM
+BO | Buffer Object
+HMM | Heterogenous Memory Management
+AQL | Architected Queueing Language
+EOP | End of pipe (event indicating shader dispatch completion)
+MQD | Memory Queue Descriptors
+HQD | Hardware Queue Descriptors
+PIE | Position Independent Executable
+

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -95,6 +95,10 @@ static void free_e(CriuKfd *e)
 		if (e->devinfo_entries[i])
 			xfree(e->devinfo_entries[i]);
 	}
+	for (int i = 0; i < e->n_q_entries; i++) {
+		if (e->q_entries[i])
+			xfree(e->q_entries[i]);
+	}
 	xfree(e);
 }
 
@@ -159,6 +163,29 @@ static int allocate_bo_info_test(CriuKfd *e, int num_bos, struct kfd_criu_bo_buc
 	return 0;
 }
 
+static int allocate_q_entries(CriuKfd *e, int num_queues)
+{
+	e->q_entries = xmalloc(sizeof(QEntry*) * num_queues);
+	if (!e->q_entries) {
+		pr_err("Failed to allocate q_entries\n");
+		return -1;
+	}
+
+	for (int i = 0; i < num_queues; i++) {
+		QEntry *q_entry = xmalloc(sizeof(QEntry));
+		if (!q_entry) {
+			pr_err("Failed to allocate q_entry\n");
+			return -ENOMEM;
+		}
+		q_entry__init(q_entry);
+
+		e->q_entries[i] = q_entry;
+		e->n_q_entries++;
+
+	}
+	return 0;
+}
+
 int amdgpu_plugin_init(int stage)
 {
 	pr_info("amdgpu_plugin: initialized:  %s (AMDGPU/KFD)\n",
@@ -179,6 +206,7 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	struct kfd_criu_devinfo_bucket *devinfo_bucket_ptr;
 	struct kfd_ioctl_criu_dumper_args args = {0};
 	struct kfd_criu_bo_buckets *bo_bucket_ptr;
+	struct kfd_criu_q_bucket *q_bucket_ptr;
 	int img_fd, ret, len, mem_fd, drm_fd;
 	char img_path[PATH_MAX];
 	struct stat st, st_kfd;
@@ -273,6 +301,29 @@ int amdgpu_plugin_dump_file(int fd, int id)
 
 	args.num_of_bos = helper_args.num_of_bos;
 	args.kfd_criu_bo_buckets_ptr = (uintptr_t)bo_bucket_ptr;
+
+	pr_info("amdgpu_plugin: num of queues = %u\n", helper_args.num_of_queues);
+
+	q_bucket_ptr = xmalloc(helper_args.num_of_queues *
+			       sizeof(struct kfd_criu_q_bucket));
+
+	if (!q_bucket_ptr) {
+		pr_perror("amdgpu_plugin: failed to allocate args for dumper ioctl\n");
+		return -1;
+	}
+
+	args.num_of_queues = helper_args.num_of_queues;
+	args.kfd_criu_q_buckets_ptr = (uintptr_t)q_bucket_ptr;
+
+	if (helper_args.queues_data_size) {
+		args.queues_data_ptr = (uintptr_t)xmalloc(helper_args.queues_data_size);
+		if (!args.queues_data_ptr) {
+			pr_perror("amdgpu_plugin: failed to allocate args for dumper ioctl\n");
+			return -1;
+		}
+		args.queues_data_size = helper_args.queues_data_size;
+		pr_info("amdgpu_plugin: queues data size:%llu\n", args.queues_data_size);
+	}
 
 	/* call dumper ioctl, pass num of BOs to dump */
         if (kmtIoctl(fd, AMDKFD_IOC_CRIU_DUMPER, &args) == -1) {
@@ -443,6 +494,55 @@ int amdgpu_plugin_dump_file(int fd, int id)
 
 	}
 
+	ret = allocate_q_entries(e, helper_args.num_of_queues);
+	if (ret)
+		return ret;
+
+	e->num_of_queues = helper_args.num_of_queues;
+
+	for (int i = 0; i < e->num_of_queues; i++)
+	{
+		uint8_t *queue_data_ptr = (uint8_t *)args.queues_data_ptr
+					+ q_bucket_ptr[i].queues_data_offset;
+
+		pr_info("Dumping Queue[%d]:\n", i);
+		pr_info("\tgpu_id:%x type:%x format:%x q_id:%x q_address:%llx ",
+			q_bucket_ptr[i].gpu_id,
+			q_bucket_ptr[i].type,
+			q_bucket_ptr[i].format,
+			q_bucket_ptr[i].q_id,
+			q_bucket_ptr[i].q_address);
+
+		e->q_entries[i]->gpu_id = q_bucket_ptr[i].gpu_id;
+		e->q_entries[i]->type = q_bucket_ptr[i].type;
+		e->q_entries[i]->format = q_bucket_ptr[i].format;
+		e->q_entries[i]->q_id = q_bucket_ptr[i].q_id;
+		e->q_entries[i]->q_address = q_bucket_ptr[i].q_address;
+		e->q_entries[i]->q_size = q_bucket_ptr[i].q_size;
+		e->q_entries[i]->priority = q_bucket_ptr[i].priority;
+		e->q_entries[i]->q_percent = q_bucket_ptr[i].q_percent;
+		e->q_entries[i]->read_ptr_addr = q_bucket_ptr[i].read_ptr_addr;
+		e->q_entries[i]->write_ptr_addr = q_bucket_ptr[i].write_ptr_addr;
+		e->q_entries[i]->doorbell_id = q_bucket_ptr[i].doorbell_id;
+		e->q_entries[i]->doorbell_off = q_bucket_ptr[i].doorbell_off;
+		e->q_entries[i]->is_gws = q_bucket_ptr[i].is_gws;
+		e->q_entries[i]->sdma_id = q_bucket_ptr[i].sdma_id;
+		e->q_entries[i]->eop_ring_buffer_address = q_bucket_ptr[i].eop_ring_buffer_address;
+		e->q_entries[i]->eop_ring_buffer_size = q_bucket_ptr[i].eop_ring_buffer_size;
+		e->q_entries[i]->ctx_save_restore_area_address = q_bucket_ptr[i].ctx_save_restore_area_address;
+		e->q_entries[i]->ctx_save_restore_area_size = q_bucket_ptr[i].ctx_save_restore_area_size;
+		e->q_entries[i]->ctl_stack_size = q_bucket_ptr[i].ctl_stack_size;
+
+		e->q_entries[i]->cu_mask.len = q_bucket_ptr[i].cu_mask_size;
+		e->q_entries[i]->cu_mask.data = queue_data_ptr;
+
+		e->q_entries[i]->mqd.len = q_bucket_ptr[i].mqd_size;
+		e->q_entries[i]->mqd.data = queue_data_ptr + q_bucket_ptr[i].cu_mask_size;
+
+		e->q_entries[i]->ctl_stack.len = q_bucket_ptr[i].ctl_stack_size;
+		e->q_entries[i]->ctl_stack.data = queue_data_ptr + q_bucket_ptr[i].cu_mask_size + q_bucket_ptr[i].mqd_size;
+	}
+
 	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
 	pr_info("amdgpu_plugin: img_path = %s", img_path);
 	img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
@@ -478,6 +578,7 @@ exit:
 failed:
 	xfree(devinfo_bucket_ptr);
 	xfree(bo_bucket_ptr);
+	xfree(q_bucket_ptr);
 	free_e(e);
 	pr_info("amdgpu_plugin: Exiting from dumper for fd = %d\n", major(st.st_rdev));
         return ret;
@@ -491,6 +592,7 @@ int amdgpu_plugin_restore_file(int id)
 	int img_fd, len, fd, mem_fd;
 	struct kfd_ioctl_criu_restorer_args args = {0};
 	struct kfd_criu_bo_buckets *bo_bucket_ptr;
+	struct kfd_criu_q_bucket *q_bucket_ptr;
 	__u64 *restored_bo_offsets_array;
 	char img_path[PATH_MAX];
 	struct stat filestat;
@@ -663,6 +765,93 @@ int amdgpu_plugin_restore_file(int id)
 	args.restored_bo_array_ptr = (uint64_t)restored_bo_offsets_array;
 	args.num_of_devices = 1; /* Only support 1 gpu for now */
 
+	q_bucket_ptr = xmalloc(e->num_of_queues * sizeof(struct kfd_criu_q_bucket));
+        if (!q_bucket_ptr) {
+               pr_perror("amdgpu_plugin: failed to allocate args for dumper ioctl\n");
+               return -1;
+	}
+
+	pr_info("Number of queues:%u\n", e->num_of_queues);
+
+	args.queues_data_size = 0;
+	for (int i = 0; i < e->num_of_queues; i++ ) {
+		args.queues_data_size += e->q_entries[i]->cu_mask.len
+					+ e->q_entries[i]->mqd.len
+					+ e->q_entries[i]->ctl_stack.len;
+	}
+
+	pr_info("Queues data size:%llu\n", args.queues_data_size);
+
+	args.queues_data_ptr = (uintptr_t)xmalloc(args.queues_data_size);
+	if (!args.queues_data_ptr) {
+		pr_perror("amdgpu_plugin: failed to allocate args for dumper ioctl\n");
+		return -1;
+	}
+
+	uint32_t queues_data_offset = 0;
+
+	for (int i = 0; i < e->num_of_queues; i++ )
+	{
+		uint8_t *queue_data;
+		pr_info("Restoring Queue[%d]:\n", i);
+		pr_info("\tgpu_id:%x type:%x format:%x q_id:%x q_address:%lx "
+			"cu_mask_size:%lx mqd_size:%lx ctl_stack_size:%lx\n",
+			e->q_entries[i]->gpu_id,
+			e->q_entries[i]->type,
+			e->q_entries[i]->format,
+			e->q_entries[i]->q_id,
+			e->q_entries[i]->q_address,
+			e->q_entries[i]->cu_mask.len,
+			e->q_entries[i]->mqd.len,
+			e->q_entries[i]->ctl_stack.len);
+
+		q_bucket_ptr[i].gpu_id = e->q_entries[i]->gpu_id;
+		q_bucket_ptr[i].type = e->q_entries[i]->type;
+		q_bucket_ptr[i].format = e->q_entries[i]->format;
+		q_bucket_ptr[i].q_id = e->q_entries[i]->q_id;
+		q_bucket_ptr[i].q_address = e->q_entries[i]->q_address;
+		q_bucket_ptr[i].q_size = e->q_entries[i]->q_size;
+		q_bucket_ptr[i].priority = e->q_entries[i]->priority;
+		q_bucket_ptr[i].q_percent = e->q_entries[i]->q_percent;
+		q_bucket_ptr[i].read_ptr_addr = e->q_entries[i]->read_ptr_addr;
+		q_bucket_ptr[i].write_ptr_addr = e->q_entries[i]->write_ptr_addr;
+		q_bucket_ptr[i].doorbell_id = e->q_entries[i]->doorbell_id;
+		q_bucket_ptr[i].doorbell_off = e->q_entries[i]->doorbell_off;
+		q_bucket_ptr[i].is_gws = e->q_entries[i]->is_gws;
+		q_bucket_ptr[i].sdma_id = e->q_entries[i]->sdma_id;
+		q_bucket_ptr[i].eop_ring_buffer_address = e->q_entries[i]->eop_ring_buffer_address;
+		q_bucket_ptr[i].eop_ring_buffer_size = e->q_entries[i]->eop_ring_buffer_size;
+		q_bucket_ptr[i].ctx_save_restore_area_address = e->q_entries[i]->ctx_save_restore_area_address;
+		q_bucket_ptr[i].ctx_save_restore_area_size = e->q_entries[i]->ctx_save_restore_area_size;
+		q_bucket_ptr[i].ctl_stack_size = e->q_entries[i]->ctl_stack_size;
+
+		q_bucket_ptr[i].queues_data_offset = queues_data_offset;
+		queue_data = (uint8_t *)args.queues_data_ptr + queues_data_offset;
+
+		q_bucket_ptr[i].cu_mask_size = e->q_entries[i]->cu_mask.len;
+		memcpy(queue_data,
+			e->q_entries[i]->cu_mask.data,
+			e->q_entries[i]->cu_mask.len);
+
+		q_bucket_ptr[i].mqd_size = e->q_entries[i]->mqd.len;
+		memcpy(queue_data + e->q_entries[i]->cu_mask.len,
+			e->q_entries[i]->mqd.data,
+			e->q_entries[i]->mqd.len);
+
+		q_bucket_ptr[i].ctl_stack_size = e->q_entries[i]->ctl_stack.len;
+		memcpy(queue_data + e->q_entries[i]->cu_mask.len + e->q_entries[i]->mqd.len,
+			e->q_entries[i]->ctl_stack.data,
+			e->q_entries[i]->ctl_stack.len);
+
+		queues_data_offset += e->q_entries[i]->cu_mask.len
+					+ e->q_entries[i]->mqd.len
+					+ e->q_entries[i]->ctl_stack.len;
+
+	}
+
+	args.num_of_queues = e->num_of_queues;
+	args.kfd_criu_q_buckets_ptr = (uintptr_t)q_bucket_ptr;
+
 	if (kmtIoctl(fd, AMDKFD_IOC_CRIU_RESTORER, &args) == -1) {
 		pr_perror("amdgpu_plugin: failed to call kfd ioctl from plugin restorer for id = %d\n", id);
 		fd = -EBADFD;
@@ -780,9 +969,14 @@ int amdgpu_plugin_restore_file(int id)
 	}
 clean:
 	xfree(devinfo_bucket_ptr);
+	if (q_bucket_ptr)
+		xfree(q_bucket_ptr);
 	xfree(restored_bo_offsets_array);
 	xfree(bo_bucket_ptr);
 	xfree(buf);
+	if (args.queues_data_ptr)
+		xfree((void*)args.queues_data_ptr);
+
 	criu_kfd__free_unpacked(e, NULL);
 	pr_info("amdgpu_plugin: returning kfd fd from plugin, fd = %d\n", fd);
 	return fd;

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -32,6 +32,17 @@
 #define _GNU_SOURCE 1
 #endif
 
+#ifdef LOG_PREFIX
+#undef LOG_PREFIX
+#endif
+#define LOG_PREFIX "amdgpu_plugin: "
+
+#ifdef DEBUG
+#define plugin_log_msg(fmt, ...) pr_debug(fmt, ##__VA_ARGS__)
+#else
+#define plugin_log_msg(fmt, ...) {}
+#endif
+
 struct vma_metadata {
 	struct list_head list;
 	uint64_t old_pgoff;
@@ -464,7 +475,7 @@ int amdgpu_plugin_dump_file(int fd, int id)
 				pr_info("log initial few bytes of the raw data for this BO\n");
 				for (int i = 0; i < 10; i ++)
 				{
-					pr_info("0x%llx\n",((__u64*)local_buf)[i]);
+					plugin_log_msg("0x%llx\n",((__u64*)local_buf)[i]);
 				}
 
 				close(mem_fd);
@@ -479,11 +490,11 @@ int amdgpu_plugin_dump_file(int fd, int id)
 
 	e->num_of_bos = helper_args.num_of_bos;
 
-	pr_info("Dumping bo_info_test \n");
+	plugin_log_msg("Dumping bo_info_test \n");
 	for (int i = 0; i < helper_args.num_of_bos; i++)
 	{
-		pr_info("e->bo_info_test[%d]:\n", i);
-		pr_info("bo_addr = 0x%lx, bo_size = 0x%lx, bo_offset = 0x%lx, gpu_id = 0x%x, "
+		plugin_log_msg("e->bo_info_test[%d]:\n", i);
+		plugin_log_msg("bo_addr = 0x%lx, bo_size = 0x%lx, bo_offset = 0x%lx, gpu_id = 0x%x, "
 			"bo_alloc_flags = 0x%x, idr_handle = 0x%x\n",
 		  (e->bo_info_test[i])->bo_addr,
 		  (e->bo_info_test[i])->bo_size,
@@ -491,6 +502,15 @@ int amdgpu_plugin_dump_file(int fd, int id)
 		  (e->bo_info_test[i])->gpu_id,
 		  (e->bo_info_test[i])->bo_alloc_flags,
 		  (e->bo_info_test[i])->idr_handle);
+		plugin_log_msg("(bo_bucket_ptr)[%d]:\n", i);
+		plugin_log_msg("bo_addr = 0x%llx, bo_size = 0x%llx, bo_offset = 0x%llx, "
+			"gpu_id = 0x%x, bo_alloc_flags = 0x%x, idr_handle = 0x%x\n",
+		  (bo_bucket_ptr)[i].bo_addr,
+		  (bo_bucket_ptr)[i].bo_size,
+		  (bo_bucket_ptr)[i].bo_offset,
+		  (bo_bucket_ptr)[i].gpu_id,
+		  (bo_bucket_ptr)[i].bo_alloc_flags,
+		  (bo_bucket_ptr)[i].idr_handle);
 
 	}
 
@@ -505,8 +525,8 @@ int amdgpu_plugin_dump_file(int fd, int id)
 		uint8_t *queue_data_ptr = (uint8_t *)args.queues_data_ptr
 					+ q_bucket_ptr[i].queues_data_offset;
 
-		pr_info("Dumping Queue[%d]:\n", i);
-		pr_info("\tgpu_id:%x type:%x format:%x q_id:%x q_address:%llx ",
+		plugin_log_msg("Dumping Queue[%d]:\n", i);
+		plugin_log_msg("\tgpu_id:%x type:%x format:%x q_id:%x q_address:%llx ",
 			q_bucket_ptr[i].gpu_id,
 			q_bucket_ptr[i].type,
 			q_bucket_ptr[i].format,
@@ -696,7 +716,7 @@ int amdgpu_plugin_restore_file(int id)
 		return -1;
 	}
 
-	pr_info("amdgpu_plugin: read image file data\n");
+	plugin_log_msg("amdgpu_plugin: read image file data\n");
 
 	devinfo_bucket_ptr = xmalloc(e->num_of_devices * sizeof(struct kfd_criu_devinfo_bucket));
 	if (!devinfo_bucket_ptr) {
@@ -722,12 +742,12 @@ int amdgpu_plugin_restore_file(int id)
 
 	for (int i = 0; i < e->num_of_bos; i++ )
 	{
-		pr_info("reading e->bo_info_test[%d]:\n", i);
-		pr_info("bo_addr = 0x%lx, bo_size = 0x%lx, bo_offset = 0x%lx, gpu_id = 0x%x, "
-			"bo_alloc_flags = 0x%x, idr_handle = 0x%x user_addr=0x%lx\n",
+		plugin_log_msg("reading e->bo_info_test[%d]:\n", i);
+		plugin_log_msg("bo_addr = 0x%lx, bo_size = 0x%lx, bo_offset = 0x%lx, "
+			"gpu_id = 0x%x, bo_alloc_flags = 0x%x, idr_handle = 0x%x user_addr=0x%lx\n",
 		  (e->bo_info_test[i])->bo_addr,
 		  (e->bo_info_test[i])->bo_size,
-		  (e->bo_info_test[i])->bo_offset,
+		  (e->bo_info_test[i])->bo_offset,s
 		  (e->bo_info_test[i])->gpu_id,
 		  (e->bo_info_test[i])->bo_alloc_flags,
 		  (e->bo_info_test[i])->idr_handle,
@@ -793,8 +813,8 @@ int amdgpu_plugin_restore_file(int id)
 	for (int i = 0; i < e->num_of_queues; i++ )
 	{
 		uint8_t *queue_data;
-		pr_info("Restoring Queue[%d]:\n", i);
-		pr_info("\tgpu_id:%x type:%x format:%x q_id:%x q_address:%lx "
+		plugin_log_msg("Restoring Queue[%d]:\n", i);
+		plugin_log_msg("\tgpu_id:%x type:%x format:%x q_id:%x q_address:%lx "
 			"cu_mask_size:%lx mqd_size:%lx ctl_stack_size:%lx\n",
 			e->q_entries[i]->gpu_id,
 			e->q_entries[i]->type,

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -77,6 +77,69 @@ int open_drm_render_device(int minor)
 	return fd;
 }
 
+int write_file(const char *file_path, const void *buf, const size_t buf_len)
+{
+	int fd;
+	FILE *fp;
+	size_t len_wrote;
+
+	fd = openat(criu_get_image_dir(), file_path, O_WRONLY | O_CREAT, 0600);
+	if (fd < 0) {
+		pr_perror("Cannot open %s", file_path);
+		return -EPERM;
+	}
+
+	fp = fdopen(fd, "w");
+	if (!fp) {
+		pr_perror("Cannot fdopen %s", file_path);
+		return -EPERM;
+	}
+
+	len_wrote = fwrite(buf, 1, buf_len, fp);
+	if (len_wrote != buf_len) {
+		pr_perror("Unable to write %s (wrote:%ld buf_len:%ld)\n", file_path, len_wrote, buf_len);
+		fclose(fp);
+		return -EIO;
+	}
+
+	pr_info("Wrote file:%s (%ld bytes)\n", file_path, buf_len);
+	/* this will also close fd */
+	fclose(fp);
+	return 0;
+}
+
+int read_file(const char *file_path, void *buf, const size_t buf_len)
+{
+	int fd;
+	FILE *fp;
+	size_t len_read;
+
+	fd = openat(criu_get_image_dir(), file_path, O_RDONLY);
+	if (fd < 0) {
+		pr_perror("Cannot open %s", file_path);
+		return -ENOENT;
+	}
+
+	fp = fdopen(fd, "r");
+	if (!fp) {
+		pr_perror("Cannot fdopen %s", file_path);
+		return -EPERM;
+	}
+
+	len_read = fread(buf, 1, buf_len, fp);
+	if (len_read != buf_len) {
+		pr_perror("Unable to read %s\n", file_path);
+		fclose(fp);
+		return -EIO;
+	}
+
+	pr_info("Read file:%s (%ld bytes)\n", file_path, buf_len);
+
+	/* this will also close fd */
+	fclose(fp);
+	return 0;
+}
+
 /* Call ioctl, restarting if it is interrupted */
 int kmtIoctl(int fd, unsigned long request, void *arg)
 {
@@ -218,14 +281,13 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	struct kfd_ioctl_criu_dumper_args args = {0};
 	struct kfd_criu_bo_buckets *bo_bucket_ptr;
 	struct kfd_criu_q_bucket *q_bucket_ptr;
-	int img_fd, ret, len, mem_fd, drm_fd;
+	int ret, drm_fd;
 	char img_path[PATH_MAX];
 	struct stat st, st_kfd;
 	unsigned char *buf;
 	char fd_path[128];
-	uint8_t *local_buf;
-	char *fname;
 	void *addr;
+	size_t len;
 
 	pr_debug("amdgpu_plugin: Enter cr_plugin_dump_file()- ID = 0x%x\n", id);
 	ret = 0;
@@ -256,26 +318,17 @@ int amdgpu_plugin_dump_file(int fd, int id)
 		rd.minor_number = minor(st.st_rdev);
 		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
 
-		img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
-		if (img_fd < 0) {
-			pr_perror("Can't open %s", img_path);
-			return -1;
-		}
-
 		len = criu_render_node__get_packed_size(&rd);
 		buf = xmalloc(len);
 		if (!buf)
 			return -ENOMEM;
 
 		criu_render_node__pack(&rd, buf);
-		ret = write(img_fd,  buf, len);
-
-		if (ret != len) {
-			pr_perror("Unable to write in %s", img_path);
+		ret = write_file(img_path,  buf, len);
+		if (ret)
 			ret = -1;
-		}
+
 		xfree(buf);
-		close(img_fd);
 
 		/* Need to return success here so that criu can call plugins for
 		 * renderD nodes */
@@ -399,13 +452,6 @@ int amdgpu_plugin_dump_file(int fd, int id)
 		(e->bo_info_test[i])->idr_handle = (bo_bucket_ptr)[i].idr_handle;
 		(e->bo_info_test[i])->user_addr = (bo_bucket_ptr)[i].user_addr;
 
-		local_buf = xmalloc((bo_bucket_ptr)[i].bo_size);
-		if (!local_buf) {
-			pr_err("failed to allocate memory for BO rawdata\n");
-			ret = -1;
-			goto failed;
-		}
-
 		if ((bo_bucket_ptr)[i].bo_alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) {
 			pr_info("VRAM BO Found\n");
 		}
@@ -418,6 +464,9 @@ int amdgpu_plugin_dump_file(int fd, int id)
 		    KFD_IOC_ALLOC_MEM_FLAGS_VRAM ||
 		    (bo_bucket_ptr)[i].bo_alloc_flags &
 		    KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
+			char *fname;
+			int mem_fd;
+
 			if ((e->bo_info_test[i])->bo_alloc_flags &
 			    KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
 				pr_info("amdgpu_plugin: large bar read possible\n");
@@ -464,7 +513,7 @@ int amdgpu_plugin_dump_file(int fd, int id)
 				}
 				pr_info("Try to read file now\n");
 
-				if (read(mem_fd, local_buf,
+				if (read(mem_fd, e->bo_info_test[i]->bo_rawdata.data,
 					 (e->bo_info_test[i])->bo_size) !=
 				    (e->bo_info_test[i])->bo_size) {
 					pr_perror("Can't read buffer\n");
@@ -472,17 +521,7 @@ int amdgpu_plugin_dump_file(int fd, int id)
 					goto failed;
 				}
 
-				pr_info("log initial few bytes of the raw data for this BO\n");
-				for (int i = 0; i < 10; i ++)
-				{
-					plugin_log_msg("0x%llx\n",((__u64*)local_buf)[i]);
-				}
-
 				close(mem_fd);
-				memcpy((e->bo_info_test[i])->bo_rawdata.data,
-				       (uint8_t*)local_buf,
-				       (e->bo_info_test[i])->bo_size);
-				xfree(local_buf);
 			} /* PROCPIDMEM read done */
 		}
 	}
@@ -565,36 +604,25 @@ int amdgpu_plugin_dump_file(int fd, int id)
 
 	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
 	pr_info("amdgpu_plugin: img_path = %s", img_path);
-	img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
-	if (img_fd < 0) {
-		pr_perror("Can't open %s", img_path);
-		ret = -1;
-		goto failed;
-	}
 
 	len = criu_kfd__get_packed_size(e);
 
-	pr_info("amdgpu_plugin: Len = %d\n", len);
+	pr_info("amdgpu_plugin: Len = %ld\n", len);
 
 	buf = xmalloc(len);
 	if (!buf) {
 		pr_perror("failed to allocate memory\n");
-		close(img_fd);
 		ret = -ENOMEM;
 		goto failed;
 	}
 
 	criu_kfd__pack(e, buf);
 
-	ret = write(img_fd,  buf, len);
-	if (ret != len) {
-		pr_perror("Unable to write in %s", img_path);
+	ret = write_file(img_path,  buf, len);
+	if (ret != len)
 		ret = -1;
-		goto exit;
-	}
-exit:
+
 	xfree(buf);
-	close(img_fd);
 failed:
 	xfree(devinfo_bucket_ptr);
 	xfree(bo_bucket_ptr);
@@ -609,7 +637,7 @@ CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__DUMP_EXT_FILE, amdgpu_plugin_dump_file)
 int amdgpu_plugin_restore_file(int id)
 {
 	struct kfd_criu_devinfo_bucket *devinfo_bucket_ptr = NULL;
-	int img_fd, len, fd, mem_fd;
+	int fd;
 	struct kfd_ioctl_criu_restorer_args args = {0};
 	struct kfd_criu_bo_buckets *bo_bucket_ptr;
 	struct kfd_criu_q_bucket *q_bucket_ptr;
@@ -625,8 +653,8 @@ int amdgpu_plugin_restore_file(int id)
 	pr_info("amdgpu_plugin: Initialized kfd plugin restorer with ID = %d\n", id);
 
 	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
-	img_fd = openat(criu_get_image_dir(), img_path, O_RDONLY, 0600);
-	if (img_fd < 0) {
+
+	if (stat(img_path, &filestat) == -1) {
 		pr_perror("open(%s)", img_path);
 
 		/* This is restorer plugin for renderD nodes. Since criu doesn't
@@ -637,11 +665,6 @@ int amdgpu_plugin_restore_file(int id)
 		 * restore both, the kfd plugin gets called first.
 		 */
 		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
-		img_fd = openat(criu_get_image_dir(), img_path, O_RDONLY, 0600);
-		if (img_fd < 0) {
-			pr_perror("open(%s)", img_path);
-			return -ENOTSUP;
-		}
 
 		if (stat(img_path, &filestat) == -1)
 		{
@@ -656,16 +679,13 @@ int amdgpu_plugin_restore_file(int id)
 			return -ENOMEM;
 		}
 
-		len = read(img_fd, buf, filestat.st_size);
-		if (len <= 0) {
+		if (read_file(img_path, buf, filestat.st_size)) {
 			pr_perror("Unable to read from %s", img_path);
 			xfree(buf);
-			close(img_fd);
 			return -1;
 		}
-		close(img_fd);
 
-		rd = criu_render_node__unpack(NULL, len, buf);
+		rd = criu_render_node__unpack(NULL, filestat.st_size, buf);
 		if (rd == NULL) {
 			pr_perror("Unable to parse the KFD message %d", id);
 			xfree(buf);
@@ -684,32 +704,21 @@ int amdgpu_plugin_restore_file(int id)
 		pr_perror("failed to open kfd in plugin");
 		return -1;
 	}
-
 	pr_info("amdgpu_plugin: Opened kfd, fd = %d\n", fd);
-
-
-	if (stat(img_path, &filestat) == -1)
-	{
-		pr_perror("Failed to read file stats\n");
-		return -1;
-	}
 	pr_info("kfd img file size on disk = %ld\n", filestat.st_size);
 
 	buf = xmalloc(filestat.st_size);
 	if (!buf) {
 		pr_perror("Failed to allocate memory\n");
-		close(img_fd);
 		return -ENOMEM;
 	}
-	len = read(img_fd, buf, filestat.st_size);
-	if (len <= 0) {
-		pr_perror("Unable to read from %s", img_path);
+
+	if (read_file(img_path, buf, filestat.st_size)) {
 		xfree(buf);
-		close(img_fd);
 		return -1;
 	}
-	close(img_fd);
-	e = criu_kfd__unpack(NULL, len, buf);
+
+	e = criu_kfd__unpack(NULL, filestat.st_size, buf);
 	if (e == NULL) {
 		pr_err("Unable to parse the KFD message %#x\n", id);
 		xfree(buf);
@@ -922,11 +931,12 @@ int amdgpu_plugin_restore_file(int id)
 				       (e->bo_info_test[i])->bo_size);
 				munmap(addr, e->bo_info_test[i]->bo_size);
 			} else {
+				int mem_fd;
 				/* Use indirect host data path via /proc/pid/mem
 				 * on small pci bar GPUs or for Buffer Objects
 				 * that don't have HostAccess permissions.
 				 */
-				pr_info("amdgpu_plugin: using PROCPIDMEM to restore BO contents\n");
+				plugin_log_msg("amdgpu_plugin: using PROCPIDMEM to restore BO contents\n");
 				addr = mmap(NULL,
 					    (e->bo_info_test[i])->bo_size,
 					    PROT_NONE,
@@ -955,7 +965,7 @@ int amdgpu_plugin_restore_file(int id)
 					goto clean;
 				}
 
-				pr_perror("Opened %s file for pid = %d\n", fname, e->pid);
+				plugin_log_msg("Opened %s file for pid = %d\n", fname, e->pid);
 				free (fname);
 
 				if (lseek (mem_fd, (off_t) addr, SEEK_SET) == -1) {
@@ -965,7 +975,7 @@ int amdgpu_plugin_restore_file(int id)
 					goto clean;
 				}
 
-				pr_perror("Attempt writting now\n");
+				plugin_log_msg("Attempt writting now\n");
 				if (write(mem_fd, e->bo_info_test[i]->bo_rawdata.data,
 					  (e->bo_info_test[i])->bo_size) !=
 				    (e->bo_info_test[i])->bo_size) {

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -143,8 +143,13 @@ static int allocate_bo_info_test(CriuKfd *e, int num_bos, struct kfd_criu_bo_buc
 
 		bo_entries_test__init(botest);
 
-		botest->bo_rawdata.data = xmalloc((bo_bucket_ptr)[i].bo_size);
-		botest->bo_rawdata.len = (bo_bucket_ptr)[i].bo_size;
+		if ((bo_bucket_ptr)[i].bo_alloc_flags &
+		    KFD_IOC_ALLOC_MEM_FLAGS_VRAM ||
+		    (bo_bucket_ptr)[i].bo_alloc_flags &
+		    KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
+			botest->bo_rawdata.data = xmalloc((bo_bucket_ptr)[i].bo_size);
+			botest->bo_rawdata.len = (bo_bucket_ptr)[i].bo_size;
+		}
 
 		e->bo_info_test[i] = botest;
 		e->n_bo_info_test++;

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -13,6 +13,7 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <stdint.h>
+#include <pthread.h>
 
 #include "criu-plugin.h"
 #include "criu-amdgpu.pb-c.h"
@@ -510,6 +511,116 @@ void amdgpu_plugin_fini(int stage, int ret)
 
 CR_PLUGIN_REGISTER("amdgpu_plugin", amdgpu_plugin_init, amdgpu_plugin_fini)
 
+struct thread_data {
+	pthread_t thread;
+	uint64_t num_of_bos;
+	uint32_t gpu_id;
+	pid_t pid;
+	struct kfd_criu_bo_buckets *bo_buckets;
+	BoEntriesTest **bo_info_test;
+	int ret;
+};
+
+void *dump_bo_contents(void *_thread_data)
+{
+        int i, ret = 0;
+        int num_bos = 0;
+        struct thread_data* thread_data = (struct thread_data*) _thread_data;
+        struct kfd_criu_bo_buckets *bo_buckets = thread_data->bo_buckets;
+        BoEntriesTest **bo_info_test = thread_data->bo_info_test;
+
+        pr_info("amdgpu_plugin: Thread[0x%x] started\n", thread_data->gpu_id);
+        for (i = 0; i < thread_data->num_of_bos; i++) {
+		if (bo_buckets[i].gpu_id != thread_data->gpu_id)
+                       continue;
+
+		num_bos++;
+		if (bo_buckets[i].bo_alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM ||
+		    bo_buckets[i].bo_alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
+			char *fname;
+			int mem_fd;
+
+			if (bo_info_test[i]->bo_alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
+				int drm_fd;
+				void *addr;
+				struct tp_node *dev;
+
+				plugin_log_msg("amdgpu_plugin: large bar read possible\n");
+
+				dev = sys_get_node_by_gpu_id(&src_topology, bo_buckets[i].gpu_id);
+				if (!dev) {
+					ret = -EFAULT;
+					goto failed;
+				}
+
+				drm_fd = open_drm_render_device(dev->drm_render_minor);
+				if (drm_fd < 0) {
+					ret = -EFAULT;
+					goto failed;
+				}
+
+				addr = mmap(NULL,
+						bo_buckets[i].bo_size,
+						PROT_READ,
+						MAP_SHARED,
+						drm_fd,     /* mapping on local gpu for prototype */
+						bo_buckets[i].bo_offset);
+				if (addr == MAP_FAILED) {
+					pr_perror("amdgpu_plugin: mmap failed\n");
+					close(drm_fd);
+					goto failed;
+				}
+
+				/* direct memcpy is possible on large bars */
+				memcpy(bo_info_test[i]->bo_rawdata.data,
+					addr, bo_buckets[i].bo_size);
+				munmap(addr, bo_buckets[i].bo_size);
+				close(drm_fd);
+			} else {
+				plugin_log_msg("Now try reading BO contents with /proc/pid/mem");
+				if (asprintf (&fname, PROCPIDMEM, thread_data->pid) < 0) {
+					pr_perror("failed in asprintf, %s\n", fname);
+					ret = -1;
+					goto failed;
+				}
+
+				mem_fd = open (fname, O_RDONLY);
+				if (mem_fd < 0) {
+					pr_perror("Can't open %s for pid %d\n", fname, thread_data->pid);
+					free (fname);
+					ret = -1;
+					goto failed;
+				}
+
+				plugin_log_msg("Opened %s file for pid = %d\n", fname, thread_data->pid);
+				free (fname);
+				if (lseek (mem_fd, (off_t) bo_buckets[i].bo_addr, SEEK_SET) == -1) {
+					pr_perror("Can't lseek for bo_offset for pid = %d\n", thread_data->pid);
+					ret = -1;
+					goto failed;
+				}
+				plugin_log_msg("Try to read file now\n");
+
+				if (read(mem_fd, bo_info_test[i]->bo_rawdata.data,
+					bo_info_test[i]->bo_size) != bo_info_test[i]->bo_size) {
+					pr_perror("Can't read buffer\n");
+					ret = -1;
+					goto failed;
+				}
+
+				close(mem_fd);
+			} /* PROCPIDMEM read done */
+               }
+        }
+	pr_info("amdgpu_plugin: Thread[0x%x] done num_bos:%d ret:%d\n", thread_data->gpu_id, num_bos, ret);
+	thread_data->ret = ret;
+        return NULL;
+failed:
+        pr_info("amdgpu_plugin: Thread[0x%x] failed ret:%d\n", thread_data->gpu_id, ret);
+	thread_data->ret = ret;
+        return NULL;
+};
+
 int amdgpu_plugin_dump_file(int fd, int id)
 {
 	struct kfd_ioctl_criu_helper_args helper_args = {0};
@@ -523,6 +634,9 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	struct stat st, st_kfd;
 	unsigned char *buf;
 	size_t len;
+
+	struct thread_data thread_datas[NUM_OF_SUPPORTED_GPUS];
+	memset(thread_datas, 0, sizeof(thread_datas));
 
 	pr_debug("amdgpu_plugin: Enter cr_plugin_dump_file()- ID = 0x%x\n", id);
 	ret = 0;
@@ -717,97 +831,6 @@ int amdgpu_plugin_dump_file(int fd, int id)
 			ret = -EFAULT;
 			goto failed;
 		}
-
-		if ((bo_bucket_ptr)[i].bo_alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) {
-			pr_info("VRAM BO Found\n");
-		}
-
-		if ((bo_bucket_ptr)[i].bo_alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
-			pr_info("GTT BO Found\n");
-		}
-
-		if ((bo_bucket_ptr)[i].bo_alloc_flags &
-		    KFD_IOC_ALLOC_MEM_FLAGS_VRAM ||
-		    (bo_bucket_ptr)[i].bo_alloc_flags &
-		    KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
-			char *fname;
-			int mem_fd;
-
-			if ((e->bo_info_test[i])->bo_alloc_flags &
-			    KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
-				int drm_fd;
-				void *addr;
-				struct tp_node *tp_node;
-
-
-				plugin_log_msg("amdgpu_plugin: large bar read possible\n");
-
-				tp_node = sys_get_node_by_gpu_id(&src_topology, (e->bo_info_test[i])->gpu_id);
-				if (!tp_node) {
-					ret = -EFAULT;
-					goto failed;
-				}
-
-				drm_fd = open_drm_render_device(tp_node->drm_render_minor);
-				if (drm_fd < 0) {
-					ret = -EFAULT;
-					goto failed;
-				}
-
-				addr = mmap(NULL,
-					    (bo_bucket_ptr)[i].bo_size,
-					    PROT_READ,
-					    MAP_SHARED,
-					    drm_fd,	/* mapping on local gpu for prototype */
-					    (bo_bucket_ptr)[i].bo_offset);
-				if (addr == MAP_FAILED) {
-					pr_perror("amdgpu_plugin: mmap failed\n");
-					fd = -EBADFD;
-					close(drm_fd);
-					goto failed;
-				}
-
-				/* direct memcpy is possible on large bars */
-				memcpy((e->bo_info_test[i])->bo_rawdata.data,
-				       addr, bo_bucket_ptr[i].bo_size);
-				munmap(addr, bo_bucket_ptr[i].bo_size);
-				close(drm_fd);
-			} else {
-				plugin_log_msg("Now try reading BO contents with /proc/pid/mem");
-				if (asprintf (&fname, PROCPIDMEM, e->pid) < 0) {
-					pr_perror("failed in asprintf, %s\n", fname);
-					ret = -1;
-					goto failed;
-				}
-
-				mem_fd = open (fname, O_RDONLY);
-				if (mem_fd < 0) {
-					pr_perror("Can't open %s for pid %d\n", fname, e->pid);
-					free (fname);
-					ret = -1;
-					goto failed;
-				}
-
-				pr_info("Opened %s file for pid = %d\n", fname, e->pid);
-				free (fname);
-				if (lseek (mem_fd, (off_t) (bo_bucket_ptr)[i].bo_addr, SEEK_SET) == -1) {
-					pr_perror("Can't lseek for bo_offset for pid = %d\n", e->pid);
-					ret = -1;
-					goto failed;
-				}
-				pr_info("Try to read file now\n");
-
-				if (read(mem_fd, e->bo_info_test[i]->bo_rawdata.data,
-					 (e->bo_info_test[i])->bo_size) !=
-				    (e->bo_info_test[i])->bo_size) {
-					pr_perror("Can't read buffer\n");
-					ret = -1;
-					goto failed;
-				}
-
-				close(mem_fd);
-			} /* PROCPIDMEM read done */
-		}
 	}
 	e->num_of_bos = helper_args.num_of_bos;
 
@@ -833,6 +856,31 @@ int amdgpu_plugin_dump_file(int fd, int id)
 		  (bo_bucket_ptr)[i].bo_alloc_flags,
 		  (bo_bucket_ptr)[i].idr_handle);
 
+	}
+
+	for (int i = 0; i < helper_args.num_of_devices; i++) {
+		int ret_thread = 0;
+		thread_datas[i].gpu_id = devinfo_bucket_ptr[i].actual_gpu_id;
+		thread_datas[i].bo_buckets = bo_bucket_ptr;
+		thread_datas[i].bo_info_test = e->bo_info_test;
+		thread_datas[i].pid = e->pid;
+		thread_datas[i].num_of_bos = helper_args.num_of_bos;
+
+		ret_thread = pthread_create(&thread_datas[i].thread, NULL, dump_bo_contents, (void*) &thread_datas[i]);
+		if (ret_thread) {
+			pr_err("Failed to create thread[%i]\n", i);
+			ret = -EINVAL;
+			goto failed;
+		}
+	}
+
+	for (int i = 0; i < helper_args.num_of_devices; i++) {
+		pthread_join(thread_datas[i].thread, NULL);
+		pr_info("Thread[0x%x] finished ret:%d\n", thread_datas[i].gpu_id, thread_datas[i].ret);
+		if (thread_datas[i].ret) {
+			ret = -EIO;
+			goto failed;
+		}
 	}
 
 	ret = allocate_q_entries(e, helper_args.num_of_queues);

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -22,6 +22,7 @@
 #include "criu-log.h"
 
 #include "common/list.h"
+#include "amdgpu_plugin_topology.h"
 
 #define DRM_FIRST_RENDER_NODE 128
 #define DRM_LAST_RENDER_NODE 255
@@ -166,8 +167,12 @@ static void free_e(CriuKfd *e)
 			xfree(e->bo_info_test[i]);
 	}
 	for (int i = 0; i < e->n_devinfo_entries; i++) {
-		if (e->devinfo_entries[i])
+		if (e->devinfo_entries[i]) {
+			for (int j = 0; j < e->devinfo_entries[i]->n_iolinks; j++)
+				xfree(e->devinfo_entries[i]->iolinks[j]);
+
 			xfree(e->devinfo_entries[i]);
+		}
 	}
 	for (int i = 0; i < e->n_q_entries; i++) {
 		if (e->q_entries[i])
@@ -182,7 +187,7 @@ static void free_e(CriuKfd *e)
 
 static int allocate_devinfo_entries(CriuKfd *e, int num_of_devices)
 {
-	e->devinfo_entries = xmalloc(sizeof(DevinfoEntry) * num_of_devices);
+	e->devinfo_entries = xmalloc(sizeof(DevinfoEntry*) * num_of_devices);
 	if (!e->devinfo_entries) {
 		pr_err("Failed to allocate devinfo_entries\n");
 		return -1;
@@ -287,16 +292,151 @@ static int allocate_ev_entries(CriuKfd *e, int num_events)
 	return 0;
 }
 
+int topology_to_devinfo(struct tp_system *sys, struct kfd_criu_devinfo_bucket *devinfo_buckets,
+			struct device_maps *maps, DevinfoEntry **devinfos)
+{
+	struct tp_node *node;
+	uint32_t devinfo_index = 0;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		DevinfoEntry *devinfo = devinfos[devinfo_index++];
+
+		devinfo->node_id = node->id;
+
+		if (NODE_IS_GPU(node)) {
+			devinfo->gpu_id = maps_get_dest_gpu(&checkpoint_maps, node->gpu_id);
+			if (!devinfo->gpu_id)
+				return -EINVAL;
+
+			devinfo->simd_count = node->simd_count;
+			devinfo->mem_banks_count = node->mem_banks_count;
+			devinfo->caches_count = node->caches_count;
+			devinfo->io_links_count = node->io_links_count;
+			devinfo->max_waves_per_simd = node->max_waves_per_simd;
+			devinfo->lds_size_in_kb = node->lds_size_in_kb;
+			devinfo->num_gws = node->num_gws;
+			devinfo->wave_front_size = node->wave_front_size;
+			devinfo->array_count = node->array_count;
+			devinfo->simd_arrays_per_engine = node->simd_arrays_per_engine;
+			devinfo->cu_per_simd_array = node->cu_per_simd_array;
+			devinfo->simd_per_cu = node->simd_per_cu;
+			devinfo->max_slots_scratch_cu = node->max_slots_scratch_cu;
+			devinfo->vendor_id = node->vendor_id;
+			devinfo->device_id = node->device_id;
+			devinfo->domain = node->domain;
+			devinfo->drm_render_minor = node->drm_render_minor;
+			devinfo->hive_id = node->hive_id;
+			devinfo->num_sdma_engines = node->num_sdma_engines;
+			devinfo->num_sdma_xgmi_engines = node->num_sdma_xgmi_engines;
+			devinfo->num_sdma_queues_per_engine = node->num_sdma_queues_per_engine;
+			devinfo->num_cp_queues = node->num_cp_queues;
+			devinfo->fw_version = node->fw_version;
+			devinfo->capability = node->capability;
+			devinfo->sdma_fw_version = node->sdma_fw_version;
+			devinfo->vram_public = node->vram_public;
+			devinfo->vram_size = node->vram_size;
+		} else {
+			devinfo->cpu_cores_count = node->cpu_cores_count;
+		}
+
+		if (node->num_valid_iolinks) {
+			struct tp_iolink *iolink;
+			uint32_t iolink_index = 0;
+			devinfo->iolinks = xmalloc(sizeof(DevIolink*) * node->num_valid_iolinks);
+			if (!devinfo->iolinks)
+				return -ENOMEM;
+
+			list_for_each_entry(iolink, &node->iolinks, listm) {
+				if (!iolink->valid)
+					continue;
+
+				devinfo->iolinks[iolink_index] = xmalloc(sizeof(DevIolink));
+				if (!devinfo->iolinks[iolink_index])
+					return -ENOMEM;
+
+				dev_iolink__init(devinfo->iolinks[iolink_index]);
+
+				devinfo->iolinks[iolink_index]->type = iolink->type;
+				devinfo->iolinks[iolink_index]->node_to_id = iolink->node_to_id;
+				iolink_index++;
+			}
+			devinfo->n_iolinks = iolink_index;
+		}
+	}
+	return 0;
+}
+
+int devinfo_to_topology(DevinfoEntry *devinfos[], uint32_t num_devices, struct tp_system *sys)
+{
+	for (int i = 0; i < num_devices; i++) {
+		struct tp_node *node;
+		DevinfoEntry *devinfo = devinfos[i];
+
+		node = sys_add_node(sys, devinfo->node_id, devinfo->gpu_id);
+		if (!node)
+			return -ENOMEM;
+
+		if (devinfo->cpu_cores_count) {
+			node->cpu_cores_count = devinfo->cpu_cores_count;
+		} else {
+			node->simd_count = devinfo->simd_count;
+			node->mem_banks_count = devinfo->mem_banks_count;
+			node->caches_count = devinfo->caches_count;
+			node->io_links_count = devinfo->io_links_count;
+			node->max_waves_per_simd = devinfo->max_waves_per_simd;
+			node->lds_size_in_kb = devinfo->lds_size_in_kb;
+			node->num_gws = devinfo->num_gws;
+			node->wave_front_size = devinfo->wave_front_size;
+			node->array_count = devinfo->array_count;
+			node->simd_arrays_per_engine = devinfo->simd_arrays_per_engine;
+			node->cu_per_simd_array = devinfo->cu_per_simd_array;
+			node->simd_per_cu = devinfo->simd_per_cu;
+			node->max_slots_scratch_cu = devinfo->max_slots_scratch_cu;
+			node->vendor_id = devinfo->vendor_id;
+			node->device_id = devinfo->device_id;
+			node->domain = devinfo->domain;
+			node->drm_render_minor = devinfo->drm_render_minor;
+			node->hive_id = devinfo->hive_id;
+			node->num_sdma_engines = devinfo->num_sdma_engines;
+			node->num_sdma_xgmi_engines = devinfo->num_sdma_xgmi_engines;
+			node->num_sdma_queues_per_engine = devinfo->num_sdma_queues_per_engine;
+			node->num_cp_queues = devinfo->num_cp_queues;
+			node->fw_version = devinfo->fw_version;
+			node->capability = devinfo->capability;
+			node->sdma_fw_version = devinfo->sdma_fw_version;
+			node->vram_public = devinfo->vram_public;
+			node->vram_size = devinfo->vram_size;
+		}
+
+		for (int j = 0; j < devinfo->n_iolinks; j++) {
+			struct tp_iolink *iolink;
+			DevIolink *devlink = (devinfo->iolinks[j]);
+
+			iolink = node_add_iolink(node, devlink->type, devlink->node_to_id);
+			if (!iolink)
+				return -ENOMEM;
+
+		}
+	}
+	return 0;
+}
+
 int amdgpu_plugin_init(int stage)
 {
 	pr_info("amdgpu_plugin: initialized:  %s (AMDGPU/KFD)\n",
 						CR_PLUGIN_DESC.name);
+
+	topology_init(&src_topology);
+	topology_init(&dest_topology);
 	return 0;
 }
 
 void amdgpu_plugin_fini(int stage, int ret)
 {
 	pr_info("amdgpu_plugin: finished  %s (AMDGPU/KFD)\n", CR_PLUGIN_DESC.name);
+
+	topology_free(&src_topology);
+	topology_free(&dest_topology);
 }
 
 CR_PLUGIN_REGISTER("amdgpu_plugin", amdgpu_plugin_init, amdgpu_plugin_fini)
@@ -329,6 +469,16 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	ret = stat("/dev/kfd", &st_kfd);
 	if (ret == -1) {
 		pr_perror("amdgpu_plugin: fstat error for /dev/kfd\n");
+		return -1;
+	}
+
+	if (topology_parse(&src_topology, "Checkpoint"))
+		return -1;
+
+	/* We call topology_determine_iolinks to validate io_links. If io_links are not valid
+	   we do not store them inside the checkpointed images */
+	if (topology_determine_iolinks(&src_topology)) {
+		pr_err("Failed to determine iolinks from topology\n");
 		return -1;
 	}
 
@@ -461,11 +611,17 @@ int amdgpu_plugin_dump_file(int fd, int id)
 		if (devinfo_bucket_ptr[i].user_gpu_id != devinfo_bucket_ptr[i].actual_gpu_id) {
 			pr_err("Checkpoint-Restore on different node not supported yet\n");
 			ret = -ENOTSUP;
-			goto failed;
 		}
 	}
 
-	e->num_of_devices = args.num_of_devices;
+	/* Store local topology information */
+	ret = topology_to_devinfo(&src_topology, devinfo_bucket_ptr,
+					&checkpoint_maps, e->devinfo_entries);
+	if (ret)
+		goto failed;
+
+	e->num_of_gpus = args.num_of_devices;
+	e->num_of_cpus = src_topology.num_nodes - args.num_of_devices;
 
 	ret = allocate_bo_info_test(e, helper_args.num_of_bos, bo_bucket_ptr);
 	if (ret)
@@ -726,6 +882,7 @@ int amdgpu_plugin_restore_file(int id)
 	char *fname;
 	CriuKfd *e;
 	void *addr;
+	int j;
 
 	pr_info("amdgpu_plugin: Initialized kfd plugin restorer with ID = %d\n", id);
 
@@ -804,26 +961,42 @@ int amdgpu_plugin_restore_file(int id)
 
 	plugin_log_msg("amdgpu_plugin: read image file data\n");
 
-	devinfo_bucket_ptr = xmalloc(e->num_of_devices * sizeof(struct kfd_criu_devinfo_bucket));
+	if (devinfo_to_topology(e->devinfo_entries, e->num_of_gpus + e->num_of_cpus, &src_topology)) {
+		pr_err("Failed to convert stored device information to topology\n");
+		xfree(buf);
+		return -1;
+	}
+
+	if (topology_parse(&dest_topology, "Local")) {
+		pr_err("Failed to parse local system topology\n");
+		xfree(buf);
+		return -1;
+	}
+
+	args.num_of_devices = e->num_of_gpus;
+
+	devinfo_bucket_ptr = xmalloc(args.num_of_devices * sizeof(struct kfd_criu_devinfo_bucket));
 	if (!devinfo_bucket_ptr) {
 		fd = -EBADFD;
 		goto clean;
 	}
 	args.kfd_criu_devinfo_buckets_ptr = (uintptr_t)devinfo_bucket_ptr;
 
-	for (int i = 0; i < e->num_of_devices; i++) {
-		devinfo_bucket_ptr[i].user_gpu_id = e->devinfo_entries[i]->gpu_id;
+	j = 0;
+	for (int i = 0; i < e->num_of_gpus + e->num_of_cpus; i++) {
+		devinfo_bucket_ptr[j].user_gpu_id = e->devinfo_entries[i]->gpu_id;
 
 		// for now always bind the VMA to /dev/dri/renderD128
 		// this should allow us later to restore BO on a different GPU node.
-		devinfo_bucket_ptr[i].drm_fd = open_drm_render_device(i + DRM_FIRST_RENDER_NODE);
-		if (!devinfo_bucket_ptr[i].drm_fd) {
+		devinfo_bucket_ptr[j].drm_fd = open_drm_render_device(i + DRM_FIRST_RENDER_NODE);
+		if (!devinfo_bucket_ptr[j].drm_fd) {
 			pr_perror("amdgpu_plugin: Can't pass NULL drm render fd to driver\n");
 			fd = -EBADFD;
 			goto clean;
 		} else {
-			pr_info("amdgpu_plugin: passing drm render fd = %d to driver\n", devinfo_bucket_ptr[i].drm_fd);
+			pr_info("amdgpu_plugin: passing drm render fd = %d to driver\n", devinfo_bucket_ptr[j].drm_fd);
 		}
+		j++;
 	}
 
 	for (int i = 0; i < e->num_of_bos; i++ )
@@ -1116,7 +1289,7 @@ int amdgpu_plugin_restore_file(int id)
 		}
 	} /* mmap done for VRAM BO */
 
-	for (int i = 0; i < e->num_of_devices; i++) {
+	for (int i = 0; i < e->num_of_gpus; i++) {
 		if (devinfo_bucket_ptr[i].drm_fd >= 0)
 			close(devinfo_bucket_ptr[i].drm_fd);
 	}

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -49,6 +49,7 @@ struct vma_metadata {
 	uint64_t old_pgoff;
 	uint64_t new_pgoff;
 	uint64_t vma_entry;
+	uint32_t new_minor;
 };
 
 static LIST_HEAD(update_vma_info_list);
@@ -428,12 +429,19 @@ int amdgpu_plugin_init(int stage)
 
 	topology_init(&src_topology);
 	topology_init(&dest_topology);
+
+	maps_init(&checkpoint_maps);
+	maps_init(&restore_maps);
+
 	return 0;
 }
 
 void amdgpu_plugin_fini(int stage, int ret)
 {
 	pr_info("amdgpu_plugin: finished  %s (AMDGPU/KFD)\n", CR_PLUGIN_DESC.name);
+
+	maps_free(&checkpoint_maps);
+	maps_free(&restore_maps);
 
 	topology_free(&src_topology);
 	topology_free(&dest_topology);
@@ -449,12 +457,10 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	struct kfd_criu_bo_buckets *bo_bucket_ptr;
 	struct kfd_criu_q_bucket *q_bucket_ptr;
 	struct kfd_criu_ev_bucket *ev_buckets_ptr = NULL;
-	int ret, drm_fd;
+	int ret;
 	char img_path[PATH_MAX];
 	struct stat st, st_kfd;
 	unsigned char *buf;
-	char fd_path[128];
-	void *addr;
 	size_t len;
 
 	pr_debug("amdgpu_plugin: Enter cr_plugin_dump_file()- ID = 0x%x\n", id);
@@ -485,16 +491,26 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	/* Check whether this plugin was called for kfd or render nodes */
 	if (major(st.st_rdev) != major(st_kfd.st_rdev) ||
 		 minor(st.st_rdev) != 0) {
-		/* This is RenderD dumper plugin, for now just save renderD
-		 * minor number to be used during restore. In later phases this
-		 * needs to save more data for video decode etc.
-		 */
-
+		/* This is RenderD dumper plugin, save the render minor and gpu_id */
 		CriuRenderNode rd = CRIU_RENDER_NODE__INIT;
-		pr_info("amdgpu_plugin: Dumper called for /dev/dri/renderD%d, FD = %d, ID = %d\n", minor(st.st_rdev), fd, id);
+		struct tp_node *tp_node;
 
-		rd.minor_number = minor(st.st_rdev);
-		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
+		pr_info("amdgpu_plugin: Dumper called for /dev/dri/renderD%d, FD = %d, ID = %d\n",
+			minor(st.st_rdev), fd, id);
+
+		tp_node = sys_get_node_by_render_minor(&src_topology, minor(st.st_rdev));
+		if (!tp_node) {
+			pr_err("amdgpu_plugin: Failed to find a device with minor number = %d\n",
+				minor(st.st_rdev));
+
+			return -EFAULT;
+		}
+
+		rd.gpu_id = maps_get_dest_gpu(&checkpoint_maps, tp_node->gpu_id);
+		if (!rd.gpu_id) {
+			ret = -EFAULT;
+			goto failed;
+		}
 
 		len = criu_render_node__get_packed_size(&rd);
 		buf = xmalloc(len);
@@ -502,14 +518,17 @@ int amdgpu_plugin_dump_file(int fd, int id)
 			return -ENOMEM;
 
 		criu_render_node__pack(&rd, buf);
+
+		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
 		ret = write_file(img_path,  buf, len);
-		if (ret)
-			ret = -1;
+		if (ret) {
+			xfree(buf);
+			return ret;
+		}
 
 		xfree(buf);
 
-		/* Need to return success here so that criu can call plugins for
-		 * renderD nodes */
+		/* Need to return success here so that criu can call plugins for renderD nodes */
 		return ret;
 	}
 
@@ -594,24 +613,19 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	criu_kfd__init(e);
 	e->pid = helper_args.task_pid;
 
-	ret = allocate_devinfo_entries(e, args.num_of_devices);
-	if (ret) {
-		ret = -ENOMEM;
-		goto failed;
-	}
-
 	/* When checkpointing on a node where there was already a checkpoint-restore before, the
 	 * user_gpu_id and actual_gpu_id will be different.
 	 *
-	 * For now, we assume the user_gpu_id and actual_gpu_id is the same. Once we support
-	 * restoring on a different node, then we will have a user_gpu_id to actual_gpu_id mapping.
-	 */
-	for (int i = 0; i < args.num_of_devices; i++) {
-		e->devinfo_entries[i]->gpu_id = devinfo_bucket_ptr[i].user_gpu_id;
-		if (devinfo_bucket_ptr[i].user_gpu_id != devinfo_bucket_ptr[i].actual_gpu_id) {
-			pr_err("Checkpoint-Restore on different node not supported yet\n");
-			ret = -ENOTSUP;
-		}
+	 * We store the user_gpu_id in the stored image files so that the stored images always have
+	 * the gpu_id's of the node where the application was first launched. */
+	for (int i = 0; i < args.num_of_devices; i++)
+		maps_add_gpu_entry(&checkpoint_maps, devinfo_bucket_ptr[i].actual_gpu_id,
+				   devinfo_bucket_ptr[i].user_gpu_id);
+
+	ret = allocate_devinfo_entries(e, src_topology.num_nodes);
+	if (ret) {
+		ret = -ENOMEM;
+		goto failed;
 	}
 
 	/* Store local topology information */
@@ -627,22 +641,21 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	if (ret)
 		return -1;
 
-	sprintf(fd_path, "/dev/dri/renderD%d", DRM_FIRST_RENDER_NODE);
-	drm_fd = open(fd_path, O_RDWR | O_CLOEXEC);
-	if (drm_fd < 0) {
-		pr_perror("amdgpu_plugin: failed to open drm fd for %s\n", fd_path);
-		return -1;
-	}
-
 	for (int i = 0; i < helper_args.num_of_bos; i++)
 	{
 		(e->bo_info_test[i])->bo_addr = (bo_bucket_ptr)[i].bo_addr;
 		(e->bo_info_test[i])->bo_size = (bo_bucket_ptr)[i].bo_size;
 		(e->bo_info_test[i])->bo_offset = (bo_bucket_ptr)[i].bo_offset;
-		(e->bo_info_test[i])->gpu_id = (bo_bucket_ptr)[i].gpu_id;
 		(e->bo_info_test[i])->bo_alloc_flags = (bo_bucket_ptr)[i].bo_alloc_flags;
 		(e->bo_info_test[i])->idr_handle = (bo_bucket_ptr)[i].idr_handle;
 		(e->bo_info_test[i])->user_addr = (bo_bucket_ptr)[i].user_addr;
+
+		e->bo_info_test[i]->gpu_id = maps_get_dest_gpu(&checkpoint_maps,
+							       bo_bucket_ptr[i].gpu_id);
+		if (!e->bo_info_test[i]->gpu_id) {
+			ret = -EFAULT;
+			goto failed;
+		}
 
 		if ((bo_bucket_ptr)[i].bo_alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) {
 			pr_info("VRAM BO Found\n");
@@ -661,7 +674,25 @@ int amdgpu_plugin_dump_file(int fd, int id)
 
 			if ((e->bo_info_test[i])->bo_alloc_flags &
 			    KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
-				pr_info("amdgpu_plugin: large bar read possible\n");
+				int drm_fd;
+				void *addr;
+				struct tp_node *tp_node;
+
+
+				plugin_log_msg("amdgpu_plugin: large bar read possible\n");
+
+				tp_node = sys_get_node_by_gpu_id(&src_topology, (e->bo_info_test[i])->gpu_id);
+				if (!tp_node) {
+					ret = -EFAULT;
+					goto failed;
+				}
+
+				drm_fd = open_drm_render_device(tp_node->drm_render_minor);
+				if (drm_fd < 0) {
+					ret = -EFAULT;
+					goto failed;
+				}
+
 				addr = mmap(NULL,
 					    (bo_bucket_ptr)[i].bo_size,
 					    PROT_READ,
@@ -679,9 +710,9 @@ int amdgpu_plugin_dump_file(int fd, int id)
 				memcpy((e->bo_info_test[i])->bo_rawdata.data,
 				       addr, bo_bucket_ptr[i].bo_size);
 				munmap(addr, bo_bucket_ptr[i].bo_size);
-
+				close(drm_fd);
 			} else {
-				pr_info("Now try reading BO contents with /proc/pid/mem");
+				plugin_log_msg("Now try reading BO contents with /proc/pid/mem");
 				if (asprintf (&fname, PROCPIDMEM, e->pid) < 0) {
 					pr_perror("failed in asprintf, %s\n", fname);
 					ret = -1;
@@ -717,8 +748,6 @@ int amdgpu_plugin_dump_file(int fd, int id)
 			} /* PROCPIDMEM read done */
 		}
 	}
-	close(drm_fd);
-
 	e->num_of_bos = helper_args.num_of_bos;
 
 	plugin_log_msg("Dumping bo_info_test \n");
@@ -764,7 +793,12 @@ int amdgpu_plugin_dump_file(int fd, int id)
 			q_bucket_ptr[i].q_id,
 			q_bucket_ptr[i].q_address);
 
-		e->q_entries[i]->gpu_id = q_bucket_ptr[i].gpu_id;
+		e->q_entries[i]->gpu_id = maps_get_dest_gpu(&checkpoint_maps, q_bucket_ptr[i].gpu_id);
+		if (!e->q_entries[i]->gpu_id) {
+			ret = -EFAULT;
+			goto failed;
+		}
+
 		e->q_entries[i]->type = q_bucket_ptr[i].type;
 		e->q_entries[i]->format = q_bucket_ptr[i].format;
 		e->q_entries[i]->q_id = q_bucket_ptr[i].q_id;
@@ -817,8 +851,15 @@ int amdgpu_plugin_dump_file(int fd, int id)
 					ev_buckets_ptr[i].memory_exception_data.failure.NoExecute;
 				e->ev_entries[i]->mem_exc_va =
 					ev_buckets_ptr[i].memory_exception_data.va;
-				e->ev_entries[i]->mem_exc_gpu_id =
-					ev_buckets_ptr[i].memory_exception_data.gpu_id;
+				if (ev_buckets_ptr[i].memory_exception_data.gpu_id) {
+					e->ev_entries[i]->mem_exc_gpu_id =
+						maps_get_dest_gpu(&checkpoint_maps,
+						ev_buckets_ptr[i].memory_exception_data.gpu_id);
+					if (!&e->ev_entries[i]->mem_exc_gpu_id) {
+						ret = -EFAULT;
+						goto failed;
+					}
+				}
 			} else if (e->ev_entries[i]->type == KFD_IOC_EVENT_HW_EXCEPTION) {
 				e->ev_entries[i]->hw_exc_reset_type =
 					ev_buckets_ptr[i].hw_exception_data.reset_type;
@@ -826,8 +867,16 @@ int amdgpu_plugin_dump_file(int fd, int id)
 					ev_buckets_ptr[i].hw_exception_data.reset_cause;
 				e->ev_entries[i]->hw_exc_memory_lost =
 					ev_buckets_ptr[i].hw_exception_data.memory_lost;
-				e->ev_entries[i]->hw_exc_gpu_id =
-					ev_buckets_ptr[i].hw_exception_data.gpu_id;
+				if (ev_buckets_ptr[i].hw_exception_data.gpu_id) {
+					e->ev_entries[i]->hw_exc_gpu_id =
+						maps_get_dest_gpu(&checkpoint_maps,
+						ev_buckets_ptr[i].hw_exception_data.gpu_id);
+
+					if (!e->ev_entries[i]->hw_exc_gpu_id) {
+						ret = -EFAULT;
+						goto failed;
+					}
+				}
 			}
 		}
 	}
@@ -889,14 +938,15 @@ int amdgpu_plugin_restore_file(int id)
 	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
 
 	if (stat(img_path, &filestat) == -1) {
+		struct tp_node *tp_node;
+		uint32_t target_gpu_id;
+
 		pr_perror("open(%s)", img_path);
 
-		/* This is restorer plugin for renderD nodes. Since criu doesn't
-		 * gurantee that they will be called before the plugin is called
-		 * for kfd file descriptor, we need to make sure we open the render
-		 * nodes only once and before /dev/kfd is open, the render nodes
-		 * are open too. Generally, it is seen that during checkpoint and
-		 * restore both, the kfd plugin gets called first.
+		/* This is restorer plugin for renderD nodes. Criu doesn't guarantee that they will
+		 * be called before the plugin is called for kfd file descriptor.
+		 * TODO: Currently, this code will only work if this function is called for /dev/kfd
+		 * first as we assume restore_maps is already filled. Need to fix this later.
 		 */
 		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
 
@@ -922,12 +972,31 @@ int amdgpu_plugin_restore_file(int id)
 		rd = criu_render_node__unpack(NULL, filestat.st_size, buf);
 		if (rd == NULL) {
 			pr_perror("Unable to parse the KFD message %d", id);
-			xfree(buf);
-			return -1;
+			fd = -EBADFD;
+			goto fail;
 		}
 
-		pr_info("amdgpu_plugin: render node minor num = %d\n", rd->minor_number);
-		fd = open_drm_render_device(rd->minor_number);
+		pr_info("amdgpu_plugin: render node gpu_id = 0x%04x\n", rd->gpu_id);
+
+		target_gpu_id = maps_get_dest_gpu(&restore_maps, rd->gpu_id);
+		if (!target_gpu_id) {
+			fd = -EBADFD;
+			goto fail;
+		}
+
+		tp_node = sys_get_node_by_gpu_id(&dest_topology, target_gpu_id);
+		if (!tp_node) {
+			fd = -EBADFD;
+			goto fail;
+		}
+
+		pr_info("amdgpu_plugin: render node destination gpu_id = 0x%04x\n", tp_node->gpu_id);
+
+		fd = open_drm_render_device(tp_node->drm_render_minor);
+		if (fd < 0)
+			pr_err("amdgpu_plugin: Failed to open render device (minor:%d)\n",
+									tp_node->drm_render_minor);
+fail:
 		criu_render_node__free_unpacked(rd,  NULL);
 		xfree(buf);
 		return fd;
@@ -982,20 +1051,42 @@ int amdgpu_plugin_restore_file(int id)
 	}
 	args.kfd_criu_devinfo_buckets_ptr = (uintptr_t)devinfo_bucket_ptr;
 
+	if (set_restore_gpu_maps(&src_topology, &dest_topology, &restore_maps)) {
+		fd = -EBADFD;
+		goto clean;
+	}
+
 	j = 0;
 	for (int i = 0; i < e->num_of_gpus + e->num_of_cpus; i++) {
+		struct tp_node *tp_node;
+		int drm_fd;
+
+		if (!e->devinfo_entries[i]->gpu_id)
+			continue;
+
 		devinfo_bucket_ptr[j].user_gpu_id = e->devinfo_entries[i]->gpu_id;
 
-		// for now always bind the VMA to /dev/dri/renderD128
-		// this should allow us later to restore BO on a different GPU node.
-		devinfo_bucket_ptr[j].drm_fd = open_drm_render_device(i + DRM_FIRST_RENDER_NODE);
-		if (!devinfo_bucket_ptr[j].drm_fd) {
-			pr_perror("amdgpu_plugin: Can't pass NULL drm render fd to driver\n");
+		devinfo_bucket_ptr[j].actual_gpu_id =
+				maps_get_dest_gpu(&restore_maps, e->devinfo_entries[i]->gpu_id);
+
+		if (!devinfo_bucket_ptr[j].actual_gpu_id) {
 			fd = -EBADFD;
 			goto clean;
-		} else {
-			pr_info("amdgpu_plugin: passing drm render fd = %d to driver\n", devinfo_bucket_ptr[j].drm_fd);
 		}
+
+		tp_node = sys_get_node_by_gpu_id(&dest_topology,
+							devinfo_bucket_ptr[j].actual_gpu_id);
+		if (!tp_node) {
+			fd = -EBADFD;
+			goto clean;
+		}
+
+		drm_fd = open_drm_render_device(tp_node->drm_render_minor);
+		if (drm_fd < 0) {
+			fd = -EBADFD;
+			goto clean;
+		}
+		devinfo_bucket_ptr[j].drm_fd = drm_fd;
 		j++;
 	}
 
@@ -1026,10 +1117,16 @@ int amdgpu_plugin_restore_file(int id)
 		(bo_bucket_ptr)[i].bo_addr = (e->bo_info_test[i])->bo_addr;
 		(bo_bucket_ptr)[i].bo_size = (e->bo_info_test[i])->bo_size;
 		(bo_bucket_ptr)[i].bo_offset = (e->bo_info_test[i])->bo_offset;
-		(bo_bucket_ptr)[i].gpu_id = (e->bo_info_test[i])->gpu_id;
 		(bo_bucket_ptr)[i].bo_alloc_flags = (e->bo_info_test[i])->bo_alloc_flags;
 		(bo_bucket_ptr)[i].idr_handle = (e->bo_info_test[i])->idr_handle;
 		(bo_bucket_ptr)[i].user_addr = (e->bo_info_test[i])->user_addr;
+
+		bo_bucket_ptr[i].gpu_id =
+				maps_get_dest_gpu(&restore_maps, e->bo_info_test[i]->gpu_id);
+		if (!bo_bucket_ptr[i].gpu_id) {
+			fd = -EBADFD;
+			goto clean;
+		}
 	}
 
 	args.num_of_bos = e->num_of_bos;
@@ -1042,7 +1139,6 @@ int amdgpu_plugin_restore_file(int id)
 	}
 
 	args.restored_bo_array_ptr = (uint64_t)restored_bo_offsets_array;
-	args.num_of_devices = 1; /* Only support 1 gpu for now */
 
 	q_bucket_ptr = xmalloc(e->num_of_queues * sizeof(struct kfd_criu_q_bucket));
         if (!q_bucket_ptr) {
@@ -1084,7 +1180,12 @@ int amdgpu_plugin_restore_file(int id)
 			e->q_entries[i]->mqd.len,
 			e->q_entries[i]->ctl_stack.len);
 
-		q_bucket_ptr[i].gpu_id = e->q_entries[i]->gpu_id;
+		q_bucket_ptr[i].gpu_id = maps_get_dest_gpu(&restore_maps, e->q_entries[i]->gpu_id);
+		if (!q_bucket_ptr[i].gpu_id) {
+			fd = -EBADFD;
+			goto clean;
+		}
+
 		q_bucket_ptr[i].type = e->q_entries[i]->type;
 		q_bucket_ptr[i].format = e->q_entries[i]->format;
 		q_bucket_ptr[i].q_id = e->q_entries[i]->q_id;
@@ -1157,9 +1258,15 @@ int amdgpu_plugin_restore_file(int id)
 						e->ev_entries[i]->mem_exc_fail_no_execute;
 				ev_bucket_ptr[i].memory_exception_data.va =
 						e->ev_entries[i]->mem_exc_va;
-				ev_bucket_ptr[i].memory_exception_data.gpu_id =
-						e->ev_entries[i]->mem_exc_gpu_id;
-
+				if (e->ev_entries[i]->mem_exc_gpu_id) {
+					ev_bucket_ptr[i].memory_exception_data.gpu_id =
+						maps_get_dest_gpu(&restore_maps,
+								  e->ev_entries[i]->mem_exc_gpu_id);
+					if (!ev_bucket_ptr[i].memory_exception_data.gpu_id) {
+						fd = -EBADFD;
+						goto clean;
+					}
+				}
 			} else if (e->ev_entries[i]->type == KFD_IOC_EVENT_HW_EXCEPTION) {
 				ev_bucket_ptr[i].hw_exception_data.reset_type =
 					e->ev_entries[i]->hw_exc_reset_type;
@@ -1167,8 +1274,17 @@ int amdgpu_plugin_restore_file(int id)
 					e->ev_entries[i]->hw_exc_reset_cause;
 				ev_bucket_ptr[i].hw_exception_data.memory_lost =
 					e->ev_entries[i]->hw_exc_memory_lost;
-				ev_bucket_ptr[i].hw_exception_data.gpu_id =
-					e->ev_entries[i]->hw_exc_gpu_id;
+
+				if (e->ev_entries[i]->hw_exc_gpu_id) {
+					ev_bucket_ptr[i].hw_exception_data.gpu_id =
+						maps_get_dest_gpu(&restore_maps,
+								 e->ev_entries[i]->hw_exc_gpu_id);
+
+					if (!ev_bucket_ptr[i].memory_exception_data.gpu_id) {
+						fd = -EBADFD;
+						goto clean;
+					}
+				}
 			}
 		}
 
@@ -1190,31 +1306,64 @@ int amdgpu_plugin_restore_file(int id)
 			 KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP |
 			 KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL)) {
 
+			struct tp_node *tp_node;
 			struct vma_metadata *vma_md;
 			vma_md = xmalloc(sizeof(*vma_md));
 			if (!vma_md)
 				return -ENOMEM;
 
-			vma_md->old_pgoff = (e->bo_info_test[i])->bo_offset;
-			vma_md->vma_entry = (e->bo_info_test[i])->bo_addr;
+			memset(vma_md, 0, sizeof(*vma_md));
+
+			vma_md->old_pgoff = bo_bucket_ptr[i].bo_offset;
+			vma_md->vma_entry = bo_bucket_ptr[i].bo_addr;
+
+			tp_node = sys_get_node_by_gpu_id(&dest_topology, bo_bucket_ptr[i].gpu_id);
+			if (!tp_node) {
+				pr_err("Failed to find node with gpu_id:0x%04x\n", bo_bucket_ptr[i].gpu_id);
+				fd = -EBADFD;
+				goto clean;
+			}
+			vma_md->new_minor = tp_node->drm_render_minor;
+
 			vma_md->new_pgoff = restored_bo_offsets_array[i];
+
+			plugin_log_msg("amdgpu_plugin: adding vma_entry:addr:0x%lx old-off:0x%lx \
+					new_off:0x%lx new_minor:%d\n", vma_md->vma_entry,
+					vma_md->old_pgoff, vma_md->new_pgoff, vma_md->new_minor);
+
 			list_add_tail(&vma_md->list, &update_vma_info_list);
 		}
 
 		if (e->bo_info_test[i]->bo_alloc_flags &
 			(KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_GTT)) {
 
-			pr_info("amdgpu_plugin: Trying mmap in stage 2\n");
+			int j;
+			int drm_render_fd = -EBADFD;
+
+			for (j = 0; j < e->num_of_gpus; j++) {
+				if (devinfo_bucket_ptr[j].actual_gpu_id == bo_bucket_ptr[i].gpu_id) {
+					drm_render_fd = devinfo_bucket_ptr[j].drm_fd;
+					break;
+				}
+			}
+
+			if (drm_render_fd < 0) {
+				pr_err("amdgpu_plugin: bad fd for render node\n");
+				fd = -EBADFD;
+				goto clean;
+			}
+
+			plugin_log_msg("amdgpu_plugin: Trying mmap in stage 2\n");
 			if ((e->bo_info_test[i])->bo_alloc_flags &
 			    KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC ||
 			    (e->bo_info_test[i])->bo_alloc_flags &
 			    KFD_IOC_ALLOC_MEM_FLAGS_GTT ) {
-				pr_info("amdgpu_plugin: large bar write possible\n");
+				plugin_log_msg("amdgpu_plugin: large bar write possible\n");
 				addr = mmap(NULL,
 					    (e->bo_info_test[i])->bo_size,
 					    PROT_WRITE,
 					    MAP_SHARED,
-					    devinfo_bucket_ptr[0].drm_fd,
+					    drm_render_fd,
 					    restored_bo_offsets_array[i]);
 				if (addr == MAP_FAILED) {
 					pr_perror("amdgpu_plugin: mmap failed\n");
@@ -1237,7 +1386,7 @@ int amdgpu_plugin_restore_file(int id)
 					    (e->bo_info_test[i])->bo_size,
 					    PROT_NONE,
 					    MAP_SHARED,
-					    devinfo_bucket_ptr[0].drm_fd,
+					    drm_render_fd,
 					    restored_bo_offsets_array[i]);
 				if (addr == MAP_FAILED) {
 					pr_perror("amdgpu_plugin: mmap failed\n");
@@ -1318,18 +1467,49 @@ int amdgpu_plugin_update_vmamap(const char *old_path, char *new_path, const uint
 				const uint64_t old_offset, uint64_t *new_offset)
 {
 	struct vma_metadata *vma_md;
+	char path[PATH_MAX];
+	char *p_begin;
+	char *p_end;
+	bool is_kfd = false, is_renderD = false;
+
 
 	pr_info("amdgpu_plugin: Enter %s\n", __func__);
 
-	/* Once we support restoring on different nodes, new_path may be different from old_path
-	 * because the restored gpu may have a different minor number.
-	 * For now, we are restoring on the same gpu, so new_path is the same as old_path */
+	strncpy(path, old_path, sizeof(path));
 
-	strcpy(new_path, old_path);
+	p_begin = path;
+	p_end = p_begin + strlen(path);
+
+	/*
+	 * Paths sometimes have double forward slashes (e.g //dev/dri/renderD*)
+	 * replace all '//' with '/'.
+	 */
+	while (p_begin < p_end - 1) {
+		if (*p_begin == '/' && *(p_begin + 1) == '/')
+			memmove(p_begin, p_begin + 1, p_end - p_begin);
+		else
+			p_begin++;
+	}
+
+	if (!strncmp(path, "/dev/dri/renderD", strlen("/dev/dri/renderD")))
+		is_renderD = true;
+
+	if (!strcmp(path, "/dev/kfd"))
+		is_kfd = true;
+
+	if (!is_renderD && !is_kfd) {
+		pr_info("Skipping unsupported path:%s addr:%lx old_offset:%lx\n", old_path, addr, old_offset);
+		return 0;
+	}
 
 	list_for_each_entry(vma_md, &update_vma_info_list, list) {
 		if (addr == vma_md->vma_entry && old_offset == vma_md->old_pgoff) {
 			*new_offset = vma_md->new_pgoff;
+
+			if (is_renderD)
+				sprintf(new_path, "/dev/dri/renderD%d", vma_md->new_minor);
+			else
+				strcpy(new_path, old_path);
 
 			pr_info("amdgpu_plugin: old_pgoff= 0x%lx new_pgoff = 0x%lx old_path = %s new_path = %s\n",
 				vma_md->old_pgoff, vma_md->new_pgoff, old_path, new_path);

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -1014,7 +1014,8 @@ int amdgpu_plugin_restore_file(int id)
 		if (e->bo_info_test[i]->bo_alloc_flags &
 			(KFD_IOC_ALLOC_MEM_FLAGS_VRAM |
 			 KFD_IOC_ALLOC_MEM_FLAGS_GTT |
-			 KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP)) {
+			 KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP |
+			 KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL)) {
 
 			struct vma_metadata *vma_md;
 			vma_md = xmalloc(sizeof(*vma_md));

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -1,0 +1,785 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <linux/limits.h>
+
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <stdint.h>
+
+#include "criu-plugin.h"
+#include "criu-amdgpu.pb-c.h"
+
+#include "kfd_ioctl.h"
+#include "xmalloc.h"
+#include "criu-log.h"
+
+#include "common/list.h"
+
+#define DRM_FIRST_RENDER_NODE 128
+#define DRM_LAST_RENDER_NODE 255
+
+#define PROCPIDMEM      "/proc/%d/mem"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
+struct vma_metadata {
+	struct list_head list;
+	uint64_t old_pgoff;
+	uint64_t new_pgoff;
+	uint64_t vma_entry;
+};
+
+static LIST_HEAD(update_vma_info_list);
+
+int open_drm_render_device(int minor)
+{
+	char path[128];
+	int fd;
+
+	if (minor < DRM_FIRST_RENDER_NODE || minor > DRM_LAST_RENDER_NODE) {
+		pr_perror("DRM render minor %d out of range [%d, %d]\n", minor,
+			  DRM_FIRST_RENDER_NODE, DRM_LAST_RENDER_NODE);
+		return -EINVAL;
+	}
+
+	sprintf(path, "/dev/dri/renderD%d", minor);
+	fd = open(path, O_RDWR | O_CLOEXEC);
+	if (fd < 0) {
+		if (errno != ENOENT && errno != EPERM) {
+			pr_err("Failed to open %s: %s\n", path, strerror(errno));
+			if (errno == EACCES)
+				pr_err("Check user is in \"video\" group\n");
+		}
+		return -EBADFD;
+	}
+
+	return fd;
+}
+
+/* Call ioctl, restarting if it is interrupted */
+int kmtIoctl(int fd, unsigned long request, void *arg)
+{
+        int ret;
+
+        do {
+                ret = ioctl(fd, request, arg);
+        } while (ret == -1 && (errno == EINTR || errno == EAGAIN));
+
+        if (ret == -1 && errno == EBADF)
+		/* In case pthread_atfork didn't catch it, this will
+                 * make any subsequent hsaKmt calls fail in CHECK_KFD_OPEN.
+                 */
+		pr_perror("KFD file descriptor not valid in this process\n");
+	return ret;
+}
+
+static void free_e(CriuKfd *e)
+{
+	for (int i = 0; i < e->n_bo_info_test; i++) {
+		if (e->bo_info_test[i]->bo_rawdata.data)
+			xfree(e->bo_info_test[i]->bo_rawdata.data);
+		if (e->bo_info_test[i])
+			xfree(e->bo_info_test[i]);
+	}
+	for (int i = 0; i < e->n_devinfo_entries; i++) {
+		if (e->devinfo_entries[i])
+			xfree(e->devinfo_entries[i]);
+	}
+	xfree(e);
+}
+
+static int allocate_devinfo_entries(CriuKfd *e, int num_of_devices)
+{
+	e->devinfo_entries = xmalloc(sizeof(DevinfoEntry) * num_of_devices);
+	if (!e->devinfo_entries) {
+		pr_err("Failed to allocate devinfo_entries\n");
+		return -1;
+	}
+
+	for (int i = 0; i < num_of_devices; i++)
+	{
+		DevinfoEntry *entry = xmalloc(sizeof(DevinfoEntry));
+		if (!entry) {
+			pr_err("Failed to allocate entry\n");
+			return -ENOMEM;
+		}
+
+		devinfo_entry__init(entry);
+
+		e->devinfo_entries[i] = entry;
+		e->n_devinfo_entries++;
+
+	}
+	return 0;
+}
+
+static int allocate_bo_info_test(CriuKfd *e, int num_bos, struct kfd_criu_bo_buckets *bo_bucket_ptr)
+{
+	e->bo_info_test = xmalloc(sizeof(BoEntriesTest*) * num_bos);
+	if (!e->bo_info_test) {
+		pr_err("Failed to allocate bo_info\n");
+		return -ENOMEM;
+	}
+
+	pr_info("Inside allocate_bo_info_test\n");
+	for (int i = 0; i < num_bos; i++)
+	{
+		BoEntriesTest *botest;
+		botest = xmalloc(sizeof(*botest));
+		if (!botest) {
+			pr_err("Failed to allocate botest\n");
+			return -ENOMEM;
+		}
+
+		bo_entries_test__init(botest);
+
+		botest->bo_rawdata.data = xmalloc((bo_bucket_ptr)[i].bo_size);
+		botest->bo_rawdata.len = (bo_bucket_ptr)[i].bo_size;
+
+		e->bo_info_test[i] = botest;
+		e->n_bo_info_test++;
+
+	}
+
+	return 0;
+}
+
+int amdgpu_plugin_init(int stage)
+{
+	pr_info("amdgpu_plugin: initialized:  %s (AMDGPU/KFD)\n",
+						CR_PLUGIN_DESC.name);
+	return 0;
+}
+
+void amdgpu_plugin_fini(int stage, int ret)
+{
+	pr_info("amdgpu_plugin: finished  %s (AMDGPU/KFD)\n", CR_PLUGIN_DESC.name);
+}
+
+CR_PLUGIN_REGISTER("amdgpu_plugin", amdgpu_plugin_init, amdgpu_plugin_fini)
+
+int amdgpu_plugin_dump_file(int fd, int id)
+{
+	struct kfd_ioctl_criu_helper_args helper_args = {0};
+	struct kfd_criu_devinfo_bucket *devinfo_bucket_ptr;
+	struct kfd_ioctl_criu_dumper_args args = {0};
+	struct kfd_criu_bo_buckets *bo_bucket_ptr;
+	int img_fd, ret, len, mem_fd;
+	char img_path[PATH_MAX];
+	struct stat st, st_kfd;
+	unsigned char *buf;
+	uint8_t *local_buf;
+	char *fname;
+
+	pr_debug("amdgpu_plugin: Enter cr_plugin_dump_file()- ID = 0x%x\n", id);
+	ret = 0;
+	CriuKfd *e;
+
+	if (fstat(fd, &st) == -1) {
+		pr_perror("amdgpu_plugin: fstat error");
+		return -1;
+	}
+
+	ret = stat("/dev/kfd", &st_kfd);
+	if (ret == -1) {
+		pr_perror("amdgpu_plugin: fstat error for /dev/kfd\n");
+		return -1;
+	}
+
+	/* Check whether this plugin was called for kfd or render nodes */
+	if (major(st.st_rdev) != major(st_kfd.st_rdev) ||
+		 minor(st.st_rdev) != 0) {
+		/* This is RenderD dumper plugin, for now just save renderD
+		 * minor number to be used during restore. In later phases this
+		 * needs to save more data for video decode etc.
+		 */
+
+		CriuRenderNode rd = CRIU_RENDER_NODE__INIT;
+		pr_info("amdgpu_plugin: Dumper called for /dev/dri/renderD%d, FD = %d, ID = %d\n", minor(st.st_rdev), fd, id);
+
+		rd.minor_number = minor(st.st_rdev);
+		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
+
+		img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
+		if (img_fd < 0) {
+			pr_perror("Can't open %s", img_path);
+			return -1;
+		}
+
+		len = criu_render_node__get_packed_size(&rd);
+		buf = xmalloc(len);
+		if (!buf)
+			return -ENOMEM;
+
+		criu_render_node__pack(&rd, buf);
+		ret = write(img_fd,  buf, len);
+
+		if (ret != len) {
+			pr_perror("Unable to write in %s", img_path);
+			ret = -1;
+		}
+		xfree(buf);
+		close(img_fd);
+
+		/* Need to return success here so that criu can call plugins for
+		 * renderD nodes */
+		return ret;
+	}
+
+	pr_info("amdgpu_plugin: %s : %s() called for fd = %d\n", CR_PLUGIN_DESC.name,
+		  __func__, major(st.st_rdev));
+
+	if (kmtIoctl(fd, AMDKFD_IOC_CRIU_HELPER, &helper_args) == -1) {
+		pr_perror("amdgpu_plugin: failed to call helper ioctl\n");
+		return -1;
+	}
+
+	args.num_of_devices = helper_args.num_of_devices;
+	devinfo_bucket_ptr = xmalloc(helper_args.num_of_devices *
+					sizeof(struct kfd_criu_devinfo_bucket));
+
+	if (!devinfo_bucket_ptr) {
+		pr_perror("amdgpu_plugin: failed to allocate devinfo for dumper ioctl\n");
+		return -ENOMEM;
+	}
+	args.kfd_criu_devinfo_buckets_ptr = (uintptr_t)devinfo_bucket_ptr;
+
+	pr_info("amdgpu_plugin: num of bos = %llu\n", helper_args.num_of_bos);
+
+	bo_bucket_ptr = xmalloc(helper_args.num_of_bos *
+			       sizeof(struct kfd_criu_bo_buckets));
+
+	if (!bo_bucket_ptr) {
+		pr_perror("amdgpu_plugin: failed to allocate args for dumper ioctl\n");
+		return -ENOMEM;
+	}
+
+	args.num_of_bos = helper_args.num_of_bos;
+	args.kfd_criu_bo_buckets_ptr = (uintptr_t)bo_bucket_ptr;
+
+	/* call dumper ioctl, pass num of BOs to dump */
+        if (kmtIoctl(fd, AMDKFD_IOC_CRIU_DUMPER, &args) == -1) {
+		pr_perror("amdgpu_plugin: failed to call kfd ioctl from plugin dumper for fd = %d\n", major(st.st_rdev));
+		xfree(bo_bucket_ptr);
+		return -1;
+	}
+
+	pr_info("amdgpu_plugin: success in calling dumper ioctl\n");
+
+	e = xmalloc(sizeof(*e));
+	if (!e) {
+		pr_err("Failed to allocate proto structure\n");
+		xfree(bo_bucket_ptr);
+		return -ENOMEM;
+	}
+
+	criu_kfd__init(e);
+	e->pid = helper_args.task_pid;
+
+	ret = allocate_devinfo_entries(e, args.num_of_devices);
+	if (ret) {
+		ret = -ENOMEM;
+		goto failed;
+	}
+
+	/* When checkpointing on a node where there was already a checkpoint-restore before, the
+	 * user_gpu_id and actual_gpu_id will be different.
+	 *
+	 * For now, we assume the user_gpu_id and actual_gpu_id is the same. Once we support
+	 * restoring on a different node, then we will have a user_gpu_id to actual_gpu_id mapping.
+	 */
+	for (int i = 0; i < args.num_of_devices; i++) {
+		e->devinfo_entries[i]->gpu_id = devinfo_bucket_ptr[i].user_gpu_id;
+		if (devinfo_bucket_ptr[i].user_gpu_id != devinfo_bucket_ptr[i].actual_gpu_id) {
+			pr_err("Checkpoint-Restore on different node not supported yet\n");
+			ret = -ENOTSUP;
+			goto failed;
+		}
+	}
+
+	e->num_of_devices = args.num_of_devices;
+
+	ret = allocate_bo_info_test(e, helper_args.num_of_bos, bo_bucket_ptr);
+	if (ret)
+		return -1;
+
+	for (int i = 0; i < helper_args.num_of_bos; i++)
+	{
+		(e->bo_info_test[i])->bo_addr = (bo_bucket_ptr)[i].bo_addr;
+		(e->bo_info_test[i])->bo_size = (bo_bucket_ptr)[i].bo_size;
+		(e->bo_info_test[i])->bo_offset = (bo_bucket_ptr)[i].bo_offset;
+		(e->bo_info_test[i])->gpu_id = (bo_bucket_ptr)[i].gpu_id;
+		(e->bo_info_test[i])->bo_alloc_flags = (bo_bucket_ptr)[i].bo_alloc_flags;
+		(e->bo_info_test[i])->idr_handle = (bo_bucket_ptr)[i].idr_handle;
+		(e->bo_info_test[i])->user_addr = (bo_bucket_ptr)[i].user_addr;
+
+		local_buf = xmalloc((bo_bucket_ptr)[i].bo_size);
+		if (!local_buf) {
+			pr_err("failed to allocate memory for BO rawdata\n");
+			ret = -1;
+			goto failed;
+		}
+
+		if ((bo_bucket_ptr)[i].bo_alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) {
+			pr_info("VRAM BO Found\n");
+		}
+
+		if ((bo_bucket_ptr)[i].bo_alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
+			pr_info("GTT BO Found\n");
+		}
+
+		if ((bo_bucket_ptr)[i].bo_alloc_flags &
+		    KFD_IOC_ALLOC_MEM_FLAGS_VRAM ||
+		    (bo_bucket_ptr)[i].bo_alloc_flags &
+		    KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
+
+			pr_info("Now try reading BO contents with /proc/pid/mem");
+			if (asprintf (&fname, PROCPIDMEM, helper_args.task_pid) < 0) {
+				pr_perror("failed in asprintf, %s\n", fname);
+				ret = -1;
+				goto failed;
+			}
+
+			mem_fd = open (fname, O_RDONLY);
+			if (mem_fd < 0) {
+				pr_perror("Can't open %s for pid %d\n", fname, helper_args.task_pid);
+				free (fname);
+				ret = -1;
+				goto failed;
+			}
+
+			pr_info("Opened %s file for pid = %d\n", fname, helper_args.task_pid);
+			free (fname);
+
+			if (lseek (mem_fd, (off_t) (bo_bucket_ptr)[i].bo_addr, SEEK_SET) == -1) {
+				pr_perror("Can't lseek for bo_offset for pid = %d\n", helper_args.task_pid);
+				ret = -1;
+				goto failed;
+			}
+			pr_info("Try to read file now\n");
+
+			if (read(mem_fd, local_buf,
+				 (e->bo_info_test[i])->bo_size) !=
+			    (e->bo_info_test[i])->bo_size) {
+				pr_perror("Can't read buffer\n");
+				ret = -1;
+				goto failed;
+			}
+			pr_info("log initial few bytes of the raw data for this BO\n");
+
+			for (int i = 0; i < 10; i ++)
+			{
+				pr_info("0x%llx\n",((__u64*)local_buf)[i]);
+			}
+			close(mem_fd);
+			memcpy((e->bo_info_test[i])->bo_rawdata.data,
+			       (uint8_t*)local_buf,
+			       (e->bo_info_test[i])->bo_size);
+			xfree(local_buf);
+
+		}
+	}
+
+	e->num_of_bos = helper_args.num_of_bos;
+
+	pr_info("Dumping bo_info_test \n");
+	for (int i = 0; i < helper_args.num_of_bos; i++)
+	{
+		pr_info("e->bo_info_test[%d]:\n", i);
+		pr_info("bo_addr = 0x%lx, bo_size = 0x%lx, bo_offset = 0x%lx, gpu_id = 0x%x, "
+			"bo_alloc_flags = 0x%x, idr_handle = 0x%x\n",
+		  (e->bo_info_test[i])->bo_addr,
+		  (e->bo_info_test[i])->bo_size,
+		  (e->bo_info_test[i])->bo_offset,
+		  (e->bo_info_test[i])->gpu_id,
+		  (e->bo_info_test[i])->bo_alloc_flags,
+		  (e->bo_info_test[i])->idr_handle);
+
+	}
+
+	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
+	pr_info("amdgpu_plugin: img_path = %s", img_path);
+	img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
+	if (img_fd < 0) {
+		pr_perror("Can't open %s", img_path);
+		ret = -1;
+		goto failed;
+	}
+
+	len = criu_kfd__get_packed_size(e);
+
+	pr_info("amdgpu_plugin: Len = %d\n", len);
+
+	buf = xmalloc(len);
+	if (!buf) {
+		pr_perror("failed to allocate memory\n");
+		close(img_fd);
+		ret = -ENOMEM;
+		goto failed;
+	}
+
+	criu_kfd__pack(e, buf);
+
+	ret = write(img_fd,  buf, len);
+	if (ret != len) {
+		pr_perror("Unable to write in %s", img_path);
+		ret = -1;
+		goto exit;
+	}
+exit:
+	xfree(buf);
+	close(img_fd);
+failed:
+	xfree(devinfo_bucket_ptr);
+	xfree(bo_bucket_ptr);
+	free_e(e);
+	pr_info("amdgpu_plugin: Exiting from dumper for fd = %d\n", major(st.st_rdev));
+        return ret;
+
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__DUMP_EXT_FILE, amdgpu_plugin_dump_file)
+
+int amdgpu_plugin_restore_file(int id)
+{
+	struct kfd_criu_devinfo_bucket *devinfo_bucket_ptr = NULL;
+	int img_fd, len, fd, mem_fd;
+	struct kfd_ioctl_criu_restorer_args args = {0};
+	struct kfd_criu_bo_buckets *bo_bucket_ptr;
+	__u64 *restored_bo_offsets_array;
+	char img_path[PATH_MAX];
+	struct stat filestat;
+	unsigned char *buf;
+	CriuRenderNode *rd;
+	char *fname;
+	CriuKfd *e;
+	void *addr;
+
+	pr_info("amdgpu_plugin: Initialized kfd plugin restorer with ID = %d\n", id);
+
+	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
+	img_fd = openat(criu_get_image_dir(), img_path, O_RDONLY, 0600);
+	if (img_fd < 0) {
+		pr_perror("open(%s)", img_path);
+
+		/* This is restorer plugin for renderD nodes. Since criu doesn't
+		 * gurantee that they will be called before the plugin is called
+		 * for kfd file descriptor, we need to make sure we open the render
+		 * nodes only once and before /dev/kfd is open, the render nodes
+		 * are open too. Generally, it is seen that during checkpoint and
+		 * restore both, the kfd plugin gets called first.
+		 */
+		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
+		img_fd = openat(criu_get_image_dir(), img_path, O_RDONLY, 0600);
+		if (img_fd < 0) {
+			pr_perror("open(%s)", img_path);
+			return -ENOTSUP;
+		}
+
+		if (stat(img_path, &filestat) == -1)
+		{
+			pr_perror("Failed to read file stats\n");
+			return -1;
+		}
+		pr_info("renderD file size on disk = %ld\n", filestat.st_size);
+
+		buf = xmalloc(filestat.st_size);
+		if (!buf) {
+			pr_perror("Failed to allocate memory\n");
+			return -ENOMEM;
+		}
+
+		len = read(img_fd, buf, filestat.st_size);
+		if (len <= 0) {
+			pr_perror("Unable to read from %s", img_path);
+			xfree(buf);
+			close(img_fd);
+			return -1;
+		}
+		close(img_fd);
+
+		rd = criu_render_node__unpack(NULL, len, buf);
+		if (rd == NULL) {
+			pr_perror("Unable to parse the KFD message %d", id);
+			xfree(buf);
+			return -1;
+		}
+
+		pr_info("amdgpu_plugin: render node minor num = %d\n", rd->minor_number);
+		fd = open_drm_render_device(rd->minor_number);
+		criu_render_node__free_unpacked(rd,  NULL);
+		xfree(buf);
+		return fd;
+	}
+
+	fd = open("/dev/kfd", O_RDWR | O_CLOEXEC);
+	if (fd < 0) {
+		pr_perror("failed to open kfd in plugin");
+		return -1;
+	}
+
+	pr_info("amdgpu_plugin: Opened kfd, fd = %d\n", fd);
+
+
+	if (stat(img_path, &filestat) == -1)
+	{
+		pr_perror("Failed to read file stats\n");
+		return -1;
+	}
+	pr_info("kfd img file size on disk = %ld\n", filestat.st_size);
+
+	buf = xmalloc(filestat.st_size);
+	if (!buf) {
+		pr_perror("Failed to allocate memory\n");
+		close(img_fd);
+		return -ENOMEM;
+	}
+	len = read(img_fd, buf, filestat.st_size);
+	if (len <= 0) {
+		pr_perror("Unable to read from %s", img_path);
+		xfree(buf);
+		close(img_fd);
+		return -1;
+	}
+	close(img_fd);
+	e = criu_kfd__unpack(NULL, len, buf);
+	if (e == NULL) {
+		pr_err("Unable to parse the KFD message %#x\n", id);
+		xfree(buf);
+		return -1;
+	}
+
+	pr_info("amdgpu_plugin: read image file data\n");
+
+	devinfo_bucket_ptr = xmalloc(e->num_of_devices * sizeof(struct kfd_criu_devinfo_bucket));
+	if (!devinfo_bucket_ptr) {
+		fd = -EBADFD;
+		goto clean;
+	}
+	args.kfd_criu_devinfo_buckets_ptr = (uintptr_t)devinfo_bucket_ptr;
+
+	for (int i = 0; i < e->num_of_devices; i++) {
+		devinfo_bucket_ptr[i].user_gpu_id = e->devinfo_entries[i]->gpu_id;
+
+		// for now always bind the VMA to /dev/dri/renderD128
+		// this should allow us later to restore BO on a different GPU node.
+		devinfo_bucket_ptr[i].drm_fd = open_drm_render_device(i + DRM_FIRST_RENDER_NODE);
+		if (!devinfo_bucket_ptr[i].drm_fd) {
+			pr_perror("amdgpu_plugin: Can't pass NULL drm render fd to driver\n");
+			fd = -EBADFD;
+			goto clean;
+		} else {
+			pr_info("amdgpu_plugin: passing drm render fd = %d to driver\n", devinfo_bucket_ptr[i].drm_fd);
+		}
+	}
+
+	for (int i = 0; i < e->num_of_bos; i++ )
+	{
+		pr_info("reading e->bo_info_test[%d]:\n", i);
+		pr_info("bo_addr = 0x%lx, bo_size = 0x%lx, bo_offset = 0x%lx, gpu_id = 0x%x, "
+			"bo_alloc_flags = 0x%x, idr_handle = 0x%x user_addr=0x%lx\n",
+		  (e->bo_info_test[i])->bo_addr,
+		  (e->bo_info_test[i])->bo_size,
+		  (e->bo_info_test[i])->bo_offset,
+		  (e->bo_info_test[i])->gpu_id,
+		  (e->bo_info_test[i])->bo_alloc_flags,
+		  (e->bo_info_test[i])->idr_handle,
+		  (e->bo_info_test[i])->user_addr);
+	}
+
+	bo_bucket_ptr = xmalloc(e->num_of_bos *
+			       sizeof(struct kfd_criu_bo_buckets));
+
+	if (!bo_bucket_ptr) {
+		pr_perror("amdgpu_plugin: failed to allocate args for restorer ioctl\n");
+		return -1;
+	}
+
+	for (int i = 0; i < e->num_of_bos; i++)
+	{
+		(bo_bucket_ptr)[i].bo_addr = (e->bo_info_test[i])->bo_addr;
+		(bo_bucket_ptr)[i].bo_size = (e->bo_info_test[i])->bo_size;
+		(bo_bucket_ptr)[i].bo_offset = (e->bo_info_test[i])->bo_offset;
+		(bo_bucket_ptr)[i].gpu_id = (e->bo_info_test[i])->gpu_id;
+		(bo_bucket_ptr)[i].bo_alloc_flags = (e->bo_info_test[i])->bo_alloc_flags;
+		(bo_bucket_ptr)[i].idr_handle = (e->bo_info_test[i])->idr_handle;
+		(bo_bucket_ptr)[i].user_addr = (e->bo_info_test[i])->user_addr;
+	}
+
+	args.num_of_bos = e->num_of_bos;
+	args.kfd_criu_bo_buckets_ptr = (uintptr_t)bo_bucket_ptr;
+
+	restored_bo_offsets_array = xmalloc(sizeof(uint64_t) * e->num_of_bos);
+	if (!restored_bo_offsets_array) {
+		xfree(bo_bucket_ptr);
+		return -ENOMEM;
+	}
+
+	args.restored_bo_array_ptr = (uint64_t)restored_bo_offsets_array;
+	args.num_of_devices = 1; /* Only support 1 gpu for now */
+
+	if (kmtIoctl(fd, AMDKFD_IOC_CRIU_RESTORER, &args) == -1) {
+		pr_perror("amdgpu_plugin: failed to call kfd ioctl from plugin restorer for id = %d\n", id);
+		fd = -EBADFD;
+		goto clean;
+	}
+
+	for (int i = 0; i < e->num_of_bos; i++)
+	{
+		if (e->bo_info_test[i]->bo_alloc_flags &
+			(KFD_IOC_ALLOC_MEM_FLAGS_VRAM |
+			 KFD_IOC_ALLOC_MEM_FLAGS_GTT |
+			 KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP)) {
+
+			struct vma_metadata *vma_md;
+			vma_md = xmalloc(sizeof(*vma_md));
+			if (!vma_md)
+				return -ENOMEM;
+
+			vma_md->old_pgoff = (e->bo_info_test[i])->bo_offset;
+			vma_md->vma_entry = (e->bo_info_test[i])->bo_addr;
+			vma_md->new_pgoff = restored_bo_offsets_array[i];
+			list_add_tail(&vma_md->list, &update_vma_info_list);
+		}
+
+		if (e->bo_info_test[i]->bo_alloc_flags &
+			(KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_GTT)) {
+
+			pr_info("amdgpu_plugin: Trying mmap in stage 2\n");
+			if ((e->bo_info_test[i])->bo_alloc_flags &
+			    KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC ||
+			    (e->bo_info_test[i])->bo_alloc_flags &
+			    KFD_IOC_ALLOC_MEM_FLAGS_GTT ) {
+				pr_info("amdgpu_plugin: large bar write possible\n");
+				addr = mmap(NULL,
+					    (e->bo_info_test[i])->bo_size,
+					    PROT_WRITE,
+					    MAP_SHARED,
+					    devinfo_bucket_ptr[0].drm_fd,
+					    restored_bo_offsets_array[i]);
+				if (addr == MAP_FAILED) {
+					pr_perror("amdgpu_plugin: mmap failed\n");
+					fd = -EBADFD;
+					goto clean;
+				}
+
+				/* direct memcpy is possible on large bars */
+				memcpy(addr, (void *)e->bo_info_test[i]->bo_rawdata.data,
+				       (e->bo_info_test[i])->bo_size);
+				munmap(addr, e->bo_info_test[i]->bo_size);
+			} else {
+				/* Use indirect host data path via /proc/pid/mem
+				 * on small pci bar GPUs or for Buffer Objects
+				 * that don't have HostAccess permissions.
+				 */
+				pr_info("amdgpu_plugin: using PROCPIDMEM to restore BO contents\n");
+				addr = mmap(NULL,
+					    (e->bo_info_test[i])->bo_size,
+					    PROT_NONE,
+					    MAP_SHARED,
+					    devinfo_bucket_ptr[0].drm_fd,
+					    restored_bo_offsets_array[i]);
+				if (addr == MAP_FAILED) {
+					pr_perror("amdgpu_plugin: mmap failed\n");
+					fd = -EBADFD;
+					goto clean;
+				}
+
+				if (asprintf (&fname, PROCPIDMEM, e->pid) < 0) {
+					pr_perror("failed in asprintf, %s\n", fname);
+					munmap(addr, e->bo_info_test[i]->bo_size);
+					fd = -EBADFD;
+					goto clean;
+				}
+
+				mem_fd = open (fname, O_RDWR);
+				if (mem_fd < 0) {
+					pr_perror("Can't open %s for pid %d\n", fname, e->pid);
+					free (fname);
+					munmap(addr, e->bo_info_test[i]->bo_size);
+					fd = -EBADFD;
+					goto clean;
+				}
+
+				pr_perror("Opened %s file for pid = %d\n", fname, e->pid);
+				free (fname);
+
+				if (lseek (mem_fd, (off_t) addr, SEEK_SET) == -1) {
+					pr_perror("Can't lseek for bo_offset for pid = %d\n", e->pid);
+					munmap(addr, e->bo_info_test[i]->bo_size);
+					fd = -EBADFD;
+					goto clean;
+				}
+
+				pr_perror("Attempt writting now\n");
+				if (write(mem_fd, e->bo_info_test[i]->bo_rawdata.data,
+					  (e->bo_info_test[i])->bo_size) !=
+				    (e->bo_info_test[i])->bo_size) {
+					pr_perror("Can't write buffer\n");
+					munmap(addr, e->bo_info_test[i]->bo_size);
+					fd = -EBADFD;
+					goto clean;
+				}
+				munmap(addr, e->bo_info_test[i]->bo_size);
+				close(mem_fd);
+			}
+		} else {
+			pr_info("Not a VRAM BO\n");
+			continue;
+		}
+	} /* mmap done for VRAM BO */
+
+	for (int i = 0; i < e->num_of_devices; i++) {
+		if (devinfo_bucket_ptr[i].drm_fd >= 0)
+			close(devinfo_bucket_ptr[i].drm_fd);
+	}
+clean:
+	xfree(devinfo_bucket_ptr);
+	xfree(restored_bo_offsets_array);
+	xfree(bo_bucket_ptr);
+	xfree(buf);
+	criu_kfd__free_unpacked(e, NULL);
+	pr_info("amdgpu_plugin: returning kfd fd from plugin\n");
+	return fd;
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESTORE_EXT_FILE, amdgpu_plugin_restore_file)
+
+/* return 0 if no match found
+ * return -1 for error.
+ * return 1 if vmap map must be adjusted. */
+int amdgpu_plugin_update_vmamap(const char *old_path, char *new_path, const uint64_t addr,
+				const uint64_t old_offset, uint64_t *new_offset)
+{
+	struct vma_metadata *vma_md;
+
+	pr_info("amdgpu_plugin: Enter %s\n", __func__);
+
+	/* Once we support restoring on different nodes, new_path may be different from old_path
+	 * because the restored gpu may have a different minor number.
+	 * For now, we are restoring on the same gpu, so new_path is the same as old_path */
+
+	strcpy(new_path, old_path);
+
+	list_for_each_entry(vma_md, &update_vma_info_list, list) {
+		if (addr == vma_md->vma_entry && old_offset == vma_md->old_pgoff) {
+			*new_offset = vma_md->new_pgoff;
+
+			pr_info("amdgpu_plugin: old_pgoff= 0x%lx new_pgoff = 0x%lx old_path = %s new_path = %s\n",
+				vma_md->old_pgoff, vma_md->new_pgoff, old_path, new_path);
+
+			return 1;
+		}
+	}
+	pr_info("No match for addr:0x%lx offset:%lx\n", addr, old_offset);
+	return 0;
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, amdgpu_plugin_update_vmamap)

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -424,15 +424,76 @@ int devinfo_to_topology(DevinfoEntry *devinfos[], uint32_t num_devices, struct t
 
 int amdgpu_plugin_init(int stage)
 {
+	char *opt_param = NULL;
 	pr_info("amdgpu_plugin: initialized:  %s (AMDGPU/KFD)\n",
 						CR_PLUGIN_DESC.name);
 
 	topology_init(&src_topology);
 	topology_init(&dest_topology);
-
 	maps_init(&checkpoint_maps);
 	maps_init(&restore_maps);
 
+	if (stage == CR_PLUGIN_STAGE__RESTORE) {
+		kfd_gpu_override = NULL;
+		kfd_topology_check = true;
+		kfd_fw_version_check = true;
+		kfd_sdma_fw_version_check = true;
+		kfd_caches_count_check = true;
+		kfd_num_gws_check = true;
+		kfd_vram_size_check = true;
+		kfd_ignore_numa = false;
+
+		/* Forces gpu mapping to specific gpu list */
+		/* Expected destination gpu format:
+		*	KFD_DESTINATION_GPUS=0xff31,0x90db
+		*	KFD_DESTINATION_GPUS=65329,37083
+		*	KFD_DESTINATION_GPUS=renderD129,renderD128
+		*/
+		kfd_gpu_override = getenv("KFD_DESTINATION_GPUS");
+		pr_info("param: KFD_DESTINATION_GPUS:%s\n", kfd_gpu_override ? kfd_gpu_override : "None");
+
+		if ((opt_param = getenv("KFD_TOPOLOGY_CHECK"))) {
+			if (!strcmp(opt_param, "0") || !strcmp(opt_param, "NO"))
+				kfd_topology_check = false;
+		}
+		pr_info("param: KFD_TOPOLOGY_CHECK:%s\n", kfd_topology_check ? "Y" : "N");
+
+		if ((opt_param = getenv("KFD_FW_VER_CHECK"))) {
+			if (!strcmp(opt_param, "0") || !strcmp(opt_param, "NO"))
+				kfd_fw_version_check = false;
+		}
+		pr_info("param: KFD_FW_VERSION_CHECK:%s\n", kfd_fw_version_check ? "Y" : "N");
+
+		if ((opt_param = getenv("KFD_SDMA_FW_VER_CHECK"))) {
+			if (!strcmp(opt_param, "0") || !strcmp(opt_param, "NO"))
+				kfd_sdma_fw_version_check = false;
+		}
+		pr_info("param: KFD_SDMA_FW_VER_CHECK:%s\n", kfd_sdma_fw_version_check ? "Y" : "N");
+
+		if ((opt_param = getenv("KFD_CACHES_COUNT_CHECK"))) {
+			if (!strcmp(opt_param, "0") || !strcmp(opt_param, "NO"))
+				kfd_caches_count_check = false;
+		}
+		pr_info("param: KFD_CACHES_COUNT_CHECK:%s\n", kfd_caches_count_check ? "Y" : "N");
+
+		if ((opt_param = getenv("KFD_NUM_GWS_CHECK"))) {
+			if (!strcmp(opt_param, "0") || !strcmp(opt_param, "NO"))
+				kfd_num_gws_check = false;
+		}
+		pr_info("param: KFD_NUM_GWS_CHECK:%s\n", kfd_num_gws_check ? "Y" : "N");
+
+		if ((opt_param = getenv("KFD_VRAM_SIZE_CHECK"))) {
+			if (!strcmp(opt_param, "0") || !strcmp(opt_param, "NO"))
+				kfd_vram_size_check = false;
+		}
+		pr_info("param: KFD_VRAM_SIZE_CHECK:%s\n", kfd_vram_size_check ? "Y" : "N");
+
+		if ((opt_param = getenv("KFD_IGNORE_NUMA"))) {
+			if (!strcmp(opt_param, "1") || !strcmp(opt_param, "Y"))
+				kfd_ignore_numa = true;
+		}
+		pr_info("param: KFD_IGNORE_NUMA:%s\n", kfd_ignore_numa ? "Y" : "N");
+	}
 	return 0;
 }
 

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -1,0 +1,1104 @@
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <dirent.h>
+#include "common/list.h"
+
+#include "xmalloc.h"
+#include "kfd_ioctl.h"
+#include "amdgpu_plugin_topology.h"
+
+#define TOPOLOGY_PATH   "/sys/class/kfd/kfd/topology/nodes/"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
+#ifdef DEBUG
+#define plugin_log_msg(fmt, ...) pr_debug(fmt, ##__VA_ARGS__)
+#else
+#define plugin_log_msg(fmt, ...) {}
+#endif
+
+const char *link_type(uint32_t type){
+	switch(type) {
+		case TOPO_IOLINK_TYPE_PCIE:
+			return "PCIe";
+		case TOPO_IOLINK_TYPE_XGMI:
+			return "XGMI";
+	}
+	return "Unsupported";
+}
+
+struct tp_node *p2pgroup_get_node_by_gpu_id(const struct tp_p2pgroup *group,
+					       const uint32_t gpu_id)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &group->nodes, listm_p2pgroup) {
+		if (node->gpu_id == gpu_id)
+			return node;
+	}
+	return NULL;
+}
+
+struct tp_iolink *node_get_iolink_to_node_id(const struct tp_node *node, const uint32_t type,
+					     const uint32_t node_id)
+{
+	struct tp_iolink *iolink;
+	list_for_each_entry(iolink, &node->iolinks, listm) {
+		if (iolink->node_to->id == node_id && iolink->type == type)
+			return iolink;
+	}
+	return NULL;
+}
+
+struct tp_node *sys_get_node_by_render_minor(const struct tp_system *sys,
+						const int drm_render_minor)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		if (node->drm_render_minor == drm_render_minor)
+			return node;
+	}
+	return NULL;
+}
+
+struct tp_node *sys_get_node_by_gpu_id(const struct tp_system *sys, const uint32_t gpu_id)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		if (node->gpu_id == gpu_id)
+			return node;
+	}
+	return NULL;
+}
+
+struct tp_node *sys_get_node_by_gpu_index(const struct tp_system *sys, uint32_t gpu_index)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		if (NODE_IS_GPU(node) && gpu_index-- == 0)
+			return node;
+	}
+	return NULL;
+}
+
+struct tp_node *sys_get_node_by_node_id(const struct tp_system *sys, const uint32_t node_id)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		if (node->id == node_id)
+			return node;
+	}
+	return NULL;
+}
+
+struct tp_p2pgroup *sys_get_p2pgroup_with_gpu_id(const struct tp_system *sys, const int type,
+						const uint32_t gpu_id)
+{
+	struct tp_p2pgroup *p2pgroup;
+
+	list_for_each_entry(p2pgroup, &sys->xgmi_groups, listm_system) {
+		if (p2pgroup->type != type)
+			continue;
+
+		if (p2pgroup_get_node_by_gpu_id(p2pgroup, gpu_id))
+			return p2pgroup;
+	}
+	return NULL;
+}
+
+struct tp_iolink *get_tp_peer_iolink(const struct tp_node *from_node,
+				     const struct tp_node *to_node,
+				     const uint8_t type)
+{
+	struct tp_iolink *iolink;
+
+	list_for_each_entry(iolink, &from_node->iolinks, listm) {
+		if (iolink->node_to_id == to_node->id && iolink->type == type)
+			return iolink;
+	}
+	return NULL;
+}
+
+bool maps_dest_cpu_mapped(const struct device_maps *maps, const uint32_t dest_id)
+{
+	struct id_map *id_map;
+	list_for_each_entry(id_map, &maps->cpu_maps, listm) {
+		if (id_map->dest == dest_id)
+			return true;
+	}
+	return false;
+}
+
+uint32_t maps_get_dest_cpu(const struct device_maps *maps, const uint32_t src_id)
+{
+	struct id_map *id_map;
+	list_for_each_entry(id_map, &maps->cpu_maps, listm) {
+		if (id_map->src == src_id)
+			return id_map->dest;
+	}
+	return INVALID_CPU_ID;
+}
+
+bool maps_dest_gpu_mapped(const struct device_maps *maps, const uint32_t dest_id)
+{
+	struct id_map *id_map;
+	list_for_each_entry(id_map, &maps->gpu_maps, listm) {
+		if (id_map->dest == dest_id)
+			return true;
+	}
+	return false;
+}
+
+uint32_t maps_get_dest_gpu(const struct device_maps *maps, const uint32_t src_id)
+{
+	struct id_map *id_map;
+	list_for_each_entry(id_map, &maps->gpu_maps, listm) {
+		if (id_map->src == src_id)
+			return id_map->dest;
+	}
+	return 0;
+}
+
+struct id_map *maps_add_cpu_entry(struct device_maps *maps, const uint32_t src_id, const uint32_t dest_id)
+{
+	struct id_map *id_map = xmalloc(sizeof(*id_map));
+	if (!id_map) {
+		pr_err("Failed to allocate memory for id_map\n");
+		return NULL;
+	}
+	memset(id_map, 0, sizeof(*id_map));
+	id_map->src = src_id;
+	id_map->dest = dest_id;
+
+	list_add_tail(&id_map->listm, &maps->cpu_maps);
+
+	maps->tail_cpu = &id_map->listm;
+
+	pr_debug("Added CPU mapping [%02d -> %02d]\n", src_id, dest_id);
+	return id_map;
+}
+
+struct id_map *maps_add_gpu_entry(struct device_maps *maps, const uint32_t src_id, const uint32_t dest_id)
+{
+	struct id_map *id_map = xmalloc(sizeof(*id_map));
+	if (!id_map) {
+		pr_err("Failed to allocate memory for id_map\n");
+		return NULL;
+	}
+	memset(id_map, 0, sizeof(*id_map));
+	id_map->src = src_id;
+	id_map->dest = dest_id;
+
+	list_add_tail(&id_map->listm, &maps->gpu_maps);
+
+	maps->tail_gpu = &id_map->listm;
+
+	pr_debug("Added GPU mapping [0x%04X -> 0x%04X]\n", src_id, dest_id);
+	return id_map;
+}
+
+void maps_print(struct device_maps *maps)
+{
+	struct id_map *id_map;
+	pr_info("===Maps===============\n");
+	list_for_each_entry(id_map, &maps->gpu_maps, listm)
+		pr_info("GPU: 0x%04X -> 0x%04X\n", id_map->src, id_map->dest);
+
+	list_for_each_entry(id_map, &maps->cpu_maps, listm)
+		pr_info("CPU: 0x%02d -> 0x%02d\n", id_map->src, id_map->dest);
+	pr_info("======================\n");
+}
+
+void maps_init(struct device_maps *maps)
+{
+	INIT_LIST_HEAD(&maps->cpu_maps);
+	INIT_LIST_HEAD(&maps->gpu_maps);
+	maps->tail_cpu = 0;
+	maps->tail_gpu = 0;
+}
+
+void maps_free(struct device_maps *maps)
+{
+	while (!list_empty(&maps->cpu_maps)) {
+		struct id_map *map = list_first_entry(&maps->cpu_maps, struct id_map, listm);
+		list_del(&map->listm);
+		xfree(map);
+	}
+	while (!list_empty(&maps->gpu_maps)) {
+		struct id_map *map = list_first_entry(&maps->gpu_maps, struct id_map, listm);
+		list_del(&map->listm);
+		xfree(map);
+	}
+}
+
+void maps_remove(struct device_maps *maps, struct device_maps *remove)
+{
+	if (remove->tail_cpu)
+		list_cut_position(&remove->cpu_maps, &maps->cpu_maps, remove->tail_cpu);
+
+	if (remove->tail_gpu)
+		list_cut_position(&remove->gpu_maps, &maps->gpu_maps, remove->tail_gpu);
+
+	maps_free(remove);
+}
+
+int maps_append(struct device_maps *maps, struct device_maps *new)
+{
+	struct id_map *src_id_map, *dest_id_map;
+
+	list_for_each_entry(src_id_map, &new->cpu_maps, listm) {
+		list_for_each_entry(dest_id_map, &maps->cpu_maps, listm) {
+			if (src_id_map->src == dest_id_map->src ||
+			    src_id_map->dest == dest_id_map->dest) {
+				    pr_err("CPU mapping already exists src [%02d->%02d] new [%02d->%02d]\n",
+						src_id_map->src, src_id_map->dest,
+						dest_id_map->src, dest_id_map->dest);
+				return -EINVAL;
+			}
+		}
+	}
+	list_for_each_entry(src_id_map, &new->gpu_maps, listm) {
+		list_for_each_entry(dest_id_map, &maps->gpu_maps, listm) {
+			if (src_id_map->src == dest_id_map->src ||
+			    src_id_map->dest == dest_id_map->dest) {
+				    pr_err("GPU mapping already exists src [0x%04X -> 0x%04X] new [0x%04X -> 0x%04X]\n",
+						src_id_map->src, src_id_map->dest,
+						dest_id_map->src, dest_id_map->dest);
+				return -EINVAL;
+			}
+		}
+	}
+
+	list_splice(&new->cpu_maps, &maps->cpu_maps);
+	list_splice(&new->gpu_maps, &maps->gpu_maps);
+
+	return 0;
+}
+
+struct tp_iolink *node_add_iolink(struct tp_node *node, uint32_t type, uint32_t node_to_id)
+{
+	struct tp_iolink *iolink = xmalloc(sizeof(*iolink));
+	if (!iolink) {
+		pr_err("Failed to allocate memory for iolink\n");
+		return NULL;
+	}
+
+	memset(iolink, 0, sizeof(*iolink));
+
+	iolink->type = type;
+	/* iolink->node_to will be filled in topology_determine_iolinks */
+	iolink->node_to_id = node_to_id;
+	iolink->node_from = node;
+
+	list_add_tail(&iolink->listm, &node->iolinks);
+	return iolink;
+}
+
+struct tp_p2pgroup *sys_add_group(struct tp_system *sys, uint32_t type)
+{
+	struct tp_p2pgroup *group;
+
+	group = xmalloc(sizeof(*group));
+	if (!group) {
+		pr_err("Failed to allocate memory for group\n");
+		return NULL;
+	}
+
+	memset(group, 0, sizeof(*group));
+
+	INIT_LIST_HEAD(&group->nodes);
+	group->type = type;
+	list_add_tail(&group->listm_system, &sys->xgmi_groups);
+	if (type == TOPO_IOLINK_TYPE_XGMI)
+		sys->num_xgmi_groups++;
+
+	return group;
+}
+
+struct tp_node *sys_add_node(struct tp_system *sys, uint32_t id, uint32_t gpu_id)
+{
+	struct tp_node *node = NULL;
+
+	node = xmalloc(sizeof(*node));
+	if (!node) {
+		pr_err("Failed to allocate memory for new node");
+		return NULL;
+	}
+
+	memset(node, 0, sizeof(*node));
+
+	node->id = id;
+	node->gpu_id = gpu_id;
+	INIT_LIST_HEAD(&node->iolinks);
+	list_add_tail(&node->listm_system, &sys->nodes);
+	sys->num_nodes++;
+
+	return node;
+}
+
+bool get_prop(char *line, char *name, uint64_t *value)
+{
+	char *p_begin, *p_end;
+	char field[25];
+
+	memset(field, 0, sizeof(field));
+
+	p_begin = line;
+	while (p_begin && *p_begin == ' ')
+		p_begin++;
+
+	p_end = strchr(p_begin, ' ');
+	if (!p_end)
+		return false;
+
+	strncpy(name, p_begin, p_end - p_begin);
+	name[p_end - p_begin] = '\0';
+
+	p_begin = p_end;
+	while (p_begin && *p_begin == ' ')
+		p_begin++;
+
+	p_end = strchr(p_begin, '\n');
+	if (!p_end)
+		return false;
+
+	strncpy(field, p_begin, p_end - p_begin);
+	if (sscanf(field, "%lu", value) != 1)
+		return false;
+
+	return true;
+}
+
+
+int parse_topo_node_properties(struct tp_node *dev, const char *dir_path)
+{
+	FILE *file;
+	char path[300];
+	char line[300];
+
+	sprintf(path, "%s/properties", dir_path);
+	file = fopen(path, "r");
+	if (!file) {
+		pr_perror("Failed to access %s\n", path);
+		return -EFAULT;
+	}
+
+	while (fgets(line, sizeof(line), file)) {
+		char name[30];
+		uint64_t value;
+
+		memset(name, 0, sizeof(name));
+		if (!get_prop(line, name, &value))
+			goto fail;
+
+		if (!strcmp(name, "cpu_cores_count")) dev->cpu_cores_count = (uint32_t) value;
+		else if (!strcmp(name, "simd_count")) dev->simd_count = (uint32_t) value;
+		else if (!strcmp(name, "mem_banks_count")) dev->mem_banks_count = (uint32_t) value;
+		else if (!strcmp(name, "caches_count")) dev->caches_count = (uint32_t) value;
+		else if (!strcmp(name, "io_links_count")) dev->io_links_count = (uint32_t) value;
+		else if (!strcmp(name, "max_waves_per_simd")) dev->max_waves_per_simd = (uint32_t) value;
+		else if (!strcmp(name, "lds_size_in_kb")) dev->lds_size_in_kb = (uint32_t) value;
+		else if (!strcmp(name, "num_gws")) dev->num_gws = (uint32_t) value;
+		else if (!strcmp(name, "wave_front_size")) dev->wave_front_size = (uint32_t) value;
+		else if (!strcmp(name, "array_count")) dev->array_count = (uint32_t) value;
+		else if (!strcmp(name, "simd_arrays_per_engine")) dev->simd_arrays_per_engine = (uint32_t) value;
+		else if (!strcmp(name, "cu_per_simd_array")) dev->cu_per_simd_array = (uint32_t) value;
+		else if (!strcmp(name, "simd_per_cu")) dev->simd_per_cu = (uint32_t) value;
+		else if (!strcmp(name, "max_slots_scratch_cu")) dev->max_slots_scratch_cu = (uint32_t) value;
+		else if (!strcmp(name, "vendor_id")) dev->vendor_id = (uint32_t) value;
+		else if (!strcmp(name, "device_id")) dev->device_id = (uint32_t) value;
+		else if (!strcmp(name, "domain")) dev->domain = (uint32_t) value;
+		else if (!strcmp(name, "drm_render_minor")) dev->drm_render_minor = (uint32_t) value;
+		else if (!strcmp(name, "hive_id")) dev->hive_id = value;
+		else if (!strcmp(name, "num_sdma_engines")) dev->num_sdma_engines = (uint32_t) value;
+		else if (!strcmp(name, "num_sdma_xgmi_engines")) dev->num_sdma_xgmi_engines = (uint32_t) value;
+		else if (!strcmp(name, "num_sdma_queues_per_engine")) dev->num_sdma_queues_per_engine = (uint32_t) value;
+		else if (!strcmp(name, "num_cp_queues")) dev->num_cp_queues = (uint32_t) value;
+		else if (!strcmp(name, "fw_version")) dev->fw_version = (uint32_t) value;
+		else if (!strcmp(name, "capability")) dev->capability = (uint32_t) value;
+		else if (!strcmp(name, "sdma_fw_version")) dev->sdma_fw_version = (uint32_t) value;
+
+		if (!dev->gpu_id && dev->cpu_cores_count >= 1) {
+			/* This is a CPU - we do not need to parse the other information */
+			continue;
+		}
+	}
+
+	fclose(file);
+	return 0;
+fail:
+	pr_err("Failed to parse line = %s \n", line);
+	fclose(file);
+	return -EINVAL;
+}
+
+int parse_topo_node_mem_banks(struct tp_node *node, const char *dir_path)
+{
+	struct dirent *dirent_node;
+	DIR *d_node;
+	char path[300];
+	FILE *file = NULL;
+	uint32_t heap_type = 0;
+	uint64_t mem_size = 0;
+	int ret;
+
+	if (!NODE_IS_GPU(node))
+		return 0;
+
+	sprintf(path, "%s/mem_banks", dir_path);
+
+	d_node = opendir(path);
+	if (!d_node) {
+		pr_perror("Can't open %s\n", path);
+		return -EACCES;
+	}
+
+	while ((dirent_node = readdir(d_node)) != NULL) {
+		char line[300];
+		char bank_path[300];
+		struct stat st;
+		int id;
+
+		heap_type = 0;
+		mem_size = 0;
+
+		/* Only parse numeric directories */
+		if (sscanf(dirent_node->d_name, "%d", &id) != 1)
+			continue;
+
+		sprintf(bank_path, "%s/%s", path, dirent_node->d_name);
+		if (stat(bank_path, &st)) {
+			pr_err("Cannot to access %s\n", path);
+			ret = -EACCES;
+			goto fail;
+		}
+		if ((st.st_mode & S_IFMT) == S_IFDIR) {
+			char properties_path[300];
+
+			sprintf(properties_path, "%s/properties", bank_path);
+
+			file = fopen(properties_path, "r");
+			if (!file) {
+				pr_perror("Failed to access %s\n", properties_path);
+				ret = -EACCES;
+				goto fail;
+			}
+
+			while (fgets(line, sizeof(line), file)) {
+				char name[30];
+				uint64_t value;
+
+				memset(name, 0, sizeof(name));
+				if (!get_prop(line, name, &value)) {
+					ret = -EINVAL;
+					goto fail;
+				}
+
+				if (!strcmp(name, "heap_type")) heap_type = (uint32_t) value;
+				if (!strcmp(name, "size_in_bytes")) mem_size = value;
+			}
+
+			fclose(file);
+		}
+
+		if (heap_type == TOPO_HEAP_TYPE_PUBLIC || heap_type == TOPO_HEAP_TYPE_PRIVATE)
+			break;
+	}
+
+	if ((heap_type != TOPO_HEAP_TYPE_PUBLIC && heap_type != TOPO_HEAP_TYPE_PRIVATE) || !mem_size) {
+		pr_err("Failed to determine memory type and size for device in %s\n", dir_path);
+		ret = -EINVAL;
+		goto fail;
+	}
+
+	node->vram_public = (heap_type == TOPO_HEAP_TYPE_PUBLIC);
+	node->vram_size = mem_size;
+	closedir(d_node);
+	return 0;
+fail:
+	if (file)
+		fclose(file);
+	closedir(d_node);
+	return ret;
+}
+
+int parse_topo_node_iolinks(struct tp_node *node, const char *dir_path)
+{
+	struct dirent *dirent_node;
+	DIR *d_node;
+	char path[300];
+	FILE *file = NULL;
+	int ret = 0;
+
+	sprintf(path, "%s/io_links", dir_path);
+
+	d_node = opendir(path);
+	if (!d_node) {
+		pr_perror("Can't open %s\n", path);
+		return -EACCES;
+	}
+
+	while ((dirent_node = readdir(d_node)) != NULL) {
+		char line[300];
+		char iolink_path[300];
+		struct stat st;
+		int id;
+
+		uint32_t iolink_type = 0;
+		uint32_t node_to_id = 0;
+
+		/* Only parse numeric directories */
+		if (sscanf(dirent_node->d_name, "%d", &id) != 1)
+			continue;
+
+		sprintf(iolink_path, "%s/%s", path, dirent_node->d_name);
+		if (stat(iolink_path, &st)) {
+			pr_err("Cannot to access %s\n", path);
+			ret = -EACCES;
+			goto fail;
+		}
+		if ((st.st_mode & S_IFMT) == S_IFDIR) {
+			char properties_path[300];
+
+			sprintf(properties_path, "%s/properties", iolink_path);
+
+			file = fopen(properties_path, "r");
+			if (!file) {
+				pr_perror("Failed to access %s\n", properties_path);
+				ret = -EACCES;
+				goto fail;
+			}
+
+			while (fgets(line, sizeof(line), file)) {
+				char name[30];
+				uint64_t value;
+
+				memset(name, 0, sizeof(name));
+				if (!get_prop(line, name, &value)) {
+					ret = -EINVAL;
+					goto fail;
+				}
+
+				if (!strcmp(name, "type")) iolink_type = (uint32_t) value;
+				if (!strcmp(name, "node_to")) node_to_id = (uint32_t) value;
+			}
+			fclose(file);
+		}
+
+		/* We only store the link information for now, then once all topology parsing is
+		 * finished we will confirm iolinks */
+		if (iolink_type == TOPO_IOLINK_TYPE_PCIE || iolink_type == TOPO_IOLINK_TYPE_XGMI) {
+			if (!node_add_iolink(node, iolink_type, node_to_id)) {
+				ret = -ENOMEM;
+				goto fail;
+			}
+		}
+	}
+	closedir(d_node);
+	return 0;
+fail:
+	if (file)
+		fclose(file);
+
+	closedir(d_node);
+	return ret;
+}
+
+
+int parse_topo_node(struct tp_node *node, const char* dir_path)
+{
+	if (parse_topo_node_properties(node, dir_path)) {
+		pr_err("Failed to parse node properties\n");
+		return -EINVAL;
+	}
+	if (parse_topo_node_mem_banks(node, dir_path)) {
+		pr_err("Failed to parse node mem_banks\n");
+		return -EINVAL;
+	}
+	if (parse_topo_node_iolinks(node, dir_path)) {
+		pr_err("Failed to parse node iolinks\n");
+		return -EINVAL;
+	}
+	return 0;
+}
+
+const char* p2pgroup_to_str(struct tp_p2pgroup *group)
+{
+	static char topology_printstr[60];
+	struct tp_node *node;
+	size_t str_len = 0;
+
+	topology_printstr[0] = '\0';
+	str_len += sprintf(&topology_printstr[str_len], "type:%s:", link_type(group->type));
+
+	list_for_each_entry(node, &group->nodes, listm_p2pgroup) {
+		str_len += sprintf(&topology_printstr[str_len], "0x%04X ", node->gpu_id);
+	}
+	return topology_printstr;
+}
+
+const char* mapping_list_to_str(struct list_head *node_list)
+{
+	static char topology_printstr[60];
+	struct tp_node *node;
+	size_t str_len = 0;
+
+	topology_printstr[0] = '\0';
+	list_for_each_entry(node, node_list, listm_mapping)
+		str_len += sprintf(&topology_printstr[str_len], "0x%04X ", node->gpu_id);
+
+	return topology_printstr;
+}
+
+void topology_print(const struct tp_system *sys, const char *message)
+{
+	struct tp_node *node;
+	struct tp_p2pgroup *xgmi_group;
+	pr_info("===System Topology=[%12s]==================================\n", message);
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		struct tp_iolink *iolink;
+		if (!NODE_IS_GPU(node)) {
+			pr_info("[%d] CPU\n", node->id);
+			pr_info("     cpu_cores_count:%u\n", node->cpu_cores_count);
+		} else {
+			pr_info("[%d] GPU gpu_id:0x%04X\n", node->id, node->gpu_id);
+			pr_info("     vendor_id:%u device_id:%u\n",
+					node->vendor_id, node->device_id);
+			pr_info("     vram_public:%c vram_size:%lu\n",
+					node->vram_public ? 'Y' : 'N', node->vram_size);
+			pr_info("     io_links_count:%u capability:%u \n",
+					node->io_links_count, node->capability);
+			pr_info("     mem_banks_count:%u caches_count:%d lds_size_in_kb:%u\n",
+					node->mem_banks_count, node->caches_count, node->lds_size_in_kb);
+			pr_info("     simd_count:%u max_waves_per_simd:%u \n",
+					node->simd_count, node->max_waves_per_simd);
+			pr_info("     num_gws:%u wave_front_size:%u array_count:%u\n",
+					node->num_gws, node->wave_front_size, node->array_count);
+			pr_info("     simd_arrays_per_engine:%u simd_per_cu:%u\n",
+					node->simd_arrays_per_engine, node->simd_per_cu);
+			pr_info("     max_slots_scratch_cu:%u cu_per_simd_array:%u\n",
+					node->max_slots_scratch_cu, node->cu_per_simd_array);
+			pr_info("     num_sdma_engines:%u\n",
+					node->num_sdma_engines);
+			pr_info("     num_sdma_xgmi_engines:%u num_sdma_queues_per_engine:%u\n",
+					node->num_sdma_xgmi_engines, node->num_sdma_queues_per_engine);
+			pr_info("     num_cp_queues:%u fw_version:%u sdma_fw_version:%u\n",
+					node->num_cp_queues, node->fw_version, node->sdma_fw_version);
+		}
+		list_for_each_entry(iolink, &node->iolinks, listm) {
+			if (!iolink->valid)
+				continue;
+
+			pr_info("     iolink type:%s node-to:%d (0x%04X) node-from:%d bi-dir:%s\n",
+				link_type(iolink->type), iolink->node_to_id, iolink->node_to->gpu_id,
+				iolink->node_from->id, iolink->peer ? "Y" : "N");
+		}
+	}
+
+	pr_info("===Groups==========================================================\n");
+	list_for_each_entry(xgmi_group, &sys->xgmi_groups, listm_system)
+		pr_info("%s\n", p2pgroup_to_str(xgmi_group));
+	pr_info("===================================================================\n");
+}
+
+void topology_init(struct tp_system *sys)
+{
+	memset(sys, 0, sizeof(*sys));
+	INIT_LIST_HEAD(&sys->nodes);
+	INIT_LIST_HEAD(&sys->xgmi_groups);
+}
+
+void topology_free(struct tp_system *sys)
+{
+	while (!list_empty(&sys->nodes)) {
+		struct tp_node* node = list_first_entry(&sys->nodes, struct tp_node, listm_system);
+		list_del(&node->listm_system);
+
+		while (!list_empty(&node->iolinks)) {
+			struct tp_iolink *iolink = list_first_entry(&node->iolinks, struct tp_iolink, listm);
+			list_del(&iolink->listm);
+			xfree(iolink);
+		}
+		xfree(node);
+	}
+
+	while (!list_empty(&sys->xgmi_groups)) {
+		struct tp_p2pgroup* p2pgroup = list_first_entry(&sys->xgmi_groups, struct tp_p2pgroup, listm_system);
+		list_del(&p2pgroup->listm_system);
+		xfree(p2pgroup);
+	}
+}
+
+int topology_determine_iolinks(struct tp_system *sys)
+{
+	int ret = 0;
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		struct tp_iolink *iolink;
+
+		list_for_each_entry(iolink, &node->iolinks, listm) {
+			struct tp_p2pgroup *group = NULL;
+			struct tp_node *peer_node = NULL;
+			struct tp_iolink *peer_iolink = NULL;
+
+			peer_node = sys_get_node_by_node_id(sys, iolink->node_to_id);
+			if (!peer_node) {
+				/* node not accessible, usually because it is masked by cgroups */
+				iolink->valid = false;
+				continue;
+			}
+			iolink->valid = true;
+			node->num_valid_iolinks++;
+
+			iolink->node_to = peer_node;
+			peer_iolink = get_tp_peer_iolink(peer_node, node, iolink->type);
+			if (!peer_iolink)
+				continue; /* This is a one-dir link */
+
+			/* We confirmed both sides have same type of iolink */
+			iolink->peer = peer_iolink;
+			peer_iolink->peer = iolink;
+
+			if (iolink->type == TOPO_IOLINK_TYPE_XGMI) {
+				group = sys_get_p2pgroup_with_gpu_id(sys, iolink->type, node->gpu_id);
+				if (!group) {
+					group = sys_add_group(sys, iolink->type);
+					if (!group) {
+						ret = -ENOMEM;
+						goto fail;
+					}
+					list_add_tail(&node->listm_p2pgroup, &group->nodes);
+				}
+
+				if (!p2pgroup_get_node_by_gpu_id(group, peer_node->gpu_id))
+					list_add_tail(&peer_node->listm_p2pgroup, &group->nodes);
+			}
+		}
+	}
+
+fail:
+	/* In case of failure, caller function will call topology_free which will free groups that
+         * were successfully allocated */
+	return ret;
+}
+
+int topology_parse(struct tp_system *sys, const char *message)
+{
+	struct dirent *dirent_system;
+	DIR *d_system;
+	char path[300];
+	int ret;
+
+	if (sys->parsed)
+		return 0;
+
+	sys->parsed = true;
+	INIT_LIST_HEAD(&sys->nodes);
+	INIT_LIST_HEAD(&sys->xgmi_groups);
+
+	d_system = opendir(TOPOLOGY_PATH);
+	if (!d_system) {
+		pr_perror("Can't open %s\n", TOPOLOGY_PATH);
+		return -EACCES;
+	}
+
+	while ((dirent_system = readdir(d_system)) != NULL) {
+		struct stat stbuf;
+		int id, fd;
+
+		/* Only parse numeric directories */
+		if (sscanf(dirent_system->d_name, "%d", &id) != 1)
+			continue;
+
+		sprintf(path, "%s%s", TOPOLOGY_PATH, dirent_system->d_name);
+		if (stat(path, &stbuf)) {
+			/* When cgroup is masking some devices, the path exists, but it is not
+			 * accessible, this is not an error */
+			pr_info("Cannot to access %s\n", path);
+			continue;
+		}
+
+		if ((stbuf.st_mode & S_IFMT) == S_IFDIR) {
+			struct tp_node *node;
+			int len;
+			char gpu_id_path[300];
+			char read_buf[7]; /* Max gpu_id len is 6 chars */
+			unsigned gpu_id;
+			sprintf(gpu_id_path, "%s/%s/gpu_id", TOPOLOGY_PATH, dirent_system->d_name);
+			fd = open(gpu_id_path, O_RDONLY);
+			if (fd < 0) {
+				pr_perror("Failed to access %s\n", gpu_id_path);
+				continue;
+			}
+
+			len = read(fd, read_buf, sizeof(read_buf));
+			close(fd);
+			if (len < 0)
+				continue;
+
+			if (sscanf(read_buf, "%d", &gpu_id) != 1)
+				continue;
+
+			node = sys_add_node(sys, id, gpu_id);
+			if (!node) {
+				ret = -ENOMEM;
+				goto fail;
+			}
+
+			if (parse_topo_node(node, path)) {
+				pr_err("Failed to parse node %s", path);
+				ret = -EINVAL;
+				goto fail;
+			}
+		}
+	}
+	closedir(d_system);
+	return 0;
+
+fail:
+	topology_free(sys);
+	return ret;
+}
+
+bool device_properties_match(struct tp_node *src, struct tp_node *dest)
+{
+	if (src->simd_count == dest->simd_count &&
+	    src->mem_banks_count == dest->mem_banks_count &&
+	    src->io_links_count == dest->io_links_count &&
+	    src->max_waves_per_simd == dest->max_waves_per_simd &&
+	    src->lds_size_in_kb == dest->lds_size_in_kb &&
+	    src->wave_front_size == dest->wave_front_size &&
+	    src->array_count == dest->array_count &&
+	    src->simd_arrays_per_engine == dest->simd_arrays_per_engine &&
+	    src->cu_per_simd_array == dest->cu_per_simd_array &&
+	    src->simd_per_cu == dest->simd_per_cu &&
+	    src->max_slots_scratch_cu == dest->max_slots_scratch_cu &&
+	    src->vendor_id == dest->vendor_id &&
+	    src->device_id == dest->device_id &&
+	    src->num_sdma_engines == dest->num_sdma_engines &&
+	    src->num_sdma_xgmi_engines == dest->num_sdma_xgmi_engines &&
+	    src->num_sdma_queues_per_engine == dest->num_sdma_queues_per_engine &&
+	    src->num_cp_queues == dest->num_cp_queues &&
+	    src->capability == dest->capability &&
+	    src->vram_public == dest->vram_public &&
+	    src->vram_size <= dest->vram_size &&
+	    src->num_gws <= dest->num_gws &&
+	    src->caches_count <= dest->caches_count &&
+	    src->fw_version <= dest->fw_version &&
+	    src->sdma_fw_version <= dest->sdma_fw_version) {
+		return true;
+	}
+	return false;
+
+}
+
+bool iolink_match(struct tp_iolink *src, struct tp_iolink *dest)
+{
+	if (!src->valid)
+		return true;
+
+	if (NODE_IS_GPU(src->node_to) != NODE_IS_GPU(dest->node_to))
+		return false;
+
+	/* XGMI link can replace PCIE links */
+	if (src->type == TOPO_IOLINK_TYPE_XGMI && dest->type == TOPO_IOLINK_TYPE_PCIE)
+		return false;
+
+	/* bi-directional links can replace uni-directional links */
+	if (src->peer != NULL && dest->peer == NULL)
+		return false;
+
+	return true;
+}
+
+bool map_device(struct tp_system *src_sys, struct tp_system *dest_sys, struct tp_node *src_node,
+		struct tp_node *dest_node, struct device_maps *maps, struct device_maps *new_maps)
+{
+	struct tp_iolink *src_iolink;
+
+	pr_debug("Evaluating mapping nodes [0x%04X -> 0x%04X]\n", src_node->gpu_id, dest_node->gpu_id);
+
+	if (!device_properties_match(src_node, dest_node)) {
+		pr_debug("[0x%04X -> 0x%04X] Device properties do not match\n", src_node->gpu_id, dest_node->gpu_id);
+		return false;
+	}
+
+	if (src_node->num_valid_iolinks > dest_node->num_valid_iolinks) {
+		pr_debug("[0x%04X -> 0x%04X] Mismatch between number of iolinks\n",
+				src_node->gpu_id, dest_node->gpu_id);
+		return false;
+	}
+
+	list_for_each_entry(src_iolink, &src_node->iolinks, listm) {
+		/* Go through list of iolinks to CPU and compare them */
+
+		if (!NODE_IS_GPU(src_iolink->node_to)) {
+			bool matched_iolink = false;
+			/* This is a iolink to CPU */
+			pr_debug("Found link to CPU node:%02d\n", src_iolink->node_to->id);
+
+			uint32_t dest_cpu_node_id;
+			dest_cpu_node_id = maps_get_dest_cpu(maps, src_iolink->node_to->id);
+			if (dest_cpu_node_id == INVALID_CPU_ID)
+				dest_cpu_node_id = maps_get_dest_cpu(new_maps, src_iolink->node_to->id);
+
+			if (dest_cpu_node_id == INVALID_CPU_ID)  {
+				struct tp_iolink *dest_iolink;
+				list_for_each_entry(dest_iolink, &dest_node->iolinks, listm) {
+					if (iolink_match(src_iolink, dest_iolink) &&
+						!maps_dest_cpu_mapped(maps, dest_iolink->node_to->id) &&
+						!maps_dest_cpu_mapped(new_maps, dest_iolink->node_to->id)) {
+						if (!maps_add_cpu_entry(new_maps, src_iolink->node_to->id, dest_iolink->node_to->id))
+							/* This is a critical error because we are out of memory */
+							return false;
+
+						matched_iolink = true;
+						break;
+					}
+				}
+			} else {
+				pr_debug("Existing CPU mapping found [%02d-%02d]\n", src_iolink->node_to->id, dest_cpu_node_id);
+				/* Confirm that the link to this CPU is same or better */
+
+				struct tp_iolink *dest_iolink = node_get_iolink_to_node_id(dest_node, src_iolink->type, dest_cpu_node_id);
+				if (dest_iolink && iolink_match(src_iolink, dest_iolink))
+					matched_iolink = true;
+			}
+			if (!matched_iolink) {
+				pr_debug("[0x%04X -> 0x%04X] Mismatch between iolink to CPU\n", src_node->gpu_id, dest_node->gpu_id);
+				return false;
+			}
+		} else {
+			/* If GPUs have P2P-PCIe iolinks to this GPU, then at least one CPU will
+			 * also have a P2P-PCIe iolink to this GPU, so it seems that we do not need
+			 * to consider P2P-PCIE iolinks from GPU to GPU for now */
+		}
+	}
+	pr_debug("[0x%04X -> 0x%04X] Map is possible\n", src_node->gpu_id, dest_node->gpu_id);
+
+	if (!maps_add_gpu_entry(new_maps, src_node->gpu_id, dest_node->gpu_id)) {
+		/* This is a critical error because we are out of memory */
+		return false;
+	}
+	maps_print(new_maps);
+	return true;
+}
+
+bool map_devices(struct tp_system *src_sys, struct tp_system *dest_sys, struct list_head *src_nodes,
+		struct list_head *dest_nodes, struct device_maps *maps)
+{
+	struct tp_node *src_node, *dest_node, *dest_node_tmp;
+	struct device_maps new_maps;
+
+	if (list_empty(src_nodes)) {
+		pr_debug("All nodes mapped successfully\n");
+		return true;
+	}
+
+	pr_debug("Mapping list src nodes [%s]\n", mapping_list_to_str(src_nodes));
+	pr_debug("Mapping list dest nodes [%s]\n", mapping_list_to_str(dest_nodes));
+
+	src_node = list_first_entry(src_nodes, struct tp_node, listm_mapping);
+	pr_debug("Looking for match for node 0x%04X\n", src_node->gpu_id);
+
+	list_del(&src_node->listm_mapping);
+
+	list_for_each_entry_safe(dest_node, dest_node_tmp, dest_nodes, listm_mapping) {
+		maps_init(&new_maps);
+		if (map_device(src_sys, dest_sys, src_node, dest_node, maps, &new_maps)) {
+			pr_debug("Matched destination node 0x%04X\n", dest_node->gpu_id);
+
+			list_del(&dest_node->listm_mapping);
+			if (maps_append(maps, &new_maps))
+				return -EINVAL;
+
+			if (map_devices(src_sys, dest_sys, src_nodes, dest_nodes, maps)) {
+				pr_debug("Matched nodes 0x%04X and after\n", dest_node->gpu_id);
+				return true;
+			} else {
+				pr_debug("Nodes after [0x%04X -> 0x%04X] did not match, adding list back\n", src_node->gpu_id, dest_node->gpu_id);
+
+				list_add(&dest_node->listm_mapping, dest_nodes);
+				maps_remove(maps, &new_maps);
+			}
+		}
+	}
+	pr_debug("Failed to map nodes 0x%04X and after\n", src_node->gpu_id);
+
+	list_add(&src_node->listm_mapping, src_nodes);
+
+	return false;
+}
+
+bool match_xgmi_groups(struct tp_system *src_sys, struct tp_system *dest_sys,
+			struct list_head *src_xgmi_groups, struct list_head *dest_xgmi_groups,
+			struct device_maps *maps)
+{
+	struct tp_p2pgroup *src_group;
+	struct tp_p2pgroup *dest_group;
+	struct tp_p2pgroup *dest_group_tmp;
+
+	if (list_empty(src_xgmi_groups)) {
+		pr_debug("All groups matched successfully\n");
+		return true;
+	}
+
+	src_group = list_first_entry(src_xgmi_groups, struct tp_p2pgroup, listm_system);
+	pr_debug("Looking for match for group [%s]\n", p2pgroup_to_str(src_group));
+
+	list_del(&src_group->listm_system);
+
+	list_for_each_entry_safe(dest_group, dest_group_tmp, dest_xgmi_groups, listm_system) {
+		struct tp_node *node;
+
+		LIST_HEAD(src_nodes);
+		LIST_HEAD(dest_nodes);
+
+		if (src_group->num_nodes > dest_group->num_nodes)
+			continue;
+
+		pr_debug("Trying destination group [%s]\n", p2pgroup_to_str(dest_group));
+
+		list_for_each_entry(node, &src_group->nodes, listm_p2pgroup)
+			list_add_tail(&node->listm_mapping, &src_nodes);
+
+		list_for_each_entry(node, &dest_group->nodes, listm_p2pgroup)
+			list_add_tail(&node->listm_mapping, &dest_nodes);
+
+		/* map_devices will populate maps if successful */
+		if (map_devices(src_sys, dest_sys, &src_nodes, &dest_nodes, maps)) {
+			list_del(&dest_group->listm_system);
+			pr_debug("Matched destination group [%s]\n", p2pgroup_to_str(dest_group));
+			if (match_xgmi_groups(src_sys, dest_sys, src_xgmi_groups, dest_xgmi_groups, maps)) {
+				pr_debug("Matched subgroups of [%s]\n", p2pgroup_to_str(dest_group));
+
+				xfree(src_group);
+				xfree(dest_group);
+				return true;
+			} else
+				list_add(&dest_group->listm_system, dest_xgmi_groups);
+		}
+	}
+
+	pr_debug("Failed to match groups [%s]\n", p2pgroup_to_str(src_group));
+	list_add_tail(&src_group->listm_system, src_xgmi_groups);
+
+	return false;
+}

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -23,6 +23,21 @@
 #define _GNU_SOURCE 1
 #endif
 
+#ifdef COMPILE_TESTS
+#undef pr_err
+#define pr_err(format, arg...) fprintf(stdout, "%s:%d ERROR:" format, __FILE__, __LINE__, ## arg)
+#undef pr_info
+#define pr_info(format, arg...) fprintf(stdout, "%s:%d INFO:" format, __FILE__, __LINE__, ## arg)
+#undef pr_debug
+#define pr_debug(format, arg...) fprintf(stdout, "%s:%d DBG:" format, __FILE__, __LINE__, ## arg)
+
+#undef pr_perror
+#define pr_perror(format, arg...)       \
+        fprintf(stdout, "%s:%d: " format " (errno = %d (%s))\n", \
+                __FILE__, __LINE__, ## arg, errno, strerror(errno))
+
+#endif
+
 #ifdef DEBUG
 #define plugin_log_msg(fmt, ...) pr_debug(fmt, ##__VA_ARGS__)
 #else

--- a/plugins/amdgpu/amdgpu_plugin_topology.h
+++ b/plugins/amdgpu/amdgpu_plugin_topology.h
@@ -1,0 +1,131 @@
+#ifndef __KFD_PLUGIN_TOPOLOGY_H__
+#define __KFD_PLUGIN_TOPOLOGY_H__
+
+#define TOPO_HEAP_TYPE_PUBLIC	1  /* HSA_HEAPTYPE_FRAME_BUFFER_PUBLIC */
+#define TOPO_HEAP_TYPE_PRIVATE	2  /* HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE */
+
+#define TOPO_IOLINK_TYPE_ANY    0  /* HSA_IOLINKTYPE_UNDEFINED */
+#define TOPO_IOLINK_TYPE_PCIE	2  /* HSA_IOLINKTYPE_PCIEXPRESS */
+#define TOPO_IOLINK_TYPE_XGMI	11 /* HSA_IOLINK_TYPE_XGMI */
+
+#define NODE_IS_GPU(node) (node->gpu_id != 0)
+#define INVALID_CPU_ID		0xFFFF
+
+/*************************************** Structures ***********************************************/
+struct tp_node;
+
+struct tp_iolink {
+	struct list_head listm;
+	uint32_t type;
+	uint32_t node_to_id;
+	struct tp_node *node_to;
+	struct tp_node *node_from;
+	bool valid; 	/* Set to false if target node is not accessible */
+	struct tp_iolink *peer; /* If link is bi-directional, peer link */
+};
+
+struct tp_node {
+	uint32_t id;
+	uint32_t gpu_id;
+	uint32_t cpu_cores_count;
+	uint32_t simd_count;
+	uint32_t mem_banks_count;
+	uint32_t caches_count;
+	uint32_t io_links_count;
+	uint32_t max_waves_per_simd;
+	uint32_t lds_size_in_kb;
+	uint32_t num_gws;
+	uint32_t wave_front_size;
+	uint32_t array_count;
+	uint32_t simd_arrays_per_engine;
+	uint32_t cu_per_simd_array;
+	uint32_t simd_per_cu;
+	uint32_t max_slots_scratch_cu;
+	uint32_t vendor_id;
+	uint32_t device_id;
+	uint32_t domain;
+	uint32_t drm_render_minor;
+	uint64_t hive_id;
+	uint32_t num_sdma_engines;
+	uint32_t num_sdma_xgmi_engines;
+	uint32_t num_sdma_queues_per_engine;
+	uint32_t num_cp_queues;
+	uint32_t fw_version;
+	uint32_t capability;
+	uint32_t sdma_fw_version;
+	bool vram_public;
+	uint64_t vram_size;
+
+	struct list_head listm_system;
+	struct list_head listm_p2pgroup;
+	struct list_head listm_mapping; /* Used only during device mapping */
+
+	uint32_t num_valid_iolinks;
+	struct list_head iolinks;
+};
+
+struct tp_p2pgroup {
+	uint32_t type;
+	uint32_t num_nodes;
+	struct list_head listm_system;
+	struct list_head nodes;
+};
+
+struct tp_system {
+	bool parsed;
+	uint32_t num_nodes;
+	struct list_head nodes;
+	uint32_t num_xgmi_groups;
+	struct list_head xgmi_groups;
+};
+
+struct id_map {
+	uint32_t src;
+	uint32_t dest;
+
+	struct list_head listm;
+};
+
+struct device_maps {
+	struct list_head cpu_maps; /* CPUs are mapped using node_id */
+	struct list_head gpu_maps;
+
+	struct list_head *tail_cpu; /* GPUs are mapped using gpu_id */
+	struct list_head *tail_gpu;
+};
+
+/************************************ Global Variables ********************************************/
+struct tp_system src_topology;  /* Valid during dump */
+struct tp_system dest_topology; /* Valid during restore */
+
+struct device_maps checkpoint_maps;
+struct device_maps restore_maps;
+
+/**************************************** Functions ***********************************************/
+void topology_init(struct tp_system *sys);
+void topology_free(struct tp_system *topology);
+
+int topology_parse(struct tp_system *topology, const char *msg);
+int topology_determine_iolinks(struct tp_system *sys);
+void topology_print(const struct tp_system *sys, const char *msg);
+
+struct id_map *maps_add_gpu_entry(struct device_maps *maps, const uint32_t src_id,
+				const uint32_t dest_id);
+
+struct tp_node *sys_add_node(struct tp_system *sys, uint32_t id, uint32_t gpu_id);
+struct tp_iolink *node_add_iolink(struct tp_node *node, uint32_t type, uint32_t node_to_id);
+
+struct tp_node *sys_get_node_by_gpu_id(const struct tp_system *sys, const uint32_t gpu_id);
+struct tp_node *sys_get_node_by_render_minor(const struct tp_system *sys,
+						const int drm_render_minor);
+int set_restore_gpu_maps(struct tp_system *tp_checkpoint,
+			 struct tp_system *tp_local,
+			 struct device_maps *maps);
+
+uint32_t maps_get_dest_cpu(const struct device_maps *maps, const uint32_t src_id);
+uint32_t maps_get_dest_gpu(const struct device_maps *maps, const uint32_t src_id);
+
+void maps_init(struct device_maps *maps);
+void maps_free(struct device_maps *maps);
+
+#endif /* __KFD_PLUGIN_TOPOLOGY_H__ */

--- a/plugins/amdgpu/amdgpu_plugin_topology.h
+++ b/plugins/amdgpu/amdgpu_plugin_topology.h
@@ -101,6 +101,24 @@ struct tp_system dest_topology; /* Valid during restore */
 struct device_maps checkpoint_maps;
 struct device_maps restore_maps;
 
+/* User override options */
+/* Forces gpu mapping to specific gpu list */
+char *kfd_gpu_override;
+/* Skips all topology checks inside plugin - only if kfd_gpu_override is enabled */
+bool  kfd_topology_check;
+/* Skip firmware version check */
+bool  kfd_fw_version_check;
+/* Skip SDMA firmware version check */
+bool  kfd_sdma_fw_version_check;
+/* Skip caches count check */
+bool  kfd_caches_count_check;
+/* Skip num gws check */
+bool kfd_num_gws_check;
+/* Skip vram size check */
+bool kfd_vram_size_check;
+/* Ignore NUMA regions */
+bool kfd_ignore_numa;
+
 /**************************************** Functions ***********************************************/
 void topology_init(struct tp_system *sys);
 void topology_free(struct tp_system *topology);

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -15,6 +15,33 @@ message bo_entries_test {
 	required bytes bo_rawdata = 8;
 }
 
+message q_entry {
+	required uint32 gpu_id = 1;
+	required uint32 type = 2;
+	required uint32 format = 3;
+	required uint32 q_id = 4;
+	required uint64 q_address = 5;
+	required uint64 q_size = 6;
+	required uint32 priority = 7;
+	required uint32 q_percent = 8;
+	required uint64 read_ptr_addr = 9;
+	required uint64 write_ptr_addr = 10;
+	required uint32 doorbell_id = 11;
+	required uint64 doorbell_off = 12;
+	required uint32 is_gws = 13;
+	required uint32 sdma_id = 14;
+	required uint32 sdma_vm_addr = 15;
+
+	required uint64 eop_ring_buffer_address = 16;
+	required uint32 eop_ring_buffer_size = 17;
+	required uint64 ctx_save_restore_area_address = 18;
+	required uint32 ctx_save_restore_area_size = 19;
+	required uint32 ctl_stack_size = 20;
+	required bytes cu_mask = 21;
+	required bytes mqd = 22;
+	required bytes ctl_stack = 23;
+}
+
 message criu_kfd {
 	required uint32 pid = 1;
 	required uint32 num_of_devices = 2;
@@ -22,6 +49,7 @@ message criu_kfd {
 	required uint64	num_of_bos = 4;
 	repeated bo_entries_test bo_info_test = 5;
 	required uint32	num_of_queues = 6;
+	repeated q_entry q_entries = 7;
 }
 
 message criu_render_node {

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -42,6 +42,23 @@ message q_entry {
 	required bytes ctl_stack = 23;
 }
 
+message ev_entry {
+	required uint32 event_id = 1;
+	required uint32 auto_reset = 2;
+	required uint32 type = 3;
+	required uint32 signaled = 4;
+	required uint64 user_signal_address = 5;
+	required uint32 mem_exc_fail_not_present = 6;
+	required uint32 mem_exc_fail_read_only = 7;
+	required uint32 mem_exc_fail_no_execute = 8;
+	required uint64 mem_exc_va = 9;
+	required uint32 mem_exc_gpu_id = 10;
+	required uint32 hw_exc_reset_type = 11;
+	required uint32 hw_exc_reset_cause = 12;
+	required uint32 hw_exc_memory_lost = 13;
+	required uint32 hw_exc_gpu_id = 14;
+}
+
 message criu_kfd {
 	required uint32 pid = 1;
 	required uint32 num_of_devices = 2;
@@ -50,6 +67,9 @@ message criu_kfd {
 	repeated bo_entries_test bo_info_test = 5;
 	required uint32	num_of_queues = 6;
 	repeated q_entry q_entries = 7;
+	required uint64 event_page_offset = 8;
+	required uint32 num_of_events = 9;
+	repeated ev_entry ev_entries = 10;
 }
 
 message criu_render_node {

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -1,7 +1,43 @@
 syntax = "proto2";
 
+message dev_iolink {
+	required uint32 type = 1;
+	required uint32 node_to_id = 2;
+}
+
 message devinfo_entry {
-	required uint32 gpu_id = 1;
+	required uint32 node_id = 1;
+	required uint32 gpu_id = 2;
+	required uint32 cpu_cores_count = 3;
+	required uint32 simd_count = 4;
+	required uint32 mem_banks_count = 5;
+	required uint32 caches_count = 6;
+	required uint32 io_links_count = 7;
+	required uint32 max_waves_per_simd = 8;
+	required uint32 lds_size_in_kb = 9;
+	required uint32 gds_size_in_kb = 10;
+	required uint32 num_gws = 11;
+	required uint32 wave_front_size = 12;
+	required uint32 array_count = 13;
+	required uint32 simd_arrays_per_engine = 14;
+	required uint32 cu_per_simd_array = 15;
+	required uint32 simd_per_cu = 16;
+	required uint32 max_slots_scratch_cu = 17;
+	required uint32 vendor_id = 18;
+	required uint32 device_id = 19;
+	required uint32 domain = 20;
+	required uint32 drm_render_minor = 21;
+	required uint64 hive_id = 22;
+	required uint32 num_sdma_engines = 23;
+	required uint32 num_sdma_xgmi_engines = 24;
+	required uint32 num_sdma_queues_per_engine = 25;
+	required uint32 num_cp_queues = 26;
+	required uint32 fw_version = 27;
+	required uint32 capability = 28;
+	required uint32 sdma_fw_version = 29;
+	required uint32 vram_public = 30;
+	required uint64 vram_size = 31;
+	repeated dev_iolink iolinks = 32;
 }
 
 message bo_entries_test {
@@ -61,15 +97,16 @@ message ev_entry {
 
 message criu_kfd {
 	required uint32 pid = 1;
-	required uint32 num_of_devices = 2;
-	repeated devinfo_entry devinfo_entries = 3;
-	required uint64	num_of_bos = 4;
-	repeated bo_entries_test bo_info_test = 5;
-	required uint32	num_of_queues = 6;
-	repeated q_entry q_entries = 7;
-	required uint64 event_page_offset = 8;
-	required uint32 num_of_events = 9;
-	repeated ev_entry ev_entries = 10;
+	required uint32 num_of_gpus = 2;
+	required uint32 num_of_cpus = 3;
+	repeated devinfo_entry devinfo_entries = 4;
+	required uint64	num_of_bos = 5;
+	repeated bo_entries_test bo_info_test = 6;
+	required uint32	num_of_queues = 7;
+	repeated q_entry q_entries = 8;
+	required uint64 event_page_offset = 9;
+	required uint32 num_of_events = 10;
+	repeated ev_entry ev_entries = 11;
 }
 
 message criu_render_node {

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -110,5 +110,5 @@ message criu_kfd {
 }
 
 message criu_render_node {
-        required uint32 minor_number = 1;
+	required uint32 gpu_id = 1;
 }

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -107,6 +107,8 @@ message criu_kfd {
 	required uint64 event_page_offset = 9;
 	required uint32 num_of_events = 10;
 	repeated ev_entry ev_entries = 11;
+	required uint64 shared_mem_size = 12;
+	required uint32 shared_mem_magic = 13;
 }
 
 message criu_render_node {

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -1,0 +1,29 @@
+syntax = "proto2";
+
+message devinfo_entry {
+	required uint32 gpu_id = 1;
+}
+
+message bo_entries_test {
+	required uint64	bo_addr = 1;
+	required uint64	bo_size = 2;
+	required uint64	bo_offset = 3;
+	required uint32 bo_alloc_flags = 4;
+	required uint32 gpu_id = 5;
+	required uint32 idr_handle = 6;
+	required uint64 user_addr = 7;
+	required bytes bo_rawdata = 8;
+}
+
+message criu_kfd {
+	required uint32 pid = 1;
+	required uint32 num_of_devices = 2;
+	repeated devinfo_entry devinfo_entries = 3;
+	required uint64	num_of_bos = 4;
+	repeated bo_entries_test bo_info_test = 5;
+	required uint32	num_of_queues = 6;
+}
+
+message criu_render_node {
+        required uint32 minor_number = 1;
+}

--- a/plugins/amdgpu/kfd_ioctl.h
+++ b/plugins/amdgpu/kfd_ioctl.h
@@ -1,0 +1,854 @@
+/*
+ * Copyright 2014 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef KFD_IOCTL_H_INCLUDED
+#define KFD_IOCTL_H_INCLUDED
+
+#include <drm/drm.h>
+#include <linux/ioctl.h>
+
+/*
+ * - 1.1 - initial version
+ * - 1.3 - Add SMI events support
+ * - 1.4 - Indicate new SRAM EDC bit in device properties
+ * - 1.5 - Add SVM API
+ */
+#define KFD_IOCTL_MAJOR_VERSION 1
+#define KFD_IOCTL_MINOR_VERSION 5
+
+struct kfd_ioctl_get_version_args {
+	__u32 major_version;	/* from KFD */
+	__u32 minor_version;	/* from KFD */
+};
+
+/* For kfd_ioctl_create_queue_args.queue_type. */
+#define KFD_IOC_QUEUE_TYPE_COMPUTE		0x0
+#define KFD_IOC_QUEUE_TYPE_SDMA			0x1
+#define KFD_IOC_QUEUE_TYPE_COMPUTE_AQL		0x2
+#define KFD_IOC_QUEUE_TYPE_SDMA_XGMI		0x3
+
+#define KFD_MAX_QUEUE_PERCENTAGE	100
+#define KFD_MAX_QUEUE_PRIORITY		15
+
+struct kfd_ioctl_create_queue_args {
+	__u64 ring_base_address;	/* to KFD */
+	__u64 write_pointer_address;	/* from KFD */
+	__u64 read_pointer_address;	/* from KFD */
+	__u64 doorbell_offset;	/* from KFD */
+
+	__u32 ring_size;		/* to KFD */
+	__u32 gpu_id;		/* to KFD */
+	__u32 queue_type;		/* to KFD */
+	__u32 queue_percentage;	/* to KFD */
+	__u32 queue_priority;	/* to KFD */
+	__u32 queue_id;		/* from KFD */
+
+	__u64 eop_buffer_address;	/* to KFD */
+	__u64 eop_buffer_size;	/* to KFD */
+	__u64 ctx_save_restore_address; /* to KFD */
+	__u32 ctx_save_restore_size;	/* to KFD */
+	__u32 ctl_stack_size;		/* to KFD */
+};
+
+struct kfd_ioctl_destroy_queue_args {
+	__u32 queue_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_update_queue_args {
+	__u64 ring_base_address;	/* to KFD */
+
+	__u32 queue_id;		/* to KFD */
+	__u32 ring_size;		/* to KFD */
+	__u32 queue_percentage;	/* to KFD */
+	__u32 queue_priority;	/* to KFD */
+};
+
+struct kfd_ioctl_set_cu_mask_args {
+	__u32 queue_id;		/* to KFD */
+	__u32 num_cu_mask;		/* to KFD */
+	__u64 cu_mask_ptr;		/* to KFD */
+};
+
+struct kfd_ioctl_get_queue_wave_state_args {
+	__u64 ctl_stack_address;	/* to KFD */
+	__u32 ctl_stack_used_size;	/* from KFD */
+	__u32 save_area_used_size;	/* from KFD */
+	__u32 queue_id;			/* to KFD */
+	__u32 pad;
+};
+
+/* For kfd_ioctl_set_memory_policy_args.default_policy and alternate_policy */
+#define KFD_IOC_CACHE_POLICY_COHERENT 0
+#define KFD_IOC_CACHE_POLICY_NONCOHERENT 1
+
+struct kfd_ioctl_set_memory_policy_args {
+	__u64 alternate_aperture_base;	/* to KFD */
+	__u64 alternate_aperture_size;	/* to KFD */
+
+	__u32 gpu_id;			/* to KFD */
+	__u32 default_policy;		/* to KFD */
+	__u32 alternate_policy;		/* to KFD */
+	__u32 pad;
+};
+
+/*
+ * All counters are monotonic. They are used for profiling of compute jobs.
+ * The profiling is done by userspace.
+ *
+ * In case of GPU reset, the counter should not be affected.
+ */
+
+struct kfd_ioctl_get_clock_counters_args {
+	__u64 gpu_clock_counter;	/* from KFD */
+	__u64 cpu_clock_counter;	/* from KFD */
+	__u64 system_clock_counter;	/* from KFD */
+	__u64 system_clock_freq;	/* from KFD */
+
+	__u32 gpu_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_process_device_apertures {
+	__u64 lds_base;		/* from KFD */
+	__u64 lds_limit;		/* from KFD */
+	__u64 scratch_base;		/* from KFD */
+	__u64 scratch_limit;		/* from KFD */
+	__u64 gpuvm_base;		/* from KFD */
+	__u64 gpuvm_limit;		/* from KFD */
+	__u32 gpu_id;		/* from KFD */
+	__u32 pad;
+};
+
+/*
+ * AMDKFD_IOC_GET_PROCESS_APERTURES is deprecated. Use
+ * AMDKFD_IOC_GET_PROCESS_APERTURES_NEW instead, which supports an
+ * unlimited number of GPUs.
+ */
+#define NUM_OF_SUPPORTED_GPUS 7
+struct kfd_ioctl_get_process_apertures_args {
+	struct kfd_process_device_apertures
+			process_apertures[NUM_OF_SUPPORTED_GPUS];/* from KFD */
+
+	/* from KFD, should be in the range [1 - NUM_OF_SUPPORTED_GPUS] */
+	__u32 num_of_nodes;
+	__u32 pad;
+};
+
+struct kfd_ioctl_get_process_apertures_new_args {
+	/* User allocated. Pointer to struct kfd_process_device_apertures
+	 * filled in by Kernel
+	 */
+	__u64 kfd_process_device_apertures_ptr;
+	/* to KFD - indicates amount of memory present in
+	 *  kfd_process_device_apertures_ptr
+	 * from KFD - Number of entries filled by KFD.
+	 */
+	__u32 num_of_nodes;
+	__u32 pad;
+};
+
+#define MAX_ALLOWED_NUM_POINTS    100
+#define MAX_ALLOWED_AW_BUFF_SIZE 4096
+#define MAX_ALLOWED_WAC_BUFF_SIZE  128
+
+struct kfd_ioctl_dbg_register_args {
+	__u32 gpu_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_dbg_unregister_args {
+	__u32 gpu_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_dbg_address_watch_args {
+	__u64 content_ptr;		/* a pointer to the actual content */
+	__u32 gpu_id;		/* to KFD */
+	__u32 buf_size_in_bytes;	/*including gpu_id and buf_size */
+};
+
+struct kfd_ioctl_dbg_wave_control_args {
+	__u64 content_ptr;		/* a pointer to the actual content */
+	__u32 gpu_id;		/* to KFD */
+	__u32 buf_size_in_bytes;	/*including gpu_id and buf_size */
+};
+
+/* Matching HSA_EVENTTYPE */
+#define KFD_IOC_EVENT_SIGNAL			0
+#define KFD_IOC_EVENT_NODECHANGE		1
+#define KFD_IOC_EVENT_DEVICESTATECHANGE		2
+#define KFD_IOC_EVENT_HW_EXCEPTION		3
+#define KFD_IOC_EVENT_SYSTEM_EVENT		4
+#define KFD_IOC_EVENT_DEBUG_EVENT		5
+#define KFD_IOC_EVENT_PROFILE_EVENT		6
+#define KFD_IOC_EVENT_QUEUE_EVENT		7
+#define KFD_IOC_EVENT_MEMORY			8
+
+#define KFD_IOC_WAIT_RESULT_COMPLETE		0
+#define KFD_IOC_WAIT_RESULT_TIMEOUT		1
+#define KFD_IOC_WAIT_RESULT_FAIL		2
+
+#define KFD_SIGNAL_EVENT_LIMIT			4096
+
+/* For kfd_event_data.hw_exception_data.reset_type. */
+#define KFD_HW_EXCEPTION_WHOLE_GPU_RESET	0
+#define KFD_HW_EXCEPTION_PER_ENGINE_RESET	1
+
+/* For kfd_event_data.hw_exception_data.reset_cause. */
+#define KFD_HW_EXCEPTION_GPU_HANG	0
+#define KFD_HW_EXCEPTION_ECC		1
+
+/* For kfd_hsa_memory_exception_data.ErrorType */
+#define KFD_MEM_ERR_NO_RAS		0
+#define KFD_MEM_ERR_SRAM_ECC		1
+#define KFD_MEM_ERR_POISON_CONSUMED	2
+#define KFD_MEM_ERR_GPU_HANG		3
+
+struct kfd_ioctl_create_event_args {
+	__u64 event_page_offset;	/* from KFD */
+	__u32 event_trigger_data;	/* from KFD - signal events only */
+	__u32 event_type;		/* to KFD */
+	__u32 auto_reset;		/* to KFD */
+	__u32 node_id;		/* to KFD - only valid for certain
+							event types */
+	__u32 event_id;		/* from KFD */
+	__u32 event_slot_index;	/* from KFD */
+};
+
+struct kfd_ioctl_destroy_event_args {
+	__u32 event_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_set_event_args {
+	__u32 event_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_reset_event_args {
+	__u32 event_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_memory_exception_failure {
+	__u32 NotPresent;	/* Page not present or supervisor privilege */
+	__u32 ReadOnly;	/* Write access to a read-only page */
+	__u32 NoExecute;	/* Execute access to a page marked NX */
+	__u32 imprecise;	/* Can't determine the	exact fault address */
+};
+
+/* memory exception data */
+struct kfd_hsa_memory_exception_data {
+	struct kfd_memory_exception_failure failure;
+	__u64 va;
+	__u32 gpu_id;
+	__u32 ErrorType; /* 0 = no RAS error,
+			  * 1 = ECC_SRAM,
+			  * 2 = Link_SYNFLOOD (poison),
+			  * 3 = GPU hang (not attributable to a specific cause),
+			  * other values reserved
+			  */
+};
+
+/* hw exception data */
+struct kfd_hsa_hw_exception_data {
+	__u32 reset_type;
+	__u32 reset_cause;
+	__u32 memory_lost;
+	__u32 gpu_id;
+};
+
+/* Event data */
+struct kfd_event_data {
+	union {
+		struct kfd_hsa_memory_exception_data memory_exception_data;
+		struct kfd_hsa_hw_exception_data hw_exception_data;
+	};				/* From KFD */
+	__u64 kfd_event_data_ext;	/* pointer to an extension structure
+					   for future exception types */
+	__u32 event_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_wait_events_args {
+	__u64 events_ptr;		/* pointed to struct
+					   kfd_event_data array, to KFD */
+	__u32 num_events;		/* to KFD */
+	__u32 wait_for_all;		/* to KFD */
+	__u32 timeout;		/* to KFD */
+	__u32 wait_result;		/* from KFD */
+};
+
+struct kfd_ioctl_set_scratch_backing_va_args {
+	__u64 va_addr;	/* to KFD */
+	__u32 gpu_id;	/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_get_tile_config_args {
+	/* to KFD: pointer to tile array */
+	__u64 tile_config_ptr;
+	/* to KFD: pointer to macro tile array */
+	__u64 macro_tile_config_ptr;
+	/* to KFD: array size allocated by user mode
+	 * from KFD: array size filled by kernel
+	 */
+	__u32 num_tile_configs;
+	/* to KFD: array size allocated by user mode
+	 * from KFD: array size filled by kernel
+	 */
+	__u32 num_macro_tile_configs;
+
+	__u32 gpu_id;		/* to KFD */
+	__u32 gb_addr_config;	/* from KFD */
+	__u32 num_banks;		/* from KFD */
+	__u32 num_ranks;		/* from KFD */
+	/* struct size can be extended later if needed
+	 * without breaking ABI compatibility
+	 */
+};
+
+struct kfd_ioctl_set_trap_handler_args {
+	__u64 tba_addr;		/* to KFD */
+	__u64 tma_addr;		/* to KFD */
+	__u32 gpu_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_acquire_vm_args {
+	__u32 drm_fd;	/* to KFD */
+	__u32 gpu_id;	/* to KFD */
+};
+
+/* Allocation flags: memory types */
+#define KFD_IOC_ALLOC_MEM_FLAGS_VRAM		(1 << 0)
+#define KFD_IOC_ALLOC_MEM_FLAGS_GTT		(1 << 1)
+#define KFD_IOC_ALLOC_MEM_FLAGS_USERPTR		(1 << 2)
+#define KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL	(1 << 3)
+#define KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP	(1 << 4)
+/* Allocation flags: attributes/access options */
+#define KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE	(1 << 31)
+#define KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE	(1 << 30)
+#define KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC		(1 << 29)
+#define KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE	(1 << 28)
+#define KFD_IOC_ALLOC_MEM_FLAGS_AQL_QUEUE_MEM	(1 << 27)
+#define KFD_IOC_ALLOC_MEM_FLAGS_COHERENT	(1 << 26)
+#define KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED	(1 << 25)
+
+/* Allocate memory for later SVM (shared virtual memory) mapping.
+ *
+ * @va_addr:     virtual address of the memory to be allocated
+ *               all later mappings on all GPUs will use this address
+ * @size:        size in bytes
+ * @handle:      buffer handle returned to user mode, used to refer to
+ *               this allocation for mapping, unmapping and freeing
+ * @mmap_offset: for CPU-mapping the allocation by mmapping a render node
+ *               for userptrs this is overloaded to specify the CPU address
+ * @gpu_id:      device identifier
+ * @flags:       memory type and attributes. See KFD_IOC_ALLOC_MEM_FLAGS above
+ */
+struct kfd_ioctl_alloc_memory_of_gpu_args {
+	__u64 va_addr;		/* to KFD */
+	__u64 size;		/* to KFD */
+	__u64 handle;		/* from KFD */
+	__u64 mmap_offset;	/* to KFD (userptr), from KFD (mmap offset) */
+	__u32 gpu_id;		/* to KFD */
+	__u32 flags;
+};
+
+/* Free memory allocated with kfd_ioctl_alloc_memory_of_gpu
+ *
+ * @handle: memory handle returned by alloc
+ */
+struct kfd_ioctl_free_memory_of_gpu_args {
+	__u64 handle;		/* to KFD */
+};
+
+/* Map memory to one or more GPUs
+ *
+ * @handle:                memory handle returned by alloc
+ * @device_ids_array_ptr:  array of gpu_ids (__u32 per device)
+ * @n_devices:             number of devices in the array
+ * @n_success:             number of devices mapped successfully
+ *
+ * @n_success returns information to the caller how many devices from
+ * the start of the array have mapped the buffer successfully. It can
+ * be passed into a subsequent retry call to skip those devices. For
+ * the first call the caller should initialize it to 0.
+ *
+ * If the ioctl completes with return code 0 (success), n_success ==
+ * n_devices.
+ */
+struct kfd_ioctl_map_memory_to_gpu_args {
+	__u64 handle;			/* to KFD */
+	__u64 device_ids_array_ptr;	/* to KFD */
+	__u32 n_devices;		/* to KFD */
+	__u32 n_success;		/* to/from KFD */
+};
+
+/* Unmap memory from one or more GPUs
+ *
+ * same arguments as for mapping
+ */
+struct kfd_ioctl_unmap_memory_from_gpu_args {
+	__u64 handle;			/* to KFD */
+	__u64 device_ids_array_ptr;	/* to KFD */
+	__u32 n_devices;		/* to KFD */
+	__u32 n_success;		/* to/from KFD */
+};
+
+/* Allocate GWS for specific queue
+ *
+ * @queue_id:    queue's id that GWS is allocated for
+ * @num_gws:     how many GWS to allocate
+ * @first_gws:   index of the first GWS allocated.
+ *               only support contiguous GWS allocation
+ */
+struct kfd_ioctl_alloc_queue_gws_args {
+	__u32 queue_id;		/* to KFD */
+	__u32 num_gws;		/* to KFD */
+	__u32 first_gws;	/* from KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_get_dmabuf_info_args {
+	__u64 size;		/* from KFD */
+	__u64 metadata_ptr;	/* to KFD */
+	__u32 metadata_size;	/* to KFD (space allocated by user)
+				 * from KFD (actual metadata size)
+				 */
+	__u32 gpu_id;	/* from KFD */
+	__u32 flags;		/* from KFD (KFD_IOC_ALLOC_MEM_FLAGS) */
+	__u32 dmabuf_fd;	/* to KFD */
+};
+
+struct kfd_ioctl_import_dmabuf_args {
+	__u64 va_addr;	/* to KFD */
+	__u64 handle;	/* from KFD */
+	__u32 gpu_id;	/* to KFD */
+	__u32 dmabuf_fd;	/* to KFD */
+};
+
+/*
+ * KFD SMI(System Management Interface) events
+ */
+enum kfd_smi_event {
+	KFD_SMI_EVENT_NONE = 0, /* not used */
+	KFD_SMI_EVENT_VMFAULT = 1, /* event start counting at 1 */
+	KFD_SMI_EVENT_THERMAL_THROTTLE = 2,
+	KFD_SMI_EVENT_GPU_PRE_RESET = 3,
+	KFD_SMI_EVENT_GPU_POST_RESET = 4,
+};
+
+#define KFD_SMI_EVENT_MASK_FROM_INDEX(i) (1ULL << ((i) - 1))
+
+struct kfd_ioctl_smi_events_args {
+	__u32 gpuid;	/* to KFD */
+	__u32 anon_fd;	/* from KFD */
+};
+
+struct kfd_criu_devinfo_bucket {
+	__u32 user_gpu_id;
+	__u32 actual_gpu_id;
+	__u32 drm_fd;
+};
+
+struct kfd_criu_bo_buckets {
+	__u64 bo_addr;  /* from KFD */
+	__u64 bo_size;  /* from KFD */
+	__u64 bo_offset;/* from KFD */
+	__u64 user_addr; /* from KFD */
+	__u32 bo_alloc_flags;/* from KFD */
+	__u32 gpu_id;/* from KFD */
+	__u32 idr_handle;/* from KFD */
+};
+
+struct kfd_criu_q_bucket {
+	__u64 q_address;
+	__u64 q_size;
+	__u64 read_ptr_addr;
+	__u64 write_ptr_addr;
+	__u64 doorbell_off;
+	__u64 eop_ring_buffer_address;		/* Relevant only for VI */
+	__u64 ctx_save_restore_area_address;	/* Relevant only for VI */
+	__u64 queues_data_offset;
+	__u32 gpu_id;
+	__u32 type;
+	__u32 format;
+	__u32 q_id;
+	__u32 priority;
+	__u32 q_percent;
+	__u32 doorbell_id;
+	__u32 is_gws;				/* TODO Implement me */
+	__u32 sdma_id;			/* Relevant only for sdma queues*/
+	__u32 eop_ring_buffer_size;		/* Relevant only for VI */
+	__u32 ctx_save_restore_area_size;	/* Relevant only for VI */
+	__u32 ctl_stack_size;			/* Relevant only for VI */
+	__u32 cu_mask_size;
+	__u32 mqd_size;
+};
+
+struct kfd_criu_ev_bucket {
+	__u32 event_id;
+	__u32 auto_reset;
+	__u32 type;
+	__u32 signaled;
+
+	union {
+		struct kfd_hsa_memory_exception_data memory_exception_data;
+		struct kfd_hsa_hw_exception_data hw_exception_data;
+	};
+};
+
+struct kfd_ioctl_criu_dumper_args {
+	__u64 num_of_bos;
+	__u64 kfd_criu_bo_buckets_ptr;
+	__u64 kfd_criu_q_buckets_ptr;
+	__u64 kfd_criu_ev_buckets_ptr;
+	__u64 kfd_criu_devinfo_buckets_ptr;
+	__u64 queues_data_size;
+	__u64 queues_data_ptr;
+	__u64 event_page_offset;
+	__u32 num_of_queues;
+	__u32 num_of_devices;
+	__u32 num_of_events;
+};
+
+struct kfd_ioctl_criu_restorer_args {
+	__u64 handle;   /* from KFD */
+	__u64 num_of_bos;
+	__u64 kfd_criu_bo_buckets_ptr;
+	__u64 restored_bo_array_ptr;
+	__u64 kfd_criu_q_buckets_ptr;
+	__u64 kfd_criu_ev_buckets_ptr;
+	__u64 kfd_criu_devinfo_buckets_ptr;
+	__u64 queues_data_size;
+	__u64 queues_data_ptr;
+	__u64 event_page_offset;
+	__u32 num_of_devices;
+	__u32 num_of_queues;
+	__u32 num_of_events;
+};
+
+struct kfd_ioctl_criu_helper_args {
+	__u64 num_of_bos;	/* from KFD */
+	__u64 queues_data_size;
+	__u32 task_pid;
+	__u32 num_of_devices;
+	__u32 num_of_queues;    /* from KFD */
+	__u32 num_of_events;	/* from KFD */
+};
+
+struct kfd_ioctl_criu_resume_args {
+	__u32 pid;	/* to KFD */
+};
+
+/* Register offset inside the remapped mmio page
+ */
+enum kfd_mmio_remap {
+	KFD_MMIO_REMAP_HDP_MEM_FLUSH_CNTL = 0,
+	KFD_MMIO_REMAP_HDP_REG_FLUSH_CNTL = 4,
+};
+
+/* Guarantee host access to memory */
+#define KFD_IOCTL_SVM_FLAG_HOST_ACCESS 0x00000001
+/* Fine grained coherency between all devices with access */
+#define KFD_IOCTL_SVM_FLAG_COHERENT    0x00000002
+/* Use any GPU in same hive as preferred device */
+#define KFD_IOCTL_SVM_FLAG_HIVE_LOCAL  0x00000004
+/* GPUs only read, allows replication */
+#define KFD_IOCTL_SVM_FLAG_GPU_RO      0x00000008
+/* Allow execution on GPU */
+#define KFD_IOCTL_SVM_FLAG_GPU_EXEC    0x00000010
+/* GPUs mostly read, may allow similar optimizations as RO, but writes fault */
+#define KFD_IOCTL_SVM_FLAG_GPU_READ_MOSTLY     0x00000020
+
+/**
+ * kfd_ioctl_svm_op - SVM ioctl operations
+ *
+ * @KFD_IOCTL_SVM_OP_SET_ATTR: Modify one or more attributes
+ * @KFD_IOCTL_SVM_OP_GET_ATTR: Query one or more attributes
+ */
+enum kfd_ioctl_svm_op {
+	KFD_IOCTL_SVM_OP_SET_ATTR,
+	KFD_IOCTL_SVM_OP_GET_ATTR
+};
+
+/** kfd_ioctl_svm_location - Enum for preferred and prefetch locations
+ *
+ * GPU IDs are used to specify GPUs as preferred and prefetch locations.
+ * Below definitions are used for system memory or for leaving the preferred
+ * location unspecified.
+ */
+enum kfd_ioctl_svm_location {
+	KFD_IOCTL_SVM_LOCATION_SYSMEM = 0,
+	KFD_IOCTL_SVM_LOCATION_UNDEFINED = 0xffffffff
+};
+
+/**
+ * kfd_ioctl_svm_attr_type - SVM attribute types
+ *
+ * @KFD_IOCTL_SVM_ATTR_PREFERRED_LOC: gpuid of the preferred location, 0 for
+ *                                    system memory
+ * @KFD_IOCTL_SVM_ATTR_PREFETCH_LOC: gpuid of the prefetch location, 0 for
+ *                                   system memory. Setting this triggers an
+ *                                   immediate prefetch (migration).
+ * @KFD_IOCTL_SVM_ATTR_ACCESS:
+ * @KFD_IOCTL_SVM_ATTR_ACCESS_IN_PLACE:
+ * @KFD_IOCTL_SVM_ATTR_NO_ACCESS: specify memory access for the gpuid given
+ *                                by the attribute value
+ * @KFD_IOCTL_SVM_ATTR_SET_FLAGS: bitmask of flags to set (see
+ *                                KFD_IOCTL_SVM_FLAG_...)
+ * @KFD_IOCTL_SVM_ATTR_CLR_FLAGS: bitmask of flags to clear
+ * @KFD_IOCTL_SVM_ATTR_GRANULARITY: migration granularity
+ *                                  (log2 num pages)
+ */
+enum kfd_ioctl_svm_attr_type {
+	KFD_IOCTL_SVM_ATTR_PREFERRED_LOC,
+	KFD_IOCTL_SVM_ATTR_PREFETCH_LOC,
+	KFD_IOCTL_SVM_ATTR_ACCESS,
+	KFD_IOCTL_SVM_ATTR_ACCESS_IN_PLACE,
+	KFD_IOCTL_SVM_ATTR_NO_ACCESS,
+	KFD_IOCTL_SVM_ATTR_SET_FLAGS,
+	KFD_IOCTL_SVM_ATTR_CLR_FLAGS,
+	KFD_IOCTL_SVM_ATTR_GRANULARITY
+};
+
+/**
+ * kfd_ioctl_svm_attribute - Attributes as pairs of type and value
+ *
+ * The meaning of the @value depends on the attribute type.
+ *
+ * @type: attribute type (see enum @kfd_ioctl_svm_attr_type)
+ * @value: attribute value
+ */
+struct kfd_ioctl_svm_attribute {
+	__u32 type;
+	__u32 value;
+};
+
+/**
+ * kfd_ioctl_svm_args - Arguments for SVM ioctl
+ *
+ * @op specifies the operation to perform (see enum
+ * @kfd_ioctl_svm_op).  @start_addr and @size are common for all
+ * operations.
+ *
+ * A variable number of attributes can be given in @attrs.
+ * @nattr specifies the number of attributes. New attributes can be
+ * added in the future without breaking the ABI. If unknown attributes
+ * are given, the function returns -EINVAL.
+ *
+ * @KFD_IOCTL_SVM_OP_SET_ATTR sets attributes for a virtual address
+ * range. It may overlap existing virtual address ranges. If it does,
+ * the existing ranges will be split such that the attribute changes
+ * only apply to the specified address range.
+ *
+ * @KFD_IOCTL_SVM_OP_GET_ATTR returns the intersection of attributes
+ * over all memory in the given range and returns the result as the
+ * attribute value. If different pages have different preferred or
+ * prefetch locations, 0xffffffff will be returned for
+ * @KFD_IOCTL_SVM_ATTR_PREFERRED_LOC or
+ * @KFD_IOCTL_SVM_ATTR_PREFETCH_LOC resepctively. For
+ * @KFD_IOCTL_SVM_ATTR_SET_FLAGS, flags of all pages will be
+ * aggregated by bitwise AND. The minimum  migration granularity
+ * throughout the range will be returned for
+ * @KFD_IOCTL_SVM_ATTR_GRANULARITY.
+ *
+ * Querying of accessibility attributes works by initializing the
+ * attribute type to @KFD_IOCTL_SVM_ATTR_ACCESS and the value to the
+ * GPUID being queried. Multiple attributes can be given to allow
+ * querying multiple GPUIDs. The ioctl function overwrites the
+ * attribute type to indicate the access for the specified GPU.
+ *
+ * @KFD_IOCTL_SVM_ATTR_CLR_FLAGS is invalid for
+ * @KFD_IOCTL_SVM_OP_GET_ATTR.
+ */
+struct kfd_ioctl_svm_args {
+	__u64 start_addr;
+	__u64 size;
+	__u32 op;
+	__u32 nattr;
+	/* Variable length array of attributes */
+	struct kfd_ioctl_svm_attribute attrs[0];
+};
+
+/**
+ * kfd_ioctl_set_xnack_mode_args - Arguments for set_xnack_mode
+ *
+ * @xnack_enabled:       [in/out] Whether to enable XNACK mode for this process
+ *
+ * @xnack_enabled indicates whether recoverable page faults should be
+ * enabled for the current process. 0 means disabled, positive means
+ * enabled, negative means leave unchanged. If enabled, virtual address
+ * translations on GFXv9 and later AMD GPUs can return XNACK and retry
+ * the access until a valid PTE is available. This is used to implement
+ * device page faults.
+ *
+ * On output, @xnack_enabled returns the (new) current mode (0 or
+ * positive). Therefore, a negative input value can be used to query
+ * the current mode without changing it.
+ *
+ * The XNACK mode fundamentally changes the way SVM managed memory works
+ * in the driver, with subtle effects on application performance and
+ * functionality.
+ *
+ * Enabling XNACK mode requires shader programs to be compiled
+ * differently. Furthermore, not all GPUs support changing the mode
+ * per-process. Therefore changing the mode is only allowed while no
+ * user mode queues exist in the process. This ensure that no shader
+ * code is running that may be compiled for the wrong mode. And GPUs
+ * that cannot change to the requested mode will prevent the XNACK
+ * mode from occurring. All GPUs used by the process must be in the
+ * same XNACK mode.
+ *
+ * GFXv8 or older GPUs do not support 48 bit virtual addresses or SVM.
+ * Therefore those GPUs are not considered for the XNACK mode switch.
+ *
+ * Return: 0 on success, -errno on failure
+ */
+struct kfd_ioctl_set_xnack_mode_args {
+	__s32 xnack_enabled;
+};
+
+#define AMDKFD_IOCTL_BASE 'K'
+#define AMDKFD_IO(nr)			_IO(AMDKFD_IOCTL_BASE, nr)
+#define AMDKFD_IOR(nr, type)		_IOR(AMDKFD_IOCTL_BASE, nr, type)
+#define AMDKFD_IOW(nr, type)		_IOW(AMDKFD_IOCTL_BASE, nr, type)
+#define AMDKFD_IOWR(nr, type)		_IOWR(AMDKFD_IOCTL_BASE, nr, type)
+
+#define AMDKFD_IOC_GET_VERSION			\
+		AMDKFD_IOR(0x01, struct kfd_ioctl_get_version_args)
+
+#define AMDKFD_IOC_CREATE_QUEUE			\
+		AMDKFD_IOWR(0x02, struct kfd_ioctl_create_queue_args)
+
+#define AMDKFD_IOC_DESTROY_QUEUE		\
+		AMDKFD_IOWR(0x03, struct kfd_ioctl_destroy_queue_args)
+
+#define AMDKFD_IOC_SET_MEMORY_POLICY		\
+		AMDKFD_IOW(0x04, struct kfd_ioctl_set_memory_policy_args)
+
+#define AMDKFD_IOC_GET_CLOCK_COUNTERS		\
+		AMDKFD_IOWR(0x05, struct kfd_ioctl_get_clock_counters_args)
+
+#define AMDKFD_IOC_GET_PROCESS_APERTURES	\
+		AMDKFD_IOR(0x06, struct kfd_ioctl_get_process_apertures_args)
+
+#define AMDKFD_IOC_UPDATE_QUEUE			\
+		AMDKFD_IOW(0x07, struct kfd_ioctl_update_queue_args)
+
+#define AMDKFD_IOC_CREATE_EVENT			\
+		AMDKFD_IOWR(0x08, struct kfd_ioctl_create_event_args)
+
+#define AMDKFD_IOC_DESTROY_EVENT		\
+		AMDKFD_IOW(0x09, struct kfd_ioctl_destroy_event_args)
+
+#define AMDKFD_IOC_SET_EVENT			\
+		AMDKFD_IOW(0x0A, struct kfd_ioctl_set_event_args)
+
+#define AMDKFD_IOC_RESET_EVENT			\
+		AMDKFD_IOW(0x0B, struct kfd_ioctl_reset_event_args)
+
+#define AMDKFD_IOC_WAIT_EVENTS			\
+		AMDKFD_IOWR(0x0C, struct kfd_ioctl_wait_events_args)
+
+#define AMDKFD_IOC_DBG_REGISTER			\
+		AMDKFD_IOW(0x0D, struct kfd_ioctl_dbg_register_args)
+
+#define AMDKFD_IOC_DBG_UNREGISTER		\
+		AMDKFD_IOW(0x0E, struct kfd_ioctl_dbg_unregister_args)
+
+#define AMDKFD_IOC_DBG_ADDRESS_WATCH		\
+		AMDKFD_IOW(0x0F, struct kfd_ioctl_dbg_address_watch_args)
+
+#define AMDKFD_IOC_DBG_WAVE_CONTROL		\
+		AMDKFD_IOW(0x10, struct kfd_ioctl_dbg_wave_control_args)
+
+#define AMDKFD_IOC_SET_SCRATCH_BACKING_VA	\
+		AMDKFD_IOWR(0x11, struct kfd_ioctl_set_scratch_backing_va_args)
+
+#define AMDKFD_IOC_GET_TILE_CONFIG                                      \
+		AMDKFD_IOWR(0x12, struct kfd_ioctl_get_tile_config_args)
+
+#define AMDKFD_IOC_SET_TRAP_HANDLER		\
+		AMDKFD_IOW(0x13, struct kfd_ioctl_set_trap_handler_args)
+
+#define AMDKFD_IOC_GET_PROCESS_APERTURES_NEW	\
+		AMDKFD_IOWR(0x14,		\
+			struct kfd_ioctl_get_process_apertures_new_args)
+
+#define AMDKFD_IOC_ACQUIRE_VM			\
+		AMDKFD_IOW(0x15, struct kfd_ioctl_acquire_vm_args)
+
+#define AMDKFD_IOC_ALLOC_MEMORY_OF_GPU		\
+		AMDKFD_IOWR(0x16, struct kfd_ioctl_alloc_memory_of_gpu_args)
+
+#define AMDKFD_IOC_FREE_MEMORY_OF_GPU		\
+		AMDKFD_IOW(0x17, struct kfd_ioctl_free_memory_of_gpu_args)
+
+#define AMDKFD_IOC_MAP_MEMORY_TO_GPU		\
+		AMDKFD_IOWR(0x18, struct kfd_ioctl_map_memory_to_gpu_args)
+
+#define AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU	\
+		AMDKFD_IOWR(0x19, struct kfd_ioctl_unmap_memory_from_gpu_args)
+
+#define AMDKFD_IOC_SET_CU_MASK		\
+		AMDKFD_IOW(0x1A, struct kfd_ioctl_set_cu_mask_args)
+
+#define AMDKFD_IOC_GET_QUEUE_WAVE_STATE		\
+		AMDKFD_IOWR(0x1B, struct kfd_ioctl_get_queue_wave_state_args)
+
+#define AMDKFD_IOC_GET_DMABUF_INFO		\
+		AMDKFD_IOWR(0x1C, struct kfd_ioctl_get_dmabuf_info_args)
+
+#define AMDKFD_IOC_IMPORT_DMABUF		\
+		AMDKFD_IOWR(0x1D, struct kfd_ioctl_import_dmabuf_args)
+
+#define AMDKFD_IOC_ALLOC_QUEUE_GWS		\
+		AMDKFD_IOWR(0x1E, struct kfd_ioctl_alloc_queue_gws_args)
+
+#define AMDKFD_IOC_SMI_EVENTS			\
+		AMDKFD_IOWR(0x1F, struct kfd_ioctl_smi_events_args)
+
+#define AMDKFD_IOC_SVM	AMDKFD_IOWR(0x20, struct kfd_ioctl_svm_args)
+
+#define AMDKFD_IOC_SET_XNACK_MODE		\
+		AMDKFD_IOWR(0x21, struct kfd_ioctl_set_xnack_mode_args)
+
+#define AMDKFD_IOC_CRIU_DUMPER			\
+		AMDKFD_IOWR(0x22, struct kfd_ioctl_criu_dumper_args)
+
+#define AMDKFD_IOC_CRIU_RESTORER			\
+		AMDKFD_IOWR(0x23, struct kfd_ioctl_criu_restorer_args)
+
+#define AMDKFD_IOC_CRIU_HELPER			\
+		AMDKFD_IOWR(0x24, struct kfd_ioctl_criu_helper_args)
+
+#define AMDKFD_IOC_CRIU_RESUME			\
+		AMDKFD_IOWR(0x25, struct kfd_ioctl_criu_resume_args)
+
+#define AMDKFD_COMMAND_START		0x01
+#define AMDKFD_COMMAND_END		0x26
+
+#endif

--- a/plugins/amdgpu/tests/test_topology_remap.c
+++ b/plugins/amdgpu/tests/test_topology_remap.c
@@ -1,0 +1,985 @@
+/**************************************************************************************************
+ * GPU groups remapping unit tests
+ *
+ * Test cases for GPU topology group remapping when there are P2P iolinks between the GPUs. GPUs are
+ * considered to be grouped when they have a P2P iolink.
+ * 	a. P2P-XGMI: They are connected through a XGMI bridge
+ * 	b. P2P-PCIe: They have large BAR enabled and each GPU can address full address space of the
+ *         other GPU (44-bits address limitation)
+ *
+ * When GPUs have large BAR, but each GPU cannot address full address of each other, they do not
+ * have P2P-PCIe links and are not considered for GPU grouping. The GPU still has to be remapped to
+ * a GPU with large BAR on restore.
+ *
+ * GPUs can be part of 2 groups at the same time, i.e have P2P-XGMI links with one set of GPUs and
+ * have P2P-PCIe links with another set of GPUs.
+ *
+ *
+ * Test 0: 8 GPUs in 2 XGMI hives (full P2P-PCIe)
+ *	2 XGMI hives of 4 GPUs
+ *      Each hives have different type of GPU's
+ *	All 8 GPUs have P2P-PCIe links
+ *      2 CPU's - each cpu can access alternate GPU's
+ *      EXPECT: SUCCESS
+ *
+ * Test 1: 8 GPUs in 2 XGMI hives (partial P2P-PCIe case 1)
+ *	2 XGMI hives of 4 GPUs
+ *      Last 2 GPUs do not have Large BAR, i.e
+ *	6 GPUs have P2P-PCIe links and P2P-XGMI links
+ *	2 GPUs only have P2P-XGMI links
+ *	4 GPUs with P2P-PCIe link in first XGMI hive, 2 GPUs in the second XGMI hive
+ *      EXPECT: SUCCESS
+ *
+ * Test 2: 8 GPUs in 2 XGMI hives (partial P2P-PCIe case 1)
+ *	Same as test 2 but each hive have different device_id's so it is not possible to swap
+ *      hives 1 and 2 on restore.
+ *      EXPECT: FAIL
+ *
+ * Test 3:8 GPU's in 2 XGMI hives (partial P2P-PCIe case 2)
+ *	2 XGMI hives of 4 GPUs
+ *      6 GPUs do not have Large BAR, i.e
+ *	Only 2 GPU's have P2P PCIe links
+ * 	Both GPUs with P2P-PCIe links are in different XGMI hives but at different index between
+ *      checkpointed and restored nodes
+ *      Only possible way to map is to map A002 -> B0000 and A017 -> B015
+ *      EXPECT: SUCCESS
+ *
+ * Test 4:8 GPU's in 2 XGMI hives (partial P2P-PCIe case 2)
+ *	Same as 3 but not possible to map because of CPU iolink changed
+ *      EXPECT: FAIL
+ *
+ * Test 5: 8 GPUs with 1 XGMI hive
+ *    	4 GPUs in 1 XGMI hive, 4 GPUs have no XGMI bridge
+ *    	All 8 GPUs have P2P-PCIe links
+ *      EXPECT: SUCCESS
+ *
+ * Test 6: 5 GPUs (mix and match GPU types and partial large BAR)
+ *	No XGMI bridges
+ *	First 4 GPUs have P2P-PCIe links
+ *      1 GPU has different device_id's at different locations
+ *      EXPECT: SUCCESS
+ *
+ **************************************************************************************************
+ * Tests where restore node has more bigger/more groups than checkpointed node
+ *
+ * Test 7: Checkpoint node has 8 GPUs (4 in XGMI hive, 4 without XGMI bridge)
+ *      Restore node has 8 GPUs (2 XGMI hives)
+ *      Restore should succeed - user application will not take advantage of 2 XGMI bridge
+ *      EXPECT: SUCCESS
+ *
+ * Test 8: Checkpoint node has 5 GPUs (3 GPU's with P2P-PCIe links)
+ *     Restore node has 5 GPUs (4 GPU's with P2P-PCIe links)
+ *      EXPECT: SUCCESS
+ *
+ **************************************************************************************************/
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <errno.h>
+#include "common/list.h"
+
+#include "amdgpu_plugin_topology.h"
+
+
+#define pr_err(...) fprintf(stdout, "ERR:" __VA_ARGS__)
+#define pr_info(...) fprintf(stdout, "INFO:" __VA_ARGS__)
+#define pr_debug(...) fprintf(stdout, "DBG:" __VA_ARGS__)
+
+int verify_maps(const struct device_maps *maps, uint32_t num_cpus, uint32_t num_gpus)
+{
+        struct id_map *map;
+
+        list_for_each_entry(map, &maps->cpu_maps, listm) {
+                if (num_cpus-- == 0) {
+                        pr_err("Results had more mappings than number of CPUs\n");
+                        return -EINVAL;
+                }
+        }
+        if (num_cpus > 0) {
+                pr_err("Results did not map all CPUs\n");
+                return -EINVAL;
+        }
+
+        list_for_each_entry(map, &maps->gpu_maps, listm) {
+                if (num_gpus-- == 0) {
+                        pr_err("Results had more mappings than number of GPUs\n");
+                        return -EINVAL;
+                }
+        }
+        if (num_gpus > 0) {
+                pr_err("Results did not map all GPUs\n");
+                return -EINVAL;
+        }
+	return 0;
+}
+
+int test_0(void)
+{
+        int ret = 0;
+        struct device_maps maps;
+
+        struct tp_node *node_gpus[8];
+        struct tp_node *node_cpus[2];
+
+        struct tp_system tp_src = { 0 };
+        struct tp_system tp_dest = { 0 };
+
+        /* Fill src struct */
+        topology_init(&tp_src);
+        tp_src.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+        }
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+                node_gpus[i]->device_id = 0xD001;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 2);
+        }
+
+        /* Fill dest struct */
+        topology_init(&tp_dest);
+        tp_dest.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+                node_gpus[i]->device_id = 0xD001;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+        }
+
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 2);
+        }
+
+        ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+        if (!ret) {
+                if (verify_maps(&maps,
+                                sizeof(node_cpus)/sizeof(node_cpus[0]),
+                                sizeof(node_gpus)/sizeof(node_gpus[0]))) {
+
+                        pr_err("Mapping returned success, but results had errors\n");
+                        ret = -1;
+                }
+        }
+        topology_free(&tp_src);
+        topology_free(&tp_dest);
+        maps_free(&maps);
+        return ret;
+}
+
+int test_1(void)
+{
+        int ret = 0;
+        struct device_maps maps;
+
+        struct tp_node *node_gpus[8];
+        struct tp_node *node_cpus[2];
+
+        struct tp_system tp_src = { 0 };
+        struct tp_system tp_dest = { 0 };
+
+        /* Fill src struct */
+        topology_init(&tp_src);
+        tp_src.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+                for (int j = 4; j < 8; j++) {
+                        if (((i + j) % 4) + 6 < 8)
+                                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+                }
+        }
+
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+                node_gpus[i]->device_id = 0xD000;
+
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                if (i < 6)
+                        node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 2);
+        }
+
+        /* Fill dest struct */
+        topology_init(&tp_dest);
+        tp_dest.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+                for (int j = 4; j < 8; j++) {
+                        if (((i + j) % 4) + 6 < 8)
+                                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+                }
+        }
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+                node_gpus[i]->device_id = 0xD000;
+
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                if (i < 6)
+                        node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 2);
+        }
+
+        ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+        if (!ret) {
+                if (verify_maps(&maps,
+                                sizeof(node_cpus)/sizeof(node_cpus[0]),
+                                sizeof(node_gpus)/sizeof(node_gpus[0]))) {
+
+                        pr_err("Mapping returned success, but results had errors\n");
+                        ret = -1;
+                }
+        }
+        topology_free(&tp_src);
+        topology_free(&tp_dest);
+        maps_free(&maps);
+        return ret;
+}
+
+int test_2(void)
+{
+        int ret = 0;
+        struct device_maps maps;
+
+        struct tp_node *node_gpus[8];
+        struct tp_node *node_cpus[2];
+
+        struct tp_system tp_src = { 0 };
+        struct tp_system tp_dest = { 0 };
+
+        /* Fill src struct */
+        topology_init(&tp_src);
+        tp_src.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+                for (int j = 4; j < 8; j++) {
+                        if (((i + j) % 4) + 6 < 8)
+                                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+                }
+        }
+
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+                node_gpus[i]->device_id = 0xD001;
+
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                if (i < 6)
+                        node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 2);
+        }
+
+        /* Fill dest struct */
+        topology_init(&tp_dest);
+        tp_dest.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+                node_gpus[i]->device_id = 0xD001;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+                for (int j = 4; j < 8; j++) {
+                        if (((i + j) % 4) + 6 < 8)
+                                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+                }
+        }
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+                node_gpus[i]->device_id = 0xD000;
+
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                if (i < 6)
+                        node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 2);
+        }
+
+        ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+        if (!ret) {
+                if (verify_maps(&maps,
+                                sizeof(node_cpus)/sizeof(node_cpus[0]),
+                                sizeof(node_gpus)/sizeof(node_gpus[0]))) {
+
+                        pr_err("Mapping returned success, but results had errors\n");
+                        ret = -1;
+                }
+        }
+        topology_free(&tp_src);
+        topology_free(&tp_dest);
+        maps_free(&maps);
+        return ret;
+}
+
+int test_3(void)
+{
+        int ret = 0;
+        struct device_maps maps;
+
+        struct tp_node *node_gpus[8];
+        struct tp_node *node_cpus[2];
+
+        struct tp_system tp_src = { 0 };
+        struct tp_system tp_dest = { 0 };
+
+        /* Fill src struct */
+        topology_init(&tp_src);
+        tp_src.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+        }
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+                node_gpus[i]->device_id = 0xD001;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+        }
+
+        node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, 4);
+        node_add_iolink(node_cpus[1], TOPO_IOLINK_TYPE_PCIE, 9);
+
+
+        /* Fill dest struct */
+        topology_init(&tp_dest);
+        tp_dest.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+        }
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+                node_gpus[i]->device_id = 0xD001;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+        }
+
+        node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, 2);
+        node_add_iolink(node_cpus[1], TOPO_IOLINK_TYPE_PCIE, 7);
+
+        ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+        if (!ret) {
+                if (verify_maps(&maps,
+                                sizeof(node_cpus)/sizeof(node_cpus[0]),
+                                sizeof(node_gpus)/sizeof(node_gpus[0]))) {
+
+                        pr_err("Mapping returned success, but results had errors\n");
+                        ret = -1;
+                }
+        }
+        topology_free(&tp_src);
+        topology_free(&tp_dest);
+        maps_free(&maps);
+        return ret;
+}
+
+int test_4(void)
+{
+        int ret = 0;
+        struct device_maps maps;
+
+        struct tp_node *node_gpus[8];
+        struct tp_node *node_cpus[2];
+
+        struct tp_system tp_src = { 0 };
+        struct tp_system tp_dest = { 0 };
+
+        /* Fill src struct */
+        topology_init(&tp_src);
+        tp_src.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+        }
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+                node_gpus[i]->device_id = 0xD001;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+        }
+
+        node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, 4);
+        node_add_iolink(node_cpus[1], TOPO_IOLINK_TYPE_PCIE, 9);
+
+
+        /* Fill dest struct */
+        topology_init(&tp_dest);
+        tp_dest.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+        }
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+                node_gpus[i]->device_id = 0xD001;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+        }
+
+        node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, 2);
+        node_add_iolink(node_cpus[1], TOPO_IOLINK_TYPE_PCIE, 6);
+
+        ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+        if (!ret) {
+                if (verify_maps(&maps,
+                                sizeof(node_cpus)/sizeof(node_cpus[0]),
+                                sizeof(node_gpus)/sizeof(node_gpus[0]))) {
+
+                        pr_err("Mapping returned success, but results had errors\n");
+                        ret = -1;
+                }
+        }
+        topology_free(&tp_src);
+        topology_free(&tp_dest);
+        maps_free(&maps);
+        return ret;
+}
+
+int test_5(void)
+{
+        int ret = 0;
+        struct device_maps maps;
+
+        struct tp_node *node_gpus[8];
+        struct tp_node *node_cpus[2];
+
+        struct tp_system tp_src = { 0 };
+        struct tp_system tp_dest = { 0 };
+
+        /* Fill src struct */
+        topology_init(&tp_src);
+        tp_src.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+        }
+
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 2);
+        }
+
+        /* Fill dest struct */
+        topology_init(&tp_dest);
+        tp_dest.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+        }
+
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+                node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+                for (int j = 4; j < 8; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 2);
+        }
+
+        ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+        if (!ret) {
+                if (verify_maps(&maps,
+                                sizeof(node_cpus)/sizeof(node_cpus[0]),
+                                sizeof(node_gpus)/sizeof(node_gpus[0]))) {
+
+                        pr_err("Mapping returned success, but results had errors\n");
+                        ret = -1;
+                }
+        }
+        topology_free(&tp_src);
+        topology_free(&tp_dest);
+        maps_free(&maps);
+        return ret;
+}
+
+int test_6(void)
+{
+        int ret = 0;
+        struct device_maps maps;
+
+        struct tp_node *node_gpus[5];
+        struct tp_node *node_cpus[1];
+
+        struct tp_system tp_src = { 0 };
+        struct tp_system tp_dest = { 0 };
+
+        /* Fill src struct */
+        topology_init(&tp_src);
+        tp_src.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 5; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 1, 0xA000 + i);
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, 0);
+                node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, i + 1);
+        }
+        node_gpus[0]->device_id = 0xD000;
+        node_gpus[1]->device_id = 0xD000;
+        node_gpus[2]->device_id = 0xD001;
+        node_gpus[3]->device_id = 0xD000;
+        node_gpus[4]->device_id = 0xD001;
+
+        for (int i = 0; i < 5; i++) {
+                for (int j = 1; j < 5; j++) {
+                        if (((i + j) % 5) + 1 < 5)
+                                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 5) + 1);
+                }
+        }
+
+        /* Fill dest struct */
+        topology_init(&tp_dest);
+        tp_dest.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 5; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 1, 0xB000 + i);
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, 0);
+                node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, i + 1);
+        }
+        node_gpus[0]->device_id = 0xD000;
+        node_gpus[1]->device_id = 0xD001;
+        node_gpus[2]->device_id = 0xD000;
+        node_gpus[3]->device_id = 0xD000;
+        node_gpus[4]->device_id = 0xD001;
+
+        for (int i = 0; i < 5; i++) {
+                for (int j = 1; j < 5; j++) {
+                        if (((i + j) % 5) + 1 < 5)
+                                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 5) + 1);
+                }
+        }
+
+        ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+        if (!ret) {
+                if (verify_maps(&maps,
+                                sizeof(node_cpus)/sizeof(node_cpus[0]),
+                                sizeof(node_gpus)/sizeof(node_gpus[0]))) {
+
+                        pr_err("Mapping returned success, but results had errors\n");
+                        ret = -1;
+                }
+        }
+        topology_free(&tp_src);
+        topology_free(&tp_dest);
+        maps_free(&maps);
+        return ret;
+}
+
+int test_7(void)
+{
+        int ret = 0;
+        struct device_maps maps;
+
+        struct tp_node *node_gpus[8];
+        struct tp_node *node_cpus[2];
+
+        struct tp_system tp_src = { 0 };
+        struct tp_system tp_dest = { 0 };
+
+        /* Fill src struct */
+        topology_init(&tp_src);
+        tp_src.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+        }
+
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+                node_gpus[i]->device_id = 0xD000;
+        }
+
+        /* Fill dest struct */
+        topology_init(&tp_dest);
+        tp_dest.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+        node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+        node_cpus[1]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 4; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+        }
+        for (int i = 0; i < 4; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+        }
+
+
+        for (int i = 4; i < 8; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+                node_gpus[i]->device_id = 0xD000;
+        }
+        for (int i = 4; i < 8; i++) {
+                for (int j = 1; j < 4; j++)
+                        node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+        }
+
+        ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+
+        if (!ret) {
+                if (verify_maps(&maps,
+                                sizeof(node_cpus)/sizeof(node_cpus[0]),
+                                sizeof(node_gpus)/sizeof(node_gpus[0]))) {
+
+                        pr_err("Mapping returned success, but results had errors\n");
+                        ret = -1;
+                }
+        }
+        topology_free(&tp_src);
+        topology_free(&tp_dest);
+        maps_free(&maps);
+        return ret;
+}
+
+int test_8(void)
+{
+        int ret = 0;
+        struct device_maps maps;
+
+        struct tp_node *node_gpus[5];
+        struct tp_node *node_cpus[1];
+
+        struct tp_system tp_src = { 0 };
+        struct tp_system tp_dest = { 0 };
+
+        /* Fill src struct */
+        topology_init(&tp_src);
+        tp_src.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 5; i++) {
+                node_gpus[i] = sys_add_node(&tp_src, i + 1, 0xA000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, 0);
+                node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, i + 1);
+        }
+
+        for (int i = 0; i < 5; i++) {
+                for (int j = 1; j < 5; j++) {
+                        if (((i + j) % 5) + 1 < 4)
+                                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 5) + 1);
+                }
+        }
+
+        /* Fill dest struct */
+        topology_init(&tp_dest);
+        tp_dest.parsed = true;
+
+        node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+        node_cpus[0]->cpu_cores_count = 1;
+
+        for (int i = 0; i < 5; i++) {
+                node_gpus[i] = sys_add_node(&tp_dest, i + 1, 0xB000 + i);
+                node_gpus[i]->device_id = 0xD000;
+                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, 0);
+                node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, i + 1);
+        }
+
+        for (int i = 0; i < 5; i++) {
+                for (int j = 1; j < 5; j++) {
+                        if (((i + j) % 5) + 1 < 5)
+                                node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 5) + 1);
+                }
+        }
+
+        ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+
+        if (!ret) {
+                if (verify_maps(&maps,
+                                sizeof(node_cpus)/sizeof(node_cpus[0]),
+                                sizeof(node_gpus)/sizeof(node_gpus[0]))) {
+
+                        pr_err("Mapping returned success, but results had errors\n");
+                        ret = -1;
+                }
+        }
+        topology_free(&tp_src);
+        topology_free(&tp_dest);
+        maps_free(&maps);
+        return ret;
+}
+
+struct test {
+        int (*test_func)(void);
+        bool success; /* true if we expect function to return 0 */
+};
+
+int main(int argc, char** argv)
+{
+        int ret;
+
+        struct test tests[] = {
+                { test_0, true },
+                { test_1, true },
+                { test_2, false },
+                { test_3, true },
+                { test_4, false },
+                { test_5, true },
+                { test_6, true },
+                { test_7, true },
+                { test_8, true },
+        };
+
+        if (argc > 1) {
+                int run;
+                if (sscanf(argv[1], "%d", &run) != 1 ||
+                    (run >= sizeof(tests)/sizeof(tests[0]))) {
+                        pr_err("Usage: test_topology_remap [test_number]\n");
+                        pr_err("       Test number range:0-%ld\n", sizeof(tests)/sizeof(tests[0])-1);
+                        return -EINVAL;
+                }
+                pr_info("===============================================================================\n");
+                pr_info("Starting test %d\n", run);
+                ret = tests[run].test_func();
+                pr_info("\n\nTest %d: %s\n", run, (!!ret == tests[run].success) ? "FAILED" : "PASS");
+                pr_info("===============================================================================\n");
+                return 0;
+        }
+
+        for (int i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+                pr_info("===============================================================================\n");
+                pr_info("Starting test %d\n", i);
+                ret = tests[i].test_func();
+                pr_info("\n\nTest %d: %s\n", i, (!!ret == tests[i].success) ? "FAILED" : "PASS");
+                pr_info("===============================================================================\n");
+        }
+        return 0;
+}


### PR DESCRIPTION
Libhsakmt(thunk) uses a shared memory file in /dev/shm/hsakmt_shared_mem
and its semaphore in /dev/shm/hsakmt_shared_mem. Adding a check during
checkpoint to see if these two files exist. If they exist then the
plugin will try to restore them during restore.