### PR TITLE
parasite: don't block SIGTRAP

### DIFF
--- a/compel/include/uapi/ksigset.h
+++ b/compel/include/uapi/ksigset.h
@@ -22,4 +22,10 @@ static inline void ksigaddset(k_rtsigset_t *set, int _sig)
 	int sig = _sig - 1;
 	set->sig[sig / _NSIG_BPW] |= 1UL << (sig % _NSIG_BPW);
 }
+
+static inline void ksigdelset(k_rtsigset_t *set, int _sig)
+{
+	int sig = _sig - 1;
+	set->sig[sig / _NSIG_BPW] |= ~(1UL << (sig % _NSIG_BPW));
+}
 #endif

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -237,6 +237,7 @@ TST_NOFILE	:=				\
 		timens_nested			\
 		timens_for_kids			\
 		zombie_leader			\
+		sigtrap				\
 #		jobctl00			\
 
 pkg-config-check = $(shell sh -c 'pkg-config $(1) && echo y')

--- a/test/zdtm/static/sigtrap.c
+++ b/test/zdtm/static/sigtrap.c
@@ -1,0 +1,81 @@
+#include <unistd.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/signalfd.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc	= "Check that a pending SIGTRAP handled correctly";
+const char *test_author	= "Andrei Vagin <avagin@gmail.com>";
+
+static void sigh(int signo) {}
+
+int main(int argc, char *argv[])
+{
+	int fd, ret;
+	sigset_t mask;
+	siginfo_t info;
+	struct sigaction act = {
+		.sa_handler = sigh,
+	};
+
+	test_init(argc, argv);
+
+	if (sigaction(SIGTRAP, &act, NULL)) {
+		pr_perror("sigaction");
+		exit(1);
+	}
+
+	sigemptyset(&mask);
+	sigaddset(&mask, SIGTRAP);
+	fd = signalfd(-1, &mask, SFD_NONBLOCK);
+	if (fd < 0) {
+		fail("Can't create signalfd");
+		exit(1);
+	}
+
+	sigemptyset(&mask);
+	sigaddset(&mask, SIGTRAP);
+	sigprocmask(SIG_BLOCK, &mask, NULL);
+	kill(getpid(), SIGTRAP);
+
+	test_daemon();
+	test_waitsig();
+
+	ret = read(fd, &info, sizeof(info));
+	if (ret < 0) {
+		fail("can't read signals");
+		exit(1);
+	}
+
+	if (info.si_signo != SIGTRAP) {
+		fail("wrong signal");
+		exit(1);
+	}
+
+	if (sigaction(SIGTRAP, NULL, &act)) {
+		pr_perror("sigaction");
+		exit(1);
+	}
+
+	if (act.sa_handler != sigh) {
+		fail("unexpected sighanl hanlder");
+		exit(1);
+	}
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/sigtrap.desc
+++ b/test/zdtm/static/sigtrap.desc
@@ -1,0 +1,1 @@
+{'flags': 'crfail'}


### PR DESCRIPTION
This is the workaround for #1429.
    
The parasite code contains instructions that trigger SIGTRAP to stop at certain points. In such cases, the kernel sends a force SIGTRAP that can't be ignored and if it is blocked, the kernel resets its signal handler to a default one and unblocks it. It means that if we want to  save the origin signal handle
