### PR TITLE
uffd: fixed for exiting exiting program as user

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -919,7 +919,10 @@ static int kerndat_uffd(void)
 	if (uffd < 0) {
 		if (uffd == -ENOSYS)
 			return 0;
-
+		if (uffd == -EPERM) {
+			pr_info("Lazy pages are disabled\n");
+			return 0;
+		}
 		pr_err("Lazy pages are not available\n");
 		return -1;
 	}


### PR DESCRIPTION
While Dumping the process, it fails and exits as a user because of kerndat_uffd() returns -1 and due permission error 
uffd = syscall(SYS_userfaultfd, flags); this function fails inturn kerndat_uffd() fails. 
In the change it ignores the permission error and proceeds further.  
 