### PR TITLE
cr_options: handle the case where __dest == __src in SET_CHAR_OPTS

### DIFF
--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -15,11 +15,12 @@
 #define PARSING_RPC_CONF	6
 #define PARSING_LAST		7
 
-#define SET_CHAR_OPTS(__dest, __src) \
-	do { \
-		free(opts.__dest); \
-		opts.__dest = xstrdup(__src); \
-	} while(0)
+#define SET_CHAR_OPTS(__dest, __src)              \
+	do {                                      \
+		char *__src_dup = xstrdup(__src); \
+		free(opts.__dest);                \
+		opts.__dest = __src_dup;          \
+	} while (0)
 
 /*
  * CPU capability options.


### PR DESCRIPTION
The `SET_CHAR_OPT(__dest, __src)` macro is essentially:
```
free(opts.__dest);
opts.__dest = xstrdup(__src);
```

So if __dest == __src the string that get's copied is freed. This e.g.
is the case in criu/lsm.c

```
int lsm_check_opts(void)
{
	char *aux;

	if (!opts.lsm_supplied)
		return 0;

	aux = strchr(opts.lsm_profile, ':');
	if (aux == NULL) {
		pr_err("invalid argument %s for --lsm-profile\n", opts.lsm_profile);
		return -1;
	}

	*aux = '\0';
	aux++;

	if (strcmp(opts.lsm_profile, "apparmor") == 0) {
		if (kdat.lsm != LSMTYPE__APPARMOR) {
			pr_err("apparmor LSM specified but apparmor not supported by kernel\n");
			return -1;
		}

		SET_CHAR_OPTS(lsm_profile, aux);
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

	} else if (strcmp(opts.lsm_profile, "selinux") == 0) {
		if (kdat.lsm != LSMTYPE__SELINUX) {
			pr_err("selinux LSM specified but selinux not supported by kernel\n");
			return -1;
		}

		SET_CHAR_OPTS(lsm_profile, aux);
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

	} else if (strcmp(opts.lsm_profile, "none") == 0) {
		xfree(opts.lsm_profile);
		opts.lsm_profile = NULL;
	} else {
		pr_err("unknown lsm %s\n", opts.lsm_profile);
		return -1;
	}

	return 0;
}
```

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>