### PR TITLE
github: Add templates for new issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,63 @@
+<!--
+Before reporting a new issue, please make sure that it's not a duplicate.
+
+If you suspect your issue is a bug, please provide information as shown below. If your issue is a feature request, this information is not always necessary.
+-->
+
+**Description**
+
+<!--
+Briefly describe the problem you are having in a few paragraphs.
+-->
+
+**Steps to reproduce the issue:**
+1.
+2.
+3.
+
+**Describe the results you received:**
+
+
+**Describe the results you expected:**
+
+
+**Additional information you deem important (e.g. issue happens only occasionally):**
+
+
+**CRIU logs and information:**
+
+<!--
+You can either attach logs as files to the issue or put them under details
+-->
+
+<details><summary>CRIU full dump/restore logs:</summary>
+<p>
+
+```
+(paste your output here)
+```
+
+</p>
+</details>
+
+<details><summary>Output of `criu --version`:</summary>
+<p>
+
+```
+(paste your output here)
+```
+
+</p>
+</details>
+
+<details><summary>Output of `criu check --all`:</summary>
+<p>
+
+```
+(paste your output here)
+```
+
+</p>
+</details>
+
+**Additional environment details:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+Please make sure you've read and understood our contributing guidelines:
+https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md
+
+In short you need to:
+
+- Describe What you do and How you do it;
+- Separate each logical change into a separate commit;
+- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
+- If you fix some specific bug or commit, please add "Fixes: ..." line;
+- Review fixes should be made by amending the original commits. For example:
+  a) fix the code (e.g. this fixes commit with hash aaa1111)
+  b) git commit -a --fixup aaa1111
+  c) git rebase --interactive --autosquash aaa1111^
+- Pull request integration tests should generally be passing;
+- If you change something non-obvious, please consider adding a ZDTM test for it;
+
+-->


### PR DESCRIPTION
This way users would be able to create more meaningfull pull-requests
and issues. And we would not need to ask them to provide basic
information each time.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>