### PR TITLE
zdtm/tun_ns: add per-test dependencies

### DIFF
--- a/test/zdtm/static/tun_ns.desc
+++ b/test/zdtm/static/tun_ns.desc
@@ -1,1 +1,1 @@
-{'flavor': 'ns uns', 'flags': 'suid', 'feature': 'tun tun_ns'}
+{'deps': ['/bin/sh', '/sbin/ip|/bin/ip'], 'flavor': 'ns uns', 'flags': 'suid', 'feature': 'tun tun_ns'}


### PR DESCRIPTION
The tun_ns test was introduced with https://github.com/checkpoint-restore/criu/commit/7e355e7 and https://github.com/checkpoint-restore/criu/commit/3ba0893, however, these commits didn't add per-test dependencies required for the test. Per-test dependencies are listed in the `.desc` file as `'deps': [<list>]`. These dependencies are made available inside the test namespace and without the ip dependency, the tests fails on Fedora 34 with `Error: ipv4: FIB table does not exist.`