### PR TITLE
kdat: make kerndat_uffd differentiate -EPERM and -1 from uffd_open

### DIFF
--- a/criu/include/uffd.h
+++ b/criu/include/uffd.h
@@ -3,7 +3,7 @@
 
 struct task_restore_args;
 
-extern int uffd_open(int flags, unsigned long *features);
+extern int uffd_open(int flags, unsigned long *features, int *err);
 extern bool uffd_noncooperative(void);
 extern int setup_uffd(int pid, struct task_restore_args *task_args);
 extern int lazy_pages_setup_zombie(int pid);


### PR DESCRIPTION
Else "Failed to get uffd API" and "Incompatible uffd API ..." errors are
just ignored, which is probably not what we want.

Fixes: cfdeac4a4 ("kerndat: Handle non-root mode when checking uffd")
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>