### PR TITLE
mem/pidfd: fix poll retry error checking

### DIFF
--- a/criu/mem.c
+++ b/criu/mem.c
@@ -246,7 +246,7 @@ static int check_pidfd_entry_state(struct pidfd_entry *entry)
 
 	while (1) {
 		ret = poll(&pollfd, 1, 0);
-		if (errno == EINTR && restart_cnt < MAX_RESTARTS) {
+		if (ret == -1 && errno == EINTR && restart_cnt < MAX_RESTARTS) {
 			restart_cnt++;
 			continue; /* restart polling */
 		}


### PR DESCRIPTION
One should never rely on errno if libc syscall is successful. We can
either see an errno set from some previous failed syscall or even errno
set by a this successful libc syscall. So lets check ret first.

Fixes: 1ccdaf47 ("criu: add pidfd based pid reuse detection for RPC
clients")
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>