### PR TITLE
ci: no longer avoid overlayfs

### DIFF
--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -21,10 +21,7 @@ add-apt-repository \
 
 . /etc/lsb-release
 
-# overlayfs behaves differently on Ubuntu (18.04) and breaks CRIU
-# https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1857257
-# Switch to devicemapper
-echo '{ "experimental": true, "storage-driver": "devicemapper" }' > /etc/docker/daemon.json
+echo '{ "experimental": true }' > /etc/docker/daemon.json
 
 CRIU_LOG='/criu.log'
 mkdir -p /etc/criu

--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -23,10 +23,7 @@ apt-get -y purge docker-ce || :
     curl \
     software-properties-common
 
-# explicitly install runc. crun is not compiled with criu support
-./apt-install cri-o-runc podman containernetworking-plugins
-
-echo -e '[engine]\nruntime="runc"' > /etc/containers/containers.conf
+./apt-install podman containernetworking-plugins
 
 export SKIP_CI_TEST=1
 
@@ -35,11 +32,6 @@ export SKIP_CI_TEST=1
 cd ../../
 
 make install
-
-# overlaysfs behaves differently on Ubuntu and breaks CRIU
-# https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1857257
-export STORAGE_DRIVER=vfs
-podman --storage-driver vfs info
 
 criu --version
 


### PR DESCRIPTION
Now that the Ubuntu kernel is no longer broken with regards to overlayfs, let's switch back to overlayfs instead of devicemapper and
vfs graphdrivers.