### PR TITLE
Make config file parser more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ images/google/protobuf/*.c
 images/google/protobuf/*.h
 .gitid
 criu/criu
+criu/unittest/unittest
 crit/crit
 criu/arch/*/sys-exec-tbl*.c
 # x86 syscalls-table is not generated

--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,10 @@ crit: criu
 	$(Q) $(MAKE) $(build)=crit all
 .PHONY: crit
 
+unittest: $(criu-deps)
+	$(Q) $(MAKE) $(build)=criu unittest
+.PHONY: unittest
+
 
 #
 # Libraries next once crit it ready
@@ -403,6 +407,7 @@ help:
 	@echo '      cscope          - Generate cscope database'
 	@echo '      test            - Run zdtm test-suite'
 	@echo '      gcov            - Make code coverage report'
+	@echo '      unittest        - Run unit tests'
 .PHONY: help
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -415,6 +415,7 @@ lint:
 	shellcheck scripts/*.sh
 	shellcheck scripts/ci/*.sh scripts/ci/apt-install
 	shellcheck test/others/crit/*.sh
+	shellcheck test/others/config-file/*.sh
 	# Do not append \n to pr_perror or fail
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*\\n"'
 	# Do not use %m with pr_perror or fail

--- a/criu/Makefile
+++ b/criu/Makefile
@@ -87,6 +87,26 @@ $(obj)/criu: $(PROGRAM-BUILTINS)
 	$(call msg-link, $@)
 	$(Q) $(CC) $(CFLAGS) $^ $(LIBS) $(WRAPFLAGS) $(LDFLAGS) $(GMONLDOPT) -rdynamic -o $@
 
+UNIT-BUILTINS		+= $(obj)/config.o
+UNIT-BUILTINS		+= $(obj)/log.o
+UNIT-BUILTINS		+= $(obj)/string.o
+UNIT-BUILTINS		+= $(obj)/unittest/built-in.o
+
+$(obj)/unittest/Makefile: ;
+
+$(obj)/unittest/%: .FORCE
+
+$(obj)/unittest/built-in.o: .FORCE
+	$(Q) $(MAKE) $(call build-as,Makefile,criu/unittest) all
+
+$(obj)/unittest/unittest: $(UNIT-BUILTINS)
+	$(call msg-link, $@)
+	$(Q) $(CC) $(CFLAGS) $^ $(LIBS) $(WRAPFLAGS) $(LDFLAGS) -rdynamic -o $@
+
+unittest: $(obj)/unittest/unittest
+	$(Q) $(obj)/unittest/$@
+
+.PHONY: unittest
 
 #
 # Clean the most, except generated c files
@@ -97,6 +117,7 @@ subclean:
 	$(Q) $(MAKE) $(build)=$(ARCH_DIR) clean
 	$(Q) $(MAKE) $(call build-as,Makefile.library,$(PIE_DIR)) clean
 	$(Q) $(MAKE) $(call build-as,Makefile.crtools,criu) clean
+	$(Q) $(MAKE) $(call build-as,Makefile,criu/unittest) clean
 	$(Q) $(MAKE) $(build)=$(PIE_DIR) clean
 .PHONY: subclean
 cleanup-y      += $(obj)/criu

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -388,4 +388,11 @@ extern char *get_legacy_iptables_bin(bool ipv6);
 extern ssize_t read_all(int fd, void *buf, size_t size);
 extern ssize_t write_all(int fd, const void *buf, size_t size);
 
+#define cleanup_free __attribute__ ((cleanup (cleanup_freep)))
+static inline void cleanup_freep (void *p)
+{
+	void **pp = (void **) p;
+	free (*pp);
+}
+
 #endif /* __CR_UTIL_H__ */

--- a/criu/unittest/Makefile
+++ b/criu/unittest/Makefile
@@ -1,0 +1,6 @@
+ldflags-y	+= -r
+
+obj-y		+= unit.o
+obj-y		+= mock.o
+
+cleanup-y	+= $(obj)/unittest

--- a/criu/unittest/mock.c
+++ b/criu/unittest/mock.c
@@ -1,0 +1,99 @@
+/* This file contains dummy functions to make the unittest compile */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+int add_external(char *key)
+{
+	return 0;
+}
+
+int irmap_scan_path_add(char *path)
+{
+	return 0;
+}
+
+bool add_fsname_auto(const char *names)
+{
+	return true;
+}
+
+bool add_skip_mount(const char *mountpoint)
+{
+	return true;
+}
+
+int check_add_feature(char *feat)
+{
+	return 0;
+}
+
+int inherit_fd_parse(char *optarg)
+{
+	return 0;
+}
+
+int new_cg_root_add(char *controller, char *newroot)
+{
+	return 0;
+}
+
+int add_script(char *path)
+{
+	return 0;
+}
+
+int veth_pair_add(char *in, char *out)
+{
+	return 0;
+}
+
+int unix_sk_ids_parse(char *optarg)
+{
+	return 0;
+}
+
+bool cgp_add_dump_controller(const char *name)
+{
+	return 0;
+}
+
+int join_ns_add(const char *type, char *ns_file, char *extra_opts)
+{
+	return 0;
+}
+
+int ext_mount_add(char *key, char *val)
+{
+	return 0;
+}
+
+int check_namespace_opts(void)
+{
+	return 0;
+}
+
+int get_service_fd(int type)
+{
+	return -1;
+}
+
+void *shmalloc(size_t bytes)
+{
+	return malloc(bytes);
+}
+
+int install_service_fd(int type, int fd)
+{
+	return 0;
+}
+
+int close_service_fd(int type)
+{
+	return 0;
+}
+
+void compel_log_init(int log_fn, unsigned int level)
+{
+}

--- a/criu/unittest/unit.c
+++ b/criu/unittest/unit.c
@@ -1,0 +1,107 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+
+#include "log.h"
+#include "criu-log.h"
+
+int parse_statement(int i, char *line, char **configuration);
+
+int main(int argc, char *argv[], char *envp[])
+{
+	char **configuration;
+	int i;
+
+	configuration = malloc(10 * sizeof(char *));
+	log_init(NULL);
+
+	i = parse_statement(0, "", configuration);
+	assert(i == 0);
+
+	i = parse_statement(0, "\n", configuration);
+	assert(i == 0);
+
+	i = parse_statement(0, "# comment\n", configuration);
+	assert(i == 0);
+
+	i = parse_statement(0, "#comment\n", configuration);
+	assert(i == 0);
+
+	i = parse_statement(0, "tcp-close #comment\n", configuration);
+	assert(i == 1);
+	assert(!strcmp(configuration[0], "--tcp-close"));
+
+	i = parse_statement(0, " tcp-close #comment\n", configuration);
+	assert(i == 1);
+	assert(!strcmp(configuration[0], "--tcp-close"));
+
+	i = parse_statement(0, "test \"test\"\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--test"));
+	assert(!strcmp(configuration[1], "test"));
+
+	i = parse_statement(0, "dsfa \"aaaaa \\\"bbbbbb\\\"\"\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--dsfa"));
+	assert(!strcmp(configuration[1], "aaaaa \"bbbbbb\""));
+
+
+	i = parse_statement(0, "verbosity 4\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--verbosity"));
+	assert(!strcmp(configuration[1], "4"));
+
+	i = parse_statement(0, "verbosity \"\n", configuration);
+	assert(i == -1);
+
+	i = parse_statement(0, "verbosity 4#comment\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--verbosity"));
+	assert(!strcmp(configuration[1], "4"));
+
+	i = parse_statement(0, "verbosity 4 #comment\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--verbosity"));
+	assert(!strcmp(configuration[1], "4"));
+
+	i = parse_statement(0, "verbosity 4  #comment\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--verbosity"));
+	assert(!strcmp(configuration[1], "4"));
+
+	i = parse_statement(0, "verbosity 4 no-comment\n", configuration);
+	assert(i == -1);
+
+	i = parse_statement(0, "lsm-profile \"\" # more comments\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--lsm-profile"));
+	assert(!strcmp(configuration[1], ""));
+
+	i = parse_statement(0, "lsm-profile \"something\"# comment\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--lsm-profile"));
+	assert(!strcmp(configuration[1], "something"));
+
+	i = parse_statement(0, "#\n", configuration);
+	assert(i == 0);
+
+	i = parse_statement(0, "lsm-profile \"selinux:something\\\"with\\\"quotes\"\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--lsm-profile"));
+	assert(!strcmp(configuration[1], "selinux:something\"with\"quotes"));
+
+	i = parse_statement(0, "work-dir \"/tmp with spaces\" no-comment\n", configuration);
+	assert(i == -1);
+
+	i = parse_statement(0, "work-dir \"/tmp with spaces\"\n", configuration);
+	assert(i == 2);
+	assert(!strcmp(configuration[0], "--work-dir"));
+	assert(!strcmp(configuration[1], "/tmp with spaces"));
+
+	i = parse_statement(0, "a b c d e f g h i\n", configuration);
+	assert(i == -1);
+
+	pr_msg("OK\n");
+	return 0;
+}

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -126,6 +126,10 @@ if [ "$WIDTH" -gt 80 ]; then
 	exit 1
 fi
 
+# Unit tests at this point do not require any kernel or hardware capabilities.
+# Just try to run it everywhere for now.
+time make unittest
+
 [ -n "$SKIP_CI_TEST" ] && exit 0
 
 ulimit -c unlimited

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -261,6 +261,9 @@ make -C test/others/libcriu run
 # external namespace testing
 make -C test/others/ns_ext run
 
+# config file parser and parameter testing
+make -C test/others/config-file run
+
 # Skip all further tests when running with GCOV=1
 # The one test which currently cannot handle GCOV testing is compel/test
 # Probably because the GCOV Makefile infrastructure does not exist in compel

--- a/test/others/config-file/Makefile
+++ b/test/others/config-file/Makefile
@@ -1,0 +1,3 @@
+run:
+	./run.sh
+.PHONY: run

--- a/test/others/config-file/conf1.test
+++ b/test/others/config-file/conf1.test
@@ -1,0 +1,13 @@
+#
+#
+#
+verbosity 4
+lsm-profile "" # more comments
+lsm-profile "something"# comment
+lsm-profile "selinux:something\"with\"quotes"
+lsm-profile "apparmor:something\"with\"quotes"
+work-dir /tmp
+work-dir "/tmp"
+work-dir "/dir with spaces"
+a b c d e f g h i j k l m n o p
+dsfa "aaaaa \"bbbbbb\""

--- a/test/others/config-file/conf2.test
+++ b/test/others/config-file/conf2.test
@@ -1,0 +1,16 @@
+#
+#
+#
+verbosity 4
+lsm-profile "" # more comments
+lsm-profile "something"# comment
+lsm-profile "selinux:something\"with\"quotes"
+lsm-profile "apparmor:something\"with\"quotes"
+work-dir /tmp
+work-dir "/tmp"
+work-dir "/dir with spaces" 
+work-dir "/dir with spaces" #comment
+work-dir "/dir with spaces" # comment
+work-dir "/dir with spaces"# comment
+work-dir "/dir with spaces"#comment
+dsfa "aaaaa \"bbbbbb\""

--- a/test/others/config-file/conf3.test
+++ b/test/others/config-file/conf3.test
@@ -1,0 +1,17 @@
+#
+#
+#
+verbosity 4
+lsm-profile "" # more comments
+lsm-profile "something"# comment
+lsm-profile "selinux:something\"with\"quotes"
+lsm-profile "apparmor:something\"with\"quotes"
+work-dir /tmp
+work-dir "/tmp"
+work-dir "/dir with spaces" 
+work-dir "/dir with spaces" #comment
+work-dir "/dir with spaces" # comment
+work-dir "/dir with spaces"# comment
+work-dir "/dir with spaces"#comment
+dsfa "aaaaa \"bbbbbb\""
+dsfa "aaaaa \"bbbbbb\"" more

--- a/test/others/config-file/run.sh
+++ b/test/others/config-file/run.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# This script tries to run criu with different options to ensure
+# the configuration file and option handling does not break.
+#
+# The options have been selected by looking at the existing
+# test code coverage and missing code coverage should be handled
+# by the options used in this file.
+#
+# This script tries to only exit if criu crashes. A return value
+# of '1' should not stop the script.
+
+set -xbm
+
+#shellcheck disable=SC1091
+source ../env.sh
+
+if [ ! -d /etc/criu ]; then
+	mkdir -p /etc/criu
+fi
+
+if [ ! -e /etc/criu/default.conf ]; then
+	touch /etc/criu/default.conf
+fi
+
+# This tries to capture any exit codes other than 0 and 1
+# Especially looking for crashes
+trap '
+RESULT=$?
+if [[ $RESULT -gt 1 ]]; then
+	echo "unexpected exit code $RESULT"
+	exit 2
+fi
+' CHLD
+
+# Just some random combination of flags
+$CRIU check --pre-dump-mode read --auto-dedup --page-server --track-mem --display-stats -v0
+$CRIU check --pre-dump-mode splice --auto-dedup --page-server --track-mem --display-stats -v0
+$CRIU check --pre-dump-mode splice --auto-dedup --page-server --track-mem --display-stats -v0 --conf conf1.test
+$CRIU check --pre-dump-mode splice --auto-dedup --page-server --track-mem --display-stats -v0 --conf=conf1.test
+$CRIU check --pre-dump-mode invalid --auto-dedup --page-server --track-mem --display-stats -v0 --conf=conf1.test
+$CRIU check --pre-dump-mode splice --auto-dedup --page-server --track-mem --display-stats -v0 --conf conf2.test
+$CRIU check --pre-dump-mode splice --auto-dedup --page-server --track-mem --display-stats -v0 --conf=conf2.test
+$CRIU check --pre-dump-mode invalid --auto-dedup --page-server --track-mem --display-stats -v0 --conf=conf2.test
+$CRIU check --pre-dump-mode splice --auto-dedup --page-server --track-mem --display-stats -v0 --conf conf3.test
+$CRIU check --pre-dump-mode splice --auto-dedup --page-server --track-mem --display-stats -v0 --conf=conf3.test
+$CRIU check --pre-dump-mode invalid --auto-dedup --page-server --track-mem --display-stats -v0 --conf=conf3.test
+$CRIU check --no-default-config
+$CRIU check --no-default-config --config=conf
+$CRIU check --no-default-config --config=conf1.test
+$CRIU check --no-default-config --config=conf1.test --help
+$CRIU check --no-default-config --config=conf1.test --h
+$CRIU check --no-default-config --config=conf2.test
+$CRIU check --no-default-config --config=conf2.test --help
+$CRIU check --no-default-config --config=conf2.test --h
+$CRIU check --no-default-config --config=conf3.test
+$CRIU check --no-default-config --config=conf3.test --help
+$CRIU check --no-default-config --config=conf3.test --h
+
+if [ ! -e "$HOME"/.criu.default ]; then
+	touch "$HOME"/.criu.default
+fi
+$CRIU check --pre-dump-mode read --auto-dedup --page-server --track-mem --display-stats -v0 -s -t "-1"
+$CRIU check --pre-dump-mode read --auto-dedup --page-server --track-mem --display-stats -S -R -vvvvvv
+$CRIU check --pre-dump-mode read --auto-dedup --page-server --track-mem --display-stats -J invalidjoin-invalid
+$CRIU check --pre-dump-mode read --auto-dedup --page-server --track-mem --display-stats -d -r
+$CRIU check --pre-dump-mode read --auto-dedup --page-server --track-mem --display-stats -d -r none
+unset HOME
+$CRIU check --close
+export HOME=/ROOOOT
+$CRIU check --close
+$CRIU check --port
+$CRIU check --port 20000
+$CRIU check --port some-port -l
+CRIU_CONFIG_FILE=conf $CRIU check --port some-port -l
+CRIU_CONFIG_FILE=conf1.test $CRIU check
+CRIU_CONFIG_FILE=conf2.test $CRIU check
+CRIU_CONFIG_FILE=conf3.test $CRIU check
+CRIU_CONFIG_FILE=conf1.test $CRIU check --port some-port -l
+CRIU_CONFIG_FILE=conf2.test $CRIU check --port some-port -l
+CRIU_CONFIG_FILE=conf3.test $CRIU check --port some-port -l
+$CRIU check --ms -L
+CRIU_DEPRECATED=1 $CRIU check --ms
+CRIU_DEPRECATED=1 $CRIU check
+$CRIU check -l
+$CRIU check -l 17
+$CRIU check -L
+$CRIU check -L 13
+$CRIU check -L /tmp
+$CRIU check --skip-mnt
+$CRIU check --skip-mnt 13
+$CRIU check --skip-mnt -13
+$CRIU check --skip-mnt /tmp
+$CRIU check --force-irmap --link-remap --evasive-devices
+$CRIU check -M 1:2 --status-fd
+$CRIU check -M 1:2 --status-fd 1 --ps-socket 1
+$CRIU check -M 1:2 --status-fd 1 --ps-socket 1 -D
+$CRIU check -M 1:2 --status-fd 1 --ps-socket 1 --port 4242
+$CRIU check -M 1:2 --status-fd 1 --ps-socket one
+$CRIU check -M 1:2 --status-fd one
+$CRIU check --cgroup-props conf.test --cgroup-props-file conf.test
+$CRIU -V
+$CRIU dump --file-validation
+$CRIU restore --file-validation 1
+$CRIU check --file-validation filesizefilesize
+$CRIU dump --file-validation filesize
+$CRIU restore --file-validation buildid
+$CRIU check --file-validation buildid --deprecated
+exit 0


### PR DESCRIPTION
Trying to see how robust the configuration parser I was able to crash CRIU pretty quickly. This fixes a few crashes in the existing configuration file parser.

This also adds tests for not tested option parsing and configuration file handling.