### PR TITLE
test: skip time namespaced tests on <= 5

### DIFF
--- a/test/zdtm_ct.c
+++ b/test/zdtm_ct.c
@@ -61,7 +61,7 @@ static int create_timens()
 	if (sscanf(buf.release, "%u.%u", &major, &minor) != 2)
 		return -1;
 
-	if (major == 5 && minor < 11) {
+	if ((major <= 5) || (major == 5 && minor < 11)) {
 		fprintf(stderr, "timens isn't supported on %s\n", buf.release);
 		return 0;
 	}


### PR DESCRIPTION
Although CentOS 8 comes with 4.18 kernel it has time namespace patches backported but not all the required once. This changes the kernel version check from major == 5 to major <= 5 to also exclude CentOS 8.