### PR TITLE
docker-test: use latest containerd release

### DIFF
--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -28,10 +28,15 @@ mkdir -p /etc/criu
 echo "log-file=$CRIU_LOG" > /etc/criu/runc.conf
 
 service docker stop
+systemctl stop containerd.service
 
-# Restore with containerd versions after v1.2.14 and before v1.5.0-beta.0 is broken.
-wget -nv https://github.com/containerd/containerd/releases/download/v1.5.0-beta.0/containerd-1.5.0-beta.0-linux-amd64.tar.gz -O - | tar -xz -C /usr/bin/
+# Always use the latest containerd release.
+# Restore with containerd versions after v1.2.14 and before v1.5.0-beta.0 are broken.
+# https://github.com/checkpoint-restore/criu/issues/1223
+CONTAINERD_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/containerd/containerd/releases/latest | grep '"browser_download_url":.*/containerd-.*-linux-amd64.tar.gz.$' | cut -d\" -f4)
+wget -nv "$CONTAINERD_DOWNLOAD_URL" -O - | tar -xz -C /usr/
 
+systemctl restart containerd.service
 service docker restart
 
 export SKIP_CI_TEST=1


### PR DESCRIPTION
This patch improves the changes from 19be9ced9. To use the newer version of containerd, we need to make sure that the containerd service has been restarted after install. Instead of hard-coding a version number, we can use github API to get the latest release. In addition, the tar file contains all binary files in a `./bin` sub-folder. Thus, it should be extracted in `/usr`.