### PR TITLE
bfd: loop through read()/write() when the action is incomplete

### DIFF
--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -385,4 +385,7 @@ extern int mount_detached_fs(const char *fsname);
 
 extern char *get_legacy_iptables_bin(bool ipv6);
 
+extern ssize_t read_all(int fd, void *buf, size_t size);
+extern ssize_t write_all(int fd, const void *buf, size_t size);
+
 #endif /* __CR_UTIL_H__ */


### PR DESCRIPTION
The callers of bread() and bwrite() assume the operation reads/writes
the complete length of the passed buffer.
We must loop when invoking the read()/write() APIs.

Fixes #1504