### PR TITLE
add PKG_CONFIG default in a few more places

### DIFF
--- a/test/zdtm/lib/Makefile
+++ b/test/zdtm/lib/Makefile
@@ -6,6 +6,7 @@ LIB	:= libzdtmtst.a
 
 LIBSRC	:= datagen.c msg.c parseargs.c test.c streamutil.c lock.c ns.c tcp.c unix.c fs.c sysctl.c
 
+PKG_CONFIG ?= pkg-config
 pkg-config-check = $(shell sh -c '$(PKG_CONFIG) $(1) && echo y')
 ifeq ($(call pkg-config-check,libbpf),y)
 LIBSRC	+= bpfmap_zdtm.c

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -241,6 +241,7 @@ TST_NOFILE	:=				\
 		sigtrap01			\
 #		jobctl00			\
 
+PKG_CONFIG ?= pkg-config
 pkg-config-check = $(shell sh -c '$(PKG_CONFIG) $(1) && echo y')
 ifeq ($(call pkg-config-check,libbpf),y)
 TST_NOFILE	+=				\


### PR DESCRIPTION
These files use $PKG_CONFIG before they include the common files that
setup a default, so set early defaults in them too.

Signed-off-by: Mike Frysinger <vapier@chromium.org>