### PR TITLE
Keep inherit-fd strings alive until task restore

### DIFF
--- a/criu/files.c
+++ b/criu/files.c
@@ -1568,7 +1568,10 @@ int inherit_fd_add(int fd, char *key)
 	if (fd > inh_fd_max)
 		inh_fd_max = fd;
 
-	inh->inh_id = key;
+	inh->inh_id = xstrdup(key);
+	if (inh->inh_id == NULL)
+		return -1;
+
 	inh->inh_fd = fd;
 	list_add_tail(&inh->inh_list, &opts.inherit_fds);
 	return 0;


### PR DESCRIPTION
If inherit-fd is read from a config file its buffer will be freed after the config file is parsed but before task restore, which is when we need to use the mapping. Therefore, when adding an inherit-fd mapping to the opts list, copy the key string to a new buffer and free all such buffers after task restore.