### PR TITLE
get rid of using glibc's getpid

### DIFF
--- a/criu/action-scripts.c
+++ b/criu/action-scripts.c
@@ -62,7 +62,7 @@ static int run_shell_scripts(const char *action)
 
 	if (!(env_set & ENV_IMGDIR)) {
 		char image_dir[PATH_MAX];
-		sprintf(image_dir, "/proc/%ld/fd/%d", (long) getpid(), get_service_fd(IMG_FD_OFF));
+		sprintf(image_dir, "/proc/%ld/fd/%d", (long) syscall(__NR_getpid), get_service_fd(IMG_FD_OFF));
 		if (setenv("CRTOOLS_IMAGE_DIR", image_dir, 1)) {
 			pr_perror("Can't set CRTOOLS_IMAGE_DIR=%s", image_dir);
 			return -1;

--- a/criu/arch/x86/kerndat.c
+++ b/criu/arch/x86/kerndat.c
@@ -176,13 +176,14 @@ int kdat_compatible_cr(void)
 
 static int kdat_x86_has_ptrace_fpu_xsave_bug_child(void *arg)
 {
+	int pid = syscall(__NR_getpid);
 	if (ptrace(PTRACE_TRACEME, 0, 0, 0)) {
-		pr_perror("%d: ptrace(PTRACE_TRACEME) failed", getpid());
+		pr_perror("%d: ptrace(PTRACE_TRACEME) failed", pid);
 		_exit(1);
 	}
 
-	if (kill(getpid(), SIGSTOP))
-		pr_perror("%d: failed to kill myself", getpid());
+	if (kill(pid, SIGSTOP))
+		pr_perror("%d: failed to kill myself", pid);
 
 	pr_err("Continue after SIGSTOP.. Urr what?\n");
 	_exit(1);

--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -735,7 +735,7 @@ int dump_task_cgroup(struct pstree_item *item, u32 *cg_id, struct parasite_dump_
 	if (item)
 		pid = item->pid->real;
 	else
-		pid = getpid();
+		pid = syscall(__NR_getpid);
 
 	pr_info("Dumping cgroups for %d\n", pid);
 	if (parse_task_cgroup(pid, args, &ctls, &n_ctls))

--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -171,7 +171,7 @@ static int check_sock_peek_off(void)
 
 static int check_kcmp(void)
 {
-	int ret = syscall(SYS_kcmp, getpid(), -1, -1, -1, -1);
+	int ret = syscall(SYS_kcmp, syscall(__NR_getpid), -1, -1, -1, -1);
 
 	if (ret < 0 && errno == ENOSYS) {
 		pr_perror("System call kcmp is not supported");
@@ -263,7 +263,7 @@ static int check_proc_stat(void)
 	struct proc_pid_stat stat;
 	int ret;
 
-	ret = parse_pid_stat(getpid(), &stat);
+	ret = parse_pid_stat(syscall(__NR_getpid), &stat);
 	if (ret) {
 		pr_msg("procfs: stat extension is not supported\n");
 		return -1;
@@ -519,7 +519,7 @@ static int check_sigqueuinfo(void)
 
 	signal(SIGUSR1, SIG_IGN);
 
-	if (syscall(SYS_rt_sigqueueinfo, getpid(), SIGUSR1, &info) < 0) {
+	if (syscall(SYS_rt_sigqueueinfo, syscall(__NR_getpid), SIGUSR1, &info) < 0) {
 		pr_perror("Unable to send siginfo with positive si_code to itself");
 		return -1;
 	}
@@ -679,7 +679,7 @@ static void check_special_mapping_mremap_child(struct special_mapping *vmas,
 {
 	size_t i, parking_size = 0;
 	void *parking_lot;
-	pid_t self = getpid();
+	pid_t self = syscall(__NR_getpid);
 
 	for (i = 0; i < nr; i++) {
 		if (vmas[i].addr != MAP_FAILED)
@@ -1383,7 +1383,7 @@ int cr_check(void)
 	if (root_item == NULL)
 		return -1;
 
-	root_item->pid->real = getpid();
+	root_item->pid->real = syscall(__NR_getpid);
 
 	if (collect_pstree_ids())
 		return -1;

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -812,7 +812,7 @@ static int collect_pstree_ids_predump(void)
 	 */
 
 	crt.i.pid->state = TASK_ALIVE;
-	crt.i.pid->real = getpid();
+	crt.i.pid->real = syscall(__NR_getpid);
 
 	if (predump_task_ns_ids(&crt.i))
 		return -1;
@@ -1308,7 +1308,7 @@ static int dump_one_task(struct pstree_item *item, InventoryEntry *parent_ie)
 
 	if (fault_injected(FI_DUMP_EARLY)) {
 		pr_info("fault: CRIU sudden detach\n");
-		kill(getpid(), SIGKILL);
+		kill(syscall(__NR_getpid), SIGKILL);
 	}
 
 	if (root_ns_mask & CLONE_NEWPID && root_item == item) {

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1811,7 +1811,7 @@ static int restore_task_with_children(void *_arg)
 				current->pid->real, vpid(current));
 	}
 
-	pid = getpid();
+	pid = syscall(__NR_getpid);
 	if (vpid(current) != pid) {
 		pr_err("Pid %d do not match expected %d\n", pid, vpid(current));
 		set_task_cr_err(EEXIST);
@@ -1913,7 +1913,7 @@ static int restore_task_with_children(void *_arg)
 
 	if (fault_injected(FI_RESTORE_ROOT_ONLY)) {
 		pr_info("fault: Restore root task failure!\n");
-		kill(getpid(), SIGKILL);
+		kill(syscall(__NR_getpid), SIGKILL);
 	}
 
 	if (open_transport_socket())
@@ -2163,7 +2163,7 @@ static int prepare_userns_hook(void)
 	 * inside container due to permissions.
 	 * But you still can set this value if it was unset.
 	 */
-	saved_loginuid = parse_pid_loginuid(getpid(), &ret, false);
+	saved_loginuid = parse_pid_loginuid(syscall(__NR_getpid), &ret, false);
 	if (ret < 0)
 		return -1;
 

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -1398,7 +1398,7 @@ int cr_service(bool daemon_mode)
 	}
 
 	if (opts.pidfile) {
-		if (write_pidfile(getpid()) == -1) {
+		if (write_pidfile(syscall(__NR_getpid)) == -1) {
 			pr_perror("Can't write pidfile");
 			goto err;
 		}

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -2069,7 +2069,7 @@ int open_path(struct file_desc *d,
 			 * PROC_SELF isn't used, because only service
 			 * descriptors can be used here.
 			 */
-			mntns_root = open_pid_proc(getpid());
+			mntns_root = open_pid_proc(syscall(__NR_getpid));
 			snprintf(path, sizeof(path), "fd/%d", tmp);
 			orig_path = rfi->path;
 			rfi->path = path;
@@ -2080,7 +2080,7 @@ int open_path(struct file_desc *d,
 	if (rfi->remap) {
 		if (fault_injected(FI_RESTORE_OPEN_LINK_REMAP)) {
 			pr_info("fault: Open link-remap failure!\n");
-			kill(getpid(), SIGKILL);
+			kill(syscall(__NR_getpid), SIGKILL);
 		}
 
 		mutex_lock(remap_open_lock);

--- a/criu/files.c
+++ b/criu/files.c
@@ -595,7 +595,7 @@ int dump_my_file(int lfd, u32 *id, int *type)
 	struct fd_opts fo = {};
 	FdinfoEntry e = FDINFO_ENTRY__INIT;
 
-	me.real = getpid();
+	me.real = syscall(__NR_getpid);
 	me.ns[0].virt = -1; /* FIXME */
 
 	if (dump_one_file(&me, lfd, lfd, &fo, NULL, &e, NULL))

--- a/criu/image.c
+++ b/criu/image.c
@@ -207,7 +207,7 @@ int prepare_inventory(InventoryEntry *he)
 	he->lsmtype = host_lsm_type();
 
 	crt.i.pid->state = TASK_ALIVE;
-	crt.i.pid->real = getpid();
+	crt.i.pid->real = syscall(__NR_getpid);
 	if (get_task_ids(&crt.i))
 		return -1;
 

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -326,7 +326,7 @@ static int kerndat_get_dirty_track(void)
 	 * was at least once re-set. (this is to be removed in
 	 * a couple of kernel releases)
 	 */
-	ret = do_task_reset_dirty_track(getpid());
+	ret = do_task_reset_dirty_track(syscall(__NR_getpid));
 	if (ret < 0)
 		return ret;
 	if (ret == 1)
@@ -604,7 +604,7 @@ int kerndat_nsid(void)
 		return -1;
 	}
 
-	if (net_get_nsid(sk, getpid(), &nsid) < 0) {
+	if (net_get_nsid(sk, syscall(__NR_getpid), &nsid) < 0) {
 		pr_err("NSID is not supported\n");
 		close(sk);
 		return -1;
@@ -748,7 +748,7 @@ static int has_kcmp_epoll_tfd(void)
 {
 	kcmp_epoll_slot_t slot = { };
 	int ret = -1, efd, tfd;
-	pid_t pid = getpid();
+	pid_t pid = syscall(__NR_getpid);
 	struct epoll_event ev;
 	int pipefd[2];
 

--- a/criu/lsm.c
+++ b/criu/lsm.c
@@ -228,7 +228,7 @@ void kerndat_lsm(void)
 		 * seem to be enough for CRIU's use case. CRIU actually needs to look if
 		 * a valid label is returned.
 		 */
-		if (getpidcon_raw(getpid(), &ctx) < 0)
+		if (getpidcon_raw(syscall(__NR_getpid), &ctx) < 0)
 			goto no_lsm;
 
 		if (verify_selinux_label(ctx)) {

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -2052,7 +2052,7 @@ static int userns_mount(char *src, void *args, int fd, pid_t pid)
 
 	snprintf(target, sizeof(target), "/proc/self/fd/%d", fd);
 
-	if (pid != getpid() && switch_ns(pid, &mnt_ns_desc, &rst))
+	if (pid != syscall(__NR_getpid) && switch_ns(pid, &mnt_ns_desc, &rst))
 		return -1;
 
 	err = mount(src, target, NULL, flags, NULL);

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -412,7 +412,7 @@ static unsigned int generate_ns_id(int pid, unsigned int kid, struct ns_desc *nd
 	if (nsid)
 		goto found;
 
-	if (pid != getpid()) {
+	if (pid != syscall(__NR_getpid)) {
 		type = NS_OTHER;
 		if (pid == root_item->pid->real) {
 			BUG_ON(root_ns_mask & nd->cflag);
@@ -1245,7 +1245,7 @@ static inline void unsc_msg_init(struct unsc_msg *m, uns_call_t *c,
 	ch->cmsg_type = SCM_CREDENTIALS;
 
 	ucred = (struct ucred *) CMSG_DATA(ch);
-	ucred->pid = getpid();
+	ucred->pid = syscall(__NR_getpid);
 	ucred->uid = getuid();
 	ucred->gid = getgid();
 
@@ -1372,7 +1372,7 @@ int __userns_call(const char *func_name, uns_call_t call, int flags,
 	}
 
 	if (!usernsd_pid)
-		return call(arg, fd, getpid());
+		return call(arg, fd, syscall(__NR_getpid));
 
 	sk = get_service_fd(USERNSD_SK);
 	if (sk < 0) {

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -1447,7 +1447,7 @@ int cr_page_server(bool daemon_mode, bool lazy_dump, int cfd)
 no_server:
 
 	if (!daemon_mode && cfd >= 0) {
-		struct ps_info info = {.pid = getpid(), .port = opts.port};
+		struct ps_info info = {.pid = syscall(__NR_getpid), .port = opts.port};
 		int count;
 
 		count = write(cfd, &info, sizeof(info));

--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -996,7 +996,7 @@ int prepare_pstree(void)
 		}
 	}
 
-	pid = getpid();
+	pid = syscall(__NR_getpid);
 
 	if (!ret)
 		/*

--- a/criu/servicefd.c
+++ b/criu/servicefd.c
@@ -87,7 +87,7 @@ int init_service_fd(void)
 	 * conflict with any 'real-life' ones
 	 */
 
-	if (syscall(__NR_prlimit64, getpid(), RLIMIT_NOFILE, NULL, &rlimit)) {
+	if (syscall(__NR_prlimit64, syscall(__NR_getpid), RLIMIT_NOFILE, NULL, &rlimit)) {
 		pr_perror("Can't get rlimit");
 		return -1;
 	}

--- a/criu/shmem.c
+++ b/criu/shmem.c
@@ -602,7 +602,8 @@ static int open_shmem(int pid, struct vma_area *vma)
 	}
 
 	if (f == -1) {
-		f = open_proc_rw(getpid(), "map_files/%lx-%lx",
+		pid_t pid = syscall(__NR_getpid);
+		f = open_proc_rw(pid, "map_files/%lx-%lx",
 				(unsigned long) addr,
 				(unsigned long) addr + si->size);
 		if (f < 0)

--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -1389,7 +1389,8 @@ static int post_open_standalone(struct file_desc *d, int fd)
 		return -1;
 
 	if (peer->flags & USK_GHOST_FDSTORE) {
-		procfs_self_dir = open_proc(getpid(), "fd");
+		pid_t pid = syscall(__NR_getpid);
+		procfs_self_dir = open_proc(pid, "fd");
 		fdstore_fd = fdstore_get(peer->fdstore_id);
 
 		if (fdstore_fd < 0 || procfs_self_dir < 0)

--- a/criu/tty.c
+++ b/criu/tty.c
@@ -736,7 +736,7 @@ static int tty_restore_ctl_terminal(struct file_desc *d)
 
 out:
 	pr_info("Restore session %d by %d tty (index %d)\n",
-		 info->tie->sid, (int)getpid(), index);
+		 info->tie->sid, (int)syscall(__NR_getpid), index);
 
 	ret = tty_set_sid(slave);
 	if (!ret)

--- a/criu/vdso.c
+++ b/criu/vdso.c
@@ -681,7 +681,7 @@ int kerndat_vdso_preserves_hint(void)
 		if (new_addr == MAP_FAILED)
 			exit(1);
 
-		child = getpid();
+		child = syscall(__NR_getpid);
 		new_addr = (void *)syscall(SYS_mremap, vdso_addr, vdso_size,
 			vdso_size, MREMAP_MAYMOVE | MREMAP_FIXED, new_addr);
 		if (new_addr == MAP_FAILED)


### PR DESCRIPTION
Sometimes getpid() returns parents pid when process cloned by clone3().
Error message is as following:
```
(00.002797) No pidns-9.img image
(00.002844) Warn (criu/cr-restore.c:1329): Set CLONE_PARENT | CLONE_NEWPID but it might cause restore problem,because not all kernels support such clone flags combinations!
(00.002846) Forking task with 1 pid (flags 0x6c028000)
(00.002848) Creating process using clone3()

(00.003321) PID: real 4124639 virt 1
(00.003413) Wait until namespaces are created
(00.003412) Error (criu/cr-restore.c:1816): Pid 4124632 do not match expected 1

(00.004503) Error (criu/cr-restore.c:2514): Restoring FAILED.
```

Man page of clone3 shows specific versions of glibc has a pid-cacheing behavior, which
may be not up to date. So get rid of using glibc's getpid

Signed-off-by: Liu Hua <weldonliu@tencent.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
