### PR TITLE
test: fix netns_lock CI test failure

### DIFF
--- a/test/zdtm/static/netns_lock.c
+++ b/test/zdtm/static/netns_lock.c
@@ -8,6 +8,7 @@ const char *test_author = "Zeyad Yasser <zeyady98@gmail.com>";
 #include <sched.h>
 
 #define NS_PATH "/var/run/netns/criu-net-lock-test"
+#define SYNCFILE_PATH "net_lock.sync"
 #define MAX_RETRY 3
 
 int main(int argc, char **argv)
@@ -41,8 +42,7 @@ int main(int argc, char **argv)
 	 */
 
 	for (i = 0; i < MAX_RETRY; i++) {
-		ns_fd = open(NS_PATH, O_RDONLY);
-		if (ns_fd < 0) {
+		if (access(SYNCFILE_PATH, F_OK )) {
 			/* Netns not created yet by post-start hook */
 			sleep(1);
 			continue;
@@ -50,6 +50,7 @@ int main(int argc, char **argv)
 		break;
 	}
 
+	ns_fd = open(NS_PATH, O_RDONLY);
 	if (ns_fd < 0) {
 		pr_perror("can't open network ns");
 		return 1;

--- a/test/zdtm/static/netns_lock.hook
+++ b/test/zdtm/static/netns_lock.hook
@@ -35,30 +35,32 @@ if sys.argv[1] == "--post-start":
         srv.bind(("127.0.0.1", PORT))
         srv.listen(1)
 
-        # We should accept connections normally from
-        # pre-dump client, post-restore client and
-        # the pre-restore client using SOCCR_MARK
-        # The pre-restore client without SOCCR_MARK
-        # should fail with a timeout
+        # Loop allows zdtm multiple iterations to work (i.e. --iter 3)
+        while True:
+            # We should accept connections normally from
+            # pre-dump client, post-restore client and
+            # the pre-restore client using SOCCR_MARK
+            # The pre-restore client without SOCCR_MARK
+            # should fail with a timeout
 
-        # Accept pre-dump client
-        cln, addr = srv.accept()
-        cln.sendall(str.encode("--pre-dump"))
-        cln.close()
+            # Accept pre-dump client
+            cln, addr = srv.accept()
+            cln.sendall(str.encode("--pre-dump"))
+            cln.close()
 
-        # Accept pre-restore client with SOCCR_MARK
-        srv.setsockopt(socket.SOL_SOCKET, SO_MARK, SOCCR_MARK)
-        cln, addr = srv.accept()
-        cln.sendall(str.encode("--pre-restore"))
-        cln.close()
-        srv.setsockopt(socket.SOL_SOCKET, SO_MARK, 0)
+            # Accept pre-restore client with SOCCR_MARK
+            srv.setsockopt(socket.SOL_SOCKET, SO_MARK, SOCCR_MARK)
+            cln, addr = srv.accept()
+            cln.sendall(str.encode("--pre-restore"))
+            cln.close()
+            srv.setsockopt(socket.SOL_SOCKET, SO_MARK, 0)
 
-        # Accept post-restore client
-        cln, addr = srv.accept()
-        cln.sendall(str.encode("--post-restore"))
-        cln.close()
-
-        srv.close()
+            # Accept post-restore client
+            cln, addr = srv.accept()
+            cln.sendall(str.encode("--post-restore"))
+            cln.close()
+        
+        # Server will be closed when zdtm sends SIGKILL
 
 if sys.argv[1] == "--pre-dump":
     # Network is not locked yet

--- a/test/zdtm/static/netns_lock.hook
+++ b/test/zdtm/static/netns_lock.hook
@@ -15,16 +15,24 @@ CLONE_NEWNET = 0x40000000
 PORT = 8880
 NETNS = "criu-net-lock-test"
 TIMEOUT = 0.1
+SYNCFILE = "zdtm/static/net_lock.sync"
 
 def nsenter():
     with open("/var/run/netns/{}".format(NETNS)) as f:
         libc.setns(f.fileno(), CLONE_NEWNET)
+
+def create_sync_file():
+    open(SYNCFILE, "wb").close()
 
 if sys.argv[1] == "--post-start":
     # Add test netns
     subprocess.Popen(["ip", "netns", "add", NETNS]).wait()
     nsenter() # Enter test netns
     subprocess.Popen(["ip", "link", "set", "up", "dev", "lo"]).wait()
+
+    # Lets test know that the netns is initilized successfully
+    # by checking the access of SYNCFILE
+    create_sync_file()
 
     # TCP server daemon
     pid = os.fork()
@@ -144,3 +152,5 @@ if sys.argv[1] == "--post-restore":
 if sys.argv[1] == "--clean":
     # Delete test netns
     subprocess.Popen(["ip", "netns", "delete", NETNS]).wait()
+    # Delete sync file
+    os.remove(SYNCFILE)


### PR DESCRIPTION
As mentioned in https://github.com/checkpoint-restore/criu/issues/1530 netns_lock test fails in jenkins iterative tests.

```netns_lock``` test is highly dependent on the order of the hooks, and iterations causes the ```--pre-dump``` hook to be called multiple times which expectedly causes the test to fail.

https://ci.kernoops.org/job/CRIU/job/CRIU-iter/job/criu-dev/431/testReport/(root)/criu/zdtm_static_netns_lock/

This only fixes the jenkins test failure and not the random CentOS7 failure mentioned in the issue. 

Signed-off-by: Zeyad Yasser <zeyady98@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
