### PR TITLE
criu: dump and restore notify_thread_id of posix timer

### DIFF
--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -19,6 +19,7 @@ struct seize_task_status {
 	unsigned long long	sigpnd;
 	unsigned long long	shdpnd;
 	char			state;
+	int			vpid;
 	int			ppid;
 	int			seccomp_mode;
 };

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2799,6 +2799,7 @@ static inline int decode_posix_timer(PosixTimerEntry *pte,
 	pt->spt.si_signo = pte->si_signo;
 	pt->spt.it_sigev_notify = pte->it_sigev_notify;
 	pt->spt.sival_ptr = decode_pointer(pte->sival_ptr);
+	pt->spt.notify_thread_id = pte->notify_thread_id;
 	pt->overrun = pte->overrun;
 
 	return 0;

--- a/criu/include/posix-timer.h
+++ b/criu/include/posix-timer.h
@@ -8,6 +8,7 @@ struct str_posix_timer {
 	int clock_id;
 	int si_signo;
 	int it_sigev_notify;
+	int notify_thread_id;
 	void * sival_ptr;
 };
 

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -318,14 +318,13 @@ static int core_alloc_posix_timers(TaskTimersEntry *tte, int n,
 	return 0;
 }
 
-static void encode_posix_timer(struct posix_timer *v,
-		struct proc_posix_timer *vp, PosixTimerEntry *pte)
+static int encode_posix_timer(struct pstree_item *item, struct posix_timer *v,
+			     struct proc_posix_timer *vp, PosixTimerEntry *pte)
 {
 	pte->it_id = vp->spt.it_id;
 	pte->clock_id = vp->spt.clock_id;
 	pte->si_signo = vp->spt.si_signo;
 	pte->it_sigev_notify = vp->spt.it_sigev_notify;
-	pte->notify_thread_id = vp->spt.notify_thread_id;
 	pte->sival_ptr = encode_pointer(vp->spt.sival_ptr);
 
 	pte->overrun = v->overrun;
@@ -334,6 +333,27 @@ static void encode_posix_timer(struct posix_timer *v,
 	pte->insec = v->val.it_interval.tv_nsec;
 	pte->vsec = v->val.it_value.tv_sec;
 	pte->vnsec = v->val.it_value.tv_nsec;
+	if (vp->spt.notify_thread_id != 0) {
+		pid_t vtid = 0, rtid = vp->spt.notify_thread_id;
+		int i;
+
+		for (i = 0; i < item->nr_threads; i++) {
+			if (item->threads[i].real != rtid)
+				continue;
+
+			vtid = item->threads[i].ns[0].virt;
+			break;
+		}
+
+		if (vtid == 0) {
+			pr_err("Unable to find the thread %d\n", rtid);
+			return -1;
+		}
+
+		pte->notify_thread_id = vtid;
+		pte->has_notify_thread_id = true;
+	}
+	return 0;
 }
 
 int parasite_dump_posix_timers_seized(struct proc_posix_timers_stat *proc_args,
@@ -344,8 +364,8 @@ int parasite_dump_posix_timers_seized(struct proc_posix_timers_stat *proc_args,
 	PosixTimerEntry *pte;
 	struct proc_posix_timer *temp;
 	struct parasite_dump_posix_timers_args *args;
+	int ret, exit_code = -1;
 	int args_size;
-	int ret = 0;
 	int i;
 
 	if (core_alloc_posix_timers(tte, proc_args->timer_n, &pte))
@@ -368,14 +388,16 @@ int parasite_dump_posix_timers_seized(struct proc_posix_timers_stat *proc_args,
 	i = 0;
 	list_for_each_entry(temp, &proc_args->timers, list) {
 		posix_timer_entry__init(&pte[i]);
-		encode_posix_timer(&args->timer[i], temp, &pte[i]);
+		if (encode_posix_timer(item, &args->timer[i], temp, &pte[i]))
+			goto end_posix;
 		tte->posix[i] = &pte[i];
 		i++;
 	}
 
+	exit_code = 0;
 end_posix:
 	free_posix_timers(proc_args);
-	return ret;
+	return exit_code;
 }
 
 int parasite_dump_misc_seized(struct parasite_ctl *ctl, struct parasite_dump_misc *misc)

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -325,6 +325,7 @@ static void encode_posix_timer(struct posix_timer *v,
 	pte->clock_id = vp->spt.clock_id;
 	pte->si_signo = vp->spt.si_signo;
 	pte->it_sigev_notify = vp->spt.it_sigev_notify;
+	pte->notify_thread_id = vp->spt.notify_thread_id;
 	pte->sival_ptr = encode_pointer(vp->spt.sival_ptr);
 
 	pte->overrun = v->overrun;

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1069,6 +1069,11 @@ static int create_posix_timers(struct task_restore_args *args)
 	for (i = 0; i < args->posix_timers_n; i++) {
 		sev.sigev_notify = args->posix_timers[i].spt.it_sigev_notify;
 		sev.sigev_signo = args->posix_timers[i].spt.si_signo;
+#ifdef __GLIBC__
+		sev._sigev_un._tid = args->posix_timers[i].spt.notify_thread_id;
+#else
+		sev.sigev_notify_thread_id = args->posix_timers[i].spt.notify_thread_id;
+#endif
 		sev.sigev_value.sival_ptr = args->posix_timers[i].spt.sival_ptr;
 
 		while (1) {

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -1062,7 +1062,7 @@ int parse_pid_status(pid_t pid, struct seize_task_status *ss, void *data)
 	if (bfdopenr(&f))
 		return -1;
 
-	while (done < 12) {
+	while (done < 13) {
 		str = breadline(&f);
 		if (str == NULL)
 			break;
@@ -1080,6 +1080,20 @@ int parse_pid_status(pid_t pid, struct seize_task_status *ss, void *data)
 				pr_err("Unable to parse: %s\n", str);
 				goto err_parse;
 			}
+			done++;
+			continue;
+		}
+
+		if (!strncmp(str, "NSpid:", 6)) {
+			/* Get a thread ID in the thread PID namespace. */
+			char *last;
+
+			last = strrchr(str, '\t');
+			if (!last || sscanf(last, "%d", &cr->s.vpid) != 1) {
+				pr_err("Unable to parse: %s\n", str);
+				goto err_parse;
+			}
+
 			done++;
 			continue;
 		}
@@ -1165,7 +1179,7 @@ int parse_pid_status(pid_t pid, struct seize_task_status *ss, void *data)
 	}
 
 	/* seccomp is optional */
-	if (done >= 11 || (done == 10 && !parsed_seccomp))
+	if (done >= 12 || (done == 11 && !parsed_seccomp))
 		ret = 0;
 
 err_parse:

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -2342,6 +2342,7 @@ int parse_posix_timers(pid_t pid, struct proc_posix_timers_stat *args)
 
 			if ( tidpid[0] == 't') {
 				timer->spt.it_sigev_notify = SIGEV_THREAD_ID;
+				timer->spt.notify_thread_id = pid_t;
 			} else {
 				switch (sigpid[0]) {
 					case 's' :

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -816,6 +816,7 @@ static int collect_threads(struct pstree_item *item)
 
 		BUG_ON(item->nr_threads + 1 > nr_threads);
 		item->threads[item->nr_threads].real = pid;
+		item->threads[item->nr_threads].ns[0].virt = t_creds.s.vpid;
 		item->threads[item->nr_threads].item = NULL;
 		item->nr_threads++;
 

--- a/images/timer.proto
+++ b/images/timer.proto
@@ -21,6 +21,7 @@ message posix_timer_entry {
 	required uint64		insec		= 8;
 	required uint64		vsec		= 9;
 	required uint64		vnsec		= 10;
+	optional int32		notify_thread_id= 11;
 }
 
 message task_timers_entry {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -59,6 +59,7 @@ TST_NOFILE	:=				\
 		pthread00			\
 		pthread01			\
 		pthread02			\
+		pthread_timers			\
 		vdso00				\
 		vdso01				\
 		vdso02				\
@@ -519,6 +520,7 @@ inotify_system_nodel:	CFLAGS += -DNODEL
 pthread00:		LDLIBS += -pthread
 pthread01:		LDLIBS += -pthread
 pthread02:		LDLIBS += -pthread
+pthread_timers:		LDLIBS += -lrt -pthread
 different_creds:	LDLIBS += -pthread
 sigpending:		LDLIBS += -pthread
 sigaltstack:		LDLIBS += -pthread

--- a/test/zdtm/static/pthread_timers.c
+++ b/test/zdtm/static/pthread_timers.c
@@ -1,0 +1,83 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <time.h>
+
+#include <sys/eventfd.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc	= "Check SIGEV_THREAD timers";
+const char *test_author	= "Andrei Vagin <avagin@gmail.com>";
+
+int efd;
+static void timer_func(union sigval sigval) {
+	long long int val = 1;
+
+	if (write(efd, &val, sizeof(val)) != sizeof(val)) {
+		pr_perror("write");
+		exit(1);
+	}
+}
+
+#define TEST_INTERVAL_NSEC 10000000
+
+int main(int argc, char **argv)
+{
+	struct sigevent evp = {};
+	struct itimerspec itimerspec = {};
+	long long val;
+	timer_t timerid;
+
+	test_init(argc, argv);
+
+	efd = eventfd(0, 0);
+	if (efd < 0) {
+		pr_perror("eventfd");
+		return 1;
+	}
+
+	evp.sigev_notify = SIGEV_THREAD;
+	evp.sigev_notify_function = timer_func;
+	itimerspec.it_interval.tv_nsec = TEST_INTERVAL_NSEC;
+	itimerspec.it_value.tv_nsec = TEST_INTERVAL_NSEC;
+
+	if (timer_create(CLOCK_MONOTONIC, &evp, &timerid)) {
+		pr_perror("timer_create");
+		exit(1);
+	}
+
+	if (timer_settime(timerid, 0, &itimerspec, NULL)) {
+		pr_perror("timer_create");
+		exit(1);
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	if (timer_gettime(timerid, &itimerspec)) {
+		pr_perror("timer_gettime");
+		exit(1);
+	}
+
+	if (itimerspec.it_interval.tv_nsec != TEST_INTERVAL_NSEC || itimerspec.it_interval.tv_sec) {
+		pr_perror("wrong interval: %ld:%ld", itimerspec.it_interval.tv_sec, itimerspec.it_interval.tv_nsec);
+		return 1;
+	}
+
+	/* Read old events. */
+	if (read(efd, &val, sizeof(val)) != sizeof(val)) {
+		pr_perror("read");
+		return 1;
+	}
+
+	/* Wait for new events. */
+	if (read(efd, &val, sizeof(val)) != sizeof(val)) {
+		pr_perror("read");
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
When sigev_notify_thread_id is not set, get_pid will return a NULL
pointer and do_timer_create will return -EINVAL in kernel. So criu
will failed to create posix timer:

(09.806760) pie: 41301: Error (criu/pie/restorer.c:1998): Can't restore posix timers -22
(09.806824) pie: 41301: Error (criu/pie/restorer.c:2133): Restorer fail 41301
(09.891880) Error (criu/cr-restore.c:2596): Restoring FAILED.

Signed-off-by: Liu Chao <liuchao173@huawei.com>
