### PR TITLE
ci: fix mips64el-cross test

### DIFF
--- a/compel/arch/mips/src/lib/include/uapi/asm/sigframe.h
+++ b/compel/arch/mips/src/lib/include/uapi/asm/sigframe.h
@@ -51,7 +51,7 @@ struct rt_sigframe {
 	"syscall					\n"	\
 	:							\
 	: "r"(new_sp)						\
-	: "$29","$2","memory")
+	: "$2","memory")
 
 int sigreturn_prep_fpu_frame(struct rt_sigframe *sigframe,
 		struct rt_sigframe *rsigframe);

--- a/criu/arch/mips/include/asm/restore.h
+++ b/criu/arch/mips/include/asm/restore.h
@@ -15,7 +15,7 @@
 		:							\
 		:"r"(task_args),"r"(restore_task_exec_start),		\
 		 "g"(new_sp)						\
-		: "$29", "$25", "$4","$5")
+		: "$25", "$4","$5")
 
 static inline void core_get_tls(CoreEntry *pcore, tls_t *ptls)
 {

--- a/criu/arch/mips/include/asm/restorer.h
+++ b/criu/arch/mips/include/asm/restorer.h
@@ -60,7 +60,7 @@ static inline int set_compat_robust_list(uint32_t head_ptr, uint32_t len)
 		       "r"(&thread_args[i].pid),			\
 		       "r"(clone_restore_fn),				\
 		       "r"(&thread_args[i])				\
-		 :"$2","$4","$5","$6","$7","$8","$25","$29","memory")
+		 :"$2","$4","$5","$6","$7","$8","$25","memory")
 
 #define RUN_CLONE3_RESTORE_FN(ret, clone_args, size, args, \
 			      clone_restore_fn)	do { \


### PR DESCRIPTION
The mips64el-cross test target started to show following error:

`error: listing the stack pointer register '$29' in a clobber list is deprecated [-Werror=deprecated]`

This fixes it in three different places by removing '$29' from the clobber list. This is only compile tested as we have no mips hardware for testing.