### PR TITLE
zdtm: make --sbs also stop on each predump/snap iteration

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1494,7 +1494,7 @@ def init_sbs():
 
 def sbs(what):
     if do_sbs:
-        input("Pause at %s. Press Enter to continue." % what)
+        input("Pause %s. Press Enter to continue." % what)
 
 
 #
@@ -1516,14 +1516,16 @@ def cr(cr_api, test, opts):
         pres = iter_parm(opts['pre'], 0)
         for p in pres[0]:
             if opts['snaps']:
+                sbs('before snap %d' % p)
                 cr_api.dump("dump", opts=["--leave-running", "--track-mem"])
             else:
+                sbs('before pre-dump %d' % p)
                 cr_api.dump("pre-dump")
                 try_run_hook(test, ["--post-pre-dump"])
                 test.pre_dump_notify()
             time.sleep(pres[1])
 
-        sbs('pre-dump')
+        sbs('before dump')
 
         os.environ["ZDTM_TEST_PID"] = str(test.getpid())
         if opts['norst']:
@@ -1536,13 +1538,13 @@ def cr(cr_api, test, opts):
                 test.gone()
             else:
                 test.unlink_pidfile()
-            sbs('pre-restore')
+            sbs('before restore')
             try_run_hook(test, ["--pre-restore"])
             cr_api.restore()
             os.environ["ZDTM_TEST_PID"] = str(test.getpid())
             os.environ["ZDTM_IMG_DIR"] = cr_api.logs()
             try_run_hook(test, ["--post-restore"])
-            sbs('post-restore')
+            sbs('after restore')
 
         time.sleep(iters[1])
 


### PR DESCRIPTION
This is useful to investigate problems on predump iterations. After this
patch test output with "--pre=2 --sbs" would have new usefull stop
points:

========================== Run zdtm/static/env00 in h ==========================
Start test
./env00 --pidfile=env00.pid --outfile=env00.out --envname=ENV_00_TEST
Pause at iter. Press Enter to continue.
Run criu pre-dump
Pause at iter. Press Enter to continue.
Run criu pre-dump
Pause at pre-dump. Press Enter to continue.
Run criu dump

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
