### PR TITLE
criu: introduce uncrustify to format source code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,21 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
     steps:
-    - uses: actions/checkout@v2
     - name: Install tools
-      run: sudo apt-get install -qqy flake8 shellcheck
+      run: sudo dnf -y install git make python3-flake8 ShellCheck uncrustify which
+    - uses: actions/checkout@v2
     - name: Run make lint
       run: make lint
+    - name: Run make indent
+      run: >
+        make indent &&
+        STATUS=$(git status --porcelain) &&
+        if [ ! -z "$STATUS" ]; then
+          echo "FAIL: some files are not correctly formatted.";
+          echo "$STATUS"
+          echo "FAIL: please run 'make indent'";
+          exit 1;
+        fi

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ criu-deps	+= include/common/asm
 #
 # Configure variables.
 export CONFIG_HEADER := include/common/config.h
-ifeq ($(filter tags etags cscope clean mrproper,$(MAKECMDGOALS)),)
+ifeq ($(filter tags etags cscope clean lint indent help mrproper,$(MAKECMDGOALS)),)
 include Makefile.config
 else
 # To clean all files, enable make/build options here
@@ -408,6 +408,8 @@ help:
 	@echo '      test            - Run zdtm test-suite'
 	@echo '      gcov            - Make code coverage report'
 	@echo '      unittest        - Run unit tests'
+	@echo '      lint            - Run code linters'
+	@echo '      indent          - Indent C code'
 .PHONY: help
 
 lint:
@@ -437,6 +439,11 @@ codecov: SHELL := $(shell which bash)
 codecov:
 	bash <(curl -s https://codecov.io/bash)
 .PHONY: codecov
+
+indent:
+	uncrustify -c scripts/criu.uncrustify.cfg --replace --no-backup criu/{uts_ns,lsm,cr-errno,string,sigframe,external,cr-dedup,file-ids}.c
+	uncrustify -c scripts/criu.uncrustify.cfg --replace --no-backup criu/unittest/*.c
+.PHONY: indent
 
 include Makefile.install
 

--- a/criu/cr-dedup.c
+++ b/criu/cr-dedup.c
@@ -14,7 +14,7 @@ int cr_dedup(void)
 {
 	int close_ret, ret = 0;
 	unsigned long img_id;
-	DIR * dirp;
+	DIR *dirp;
 	struct dirent *ent;
 
 	dirp = opendir(CR_PARENT_LINK);
@@ -71,7 +71,7 @@ static int cr_dedup_one_pagemap(unsigned long img_id, int flags)
 {
 	int ret;
 	struct page_read pr;
-	struct page_read * prp;
+	struct page_read *prp;
 
 	flags |= PR_MOD;
 	ret = open_page_read(img_id, &pr, flags);
@@ -87,7 +87,7 @@ static int cr_dedup_one_pagemap(unsigned long img_id, int flags)
 		if (ret <= 0)
 			goto exit;
 
-		pr_debug("dedup iovec base=%"PRIx64", len=%lu\n",
+		pr_debug("dedup iovec base=%" PRIx64 ", len=%lu\n",
 			 pr.pe->vaddr, pagemap_len(pr.pe));
 		if (!pagemap_in_parent(pr.pe)) {
 			ret = dedup_one_iovec(prp, pr.pe->vaddr,

--- a/criu/external.c
+++ b/criu/external.c
@@ -36,9 +36,10 @@ bool external_lookup_id(char *id)
 {
 	struct external *ext;
 
-	list_for_each_entry(ext, &opts.external, node)
+	list_for_each_entry(ext, &opts.external, node) {
 		if (!strcmp(ext->id, id))
 			return true;
+	}
 	return false;
 }
 

--- a/criu/file-ids.c
+++ b/criu/file-ids.c
@@ -31,11 +31,11 @@ static inline int fdid_hashfn(unsigned int s_dev, unsigned long i_ino)
 }
 
 struct fd_id {
-	int mnt_id;
-	unsigned int dev;
-	unsigned long ino;
-	u32 id;
-	struct fd_id *n;
+	int		mnt_id;
+	unsigned int	dev;
+	unsigned long	ino;
+	u32		id;
+	struct fd_id *	n;
 };
 
 static struct fd_id *fd_id_cache[FDID_SIZE];
@@ -64,7 +64,7 @@ static struct fd_id *fd_id_cache_lookup(struct fd_parms *p)
 	struct fd_id *fi;
 
 	for (fi = fd_id_cache[fdid_hashfn(st->st_dev, st->st_ino)];
-			fi; fi = fi->n)
+	     fi; fi = fi->n)
 		if (fi->dev == st->st_dev &&
 		    fi->ino == st->st_ino &&
 		    fi->mnt_id == p->mnt_id)

--- a/criu/lsm.c
+++ b/criu/lsm.c
@@ -79,7 +79,7 @@ static int verify_selinux_label(char *ctx)
 	 *
 	 *      unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
 	 */
-	pos = (char*)ctx;
+	pos = (char *)ctx;
 	for (i = 0; i < 3; i++) {
 		pos = strstr(pos, ":");
 		if (!pos)
@@ -213,7 +213,6 @@ int dump_xattr_security_selinux(int fd, FdinfoEntry *e)
 
 void kerndat_lsm(void)
 {
-
 	if (access(AA_SECURITYFS_PATH, F_OK) == 0) {
 		kdat.lsm = LSMTYPE__APPARMOR;
 		return;

--- a/criu/sigframe.c
+++ b/criu/sigframe.c
@@ -5,23 +5,23 @@
 #include "images/core.pb-c.h"
 
 #ifndef setup_sas
-static inline void setup_sas(struct rt_sigframe* sigframe, ThreadSasEntry *sas)
+static inline void setup_sas(struct rt_sigframe *sigframe, ThreadSasEntry *sas)
 {
 	if (sas) {
 #define UC	RT_SIGFRAME_UC(sigframe)
 
-		UC->uc_stack.ss_sp	= (void *)decode_pointer((sas)->ss_sp);
-		UC->uc_stack.ss_flags	= (int)(sas)->ss_flags;
-		UC->uc_stack.ss_size	= (size_t)(sas)->ss_size;
+		UC->uc_stack.ss_sp = (void *)decode_pointer((sas)->ss_sp);
+		UC->uc_stack.ss_flags = (int)(sas)->ss_flags;
+		UC->uc_stack.ss_size = (size_t)(sas)->ss_size;
 #undef UC
 	}
 }
 #endif
 
 int construct_sigframe(struct rt_sigframe *sigframe,
-				     struct rt_sigframe *rsigframe,
-				     k_rtsigset_t *blkset,
-				     CoreEntry *core)
+		       struct rt_sigframe *rsigframe,
+		       k_rtsigset_t *blkset,
+		       CoreEntry *core)
 {
 	/*
 	 * Copy basic register set in the first place: this will set

--- a/criu/string.c
+++ b/criu/string.c
@@ -52,7 +52,7 @@ size_t strlcat(char *dest, const char *src, size_t count)
 	dest += dsize;
 	count -= dsize;
 	if (len >= count)
-		len = count-1;
+		len = count - 1;
 	memcpy(dest, src, len);
 	dest[len] = 0;
 	return res;

--- a/criu/uts_ns.c
+++ b/criu/uts_ns.c
@@ -44,7 +44,7 @@ int prepare_utsns(int pid)
 	struct cr_img *img;
 	UtsnsEntry *ue;
 	struct sysctl_req req[] = {
-		{ "kernel/hostname" },
+		{ "kernel/hostname"   },
 		{ "kernel/domainname" },
 	};
 

--- a/scripts/criu.uncrustify.cfg
+++ b/scripts/criu.uncrustify.cfg
@@ -1,0 +1,103 @@
+#
+# uncrustify config file for CRIU
+#
+
+indent_with_tabs		= 2		# 1=indent to level only, 2=indent with tabs
+input_tab_size			= 8		# original tab size
+output_tab_size			= 8		# new tab size
+indent_columns			= output_tab_size
+
+indent_label			= 1		# pos: absolute col, neg: relative column
+
+# How to use tabs when indenting code
+# 0=spaces only
+# 1=indent with tabs to brace level, align with spaces
+# 2=indent and align with tabs, using spaces when not on a tabstop
+indent_with_tabs		= 2		# number
+
+nl_enum_brace			= remove	# "enum {" vs "enum \n {"
+nl_union_brace			= remove	# "union {" vs "union \n {"
+nl_struct_brace			= remove	# "struct {" vs "struct \n {"
+nl_do_brace 			= remove	# "do {" vs "do \n {"
+nl_if_brace 			= remove	# "if () {" vs "if () \n {"
+nl_for_brace 			= remove	# "for () {" vs "for () \n {"
+nl_else_brace 			= remove	# "else {" vs "else \n {"
+nl_while_brace 			= remove	# "while () {" vs "while () \n {"
+nl_switch_brace 		= remove	# "switch () {" vs "switch () \n {"
+nl_brace_while			= remove	# "} while" vs "} \n while" - cuddle while
+nl_brace_else			= remove	# "} else" vs "} \n else" - cuddle else
+sp_brace_else			= force
+sp_else_brace			= force
+nl_func_var_def_blk		= 1
+nl_fcall_brace			= remove	# "list_for_each() {" vs "list_for_each()\n{"
+nl_fdef_brace			= add		# "int foo() {" vs "int foo()\n{"
+nl_after_label_colon		= true		# "fail:\nfree(foo);" vs "fail: free(foo);"
+
+# Whether to alter newlines in '#define' macros
+nl_define_macro			= true		# false/true
+
+sp_do_brace_open		= force
+sp_brace_close_while		= force
+sp_while_paren_open		= force
+
+mod_paren_on_return		= remove	# "return 1;" vs "return (1);"
+mod_full_brace_if_chain		= true
+mod_full_brace_for		= remove	# "for () a--;" vs "for () { a--; }"
+mod_full_brace_do		= remove	# "do a--; while ();" vs "do { a--; } while ();"
+mod_full_brace_while		= remove	# "while (a) a--;" vs "while (a) { a--; }"
+mod_full_brace_nl		= 3		# don't remove if more than 3 newlines
+
+sp_return_paren			= force		# "return (1);" vs "return(1);"
+sp_sizeof_paren			= remove	# "sizeof (int)" vs "sizeof(int)"
+sp_before_sparen		= force		# "if (" vs "if("
+sp_after_sparen			= force		# "if () {" vs "if (){"
+sp_after_cast			= remove	# "(int) a" vs "(int)a"
+sp_inside_braces		= force		# "{ 1 }" vs "{1}"
+sp_inside_braces_struct		= force		# "{ 1 }" vs "{1}"
+sp_inside_braces_enum		= force		# "{ 1 }" vs "{1}"
+sp_assign			= force
+sp_arith			= force
+sp_bool				= force
+sp_compare			= force
+sp_assign			= force
+sp_after_comma			= force
+sp_func_def_paren		= remove	# "int foo (){" vs "int foo(){"
+sp_func_call_paren		= remove	# "foo (" vs "foo("
+sp_func_proto_paren		= remove	# "int foo ();" vs "int foo();"
+
+align_with_tabs			= TRUE		# use tabs to align
+align_on_tabstop		= TRUE 		# align on tabstops
+align_keep_tabs			= true
+align_enum_equ_span		= 4		# '=' in enum definition
+align_nl_cont			= TRUE
+align_struct_init_span		= 3		# align stuff in a structure init '= { }'
+align_right_cmt_span		= 3
+
+cmt_star_cont 			= true
+
+nl_func_paren			= remove
+nl_func_decl_start		= remove
+nl_func_decl_empty		= remove
+nl_func_decl_args		= remove
+nl_func_decl_end		= remove
+sp_inside_paren			= remove
+sp_inside_square		= remove
+sp_inside_paren_cast		= remove
+sp_inside_fparen		= remove
+sp_inside_sparen		= remove
+sp_paren_paren			= remove
+sp_before_ptr_star		= force
+sp_after_ptr_star		= remove
+sp_between_ptr_star		= remove
+align_func_params		= false
+align_var_struct_span		= 6
+align_var_def_span		= 0
+
+eat_blanks_after_open_brace	= true
+eat_blanks_before_close_brace	= true
+pp_indent			= remove
+
+nl_start_of_file		= remove
+nl_end_of_file			= force
+nl_end_of_file_min		= 1
+nl_comment_func_def		= 1


### PR DESCRIPTION
This is another attempt to introduce a tool to format CRIU's source code. This time it is based on uncrustify. I am regularly using
uncrustify on my patches if possible and the uncrustify configuration file is based on the uncrustify linux.cfg example with minimal changes for CRIU.

This runs uncrustify only on a small number of files to see if it works as expected and can later be extended to a larger number of files.

The changes look correct and if this is accepted I would extend it to more files in the CRIU code base.

The biggest changes will probably happen around declaration or initialization of structures. Sometimes they are space or tab aligned, sometimes not. Maybe a tool like uncrustify would help us to get consistent code style.

Personally which style we have is not that important to me, but having a consistent style would be nice. Happy to change things in the configuration file. I tried to go with a style which changes the existing code as little as possible.

@mihalicyn similar to your attempt to introduce C code formatting