### PR TITLE
ci/openj9: run mrproper before make

### DIFF
--- a/scripts/build/Dockerfile.openj9-alpine
+++ b/scripts/build/Dockerfile.openj9-alpine
@@ -1,4 +1,5 @@
 FROM adoptopenjdk/openjdk8-openj9:alpine
+ARG CC=gcc
 
 RUN apk update && apk add \
 	bash \
@@ -23,7 +24,7 @@ RUN apk update && apk add \
 COPY . /criu
 WORKDIR /criu
 
-RUN make
+RUN make mrproper && make -j $(nproc) CC="$CC"
 
 ENTRYPOINT mvn -q -f test/javaTests/pom.xml test
 

--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -1,4 +1,5 @@
 FROM adoptopenjdk/openjdk8-openj9:latest
+ARG CC=gcc
 
 COPY scripts/ci/apt-install /bin/apt-install
 
@@ -27,7 +28,7 @@ RUN apt-install protobuf-c-compiler \
 COPY . /criu
 WORKDIR /criu
 
-RUN make
+RUN make mrproper && make -j $(nproc) CC="$CC"
 
 ENTRYPOINT mvn -q -f test/javaTests/pom.xml test
 


### PR DESCRIPTION
Make sure to remove all files created from previous local build before compiling in the container.