### PR TITLE
Fix another crit-recode Jenkins error

### DIFF
--- a/lib/py/images/images.py
+++ b/lib/py/images/images.py
@@ -443,7 +443,10 @@ class ipc_msg_queue_handler:
             f.write(struct.pack('i', size))
             f.write(msg_str)
             rounded = round_up(msg.msize, sizeof_u64)
-            data = base64.decodebytes(extra[i + 1])
+            if (sys.version_info > (3, 0)):
+                data = base64.decodebytes(str.encode(extra[i + 1]))
+            else:
+                data = base64.decodebytes(extra[i + 1])
             f.write(data[:msg.msize])
             f.write(b'\0' * (rounded - msg.msize))
 

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -253,7 +253,7 @@ ip net add test
 
 ./test/zdtm.py run --empty-ns -T zdtm/static/socket-tcp*-local --iter 2
 
-./test/zdtm.py run -t zdtm/static/env00 -t zdtm/transition/fork -t zdtm/static/ghost_holes00 -t zdtm/static/socket-tcp -k always
+./test/zdtm.py run -t zdtm/static/env00 -t zdtm/transition/fork -t zdtm/static/ghost_holes00 -t zdtm/static/socket-tcp -t zdtm/static/msgque -k always
 ./test/crit-recode.py
 
 # more crit testing


### PR DESCRIPTION
This fixes Jenkins errors like:
```
b'test/dump/zdtm/static/msgque/63/1/ipcns-msg-11.img'  encode fails: expected bytes-like object, not str
b'test/dump/zdtm/static/msgque/63/1/ipcns-msg-11.img' pretty  encode fails: expected bytes-like object, not str
FAIL
```
and also adds the test case to GitHub based CI.