### PR TITLE
Amdgpu rfc 210715 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,15 +294,19 @@ clean mrproper:
 	$(Q) $(MAKE) $(build)=crit $@
 .PHONY: clean mrproper
 
+clean-dummy_amdgpu_plugin:
+	$(Q) $(MAKE) -C plugins/amdgpu clean
+.PHONY: clean dummy_amdgpu_plugin
+
 clean-top:
 	$(Q) $(MAKE) -C Documentation clean
 	$(Q) $(MAKE) $(build)=test/compel clean
 	$(Q) $(RM) .gitid
 .PHONY: clean-top
 
-clean: clean-top
+clean: clean-top clean-dummy_amdgpu_plugin
 
-mrproper-top: clean-top
+mrproper-top: clean-top clean-dummy_amdgpu_plugin
 	$(Q) $(RM) $(CONFIG_HEADER)
 	$(Q) $(RM) $(VERSION_HEADER)
 	$(Q) $(RM) $(COMPEL_VERSION_HEADER)
@@ -329,6 +333,10 @@ zdtm: all
 test: zdtm
 	$(Q) $(MAKE) -C test
 .PHONY: test
+
+dummy_amdgpu_plugin:
+	$(Q) $(MAKE) -C plugins/amdgpu all
+.PHONY: dummy_amdgpu_plugin
 
 #
 # Generating tar requires tag matched CRIU_VERSION.

--- a/Makefile.install
+++ b/Makefile.install
@@ -7,6 +7,7 @@ MANDIR		?= $(PREFIX)/share/man
 INCLUDEDIR	?= $(PREFIX)/include
 LIBEXECDIR	?= $(PREFIX)/libexec
 RUNDIR		?= /run
+PLUGINDIR	?= /var/lib/criu
 
 #
 # For recent Debian/Ubuntu with multiarch support.
@@ -26,7 +27,7 @@ endif
 LIBDIR ?= $(PREFIX)/lib
 
 export PREFIX BINDIR SBINDIR MANDIR RUNDIR
-export LIBDIR INCLUDEDIR LIBEXECDIR
+export LIBDIR INCLUDEDIR LIBEXECDIR PLUGINDIR
 
 install-man:
 	$(Q) $(MAKE) -C Documentation install
@@ -39,6 +40,10 @@ install-lib: lib
 install-criu: criu
 	$(Q) $(MAKE) $(build)=criu install
 .PHONY: install-criu
+
+install-dummy_amdgpu_plugin: dummy_amdgpu_plugin
+	$(Q) $(MAKE) -C plugins/amdgpu install
+.PHONY: install-dummy_amdgpu_plugin
 
 install-compel: $(compel-install-targets)
 	$(Q) $(MAKE) $(build)=compel install
@@ -54,4 +59,5 @@ uninstall:
 	$(Q) $(MAKE) $(build)=criu $@
 	$(Q) $(MAKE) $(build)=compel $@
 	$(Q) $(MAKE) $(build)=compel/plugins $@
+	$(Q) $(MAKE) -C plugins/amdgpu $@
 .PHONY: uninstall

--- a/criu/file-ids.c
+++ b/criu/file-ids.c
@@ -77,8 +77,14 @@ int fd_id_generate_special(struct fd_parms *p, u32 *id)
 
 		fi = fd_id_cache_lookup(p);
 		if (fi) {
-			*id = fi->id;
-			return 0;
+			if (p->stat.st_mode & (S_IFCHR | S_IFBLK)) {
+				/* Don't cache the id for mapped devices */
+				*id = fd_tree.subid++;
+				return 1;
+			} else {
+				*id = fi->id;
+				return 0;
+			}
 		}
 	}
 

--- a/criu/include/criu-plugin.h
+++ b/criu/include/criu-plugin.h
@@ -22,6 +22,8 @@
 
 #include <limits.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <sys/stat.h>
 
 #define CRIU_PLUGIN_GEN_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + (c))
 #define CRIU_PLUGIN_VERSION_MAJOR	 0
@@ -48,6 +50,12 @@ enum {
 
 	CR_PLUGIN_HOOK__DUMP_EXT_LINK = 6,
 
+	CR_PLUGIN_HOOK__HANDLE_DEVICE_VMA = 7,
+
+	CR_PLUGIN_HOOK__UPDATE_VMA_MAP = 8,
+
+	CR_PLUGIN_HOOK__RESUME_DEVICES_LATE = 9,
+
 	CR_PLUGIN_HOOK__MAX
 };
 
@@ -60,6 +68,10 @@ DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESTORE_EXT_FILE, int id);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__DUMP_EXT_MOUNT, char *mountpoint, int id);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESTORE_EXT_MOUNT, int id, char *mountpoint, char *old_root, int *is_file);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__DUMP_EXT_LINK, int index, int type, char *kind);
+DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__HANDLE_DEVICE_VMA, int fd, const struct stat *stat);
+DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, const char *old_path, char *new_path, const uint64_t addr,
+			 const uint64_t old_pgoff, uint64_t *new_pgoff);
+DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESUME_DEVICES_LATE, int pid);
 
 enum {
 	CR_PLUGIN_STAGE__DUMP,
@@ -130,5 +142,9 @@ typedef int(cr_plugin_restore_file_t)(int id);
 typedef int(cr_plugin_dump_ext_mount_t)(char *mountpoint, int id);
 typedef int(cr_plugin_restore_ext_mount_t)(int id, char *mountpoint, char *old_root, int *is_file);
 typedef int(cr_plugin_dump_ext_link_t)(int index, int type, char *kind);
+typedef int(cr_plugin_handle_device_vma_t)(int fd, const struct stat *stat);
+typedef int(cr_plugin_update_vma_map_t)(const char *old_path, char *new_path, const uint64_t addr,
+					const uint64_t old_pgoff, uint64_t *new_pgoff);
+typedef int(cr_plugin_resume_devices_late_t)(int pid);
 
 #endif /* __CRIU_PLUGIN_H__ */

--- a/criu/plugin.c
+++ b/criu/plugin.c
@@ -54,6 +54,9 @@ static cr_plugin_desc_t *cr_gen_plugin_desc(void *h, char *path)
 	__assign_hook(DUMP_EXT_MOUNT, "cr_plugin_dump_ext_mount");
 	__assign_hook(RESTORE_EXT_MOUNT, "cr_plugin_restore_ext_mount");
 	__assign_hook(DUMP_EXT_LINK, "cr_plugin_dump_ext_link");
+	__assign_hook(HANDLE_DEVICE_VMA, "cr_plugin_handle_device_vma");
+	__assign_hook(UPDATE_VMA_MAP, "cr_plugin_update_vma_map");
+	__assign_hook(RESUME_DEVICES_LATE, "cr_plugin_resume_devices_late");
 
 #undef __assign_hook
 

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -1,0 +1,13 @@
+all: dummy_plugin.so
+
+dummy_plugin.so: dummy_plugin.c
+	gcc -g -Werror -D _GNU_SOURCE -Wall -shared -nostartfiles dummy_plugin.c -o dummy_plugin.so -iquote ../../../criu/include -iquote ../../criu/include -fPIC
+
+clean:
+	$(Q) $(RM) dummy_plugin.so
+install:
+	$(Q) mkdir -p $(PLUGINDIR)
+	$(Q) install -m 644 dummy_plugin.so $(PLUGINDIR)
+
+uninstall:
+	$(Q) $(RM) $(PLUGINDIR)/dummy_plugin.so

--- a/plugins/amdgpu/dummy_plugin.c
+++ b/plugins/amdgpu/dummy_plugin.c
@@ -1,0 +1,36 @@
+#include <sys/stat.h>
+
+#include "criu-log.h"
+#include "criu-plugin.h"
+
+int dummy_plugin_handle_device_vma(int fd, const struct stat *stat)
+{
+	pr_info("dummy_plugin: Inside %s for fd = %d\n", __func__, fd);
+	/* let criu report failure for the unsupported mapping */
+	return -ENOTSUP;
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__HANDLE_DEVICE_VMA, dummy_plugin_handle_device_vma)
+
+int dummy_plugin_resume_devices_late(int target_pid)
+{
+	pr_info("dummy_plugin: Inside %s for target pid = %d\n", __func__, target_pid);
+	return -ENOTSUP;
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESUME_DEVICES_LATE, dummy_plugin_resume_devices_late)
+
+/*
+ * return 0 if no match found
+ * return -1 for error or -ENOTSUP.
+ * return 1 if vmap map must be adjusted.
+ */
+int dummy_plugin_update_vmamap(const char *old_path, char *new_path, const uint64_t addr, const uint64_t old_offset,
+			       uint64_t *new_offset)
+{
+	uint64_t temp = 100;
+
+	*new_offset = temp;
+	pr_info("dummy_plugin: old_pgoff= 0x%lu new_pgoff = 0x%lx old_path = %s new_path = %s addr = 0x%lu\n",
+		old_offset, *new_offset, old_path, new_path, addr);
+	return -ENOTSUP;
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, dummy_plugin_update_vmamap)


### PR DESCRIPTION
Hi @checkpoint-restore/maintainers ,

Thank you for the review feedback on our previous RFC PR - https://github.com/checkpoint-restore/criu/pull/1519.

As per the recommendation, we have split our work into two parts and we'll close the previous PR, #1519  
1 - This Pull Request
      *  brings in the proposed changes to CRIU
      *  new hooks and a dummy plugin
      *  some workaround/fixes for issues seen with CRIU to support amdgpu_plugin
   
2 - https://github.com/RadeonOpenCompute/criu/commits/amdgpu_rfc-210715-2
      *  changes that implement actual amdgpu_plugin
      *  several features such as multi gpu support, fast checkpoint restore using SDMA. 
      *  fixes for lint, clang, fedora32, ubuntu focal build failures.
      *  sets up build dependencies on libdrm which is required for amdgpu_plugin
   
There will be another PR with part 2.

Thanks again for your time and patience.