### PR TITLE
Amdgpu rfc 210715 2

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -14,6 +14,7 @@ FOOTER		:= footer.txt
 SRC1		+= crit.txt
 SRC1		+= criu-ns.txt
 SRC1		+= compel.txt
+SRC1		+= amdgpu_plugin.txt
 SRC8		+= criu.txt
 SRC		:= $(SRC1) $(SRC8)
 XMLS		:= $(patsubst %.txt,%.xml,$(SRC))

--- a/Documentation/amdgpu_plugin.txt
+++ b/Documentation/amdgpu_plugin.txt
@@ -35,6 +35,60 @@ Dependencies
     This work is rebased on latest criu release available at this time.
 
 
+OPTIONS
+-------
+Optional parameters can be passed in as environment variables before
+executing criu command.
+
+*KFD_FW_VER_CHECK*::
+    Enable or disable firmware version check.
+    If enabled, firmware version on restored gpu needs to be greater than or
+    equal firmware version on checkpointed GPU. Default:Enabled
+
+    E.g:
+    KFD_FW_VER_CHECK=0
+
+*KFD_SDMA_FW_VER_CHECK*::
+    Enable or disable SDMA firmware version check.
+    If enabled, SDMA firmware version on restored gpu needs to be greater than or
+    equal firmware version on checkpointed GPU. Default:Enabled
+
+    E.g:
+    KFD_SDMA_FW_VER_CHECK=0
+
+*KFD_CACHES_COUNT_CHECK*::
+    Enable or disable caches count check. If enabled, the caches count on
+    restored GPU needs to be greater than or equal caches count on checkpointed
+    GPU. Default:Enabled
+
+    E.g:
+    KFD_CACHES_COUNT_CHECK=0
+
+*KFD_NUM_GWS_CHECK*::
+    Enable or disable num_gws check. If enabled, the num_gws on
+    restored GPU needs to be greater than or equal num_gws on checkpointed
+    GPU. Default:Enabled
+
+    E.g:
+    KFD_NUM_GWS_CHECK=0
+
+*KFD_VRAM_SIZE_CHECK*::
+    Enable or disable VRAM size check. If enabled, the VRAM size on
+    restored GPU needs to be greater than or equal VRAM size on checkpointed
+    GPU. Default:Enabled
+
+    E.g:
+    KFD_VRAM_SIZE_CHECK=0
+
+*KFD_NUMA_CHECK*::
+    Enable or disable NUMA CPU region check. If enabled, the plugin will restore
+    GPUs that belong to one CPU NUMA region to the same CPU NUMA region.
+    Default:Enabled
+
+    E.g:
+    KFD_IGNORE_NUMA=1
+
+
 AUTHOR
 ------
 The AMDKFD team.

--- a/Documentation/amdgpu_plugin.txt
+++ b/Documentation/amdgpu_plugin.txt
@@ -9,7 +9,7 @@ userspace for AMD GPUs.
 
 CURRENT SUPPORT
 ---------------
-Single GPU systems (Gfx9)
+Single and Multi GPU systems (Gfx9)
 Checkpoint / Restore on same system
 Checkpoint / Restore inside a docker container
 Pytorch

--- a/Documentation/amdgpu_plugin.txt
+++ b/Documentation/amdgpu_plugin.txt
@@ -1,0 +1,45 @@
+ROCM Support(1)
+===============
+
+NAME
+----
+amdgpu_plugin - A plugin extension to CRIU to support checkpoint/restore in
+userspace for AMD GPUs.
+
+
+CURRENT SUPPORT
+---------------
+Single GPU systems (Gfx9)
+Checkpoint / Restore on same system
+Checkpoint / Restore inside a docker container
+Pytorch
+
+DESCRIPTION
+-----------
+Though *criu* is a great tool for checkpointing and restoring running
+applications, it has certain limitations such as it cannot handle
+applications that have device files open. In order to support *ROCm* based
+workloads with *criu* we need to augment criu's core functionality with a
+plugin based extension mechanism. *amdgpu_plugin* provides the necessary support
+to criu to allow Checkpoint / Restore with ROCm.
+
+
+Dependencies
+~~~~~~~~~~~~~~
+*amdkfd support*::
+    In order to snapshot the *VRAM* and other *GPU* device states, we require
+    an updated version of amdkfd(amdgpu) driver. The kernel patches are under
+    review currently.
+
+*criu 3.16*::
+    This work is rebased on latest criu release available at this time.
+
+
+AUTHOR
+------
+The AMDKFD team.
+
+
+COPYRIGHT
+---------
+Copyright \(C) 2020-2021, Advanced Micro Devices, Inc. (AMD)

--- a/Makefile
+++ b/Makefile
@@ -294,9 +294,9 @@ clean mrproper:
 	$(Q) $(MAKE) $(build)=crit $@
 .PHONY: clean mrproper
 
-clean-dummy_amdgpu_plugin:
+clean-amdgpu_plugin:
 	$(Q) $(MAKE) -C plugins/amdgpu clean
-.PHONY: clean dummy_amdgpu_plugin
+.PHONY: clean-amdgpu_plugin
 
 clean-top:
 	$(Q) $(MAKE) -C Documentation clean
@@ -304,9 +304,9 @@ clean-top:
 	$(Q) $(RM) .gitid
 .PHONY: clean-top
 
-clean: clean-top clean-dummy_amdgpu_plugin
+clean: clean-top clean-amdgpu_plugin
 
-mrproper-top: clean-top clean-dummy_amdgpu_plugin
+mrproper-top: clean-top clean-amdgpu_plugin
 	$(Q) $(RM) $(CONFIG_HEADER)
 	$(Q) $(RM) $(VERSION_HEADER)
 	$(Q) $(RM) $(COMPEL_VERSION_HEADER)
@@ -334,9 +334,9 @@ test: zdtm
 	$(Q) $(MAKE) -C test
 .PHONY: test
 
-dummy_amdgpu_plugin:
+amdgpu_plugin:
 	$(Q) $(MAKE) -C plugins/amdgpu all
-.PHONY: dummy_amdgpu_plugin
+.PHONY: amdgpu_plugin
 
 #
 # Generating tar requires tag matched CRIU_VERSION.
@@ -418,6 +418,7 @@ help:
 	@echo '      unittest        - Run unit tests'
 	@echo '      lint            - Run code linters'
 	@echo '      indent          - Indent C code'
+	@echo '      amdgpu_plugin   - Make AMD GPU plugin'
 .PHONY: help
 
 lint:

--- a/Makefile.config
+++ b/Makefile.config
@@ -21,6 +21,14 @@ ifeq ($(call pkg-config-check,libbpf),y)
         export CONFIG_HAS_LIBBPF := y
 endif
 
+ifeq ($(call pkg-config-check,libdrm),y)
+        export CONFIG_AMDGPU := y
+        $(info Note: Building criu with amdgpu_plugin.)
+else
+        $(info Note: Building criu without amdgpu_plugin.)
+        $(info Note: libdrm and libdrm_amdgpu are required to build amdgpu_plugin.)
+endif
+
 ifeq ($(NO_GNUTLS)x$(call pkg-config-check,gnutls),xy)
         LIBS_FEATURES	+= -lgnutls
         export CONFIG_GNUTLS := y

--- a/Makefile.install
+++ b/Makefile.install
@@ -41,9 +41,9 @@ install-criu: criu
 	$(Q) $(MAKE) $(build)=criu install
 .PHONY: install-criu
 
-install-dummy_amdgpu_plugin: dummy_amdgpu_plugin
+install-amdgpu_plugin: amdgpu_plugin
 	$(Q) $(MAKE) -C plugins/amdgpu install
-.PHONY: install-dummy_amdgpu_plugin
+.PHONY: install-amdgpu_plugin
 
 install-compel: $(compel-install-targets)
 	$(Q) $(MAKE) $(build)=compel install

--- a/criu/files.c
+++ b/criu/files.c
@@ -183,6 +183,18 @@ out:
 	return fd;
 }
 
+int find_unused_fd_pid(pid_t pid)
+{
+	struct pstree_item *task;
+
+	task = pstree_item_by_virt(pid);
+	if (!task) {
+		pr_err("Invalid pid:%d\n", pid);
+		return -1;
+	}
+	return find_unused_fd(task, -1);
+}
+
 int set_fds_event(pid_t virt)
 {
 	struct pstree_item *item;

--- a/criu/include/criu-plugin.h
+++ b/criu/include/criu-plugin.h
@@ -69,8 +69,8 @@ DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__DUMP_EXT_MOUNT, char *mountpoint, int i
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESTORE_EXT_MOUNT, int id, char *mountpoint, char *old_root, int *is_file);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__DUMP_EXT_LINK, int index, int type, char *kind);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__HANDLE_DEVICE_VMA, int fd, const struct stat *stat);
-DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, const char *old_path, char *new_path, const uint64_t addr,
-			 const uint64_t old_pgoff, uint64_t *new_pgoff);
+DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, const char *path, const uint64_t addr,
+			 const uint64_t old_pgoff, uint64_t *new_pgoff, int *plugin_fd);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESUME_DEVICES_LATE, int pid);
 
 enum {
@@ -143,8 +143,8 @@ typedef int(cr_plugin_dump_ext_mount_t)(char *mountpoint, int id);
 typedef int(cr_plugin_restore_ext_mount_t)(int id, char *mountpoint, char *old_root, int *is_file);
 typedef int(cr_plugin_dump_ext_link_t)(int index, int type, char *kind);
 typedef int(cr_plugin_handle_device_vma_t)(int fd, const struct stat *stat);
-typedef int(cr_plugin_update_vma_map_t)(const char *old_path, char *new_path, const uint64_t addr,
-					const uint64_t old_pgoff, uint64_t *new_pgoff);
+typedef int(cr_plugin_update_vma_map_t)(const char *path, const uint64_t addr, const uint64_t old_pgoff,
+					uint64_t *new_pgoff, int *plugin_fd);
 typedef int(cr_plugin_resume_devices_late_t)(int pid);
 
 #endif /* __CRIU_PLUGIN_H__ */

--- a/criu/include/files.h
+++ b/criu/include/files.h
@@ -195,4 +195,5 @@ extern int open_transport_socket(void);
 extern int set_fds_event(pid_t virt);
 extern void wait_fds_event(void);
 
+int find_unused_fd_pid(pid_t pid);
 #endif /* __CR_FILES_H__ */

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -12,7 +12,7 @@ include $(__nmk_dir)msg.mk
 
 CC      		:= gcc
 PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
-PLUGIN_LDFLAGS		:= -lpthread
+PLUGIN_LDFLAGS		:= -lpthread -lrt
 
 ifeq ($(CONFIG_AMDGPU),y)
         all: $(DEPS_OK)

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -12,6 +12,7 @@ include $(__nmk_dir)msg.mk
 
 CC      		:= gcc
 PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
+PLUGIN_LDFLAGS		:= -lpthread
 
 ifeq ($(CONFIG_AMDGPU),y)
         all: $(DEPS_OK)
@@ -23,7 +24,7 @@ criu-amdgpu.pb-c.c: criu-amdgpu.proto
 		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
 
 amdgpu_plugin.so: amdgpu_plugin.c amdgpu_plugin_topology.c criu-amdgpu.pb-c.c
-	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE)
+	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS)
 
 amdgpu_plugin_clean:
 	$(call msg-clean, $@)

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -22,7 +22,7 @@ endif
 criu-amdgpu.pb-c.c: criu-amdgpu.proto
 		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
 
-amdgpu_plugin.so: amdgpu_plugin.c criu-amdgpu.pb-c.c
+amdgpu_plugin.so: amdgpu_plugin.c amdgpu_plugin_topology.c criu-amdgpu.pb-c.c
 	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE)
 
 amdgpu_plugin_clean:

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -1,13 +1,49 @@
-all: dummy_plugin.so
+PLUGIN_NAME		:= amdgpu_plugin
+PLUGIN_SOBJ		:= amdgpu_plugin.so
 
-dummy_plugin.so: dummy_plugin.c
-	gcc -g -Werror -D _GNU_SOURCE -Wall -shared -nostartfiles dummy_plugin.c -o dummy_plugin.so -iquote ../../../criu/include -iquote ../../criu/include -fPIC
+PLUGIN_INC		:= ../../../criu/include
+PLUGIN_INC_EXTRA	:= ../../criu/include
+PLUGIN_INCLUDE		:= -iquote$(PLUGIN_INC) -iquote$(PLUGIN_INC_EXTRA)
+LIBDRM_INC             := -I/usr/include/libdrm
+DEPS_OK 		:= amdgpu_plugin.so
+DEPS_NOK 		:= ;
 
-clean:
-	$(Q) $(RM) dummy_plugin.so
+include $(__nmk_dir)msg.mk
+
+CC      		:= gcc
+PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
+
+ifeq ($(CONFIG_AMDGPU),y)
+        all: $(DEPS_OK)
+else
+        all: $(DEPS_NOK)
+endif
+
+criu-amdgpu.pb-c.c: criu-amdgpu.proto
+		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
+
+amdgpu_plugin.so: amdgpu_plugin.c criu-amdgpu.pb-c.c
+	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE)
+
+amdgpu_plugin_clean:
+	$(call msg-clean, $@)
+	$(Q) $(RM) amdgpu_plugin.so criu-amdgpu.pb-c*
+.PHONY: amdgpu_plugin_clean
+clean: amdgpu_plugin_clean
+
+mrproper: clean
+
 install:
 	$(Q) mkdir -p $(PLUGINDIR)
-	$(Q) install -m 644 dummy_plugin.so $(PLUGINDIR)
+ifeq ($(CONFIG_AMDGPU),y)
+	$(E) "  INSTALL " $(PLUGIN_NAME)
+	$(Q) install -m 644 $(PLUGIN_SOBJ) $(PLUGINDIR)
+endif
+.PHONY: install
 
 uninstall:
-	$(Q) $(RM) $(PLUGINDIR)/dummy_plugin.so
+ifeq ($(CONFIG_AMDGPU),y)
+	$(E) " UNINSTALL" $(PLUGIN_NAME)
+	$(Q) $(RM) $(PLUGINDIR)/$(PLUGIN_SOBJ)
+endif
+.PHONY: uninstall

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -1,10 +1,13 @@
 PLUGIN_NAME		:= amdgpu_plugin
 PLUGIN_SOBJ		:= amdgpu_plugin.so
 
-PLUGIN_INC		:= ../../../criu/include
-PLUGIN_INC_EXTRA	:= ../../criu/include
-PLUGIN_INCLUDE		:= -iquote$(PLUGIN_INC) -iquote$(PLUGIN_INC_EXTRA)
-LIBDRM_INC             := -I/usr/include/libdrm
+
+PLUGIN_INCLUDE  	:= -iquote../../../criu/include
+PLUGIN_INCLUDE  	+= -iquote../../criu/include
+PLUGIN_INCLUDE  	+= -iquote../../criu/arch/$(ARCH)/include/
+PLUGIN_INCLUDE  	+= -iquote../../
+
+LIBDRM_INC 		:= -I/usr/include/libdrm
 DEPS_OK 		:= amdgpu_plugin.so amdgpu_plugin_test
 DEPS_NOK 		:= ;
 

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -12,7 +12,7 @@ include $(__nmk_dir)msg.mk
 
 CC      		:= gcc
 PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
-PLUGIN_LDFLAGS		:= -lpthread -lrt
+PLUGIN_LDFLAGS		:= -lpthread -lrt -ldrm -ldrm_amdgpu
 
 ifeq ($(CONFIG_AMDGPU),y)
         all: $(DEPS_OK)
@@ -24,7 +24,7 @@ criu-amdgpu.pb-c.c: criu-amdgpu.proto
 		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
 
 amdgpu_plugin.so: amdgpu_plugin.c amdgpu_plugin_topology.c criu-amdgpu.pb-c.c
-	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS)
+	$(CC) $(PLUGIN_CFLAGS) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS) $(LIBDRM_INC)
 
 amdgpu_plugin_clean:
 	$(call msg-clean, $@)

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -5,7 +5,7 @@ PLUGIN_INC		:= ../../../criu/include
 PLUGIN_INC_EXTRA	:= ../../criu/include
 PLUGIN_INCLUDE		:= -iquote$(PLUGIN_INC) -iquote$(PLUGIN_INC_EXTRA)
 LIBDRM_INC             := -I/usr/include/libdrm
-DEPS_OK 		:= amdgpu_plugin.so
+DEPS_OK 		:= amdgpu_plugin.so amdgpu_plugin_test
 DEPS_NOK 		:= ;
 
 include $(__nmk_dir)msg.mk
@@ -29,7 +29,18 @@ amdgpu_plugin_clean:
 	$(call msg-clean, $@)
 	$(Q) $(RM) amdgpu_plugin.so criu-amdgpu.pb-c*
 .PHONY: amdgpu_plugin_clean
-clean: amdgpu_plugin_clean
+
+test_topology_remap: amdgpu_plugin_topology.c tests/test_topology_remap.c
+	$(CC) $^ -o $@ -DCOMPILE_TESTS $(PLUGIN_INCLUDE) -I .
+
+amdgpu_plugin_test:  test_topology_remap
+.PHONY: amdgpu_plugin_test
+
+amdgpu_plugin_test_clean:
+	$(Q) $(RM) test_topology_remap
+.PHONY: amdgpu_plugin_test_clean
+
+clean: amdgpu_plugin_clean amdgpu_plugin_test_clean
 
 mrproper: clean
 

--- a/plugins/amdgpu/README.md
+++ b/plugins/amdgpu/README.md
@@ -1,0 +1,274 @@
+Supporting ROCm with CRIU
+=========================
+
+_Felix Kuehling <Felix.Kuehling@amd.com>_<br>
+_Rajneesh Bardwaj <Rajneesh.Bhardwaj@amd.com>_<br>
+_David Yat Sin <David.YatSin@amd.com>_
+
+# Introduction
+
+ROCm is the Radeon Open Compute Platform developed by AMD to support
+high-performance computing and machine learning on AMD GPUs. It is a nearly
+fully open-source software stack starting from the kernel mode GPU driver,
+including compilers and language runtimes, all the way up to optimized
+mathematics libraries, machine learning frameworks and communication libraries.
+
+Documentation for the ROCm platform can be found here:
+https://rocmdocs.amd.com/en/latest/
+
+CRIU is a tool for freezing and checkpointing running applications or
+containers and later restoring them on the same or a different system. The
+process is transparent to the application being checkpointed. It is mostly
+implemented in user mode and relies heavily on Linux kernel features, e.g.
+cgroups, ptrace, vmsplice, and more. It can checkpoint and restore most
+applications relying on standard libraries. However, it is not able to
+checkpoint and restore applications using device drivers, with their own
+per-application kernel mode state, out of the box. This includes ROCm
+applications using the KFD device driver to access GPU hardware resources. CRIU
+includes some plugin hooks to allow extending it to add such support in the
+future.
+
+A common environment for ROCm applications is in data centers and compute
+clusters. In this environment, migrating applications using CRIU would be
+beneficial and desirable. This paper outlines AMDs plans for adding ROCm
+support to CRIU.
+
+# State associated with ROCm applications
+
+ROCm applications communicate with the kernel mode driver “amdgpu.ko” through
+the Thunk library “libhsakmt.so” to enumerate available GPUs, manage
+GPU-accessible memory, user mode queues for submitting work to the GPUs, and
+events for synchronizing with GPUs. Many of those APIs create and manipulate
+state maintained in the kernel mode driver that would need to be saved and
+restored by CRIU.
+
+## Memory
+
+ROCm manages memory in the form of buffer objects (BOs). We are also working on
+a new memory management API that will be based on virtual address ranges. For
+now, we are focusing on the buffer-object based memory management.
+
+There are different types of buffer objects supported:
+
+* VRAM (device memory managed by the kernel mode driver)
+* GTT (system memory managed by the kernel mode driver)
+* Userptr (normal system memory managed by user mode driver or application)
+* Doorbell (special aperture for sending signals to the GPU for user mode command submissions)
+* MMIO (special aperture for accessing GPU control registers, used for certain cache flushing operations)
+
+All these BOs are typically mapped into the GPU page tables for access by GPUs.
+Most of them are also mapped for CPU access. The following BO properties need
+to be saved and restored for CRIU to work with ROCm applications:
+
+* Buffer type
+* Buffer handle
+* Buffer size (page aligned)
+* Virtual address for GPU mapping (page aligned)
+* Device file offset for CPU mapping (for VRAM and GTT BOs)
+* Memory contents (for VRAM and GTT BOs)
+
+## Queues
+
+ROCm uses user mode queues to submit work to the GPUs. There are several memory
+buffers associated with queues. At the language runtime or application level,
+they expose the ring buffer as well as a signal object to tell the GPU about
+new commands added to the queue. The signal is mapped to a doorbell (a 64-bit
+entry in the doorbell aperture mapped by the doorbell BO). Internally there are
+other buffers needed for dispatch completion tracking, shader state saving
+during queue preemption and the queue state itself. Some of these buffers are
+managed in user mode, others are managed in kernel mode.
+
+When an application is checkpointed, we need to preempt all user mode queues
+belonging to the process, and then save their state, including:
+
+* Queue type (compute or DMA)
+* MQD (memory queue descriptor managed in kernel mode), with state such as
+  * ring buffer address
+  * read and write pointers
+  * doorbell offset
+  * pointer to AQL queue data structure
+* Control stack (kernel-managed piece of state needed for resuming preempted queue)
+
+The rest of the queue state is contained in user-managed buffer objects that
+will be saved by the memory state handling described above:
+
+* Ring buffer (userptr BO containing commands sent to the GPU)
+* AQL queue data structure (userptr BO containing `struct hsa_queue_t`)
+* EOP buffer (VRAM BO used for dispatch completion tracking by the command processor)
+* Context save area (userptr BO for saving shader state of preempted wavefronts)
+
+## Events
+
+Events are used to implement interrupt-based sleeping/waiting for signals sent
+from the GPU to the host. Signals are represented by some data structures in
+KFD and an entry in a user-allocated, GPU-accessible BO with event slots. We
+need to save the allocated set of event IDs and each event’s signaling state.
+The contents of the event slots will be saved by the memory state handling
+described above.
+
+## Topology
+
+When ROCm applications are started, they enumerate the device topology to find
+available GPUs, their capabilities and connectivity. An application can be
+checkpointed at any time, so it will not be at a safe place to re-enumerate the
+topology when it is restored. Therefore, we can only support restoring
+applications on systems with a very similar topology:
+
+* Same number of GPUs
+* Same type of GPUs (i.e. instruction set, cache sizes, number of compute units, etc.)
+* Same or larger memory size
+* Same VRAM accessibility by the host
+* Same connectivity and P2P memory support between GPUs
+
+At the KFD ioctl level, GPUs are identified by GPUIDs, which are unique
+identifiers created by hashing various GPU properties. That way a GPUID will
+not change during the lifetime of a process, even in a future where GPUs may be
+added or removed dynamically. When restoring a process on a different system,
+the GPUID may have changed. Or it may be desirable to restore a process using a
+different subset of GPUs on the same system (using cgroups). Therefore, we will
+need a translation of GPUIDs for restored processes that applies to all KFD
+ioctl calls after an application was restored.
+
+# CRIU plugins
+
+CRIU provides plugin hooks for device files:
+
+    int cr_plugin_dump_file(int fd, int id);
+    int cr_plugin_restore_file(int id);
+
+In a ROCm process, it will be invoked for `/dev/kfd` and `/dev/dri/renderD*`
+device nodes. `/dev/kfd` is used for KFD ioctl calls to manage memory, queues,
+signals and other functionality for all GPUs through a single device file
+descriptor. `/dev/dri/renderD*` are per GPU device files, called render nodes,
+that are used mostly for CPU mapping of VRAM and GTT BOs. Each BO is given a
+unique offset in the render node of the corresponding GPU at allocation time.
+
+Render nodes are also used for memory management and command submission by the
+Mesa user mode driver for video decoding and post processing. These use cases
+are relevant even in data centers. Support for this is not an immediate
+priority but planned for the future. This will require saving additional state
+as well as synchronization with any outstanding jobs. For now, there is no
+kernel-mode state associated with `/dev/renderD*`.
+
+The two existing plugins can be used for saving and restoring most state
+associated with ROCm applications. We are planning to add new ioctl calls to
+`/dev/kfd` to help with this.
+
+## Dumping
+
+At the “dump” stage, the ioctl will execute in the context of the CRIU dumper
+process. But the file descriptor (fd) is “drained” from the process being saved
+by the parasite code that CRIU injects into its target. This allows the plugin
+to make an ioctl call with enough context to allow KFD to access all the kernel
+mode state associated with the target process. CRIU is ptrace attached to the
+target process. KFD can use that fact to authorize access to the target
+process' information.
+
+The contents of GTT and VRAM BOs are not automatically saved by CRIU. CRIU can
+only support saving the contents of normal pageable mappings. GTT and VRAM BOs
+are special device file IO mappings. Therefore, our dumper plugin will need to
+save the contents of these BOs. In the initial implementation they can be
+accessed through `/proc/<pid>/mem`. For better performance we can use a DMA
+engine in the GPU to copy the data to system memory.
+
+## Restoring
+
+At the “restore” stage we first need to ensure that the topology of visible
+devices (in the cgroup) is compatible with the topology that was saved. Once
+this is confirmed, we can use a new ioctl to load the saved state back into
+KFD. This ioctl will run in the context of the process being restored, so no
+special authorization is needed. However, some of the data being copied back
+into kernel mode could have been tampered with. MQDs and control stacks provide
+access to privileged GPU registers. Therefore, the restore ioctl will only be
+allowed to run with root privileges.
+
+## Remapping render nodes and mmap offsets
+
+BOs are mapped for CPU access by mmapping the GPU's render node at a specific
+offset. The offset within the render node device file identifies the BO.
+However, when we recreate the BOs, we cannot guarantee that they will be
+restored with the same mmap offset that was saved, because the mmap offset
+address space per device is shared system wide.
+
+When a process is restored on a different GPU, it will need to map the BOs from
+a different render node device file altogether.
+
+A new plugin call will be needed to translate device file names and mmap
+offsets to the newly allocated ones, before CRIU's PIE code restores the VMA
+mappings. Fortunately, ROCm user mode does not remember the file names and mmap
+offsets after establishing the mappings, so changing the device files and mmap
+offsets under the hood will not be noticed by ROCm user mode.
+
+*This new plugin is enabled by the new hook `__UPDATE_VMA_MAP` in our RFC patch
+series.*
+
+## Resuming GPU execution
+
+At the time of running the `cr_plugin_restore_file` plugin, it is too early to
+restore userptr GPU page table mappings and their MMU notifiers. These mappings
+mirror CPU page tables into GPU page tables using the HMM mirror API in the
+kernel. The MMU notifiers notify the driver when the virtual address mapping
+changes so that the GPU mapping can be updated.
+
+This needs to happen after the restorer PIE code has restored all the VMAs at
+their correct virtual addresses. Otherwise, the HMM mirroring will simply fail.
+Before all the GPU memory mappings are in place, it is also too early to resume
+the user mode queue execution on the GPUs.
+
+Therefore, a new plugin is needed that runs in the context of the master
+restore process after the restorer PIE code has restored all the VMAs and
+returned control to all the restored processes via sigreturn. It needs to be
+called once for each restored target process to finalize userptr mappings and
+to resume execution on the GPUs.
+
+*This new plugin is enabled by the new hook `__RESUME_DEVICES_LATE` in our RFC
+patch series.*
+
+## Other CRIU changes
+
+In addition to the new plugins, we need to make some changes to CRIU itself to
+support device file VMAs. Currently CRIU will simply fail to dump a process
+that has such PFN or IO memory mappings. While CRIU will not need to save the
+contents of those VMAs, we do need CRIU to save and restore the VMAs
+themselves, with translated mmap offsets (see “Remapping mmap offsets” above).
+
+## Security considerations
+
+The new “dump” ioctl we are adding to `/dev/kfd` will expose information about
+remote processes. This is a potential security threat. CRIU will be
+ptrace-attached to the target process, which gives it full access to the state
+of the process being dumped. KFD can use ptrace attachment to authorize the use
+of the new ioctl on a specific target process.
+
+The new “restore” ioctl will load privileged information from user mode back
+into the kernel driver and the hardware. This includes MQD contents, which will
+eventually be loaded into HQD registers, as well as a control stack, which is a
+series of low-level commands that will be executed by the command processor.
+Therefore, we are limiting this ioctl to the root user. If CRIU restore must be
+possible for non-root users, we need to sanitize the privileged state to ensure
+it cannot be used to circumvent system security policies (e.g. arbitrary code
+execution in privileged contexts with access to page tables etc.).
+
+Modified mmap offsets could potentially be used to access BOs belonging to
+different processes. This potential threat is not new with CRIU. `amdgpu.ko`
+already implements checking of mmap offsets to ensure a context (represented by
+a render node file descriptor) is only allowed access to its own BOs.
+
+# Glossary
+
+Term | Definition
+--- | ---
+CRIU | Checkpoint/Restore In Userspace
+ROCm | Radeon Open Compute Platform
+Thunk | User-mode API interface  to interact with amdgpu.ko
+KFD | AMD Kernel Fusion Driver
+Mesa | Open source OpenGL implementation
+GTT | Graphis Translation Table, also used to denote kernel-managed system memory for GPU access
+VRAM | Video RAM
+BO | Buffer Object
+HMM | Heterogenous Memory Management
+AQL | Architected Queueing Language
+EOP | End of pipe (event indicating shader dispatch completion)
+MQD | Memory Queue Descriptors
+HQD | Hardware Queue Descriptors
+PIE | Position Independent Executable

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -81,6 +81,69 @@ int open_drm_render_device(int minor)
 	return fd;
 }
 
+int write_file(const char *file_path, const void *buf, const size_t buf_len)
+{
+	int fd;
+	FILE *fp;
+	size_t len_wrote;
+
+	fd = openat(criu_get_image_dir(), file_path, O_WRONLY | O_CREAT, 0600);
+	if (fd < 0) {
+		pr_perror("Cannot open %s", file_path);
+		return -errno;
+	}
+
+	fp = fdopen(fd, "w");
+	if (!fp) {
+		pr_perror("Cannot fdopen %s", file_path);
+		return -errno;
+	}
+
+	len_wrote = fwrite(buf, 1, buf_len, fp);
+	if (len_wrote != buf_len) {
+		pr_perror("Unable to write %s (wrote:%ld buf_len:%ld)", file_path, len_wrote, buf_len);
+		fclose(fp);
+		return -EIO;
+	}
+
+	pr_info("Wrote file:%s (%ld bytes)\n", file_path, buf_len);
+	/* this will also close fd */
+	fclose(fp);
+	return 0;
+}
+
+int read_file(const char *file_path, void *buf, const size_t buf_len)
+{
+	int fd;
+	FILE *fp;
+	size_t len_read;
+
+	fd = openat(criu_get_image_dir(), file_path, O_RDONLY);
+	if (fd < 0) {
+		pr_perror("Cannot open %s", file_path);
+		return -errno;
+	}
+
+	fp = fdopen(fd, "r");
+	if (!fp) {
+		pr_perror("Cannot fdopen %s", file_path);
+		return -errno;
+	}
+
+	len_read = fread(buf, 1, buf_len, fp);
+	if (len_read != buf_len) {
+		pr_perror("Unable to read %s", file_path);
+		fclose(fp);
+		return -EIO;
+	}
+
+	pr_info("Read file:%s (%ld bytes)\n", file_path, buf_len);
+
+	/* this will also close fd */
+	fclose(fp);
+	return 0;
+}
+
 /* Call ioctl, restarting if it is interrupted */
 int kmtIoctl(int fd, unsigned long request, void *arg)
 {
@@ -523,15 +586,7 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 				munmap(addr, boinfo->size);
 			} else {
 				size_t bo_size;
-				uint8_t *local_buf;
 				int mem_fd;
-
-				local_buf = xmalloc(bo_bucket->size);
-				if (!local_buf) {
-					pr_err("failed to allocate memory for BO rawdata\n");
-					ret = -1;
-					goto exit;
-				}
 
 				pr_info("Now try reading BO contents with /proc/pid/mem\n");
 				if (asprintf(&fname, PROCPIDMEM, info_args->task_pid) < 0) {
@@ -545,7 +600,6 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 					pr_perror("Can't open %s for pid %d", fname, info_args->task_pid);
 					free(fname);
 					close(mem_fd);
-					xfree(local_buf);
 					ret = -1;
 					goto exit;
 				}
@@ -556,22 +610,18 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 				if (lseek(mem_fd, (off_t)bo_bucket->addr, SEEK_SET) == -1) {
 					pr_perror("Can't lseek for bo_offset for pid = %d", info_args->task_pid);
 					close(mem_fd);
-					xfree(local_buf);
 					ret = -1;
 					goto exit;
 				}
 
-				bo_size = read(mem_fd, local_buf, boinfo->size);
+				bo_size = read(mem_fd, boinfo->rawdata.data, boinfo->size);
 				if (bo_size != boinfo->size) {
 					close(mem_fd);
-					xfree(local_buf);
 					pr_perror("Can't read buffer");
 					ret = -1;
 					goto exit;
 				}
 				close(mem_fd);
-				memcpy(boinfo->rawdata.data, (uint8_t *)local_buf, boinfo->size);
-				xfree(local_buf);
 			}
 		}
 	}
@@ -646,7 +696,6 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	struct stat st, st_kfd;
 	unsigned char *buf;
 	CriuKfd *e = NULL;
-	int img_fd = -1;
 	int ret = 0;
 	size_t len;
 
@@ -674,13 +723,6 @@ int amdgpu_plugin_dump_file(int fd, int id)
 			fd, id);
 
 		rd.minor_number = minor(st.st_rdev);
-		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
-
-		img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
-		if (img_fd < 0) {
-			pr_perror("Can't open %s", img_path);
-			return -1;
-		}
 
 		len = criu_render_node__get_packed_size(&rd);
 		buf = xmalloc(len);
@@ -688,15 +730,15 @@ int amdgpu_plugin_dump_file(int fd, int id)
 			return -ENOMEM;
 
 		criu_render_node__pack(&rd, buf);
-		ret = write(img_fd, buf, len);
 
-		if (ret != len) {
-			pr_perror("Unable to write in %s", img_path);
-			ret = -1;
+		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
+		ret = write_file(img_path, buf, len);
+		if (ret) {
+			xfree(buf);
+			return ret;
 		}
-		xfree(buf);
-		close(img_fd);
 
+		xfree(buf);
 		/* Need to return success here so that criu can call plugins for renderD nodes */
 		return ret;
 	}
@@ -744,13 +786,6 @@ int amdgpu_plugin_dump_file(int fd, int id)
 	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
 	pr_info("amdgpu_plugin: img_path = %s\n", img_path);
 
-	img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
-	if (img_fd < 0) {
-		pr_perror("Can't open %s", img_path);
-		ret = -1;
-		goto exit;
-	}
-
 	len = criu_kfd__get_packed_size(e);
 
 	pr_info("amdgpu_plugin: Len = %ld\n", len);
@@ -764,12 +799,7 @@ int amdgpu_plugin_dump_file(int fd, int id)
 
 	criu_kfd__pack(e, buf);
 
-	ret = write(img_fd, buf, len);
-	if (ret != len) {
-		pr_perror("Unable to write in %s", img_path);
-		ret = -1;
-		goto exit;
-	}
+	ret = write_file(img_path, buf, len);
 
 	xfree(buf);
 exit:
@@ -777,8 +807,6 @@ exit:
 	pause_process(fd, false);
 
 	free_e(e);
-	if (img_fd >= 0)
-		close(img_fd);
 
 	if (ret)
 		pr_err("amdgpu_plugin: Failed to dump (ret:%d)\n", ret);
@@ -898,7 +926,6 @@ static int restore_bos(int fd, CriuKfd *e)
 	uint8_t *priv_data;
 	int ret = 0;
 	char *fname;
-	int mem_fd;
 	void *addr;
 	int drm_fd;
 
@@ -984,6 +1011,7 @@ static int restore_bos(int fd, CriuKfd *e)
 				munmap(addr, bo_entry->size);
 			} else {
 				size_t bo_size;
+				int mem_fd;
 				/* Use indirect host data path via /proc/pid/mem
 				 * on small pci bar GPUs or for Buffer Objects
 				 * that don't have HostAccess permissions.
@@ -1098,20 +1126,18 @@ exit:
 
 int amdgpu_plugin_restore_file(int id)
 {
-	int ret = 0, fd, len;
+	int ret = 0, fd;
 	char img_path[PATH_MAX];
 	struct stat filestat;
 	unsigned char *buf;
 	CriuRenderNode *rd;
 	CriuKfd *e = NULL;
-	int img_fd;
 
 	pr_info("amdgpu_plugin: Initialized kfd plugin restorer with ID = %d\n", id);
 
 	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
 
-	img_fd = openat(criu_get_image_dir(), img_path, O_RDONLY, 0600);
-	if (img_fd < 0) {
+	if (stat(img_path, &filestat) == -1) {
 		pr_perror("open(%s)", img_path);
 		/* This is restorer plugin for renderD nodes. Since criu doesn't
 		 * gurantee that they will be called before the plugin is called
@@ -1121,11 +1147,6 @@ int amdgpu_plugin_restore_file(int id)
 		 * restore both, the kfd plugin gets called first.
 		 */
 		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
-		img_fd = openat(criu_get_image_dir(), img_path, O_RDONLY, 0600);
-		if (img_fd < 0) {
-			pr_perror("open(%s)", img_path);
-			return -ENOTSUP;
-		}
 
 		if (stat(img_path, &filestat) == -1) {
 			pr_perror("Failed to read file stats");
@@ -1139,16 +1160,13 @@ int amdgpu_plugin_restore_file(int id)
 			return -ENOMEM;
 		}
 
-		len = read(img_fd, buf, filestat.st_size);
-		if (len <= 0) {
+		if (read_file(img_path, buf, filestat.st_size)) {
 			pr_perror("Unable to read from %s", img_path);
 			xfree(buf);
-			close(img_fd);
 			return -1;
 		}
-		close(img_fd);
 
-		rd = criu_render_node__unpack(NULL, len, buf);
+		rd = criu_render_node__unpack(NULL, filestat.st_size, buf);
 		if (rd == NULL) {
 			pr_perror("Unable to parse the KFD message %d", id);
 			xfree(buf);
@@ -1170,27 +1188,20 @@ int amdgpu_plugin_restore_file(int id)
 
 	pr_info("amdgpu_plugin: Opened kfd, fd = %d\n", fd);
 
-	if (stat(img_path, &filestat) == -1) {
-		pr_perror("Failed to read file stats");
-		return -1;
-	}
 	pr_info("kfd img file size on disk = %ld\n", filestat.st_size);
 
 	buf = xmalloc(filestat.st_size);
 	if (!buf) {
 		pr_perror("Failed to allocate memory");
-		close(img_fd);
 		return -ENOMEM;
 	}
-	len = read(img_fd, buf, filestat.st_size);
-	if (len <= 0) {
+
+	if (read_file(img_path, buf, filestat.st_size)) {
 		pr_perror("Unable to read from %s", img_path);
 		xfree(buf);
-		close(img_fd);
 		return -1;
 	}
-	close(img_fd);
-	e = criu_kfd__unpack(NULL, len, buf);
+	e = criu_kfd__unpack(NULL, filestat.st_size, buf);
 	if (e == NULL) {
 		pr_err("Unable to parse the KFD message %#x\n", id);
 		xfree(buf);

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -13,6 +13,7 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <stdint.h>
+#include <pthread.h>
 
 #include "criu-plugin.h"
 #include "plugin.h"
@@ -506,6 +507,17 @@ void amdgpu_plugin_fini(int stage, int ret)
 
 CR_PLUGIN_REGISTER("amdgpu_plugin", amdgpu_plugin_init, amdgpu_plugin_fini)
 
+struct thread_data {
+	pthread_t thread;
+	uint64_t num_of_bos;
+	uint32_t gpu_id;
+	pid_t pid;
+	struct kfd_criu_bo_bucket *bo_buckets;
+	BoEntry **bo_entries;
+	int drm_fd;
+	int ret;
+};
+
 int amdgpu_plugin_handle_device_vma(int fd, const struct stat *st_buf)
 {
 	struct stat st_kfd, st_dri_min;
@@ -542,6 +554,181 @@ int amdgpu_plugin_handle_device_vma(int fd, const struct stat *st_buf)
 	return -ENOTSUP;
 }
 CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__HANDLE_DEVICE_VMA, amdgpu_plugin_handle_device_vma)
+
+void *dump_bo_contents(void *_thread_data)
+{
+	int i, ret = 0;
+	int num_bos = 0;
+	struct thread_data *thread_data = (struct thread_data *)_thread_data;
+	struct kfd_criu_bo_bucket *bo_buckets = thread_data->bo_buckets;
+	BoEntry **bo_info = thread_data->bo_entries;
+	char *fname;
+	int mem_fd = -1;
+
+	pr_info("amdgpu_plugin: Thread[0x%x] started\n", thread_data->gpu_id);
+
+	if (asprintf(&fname, PROCPIDMEM, thread_data->pid) < 0) {
+		pr_perror("failed in asprintf, %s", fname);
+		ret = -1;
+		goto exit;
+	}
+	mem_fd = open(fname, O_RDONLY);
+	if (mem_fd < 0) {
+		pr_perror("Can't open %s for pid %d", fname, thread_data->pid);
+		free(fname);
+		ret = -errno;
+		goto exit;
+	}
+	plugin_log_msg("Opened %s file for pid = %d\n", fname, thread_data->pid);
+	free(fname);
+
+	for (i = 0; i < thread_data->num_of_bos; i++) {
+		if (bo_buckets[i].gpu_id != thread_data->gpu_id)
+			continue;
+
+		num_bos++;
+		if (!(bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) &&
+		    !(bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT))
+			continue;
+
+		if (bo_info[i]->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
+			void *addr;
+
+			plugin_log_msg("amdgpu_plugin: large bar read possible\n");
+
+			addr = mmap(NULL, bo_buckets[i].size, PROT_READ, MAP_SHARED, thread_data->drm_fd,
+				    bo_buckets[i].offset);
+			if (addr == MAP_FAILED) {
+				pr_perror("amdgpu_plugin: mmap failed");
+				ret = -errno;
+				goto exit;
+			}
+
+			/* direct memcpy is possible on large bars */
+			memcpy(bo_info[i]->rawdata.data, addr, bo_buckets[i].size);
+			munmap(addr, bo_buckets[i].size);
+		} else {
+			size_t bo_size;
+			plugin_log_msg("Reading BO contents with /proc/pid/mem\n");
+			if (lseek(mem_fd, (off_t)bo_buckets[i].addr, SEEK_SET) == -1) {
+				pr_perror("Can't lseek for BO offset for pid = %d", thread_data->pid);
+				ret = -errno;
+				goto exit;
+			}
+
+			bo_size = read(mem_fd, bo_info[i]->rawdata.data, bo_info[i]->size);
+			if (bo_size != bo_info[i]->size) {
+				pr_perror("Can't read buffer");
+				ret = -errno;
+				goto exit;
+			}
+		} /* PROCPIDMEM read done */
+	}
+
+exit:
+	pr_info("amdgpu_plugin: Thread[0x%x] done num_bos:%d ret:%d\n", thread_data->gpu_id, num_bos, ret);
+
+	if (mem_fd >= 0)
+		close(mem_fd);
+
+	thread_data->ret = ret;
+	return NULL;
+};
+
+void *restore_bo_contents(void *_thread_data)
+{
+	int i, ret = 0;
+	int num_bos = 0;
+	struct thread_data *thread_data = (struct thread_data *)_thread_data;
+	struct kfd_criu_bo_bucket *bo_buckets = thread_data->bo_buckets;
+	BoEntry **bo_info = thread_data->bo_entries;
+	char *fname;
+	int mem_fd = -1;
+
+	pr_info("amdgpu_plugin: Thread[0x%x] started\n", thread_data->gpu_id);
+
+	if (asprintf(&fname, PROCPIDMEM, thread_data->pid) < 0) {
+		pr_perror("failed in asprintf, %s", fname);
+		ret = -1;
+		goto exit;
+	}
+
+	mem_fd = open(fname, O_RDWR);
+	if (mem_fd < 0) {
+		pr_perror("Can't open %s for pid %d", fname, thread_data->pid);
+		free(fname);
+		ret = -errno;
+		goto exit;
+	}
+	plugin_log_msg("Opened %s file for pid = %d\n", fname, thread_data->pid);
+	free(fname);
+
+	for (i = 0; i < thread_data->num_of_bos; i++) {
+		void *addr;
+
+		if (bo_buckets[i].gpu_id != thread_data->gpu_id)
+			continue;
+
+		num_bos++;
+
+		if (!(bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) &&
+		    !(bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT))
+			continue;
+
+		if (bo_info[i]->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
+			plugin_log_msg("amdgpu_plugin: large bar write possible\n");
+
+			addr = mmap(NULL, bo_buckets[i].size, PROT_WRITE, MAP_SHARED, thread_data->drm_fd,
+				    bo_buckets[i].restored_offset);
+			if (addr == MAP_FAILED) {
+				pr_perror("amdgpu_plugin: mmap failed");
+				ret = -errno;
+				goto exit;
+			}
+
+			/* direct memcpy is possible on large bars */
+			memcpy(addr, (void *)bo_info[i]->rawdata.data, bo_info[i]->size);
+			munmap(addr, bo_info[i]->size);
+		} else {
+			size_t bo_size;
+			/* Use indirect host data path via /proc/pid/mem on small pci bar GPUs or
+			 * for Buffer Objects that don't have HostAccess permissions.
+			 */
+			plugin_log_msg("amdgpu_plugin: using PROCPIDMEM to restore BO contents\n");
+			addr = mmap(NULL, bo_info[i]->size, PROT_NONE, MAP_SHARED, thread_data->drm_fd,
+				    bo_buckets[i].restored_offset);
+
+			if (addr == MAP_FAILED) {
+				pr_perror("amdgpu_plugin: mmap failed");
+				ret = -errno;
+				goto exit;
+			}
+
+			if (lseek(mem_fd, (off_t)addr, SEEK_SET) == -1) {
+				pr_perror("Can't lseek for BO offset for pid = %d", thread_data->pid);
+				ret = -errno;
+				goto exit;
+			}
+
+			plugin_log_msg("Attempt writing now\n");
+			bo_size = write(mem_fd, bo_info[i]->rawdata.data, bo_info[i]->size);
+			if (bo_size != bo_info[i]->size) {
+				pr_perror("Can't write buffer");
+				ret = -errno;
+				goto exit;
+			}
+			munmap(addr, bo_info[i]->size);
+		}
+	}
+
+exit:
+	pr_info("amdgpu_plugin: Thread[0x%x] done num_bos:%d ret:%d\n", thread_data->gpu_id, num_bos, ret);
+
+	if (mem_fd >= 0)
+		close(mem_fd);
+	thread_data->ret = ret;
+	return NULL;
+};
 
 static int init_dumper_args(struct kfd_ioctl_criu_dumper_args *args, __u32 type, __u64 index_start, __u64 num_objects,
 			    __u64 objects_size)
@@ -732,11 +919,17 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 {
 	struct kfd_ioctl_criu_dumper_args args = { 0 };
 	struct kfd_criu_bo_bucket *bo_buckets;
+	struct thread_data *thread_datas;
 	uint8_t *priv_data;
 	int ret = 0, i;
-	char *fname;
 
 	pr_debug("Dumping %lld BOs\n", info_args->total_bos);
+
+	thread_datas = xzalloc(sizeof(*thread_datas) * e->num_of_gpus);
+	if (!thread_datas) {
+		ret = -ENOMEM;
+		goto exit;
+	}
 
 	ret = init_dumper_args(&args, KFD_CRIU_OBJECT_TYPE_BO, 0, info_args->total_bos,
 			       (info_args->total_bos * sizeof(*bo_buckets)) + info_args->bos_priv_data_size);
@@ -786,77 +979,49 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 		boinfo->size = bo_bucket->size;
 		boinfo->offset = bo_bucket->offset;
 		boinfo->alloc_flags = bo_bucket->alloc_flags;
+	}
 
-		if (bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM ||
-		    bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
-			if (bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
-				int drm_fd;
-				void *addr;
-				struct tp_node *tp_node;
+	for (int i = 0; i < e->num_of_gpus; i++) {
+		struct tp_node *dev;
+		int ret_thread = 0;
 
-				plugin_log_msg("amdgpu_plugin: large bar read possible\n");
+		dev = sys_get_node_by_index(&src_topology, i);
+		if (!dev) {
+			ret = -ENODEV;
+			goto exit;
+		}
 
-				tp_node = sys_get_node_by_gpu_id(&src_topology, boinfo->gpu_id);
-				if (!tp_node) {
-					ret = -ENODEV;
-					goto exit;
-				}
+		thread_datas[i].gpu_id = dev->gpu_id;
+		thread_datas[i].bo_buckets = bo_buckets;
+		thread_datas[i].bo_entries = e->bo_entries;
+		thread_datas[i].pid = e->pid;
+		thread_datas[i].num_of_bos = info_args->total_bos;
+		thread_datas[i].drm_fd = node_get_drm_render_device(dev);
+		if (thread_datas[i].drm_fd < 0) {
+			ret = thread_datas[i].drm_fd;
+			goto exit;
+		}
 
-				drm_fd = node_get_drm_render_device(tp_node);
+		ret_thread = pthread_create(&thread_datas[i].thread, NULL, dump_bo_contents, (void *)&thread_datas[i]);
+		if (ret_thread) {
+			pr_err("Failed to create thread[%i]\n", i);
+			ret = -ret_thread;
+			goto exit;
+		}
+	}
 
-				addr = mmap(NULL, boinfo->size, PROT_READ, MAP_SHARED, drm_fd, boinfo->offset);
-				if (addr == MAP_FAILED) {
-					pr_perror("amdgpu_plugin: mmap failed\n");
-					ret = -errno;
-					goto exit;
-				}
+	for (int i = 0; i < e->num_of_gpus; i++) {
+		pthread_join(thread_datas[i].thread, NULL);
+		pr_info("Thread[0x%x] finished ret:%d\n", thread_datas[i].gpu_id, thread_datas[i].ret);
 
-				/* direct memcpy is possible on large bars */
-				memcpy(boinfo->rawdata.data, addr, boinfo->size);
-				munmap(addr, boinfo->size);
-			} else {
-				size_t bo_size;
-				int mem_fd;
-
-				plugin_log_msg("Now try reading BO contents with /proc/pid/mem\n");
-				if (asprintf(&fname, PROCPIDMEM, info_args->task_pid) < 0) {
-					pr_perror("failed in asprintf, %s", fname);
-					ret = -1;
-					goto exit;
-				}
-
-				mem_fd = open(fname, O_RDONLY);
-				if (mem_fd < 0) {
-					pr_perror("Can't open %s for pid %d", fname, info_args->task_pid);
-					free(fname);
-					close(mem_fd);
-					ret = -1;
-					goto exit;
-				}
-
-				pr_info("Opened %s file for pid = %d\n", fname, info_args->task_pid);
-				free(fname);
-
-				if (lseek(mem_fd, (off_t)bo_bucket->addr, SEEK_SET) == -1) {
-					pr_perror("Can't lseek for bo_offset for pid = %d", info_args->task_pid);
-					close(mem_fd);
-					ret = -1;
-					goto exit;
-				}
-
-				bo_size = read(mem_fd, boinfo->rawdata.data, boinfo->size);
-				if (bo_size != boinfo->size) {
-					close(mem_fd);
-					pr_perror("Can't read buffer");
-					ret = -1;
-					goto exit;
-				}
-				close(mem_fd);
-			}
+		if (thread_datas[i].ret) {
+			ret = thread_datas[i].ret;
+			goto exit;
 		}
 	}
 exit:
 	xfree((void *)args.objects);
+	xfree(thread_datas);
 	pr_info("Dumped bos %s (ret:%d)\n", ret ? "failed" : "ok", ret);
 	return ret;
 }
@@ -1258,14 +1423,19 @@ static int restore_bos(int fd, CriuKfd *e)
 {
 	struct kfd_ioctl_criu_restorer_args args = { 0 };
 	struct kfd_criu_bo_bucket *bo_buckets;
+	struct thread_data *thread_datas;
 	uint64_t priv_data_offset = 0;
 	uint64_t objects_size = 0;
 	uint8_t *priv_data;
 	int ret = 0;
-	char *fname;
-	void *addr;
 
 	pr_debug("Restoring %ld BOs\n", e->num_of_bos);
+
+	thread_datas = xzalloc(sizeof(*thread_datas) * e->num_of_gpus);
+	if (!thread_datas) {
+		ret = -ENOMEM;
+		goto exit;
+	}
 
 	for (int i = 0; i < e->num_of_bos; i++)
 		objects_size += sizeof(*bo_buckets) + e->bo_entries[i]->private_data.len;
@@ -1310,8 +1480,6 @@ static int restore_bos(int fd, CriuKfd *e)
 
 	for (int i = 0; i < args.num_objects; i++) {
 		struct kfd_criu_bo_bucket *bo_bucket = &bo_buckets[i];
-		BoEntry *bo_entry = e->bo_entries[i];
-
 		struct tp_node *tp_node;
 
 		if (bo_bucket->alloc_flags & (KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_GTT |
@@ -1346,85 +1514,50 @@ static int restore_bos(int fd, CriuKfd *e)
 
 			list_add_tail(&vma_md->list, &update_vma_info_list);
 		}
+	}
 
-		if (bo_bucket->alloc_flags & (KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_GTT)) {
-			int drm_fd = node_get_drm_render_device(tp_node);
+	for (int i = 0; i < e->num_of_gpus; i++) {
+		struct tp_node *dev;
+		int ret_thread = 0;
 
-			plugin_log_msg("amdgpu_plugin: Trying mmap in stage 2\n");
-			if (bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC ||
-			    bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
-				plugin_log_msg("amdgpu_plugin: large bar write possible\n");
-				addr = mmap(NULL, bo_bucket->size, PROT_WRITE, MAP_SHARED, drm_fd,
-					    bo_bucket->restored_offset);
-				if (addr == MAP_FAILED) {
-					pr_perror("amdgpu_plugin: mmap failed");
-					fd = -EBADFD;
-					goto exit;
-				}
+		dev = sys_get_node_by_index(&dest_topology, i);
+		if (!dev) {
+			ret = -ENODEV;
+			goto exit;
+		}
 
-				/* direct memcpy is possible on large bars */
-				memcpy(addr, (void *)bo_entry->rawdata.data, bo_entry->size);
-				munmap(addr, bo_entry->size);
-			} else {
-				size_t bo_size;
-				int mem_fd;
-				/* Use indirect host data path via /proc/pid/mem
-				 * on small pci bar GPUs or for Buffer Objects
-				 * that don't have HostAccess permissions.
-				 */
-				plugin_log_msg("amdgpu_plugin: using PROCPIDMEM to restore BO contents\n");
-				addr = mmap(NULL, bo_bucket->size, PROT_NONE, MAP_SHARED, drm_fd,
-					    bo_bucket->restored_offset);
-				if (addr == MAP_FAILED) {
-					pr_perror("amdgpu_plugin: mmap failed");
-					fd = -EBADFD;
-					goto exit;
-				}
+		thread_datas[i].gpu_id = dev->gpu_id;
+		thread_datas[i].bo_buckets = bo_buckets;
+		thread_datas[i].bo_entries = e->bo_entries;
+		thread_datas[i].pid = e->pid;
+		thread_datas[i].num_of_bos = e->num_of_bos;
 
-				if (asprintf(&fname, PROCPIDMEM, e->pid) < 0) {
-					pr_perror("failed in asprintf, %s", fname);
-					munmap(addr, bo_bucket->size);
-					fd = -EBADFD;
-					goto exit;
-				}
+		thread_datas[i].drm_fd = node_get_drm_render_device(dev);
+		if (thread_datas[i].drm_fd < 0) {
+			ret = -thread_datas[i].drm_fd;
+			goto exit;
+		}
 
-				mem_fd = open(fname, O_RDWR);
-				if (mem_fd < 0) {
-					pr_perror("Can't open %s for pid %d", fname, e->pid);
-					free(fname);
-					munmap(addr, bo_bucket->size);
-					fd = -EBADFD;
-					goto exit;
-				}
-
-				plugin_log_msg("Opened %s file for pid = %d", fname, e->pid);
-				free(fname);
-
-				if (lseek(mem_fd, (off_t)addr, SEEK_SET) == -1) {
-					pr_perror("Can't lseek for bo_offset for pid = %d", e->pid);
-					munmap(addr, bo_entry->size);
-					fd = -EBADFD;
-					goto exit;
-				}
-
-				plugin_log_msg("Attempt writing now");
-				bo_size = write(mem_fd, bo_entry->rawdata.data, bo_entry->size);
-				if (bo_size != bo_entry->size) {
-					pr_perror("Can't write buffer");
-					munmap(addr, bo_entry->size);
-					fd = -EBADFD;
-					goto exit;
-				}
-				munmap(addr, bo_entry->size);
-				close(mem_fd);
-			}
-		} else {
-			plugin_log_msg("Not a VRAM BO\n");
-			continue;
+		ret_thread =
+			pthread_create(&thread_datas[i].thread, NULL, restore_bo_contents, (void *)&thread_datas[i]);
+		if (ret_thread) {
+			pr_err("Failed to create thread[%i]\n", i);
+			fd = -ret_thread;
+			goto exit;
 		}
 	}
 
+	for (int i = 0; i < e->num_of_gpus; i++) {
+		pthread_join(thread_datas[i].thread, NULL);
+		pr_info("Thread[0x%x] finished ret:%d\n", thread_datas[i].gpu_id, thread_datas[i].ret);
+
+		if (thread_datas[i].ret) {
+			ret = thread_datas[i].ret;
+			goto exit;
+		}
+	}
 exit:
+	xfree(thread_datas);
 	xfree((void *)args.objects);
 	pr_info("Restore BOs %s (ret:%d)\n", ret ? "Failed" : "Ok", ret);
 	return ret;

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -1,0 +1,1043 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <linux/limits.h>
+
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <stdint.h>
+
+#include "criu-plugin.h"
+#include "plugin.h"
+#include "criu-amdgpu.pb-c.h"
+
+#include "kfd_ioctl.h"
+#include "xmalloc.h"
+#include "criu-log.h"
+
+#include "common/list.h"
+
+#define DRM_FIRST_RENDER_NODE 128
+#define DRM_LAST_RENDER_NODE  255
+
+#define AMDGPU_KFD_DEVICE "/dev/kfd"
+#define PROCPIDMEM	  "/proc/%d/mem"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
+struct vma_metadata {
+	struct list_head list;
+	uint64_t old_pgoff;
+	uint64_t new_pgoff;
+	uint64_t vma_entry;
+};
+
+static LIST_HEAD(update_vma_info_list);
+
+int open_drm_render_device(int minor)
+{
+	char path[128];
+	int fd;
+
+	if (minor < DRM_FIRST_RENDER_NODE || minor > DRM_LAST_RENDER_NODE) {
+		pr_perror("DRM render minor %d out of range [%d, %d]", minor, DRM_FIRST_RENDER_NODE,
+			  DRM_LAST_RENDER_NODE);
+		return -EINVAL;
+	}
+
+	sprintf(path, "/dev/dri/renderD%d", minor);
+	fd = open(path, O_RDWR | O_CLOEXEC);
+	if (fd < 0) {
+		if (errno != ENOENT && errno != EPERM) {
+			pr_err("Failed to open %s: %s\n", path, strerror(errno));
+			if (errno == EACCES)
+				pr_err("Check user is in \"video\" group\n");
+		}
+		return -EBADFD;
+	}
+
+	return fd;
+}
+
+/* Call ioctl, restarting if it is interrupted */
+int kmtIoctl(int fd, unsigned long request, void *arg)
+{
+	int ret;
+
+	do {
+		ret = ioctl(fd, request, arg);
+	} while (ret == -1 && (errno == EINTR || errno == EAGAIN));
+
+	if (ret == -1 && errno == EBADF)
+		/* In case pthread_atfork didn't catch it, this will
+		 * make any subsequent hsaKmt calls fail in CHECK_KFD_OPEN.
+		 */
+		pr_perror("KFD file descriptor not valid in this process");
+	return ret;
+}
+
+static void free_e(CriuKfd *e)
+{
+	for (int i = 0; i < e->n_bo_entries; i++) {
+		if (e->bo_entries[i]) {
+			if (e->bo_entries[i]->private_data.data)
+				xfree(e->bo_entries[i]->private_data.data);
+
+			if (e->bo_entries[i]->rawdata.data)
+				xfree(e->bo_entries[i]->rawdata.data);
+
+			xfree(e->bo_entries[i]);
+		}
+	}
+
+	for (int i = 0; i < e->n_device_entries; i++) {
+		if (e->device_entries[i]) {
+			if (e->device_entries[i]->private_data.data)
+				xfree(e->device_entries[i]->private_data.data);
+
+			xfree(e->device_entries[i]);
+		}
+	}
+
+	if (e->process_entry) {
+		if (e->process_entry->private_data.data)
+			xfree(e->process_entry->private_data.data);
+
+		xfree(e->process_entry);
+	}
+	xfree(e);
+}
+
+static int allocate_process_entry(CriuKfd *e)
+{
+	ProcessEntry *entry = xzalloc(sizeof(*entry));
+
+	if (!entry) {
+		pr_err("Failed to allocate entry\n");
+		return -ENOMEM;
+	}
+
+	process_entry__init(entry);
+	e->process_entry = entry;
+	return 0;
+}
+
+static int allocate_device_entries(CriuKfd *e, int num_of_devices)
+{
+	e->device_entries = xmalloc(sizeof(DeviceEntry *) * num_of_devices);
+	if (!e->device_entries) {
+		pr_err("Failed to allocate device_entries\n");
+		return -ENOMEM;
+	}
+
+	for (int i = 0; i < num_of_devices; i++) {
+		DeviceEntry *entry = xzalloc(sizeof(*entry));
+
+		if (!entry) {
+			pr_err("Failed to allocate entry\n");
+			return -ENOMEM;
+		}
+
+		device_entry__init(entry);
+
+		e->device_entries[i] = entry;
+		e->n_device_entries++;
+	}
+	return 0;
+}
+
+static int allocate_bo_entries(CriuKfd *e, int num_bos, struct kfd_criu_bo_bucket *bo_bucket_ptr)
+{
+	e->bo_entries = xmalloc(sizeof(BoEntry *) * num_bos);
+	if (!e->bo_entries) {
+		pr_err("Failed to allocate bo_info\n");
+		return -ENOMEM;
+	}
+
+	for (int i = 0; i < num_bos; i++) {
+		BoEntry *entry = xzalloc(sizeof(*entry));
+
+		if (!entry) {
+			pr_err("Failed to allocate botest\n");
+			return -ENOMEM;
+		}
+
+		bo_entry__init(entry);
+
+		if ((bo_bucket_ptr)[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM ||
+		    (bo_bucket_ptr)[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
+			entry->rawdata.data = xmalloc((bo_bucket_ptr)[i].size);
+			entry->rawdata.len = (bo_bucket_ptr)[i].size;
+		}
+
+		e->bo_entries[i] = entry;
+		e->n_bo_entries++;
+	}
+	return 0;
+}
+
+int amdgpu_plugin_init(int stage)
+{
+	pr_info("amdgpu_plugin: initialized:  %s (AMDGPU/KFD)\n", CR_PLUGIN_DESC.name);
+	return 0;
+}
+
+void amdgpu_plugin_fini(int stage, int ret)
+{
+	pr_info("amdgpu_plugin: finished  %s (AMDGPU/KFD)\n", CR_PLUGIN_DESC.name);
+}
+
+CR_PLUGIN_REGISTER("amdgpu_plugin", amdgpu_plugin_init, amdgpu_plugin_fini)
+
+int amdgpu_plugin_handle_device_vma(int fd, const struct stat *st_buf)
+{
+	struct stat st_kfd, st_dri_min;
+	char img_path[128];
+	int ret = 0;
+
+	pr_debug("amdgpu_plugin: Enter %s\n", __func__);
+	ret = stat(AMDGPU_KFD_DEVICE, &st_kfd);
+	if (ret == -1) {
+		pr_perror("stat error for /dev/kfd");
+		return ret;
+	}
+
+	snprintf(img_path, sizeof(img_path), "/dev/dri/renderD%d", DRM_FIRST_RENDER_NODE);
+
+	ret = stat(img_path, &st_dri_min);
+	if (ret == -1) {
+		pr_perror("stat error for %s", img_path);
+		return ret;
+	}
+
+	if (major(st_buf->st_rdev) == major(st_kfd.st_rdev) || ((major(st_buf->st_rdev) == major(st_dri_min.st_rdev)) &&
+								(minor(st_buf->st_rdev) >= minor(st_dri_min.st_rdev) &&
+								 minor(st_buf->st_rdev) >= DRM_FIRST_RENDER_NODE))) {
+		pr_debug("Known non-regular mapping, kfd-renderD%d -> OK\n", minor(st_buf->st_rdev));
+		pr_debug("AMD KFD(maj) = %d, DRI(maj,min) = %d:%d VMA Device fd(maj,min) = %d:%d\n",
+			 major(st_kfd.st_rdev), major(st_dri_min.st_rdev), minor(st_dri_min.st_rdev),
+			 major(st_buf->st_rdev), minor(st_buf->st_rdev));
+		/* VMA belongs to kfd */
+		return 0;
+	}
+
+	pr_perror("amdgpu_plugin: Can't handle the VMA mapping");
+	return -ENOTSUP;
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__HANDLE_DEVICE_VMA, amdgpu_plugin_handle_device_vma)
+
+static int init_dumper_args(struct kfd_ioctl_criu_dumper_args *args, __u32 type, __u64 index_start, __u64 num_objects,
+			    __u64 objects_size)
+{
+	memset(args, 0, sizeof(*args));
+
+	args->type = type;
+	/* Partial object lists not supported for now so index_start should always be 0 */
+	args->objects_index_start = index_start;
+
+	args->num_objects = num_objects;
+	args->objects_size = objects_size;
+
+	args->objects = (uintptr_t)xzalloc(args->objects_size);
+	if (!args->objects)
+		return -ENOMEM;
+
+	return 0;
+}
+
+static int init_restorer_args(struct kfd_ioctl_criu_restorer_args *args, __u32 type, __u64 index_start,
+			      __u64 num_objects, __u64 objects_size)
+{
+	memset(args, 0, sizeof(*args));
+
+	args->type = type;
+	/* Partial object lists not supported for now so index_start should always be 0 */
+	args->objects_index_start = index_start;
+
+	args->num_objects = num_objects;
+	args->objects_size = objects_size;
+
+	args->objects = (uintptr_t)xzalloc(args->objects_size);
+	if (!args->objects)
+		return -ENOMEM;
+
+	return 0;
+}
+
+static int dump_process(int fd, struct kfd_ioctl_criu_process_info_args *info_args, CriuKfd *e)
+{
+	struct kfd_criu_process_bucket *process_bucket;
+	struct kfd_ioctl_criu_dumper_args args;
+	uint8_t *priv_data;
+	int ret = 0;
+
+	pr_debug("Dump process\n");
+
+	ret = init_dumper_args(&args, KFD_CRIU_OBJECT_TYPE_PROCESS, 0, 1,
+			       sizeof(*process_bucket) + info_args->process_priv_data_size);
+
+	if (ret)
+		goto exit;
+
+	ret = kmtIoctl(fd, AMDKFD_IOC_CRIU_DUMPER, &args);
+	if (ret) {
+		pr_perror("amdgpu_plugin: Failed to call dumper (process) ioctl");
+		goto exit;
+	}
+
+	ret = allocate_process_entry(e);
+	if (ret)
+		goto exit;
+
+	process_bucket = (struct kfd_criu_process_bucket *)args.objects;
+	/* First private data starts after all buckets */
+	priv_data = (void *)(process_bucket + args.num_objects);
+
+	e->process_entry->private_data.len = process_bucket->priv_data_size;
+	e->process_entry->private_data.data = xmalloc(e->process_entry->private_data.len);
+	if (!e->process_entry->private_data.data) {
+		ret = -ENOMEM;
+		goto exit;
+	}
+
+	memcpy(e->process_entry->private_data.data, priv_data + process_bucket->priv_data_offset,
+	       e->process_entry->private_data.len);
+exit:
+	xfree((void *)args.objects);
+	pr_info("Dumped process %s (ret:%d)\n", ret ? "Failed" : "Ok", ret);
+	return ret;
+}
+
+static int dump_devices(int fd, struct kfd_ioctl_criu_process_info_args *info_args, CriuKfd *e)
+{
+	struct kfd_criu_device_bucket *device_buckets;
+	struct kfd_ioctl_criu_dumper_args args;
+	uint8_t *priv_data;
+	int ret = 0, i;
+
+	pr_debug("Dumping %d devices\n", info_args->total_devices);
+
+	ret = init_dumper_args(&args, KFD_CRIU_OBJECT_TYPE_DEVICE, 0, info_args->total_devices,
+			       (info_args->total_devices * sizeof(*device_buckets)) +
+				       info_args->devices_priv_data_size);
+	if (ret)
+		goto exit;
+
+	ret = kmtIoctl(fd, AMDKFD_IOC_CRIU_DUMPER, &args);
+	if (ret) {
+		pr_perror("amdgpu_plugin: Failed to call dumper (devices) ioctl");
+		goto exit;
+	}
+
+	device_buckets = (struct kfd_criu_device_bucket *)args.objects;
+	/* First private data starts after all buckets */
+	priv_data = (void *)(device_buckets + args.num_objects);
+
+	e->num_of_gpus = info_args->total_devices;
+
+	ret = allocate_device_entries(e, e->num_of_gpus);
+	if (ret) {
+		ret = -ENOMEM;
+		goto exit;
+	}
+
+	pr_debug("Number of GPUs:%d\n", e->num_of_gpus);
+
+	/* Add private data obtained from IOCTL for each GPU */
+	for (i = 0; i < args.num_objects; i++) {
+		struct kfd_criu_device_bucket *device_bucket = &device_buckets[i];
+		DeviceEntry *devinfo = e->device_entries[i];
+
+		pr_debug("Device[%d] user_gpu_id:%x\n", i, device_bucket->user_gpu_id);
+
+		devinfo->private_data.len = device_bucket->priv_data_size;
+		devinfo->private_data.data = xmalloc(devinfo->private_data.len);
+
+		if (!devinfo->private_data.data) {
+			ret = -ENOMEM;
+			goto exit;
+		}
+
+		memcpy(devinfo->private_data.data, priv_data + device_bucket->priv_data_offset,
+		       devinfo->private_data.len);
+	}
+exit:
+	xfree((void *)args.objects);
+	pr_info("Dumped devices %s (ret:%d)\n", ret ? "Failed" : "Ok", ret);
+	return ret;
+}
+
+static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, CriuKfd *e)
+{
+	struct kfd_ioctl_criu_dumper_args args = { 0 };
+	struct kfd_criu_bo_bucket *bo_buckets;
+	uint8_t *priv_data;
+	uint8_t *local_buf;
+	int ret = 0, i;
+	char *fname;
+
+	pr_debug("Dumping %lld BOs\n", info_args->total_bos);
+
+	ret = init_dumper_args(&args, KFD_CRIU_OBJECT_TYPE_BO, 0, info_args->total_bos,
+			       (info_args->total_bos * sizeof(*bo_buckets)) + info_args->bos_priv_data_size);
+
+	if (ret)
+		goto exit;
+
+	ret = kmtIoctl(fd, AMDKFD_IOC_CRIU_DUMPER, &args);
+	if (ret) {
+		pr_perror("amdgpu_plugin: Failed to call dumper (bos) ioctl");
+		goto exit;
+	}
+
+	bo_buckets = (struct kfd_criu_bo_bucket *)args.objects;
+	/* First private data starts after all buckets */
+	priv_data = (void *)(bo_buckets + args.num_objects);
+
+	e->num_of_bos = info_args->total_bos;
+	ret = allocate_bo_entries(e, e->num_of_bos, bo_buckets);
+	if (ret) {
+		ret = -ENOMEM;
+		goto exit;
+	}
+
+	for (i = 0; i < args.num_objects; i++) {
+		struct kfd_criu_bo_bucket *bo_bucket = &bo_buckets[i];
+		BoEntry *boinfo = e->bo_entries[i];
+
+		boinfo->private_data.len = bo_bucket->priv_data_size;
+		boinfo->private_data.data = xmalloc(boinfo->private_data.len);
+
+		if (!boinfo->private_data.data) {
+			ret = -ENOMEM;
+			goto exit;
+		}
+		memcpy(boinfo->private_data.data, priv_data + bo_bucket->priv_data_offset, boinfo->private_data.len);
+
+		pr_info("BO [%d] gpu_id:%x addr:%llx size:%llx offset:%llx dmabuf_fd:%d\n", i, bo_bucket->gpu_id,
+			bo_bucket->addr, bo_bucket->size, bo_bucket->offset, bo_bucket->dmabuf_fd);
+
+		boinfo->gpu_id = bo_bucket->gpu_id;
+		boinfo->addr = bo_bucket->addr;
+		boinfo->size = bo_bucket->size;
+		boinfo->offset = bo_bucket->offset;
+		boinfo->alloc_flags = bo_bucket->alloc_flags;
+
+		local_buf = xmalloc(bo_bucket->size);
+		if (!local_buf) {
+			pr_err("failed to allocate memory for BO rawdata\n");
+			ret = -1;
+			goto exit;
+		}
+
+		if (bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM ||
+		    bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
+			int mem_fd;
+
+			pr_info("Now try reading BO contents with /proc/pid/mem\n");
+			if (asprintf(&fname, PROCPIDMEM, info_args->task_pid) < 0) {
+				pr_perror("failed in asprintf, %s", fname);
+				ret = -1;
+				goto exit;
+			}
+
+			mem_fd = open(fname, O_RDONLY);
+			if (mem_fd < 0) {
+				pr_perror("Can't open %s for pid %d", fname, info_args->task_pid);
+				free(fname);
+				close(mem_fd);
+				xfree(local_buf);
+				ret = -1;
+				goto exit;
+			}
+
+			pr_info("Opened %s file for pid = %d\n", fname, info_args->task_pid);
+			free(fname);
+
+			if (lseek(mem_fd, (off_t)bo_bucket->addr, SEEK_SET) == -1) {
+				pr_perror("Can't lseek for bo_offset for pid = %d", info_args->task_pid);
+				close(mem_fd);
+				xfree(local_buf);
+				ret = -1;
+				goto exit;
+			}
+			pr_info("Try to read file now\n");
+
+			if (read(mem_fd, local_buf, boinfo->size) != boinfo->size) {
+				close(mem_fd);
+				xfree(local_buf);
+				pr_perror("Can't read buffer");
+				ret = -1;
+				goto exit;
+			}
+			close(mem_fd);
+			memcpy(boinfo->rawdata.data, (uint8_t *)local_buf, boinfo->size);
+			xfree(local_buf);
+		}
+	}
+exit:
+	xfree((void *)args.objects);
+	pr_info("Dumped bos %s (ret:%d)\n", ret ? "failed" : "ok", ret);
+	return ret;
+}
+
+int amdgpu_plugin_dump_file(int fd, int id)
+{
+	struct kfd_ioctl_criu_process_info_args info_args = { 0 };
+	char img_path[PATH_MAX];
+	struct stat st, st_kfd;
+	unsigned char *buf;
+	CriuKfd *e = NULL;
+	int img_fd = -1;
+	int ret = 0;
+	size_t len;
+
+	if (fstat(fd, &st) == -1) {
+		pr_perror("amdgpu_plugin: fstat error");
+		return -1;
+	}
+
+	ret = stat(AMDGPU_KFD_DEVICE, &st_kfd);
+	if (ret == -1) {
+		pr_perror("amdgpu_plugin: fstat error for /dev/kfd");
+		return -1;
+	}
+
+	/* Check whether this plugin was called for kfd or render nodes */
+	if (major(st.st_rdev) != major(st_kfd.st_rdev) || minor(st.st_rdev) != 0) {
+		/* This is RenderD dumper plugin, for now just save renderD
+		 * minor number to be used during restore. In later phases this
+		 * needs to save more data for video decode etc.
+		 */
+
+		CriuRenderNode rd = CRIU_RENDER_NODE__INIT;
+
+		pr_info("amdgpu_plugin: Dumper called for /dev/dri/renderD%d, FD = %d, ID = %d\n", minor(st.st_rdev),
+			fd, id);
+
+		rd.minor_number = minor(st.st_rdev);
+		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
+
+		img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
+		if (img_fd < 0) {
+			pr_perror("Can't open %s", img_path);
+			return -1;
+		}
+
+		len = criu_render_node__get_packed_size(&rd);
+		buf = xmalloc(len);
+		if (!buf)
+			return -ENOMEM;
+
+		criu_render_node__pack(&rd, buf);
+		ret = write(img_fd, buf, len);
+
+		if (ret != len) {
+			pr_perror("Unable to write in %s", img_path);
+			ret = -1;
+		}
+		xfree(buf);
+		close(img_fd);
+
+		/* Need to return success here so that criu can call plugins for renderD nodes */
+		return ret;
+	}
+
+	pr_info("amdgpu_plugin: %s : %s() called for fd = %d\n", CR_PLUGIN_DESC.name, __func__, major(st.st_rdev));
+
+	if (kmtIoctl(fd, AMDKFD_IOC_CRIU_PROCESS_INFO, &info_args) == -1) {
+		pr_perror("amdgpu_plugin: Failed to call process info ioctl");
+		return -1;
+	}
+
+	pr_info("amdgpu_plugin: devices:%d bos:%lld queues:%d events:%d svm-range:%lld\n", info_args.total_devices,
+		info_args.total_bos, info_args.total_queues, info_args.total_events, info_args.total_svm_ranges);
+
+	e = xmalloc(sizeof(*e));
+	if (!e) {
+		pr_err("Failed to allocate proto structure\n");
+		return -ENOMEM;
+	}
+
+	criu_kfd__init(e);
+	e->pid = info_args.task_pid;
+
+	ret = dump_process(fd, &info_args, e);
+	if (ret)
+		goto exit;
+
+	ret = dump_devices(fd, &info_args, e);
+	if (ret)
+		goto exit;
+
+	ret = dump_bos(fd, &info_args, e);
+	if (ret)
+		goto exit;
+
+	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
+	pr_info("amdgpu_plugin: img_path = %s\n", img_path);
+
+	img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
+	if (img_fd < 0) {
+		pr_perror("Can't open %s", img_path);
+		ret = -1;
+		goto exit;
+	}
+
+	len = criu_kfd__get_packed_size(e);
+
+	pr_info("amdgpu_plugin: Len = %ld\n", len);
+
+	buf = xmalloc(len);
+	if (!buf) {
+		pr_perror("Failed to allocate memory to store protobuf");
+		ret = -ENOMEM;
+		goto exit;
+	}
+
+	criu_kfd__pack(e, buf);
+
+	ret = write(img_fd, buf, len);
+	if (ret != len) {
+		pr_perror("Unable to write in %s", img_path);
+		ret = -1;
+		goto exit;
+	}
+
+	xfree(buf);
+exit:
+	free_e(e);
+	if (img_fd >= 0)
+		close(img_fd);
+
+	if (ret)
+		pr_err("amdgpu_plugin: Failed to dump (ret:%d)\n", ret);
+	else
+		pr_info("amdgpu_plugin: Dump successful\n");
+
+	return ret;
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__DUMP_EXT_FILE, amdgpu_plugin_dump_file)
+
+static int restore_process(int fd, CriuKfd *e)
+{
+	struct kfd_criu_process_bucket *process_bucket;
+	struct kfd_ioctl_criu_restorer_args args;
+	uint8_t *priv_data;
+	int ret = 0;
+
+	pr_debug("Restore process\n");
+
+	ret = init_restorer_args(&args, KFD_CRIU_OBJECT_TYPE_PROCESS, 0, 1,
+				 sizeof(*process_bucket) + e->process_entry->private_data.len);
+
+	if (ret)
+		goto exit;
+
+	process_bucket = (struct kfd_criu_process_bucket *)args.objects;
+	/* First private data starts after all buckets */
+	priv_data = (void *)(process_bucket + args.num_objects);
+
+	process_bucket->priv_data_offset = 0;
+	process_bucket->priv_data_size = e->process_entry->private_data.len;
+
+	memcpy(priv_data, e->process_entry->private_data.data, e->process_entry->private_data.len);
+
+	ret = kmtIoctl(fd, AMDKFD_IOC_CRIU_RESTORER, &args);
+	if (ret) {
+		pr_perror("amdgpu_plugin: Failed to call restorer (process) ioctl");
+		goto exit;
+	}
+
+exit:
+	pr_info("Restore process %s (ret:%d)\n", ret ? "Failed" : "Ok", ret);
+	return ret;
+}
+
+/* Restore per-device information */
+static int restore_devices(int fd, CriuKfd *e)
+{
+	struct kfd_ioctl_criu_restorer_args args = { 0 };
+	struct kfd_criu_device_bucket *device_buckets;
+	int ret = 0, bucket_index = 0;
+	uint64_t priv_data_offset = 0;
+	uint64_t objects_size = 0;
+	uint8_t *priv_data;
+
+	pr_debug("Restoring %d devices\n", e->num_of_gpus);
+
+	for (int i = 0; i < e->num_of_gpus; i++)
+		objects_size += sizeof(*device_buckets) + e->device_entries[i]->private_data.len;
+
+	ret = init_restorer_args(&args, KFD_CRIU_OBJECT_TYPE_DEVICE, 0, e->num_of_gpus, objects_size);
+	if (ret)
+		goto exit;
+
+	device_buckets = (struct kfd_criu_device_bucket *)args.objects;
+	priv_data = (void *)(device_buckets + args.num_objects);
+
+	for (int i = 0; i < e->num_of_gpus; i++) {
+		struct kfd_criu_device_bucket *device_bucket;
+		DeviceEntry *devinfo = e->device_entries[i];
+
+		device_bucket = &device_buckets[bucket_index++];
+
+		device_bucket->priv_data_size = devinfo->private_data.len;
+		device_bucket->priv_data_offset = priv_data_offset;
+
+		priv_data_offset += device_bucket->priv_data_size;
+
+		memcpy(priv_data + device_bucket->priv_data_offset, devinfo->private_data.data,
+		       device_bucket->priv_data_size);
+
+		device_bucket->user_gpu_id = devinfo->gpu_id;
+
+		device_bucket->drm_fd = open_drm_render_device(i + DRM_FIRST_RENDER_NODE);
+		if (device_bucket->drm_fd < 0) {
+			pr_perror("amdgpu_plugin: Can't pass NULL drm render fd to driver");
+			fd = -EBADFD;
+			goto exit;
+		} else {
+			pr_info("amdgpu_plugin: passing drm render fd = %d to driver\n", device_bucket->drm_fd);
+		}
+	}
+
+	ret = kmtIoctl(fd, AMDKFD_IOC_CRIU_RESTORER, &args);
+	if (ret) {
+		pr_perror("amdgpu_plugin: Failed to call restorer (devices) ioctl");
+		goto exit;
+	}
+
+	for (int i = 0; i < e->num_of_gpus; i++) {
+		if (device_buckets[i].drm_fd >= 0)
+			close(device_buckets[i].drm_fd);
+	}
+exit:
+
+	xfree((void *)args.objects);
+	pr_info("Restore devices %s (ret:%d)\n", ret ? "Failed" : "Ok", ret);
+	return ret;
+}
+
+static int restore_bos(int fd, CriuKfd *e)
+{
+	struct kfd_ioctl_criu_restorer_args args = { 0 };
+	struct kfd_criu_bo_bucket *bo_buckets;
+	uint64_t priv_data_offset = 0;
+	uint64_t objects_size = 0;
+	uint8_t *priv_data;
+	int ret = 0;
+	char *fname;
+	int mem_fd;
+	void *addr;
+	int drm_fd;
+
+	pr_debug("Restoring %ld BOs\n", e->num_of_bos);
+
+	for (int i = 0; i < e->num_of_bos; i++)
+		objects_size += sizeof(*bo_buckets) + e->bo_entries[i]->private_data.len;
+
+	ret = init_restorer_args(&args, KFD_CRIU_OBJECT_TYPE_BO, 0, e->num_of_bos, objects_size);
+	if (ret)
+		goto exit;
+
+	bo_buckets = (struct kfd_criu_bo_bucket *)args.objects;
+	priv_data = (void *)(bo_buckets + args.num_objects);
+
+	for (int i = 0; i < args.num_objects; i++) {
+		struct kfd_criu_bo_bucket *bo_bucket = &bo_buckets[i];
+		BoEntry *bo_entry = e->bo_entries[i];
+
+		bo_bucket->priv_data_size = bo_entry->private_data.len;
+		bo_bucket->priv_data_offset = priv_data_offset;
+		priv_data_offset += bo_bucket->priv_data_size;
+
+		memcpy(priv_data + bo_bucket->priv_data_offset, bo_entry->private_data.data, bo_bucket->priv_data_size);
+
+		bo_bucket->gpu_id = bo_entry->gpu_id;
+		bo_bucket->addr = bo_entry->addr;
+		bo_bucket->size = bo_entry->size;
+		bo_bucket->offset = bo_entry->offset;
+		bo_bucket->alloc_flags = bo_entry->alloc_flags;
+
+		pr_info("BO [%d] gpu_id:%x addr:%llx size:%llx offset:%llx\n", i, bo_bucket->gpu_id, bo_bucket->addr,
+			bo_bucket->size, bo_bucket->offset);
+	}
+
+	ret = kmtIoctl(fd, AMDKFD_IOC_CRIU_RESTORER, &args);
+	if (ret) {
+		pr_perror("amdgpu_plugin: Failed to call restorer (bos) ioctl");
+		goto exit;
+	}
+
+	/* This only works for single-gpu, need to fix for multi-gpu */
+	drm_fd = open_drm_render_device(DRM_FIRST_RENDER_NODE);
+
+	for (int i = 0; i < args.num_objects; i++) {
+		struct kfd_criu_bo_bucket *bo_bucket = &bo_buckets[i];
+		BoEntry *bo_entry = e->bo_entries[i];
+
+		if (bo_bucket->alloc_flags & (KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_GTT |
+					      KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP | KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL)) {
+			struct vma_metadata *vma_md;
+
+			vma_md = xmalloc(sizeof(*vma_md));
+			if (!vma_md)
+				return -ENOMEM;
+
+			vma_md->old_pgoff = bo_bucket->offset;
+			vma_md->vma_entry = bo_bucket->addr;
+			vma_md->new_pgoff = bo_bucket->restored_offset;
+			list_add_tail(&vma_md->list, &update_vma_info_list);
+		}
+
+		if (bo_bucket->alloc_flags & (KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_GTT)) {
+			pr_info("amdgpu_plugin: Trying mmap in stage 2\n");
+			if (bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC ||
+			    bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
+				pr_info("amdgpu_plugin: large bar write possible\n");
+				addr = mmap(NULL, bo_bucket->size, PROT_WRITE, MAP_SHARED, drm_fd,
+					    bo_bucket->restored_offset);
+				if (addr == MAP_FAILED) {
+					pr_perror("amdgpu_plugin: mmap failed");
+					fd = -EBADFD;
+					goto exit;
+				}
+
+				/* direct memcpy is possible on large bars */
+				memcpy(addr, (void *)bo_entry->rawdata.data, bo_entry->size);
+				munmap(addr, bo_entry->size);
+			} else {
+				size_t bo_size;
+				/* Use indirect host data path via /proc/pid/mem
+				 * on small pci bar GPUs or for Buffer Objects
+				 * that don't have HostAccess permissions.
+				 */
+				pr_info("amdgpu_plugin: using PROCPIDMEM to restore BO contents\n");
+				addr = mmap(NULL, bo_bucket->size, PROT_NONE, MAP_SHARED, drm_fd,
+					    bo_bucket->restored_offset);
+				if (addr == MAP_FAILED) {
+					pr_perror("amdgpu_plugin: mmap failed");
+					fd = -EBADFD;
+					goto exit;
+				}
+
+				if (asprintf(&fname, PROCPIDMEM, e->pid) < 0) {
+					pr_perror("failed in asprintf, %s", fname);
+					munmap(addr, bo_bucket->size);
+					fd = -EBADFD;
+					goto exit;
+				}
+
+				mem_fd = open(fname, O_RDWR);
+				if (mem_fd < 0) {
+					pr_perror("Can't open %s for pid %d", fname, e->pid);
+					free(fname);
+					munmap(addr, bo_bucket->size);
+					fd = -EBADFD;
+					goto exit;
+				}
+
+				pr_perror("Opened %s file for pid = %d", fname, e->pid);
+				free(fname);
+
+				if (lseek(mem_fd, (off_t)addr, SEEK_SET) == -1) {
+					pr_perror("Can't lseek for bo_offset for pid = %d", e->pid);
+					munmap(addr, bo_entry->size);
+					fd = -EBADFD;
+					goto exit;
+				}
+
+				pr_perror("Attempt writing now");
+				bo_size = write(mem_fd, bo_entry->rawdata.data, bo_entry->size);
+				if (bo_size != bo_entry->size) {
+					pr_perror("Can't write buffer");
+					munmap(addr, bo_entry->size);
+					fd = -EBADFD;
+					goto exit;
+				}
+				munmap(addr, bo_entry->size);
+				close(mem_fd);
+			}
+		} else {
+			pr_info("Not a VRAM BO\n");
+			continue;
+		}
+	}
+
+exit:
+	xfree((void *)args.objects);
+	pr_info("Restore BOs %s (ret:%d)\n", ret ? "Failed" : "Ok", ret);
+	return ret;
+}
+
+int amdgpu_plugin_restore_file(int id)
+{
+	int ret = 0, fd, len;
+	char img_path[PATH_MAX];
+	struct stat filestat;
+	unsigned char *buf;
+	CriuRenderNode *rd;
+	CriuKfd *e = NULL;
+	int img_fd;
+
+	pr_info("amdgpu_plugin: Initialized kfd plugin restorer with ID = %d\n", id);
+
+	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
+
+	img_fd = openat(criu_get_image_dir(), img_path, O_RDONLY, 0600);
+	if (img_fd < 0) {
+		pr_perror("open(%s)", img_path);
+		/* This is restorer plugin for renderD nodes. Since criu doesn't
+		 * gurantee that they will be called before the plugin is called
+		 * for kfd file descriptor, we need to make sure we open the render
+		 * nodes only once and before /dev/kfd is open, the render nodes
+		 * are open too. Generally, it is seen that during checkpoint and
+		 * restore both, the kfd plugin gets called first.
+		 */
+		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
+		img_fd = openat(criu_get_image_dir(), img_path, O_RDONLY, 0600);
+		if (img_fd < 0) {
+			pr_perror("open(%s)", img_path);
+			return -ENOTSUP;
+		}
+
+		if (stat(img_path, &filestat) == -1) {
+			pr_perror("Failed to read file stats");
+			return -1;
+		}
+		pr_info("renderD file size on disk = %ld\n", filestat.st_size);
+
+		buf = xmalloc(filestat.st_size);
+		if (!buf) {
+			pr_perror("Failed to allocate memory");
+			return -ENOMEM;
+		}
+
+		len = read(img_fd, buf, filestat.st_size);
+		if (len <= 0) {
+			pr_perror("Unable to read from %s", img_path);
+			xfree(buf);
+			close(img_fd);
+			return -1;
+		}
+		close(img_fd);
+
+		rd = criu_render_node__unpack(NULL, len, buf);
+		if (rd == NULL) {
+			pr_perror("Unable to parse the KFD message %d", id);
+			xfree(buf);
+			return -1;
+		}
+
+		pr_info("amdgpu_plugin: render node minor num = %d\n", rd->minor_number);
+		fd = open_drm_render_device(rd->minor_number);
+		criu_render_node__free_unpacked(rd, NULL);
+		xfree(buf);
+		return fd;
+	}
+
+	fd = open(AMDGPU_KFD_DEVICE, O_RDWR | O_CLOEXEC);
+	if (fd < 0) {
+		pr_perror("failed to open kfd in plugin");
+		return -1;
+	}
+
+	pr_info("amdgpu_plugin: Opened kfd, fd = %d\n", fd);
+
+	if (stat(img_path, &filestat) == -1) {
+		pr_perror("Failed to read file stats");
+		return -1;
+	}
+	pr_info("kfd img file size on disk = %ld\n", filestat.st_size);
+
+	buf = xmalloc(filestat.st_size);
+	if (!buf) {
+		pr_perror("Failed to allocate memory");
+		close(img_fd);
+		return -ENOMEM;
+	}
+	len = read(img_fd, buf, filestat.st_size);
+	if (len <= 0) {
+		pr_perror("Unable to read from %s", img_path);
+		xfree(buf);
+		close(img_fd);
+		return -1;
+	}
+	close(img_fd);
+	e = criu_kfd__unpack(NULL, len, buf);
+	if (e == NULL) {
+		pr_err("Unable to parse the KFD message %#x\n", id);
+		xfree(buf);
+		return -1;
+	}
+
+	pr_info("amdgpu_plugin: read image file data\n");
+
+	ret = restore_process(fd, e);
+	if (ret)
+		goto exit;
+
+	ret = restore_devices(fd, e);
+	if (ret)
+		goto exit;
+
+	ret = restore_bos(fd, e);
+	if (ret)
+		goto exit;
+
+exit:
+	if (e)
+		criu_kfd__free_unpacked(e, NULL);
+
+	if (ret) {
+		pr_err("amdgpu_plugin: Failed to restore (ret:%d)\n", ret);
+		fd = ret;
+	} else {
+		pr_info("amdgpu_plugin: Restore successful (fd:%d)\n", fd);
+	}
+
+	return fd;
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESTORE_EXT_FILE, amdgpu_plugin_restore_file)
+
+/* return 0 if no match found
+ * return -1 for error.
+ * return 1 if vmap map must be adjusted.
+ */
+int amdgpu_plugin_update_vmamap(const char *path, const uint64_t addr, const uint64_t old_offset, uint64_t *new_offset,
+				int *updated_fd)
+{
+	struct vma_metadata *vma_md;
+
+	pr_info("amdgpu_plugin: Enter %s\n", __func__);
+
+	/*
+	 * On newer versions of AMD KFD driver, only the file descriptor that was used to open the
+	 * device can be used for mmap, so we will have to return the proper file descriptor here
+	 */
+	*updated_fd = -1;
+
+	list_for_each_entry(vma_md, &update_vma_info_list, list) {
+		if (addr == vma_md->vma_entry && old_offset == vma_md->old_pgoff) {
+			*new_offset = vma_md->new_pgoff;
+
+			pr_info("amdgpu_plugin: old_pgoff= 0x%lx new_pgoff = 0x%lx path = %s\n", vma_md->old_pgoff,
+				vma_md->new_pgoff, path);
+
+			return 1;
+		}
+	}
+	pr_info("No match for addr:0x%lx offset:%lx\n", addr, old_offset);
+	return 0;
+}
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, amdgpu_plugin_update_vmamap)

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -65,6 +65,14 @@ struct device_maps checkpoint_maps;
 struct device_maps restore_maps;
 
 static LIST_HEAD(update_vma_info_list);
+
+extern bool kfd_fw_version_check;
+extern bool kfd_sdma_fw_version_check;
+extern bool kfd_caches_count_check;
+extern bool kfd_num_gws_check;
+extern bool kfd_vram_size_check;
+extern bool kfd_numa_check;
+
 /**************************************************************************************************/
 
 int write_file(const char *file_path, const void *buf, const size_t buf_len)
@@ -442,16 +450,46 @@ int devinfo_to_topology(DeviceEntry *devinfos[], uint32_t num_devices, struct tp
 	return 0;
 }
 
+void getenv_bool(const char *var, bool *value)
+{
+	char *value_str = getenv(var);
+
+	if (value_str) {
+		if (!strcmp(value_str, "0") || !strcasecmp(value_str, "NO"))
+			*value = false;
+		else if (!strcmp(value_str, "1") || !strcasecmp(value_str, "YES"))
+			*value = true;
+		else
+			pr_err("Ignoring invalid value for %s=%s, expecting (YES/NO)\n", var, value_str);
+	}
+	pr_info("param: %s:%s\n", var, *value ? "Y" : "N");
+}
+
 int amdgpu_plugin_init(int stage)
 {
 	pr_info("amdgpu_plugin: initialized:  %s (AMDGPU/KFD)\n", CR_PLUGIN_DESC.name);
 
 	topology_init(&src_topology);
 	topology_init(&dest_topology);
-
 	maps_init(&checkpoint_maps);
 	maps_init(&restore_maps);
 
+	if (stage == CR_PLUGIN_STAGE__RESTORE) {
+		/* Default Values */
+		kfd_fw_version_check = true;
+		kfd_sdma_fw_version_check = true;
+		kfd_caches_count_check = true;
+		kfd_num_gws_check = true;
+		kfd_vram_size_check = true;
+		kfd_numa_check = true;
+
+		getenv_bool("KFD_FW_VER_CHECK", &kfd_fw_version_check);
+		getenv_bool("KFD_SDMA_FW_VER_CHECK", &kfd_sdma_fw_version_check);
+		getenv_bool("KFD_CACHES_COUNT_CHECK", &kfd_caches_count_check);
+		getenv_bool("KFD_NUM_GWS_CHECK", &kfd_num_gws_check);
+		getenv_bool("KFD_VRAM_SIZE_CHECK", &kfd_vram_size_check);
+		getenv_bool("KFD_NUMA_CHECK", &kfd_numa_check);
+	}
 	return 0;
 }
 

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -16,6 +16,10 @@
 #include <pthread.h>
 #include <semaphore.h>
 
+#include <xf86drm.h>
+#include <libdrm/amdgpu.h>
+#include <libdrm/amdgpu_drm.h>
+
 #include "criu-plugin.h"
 #include "plugin.h"
 #include "criu-amdgpu.pb-c.h"
@@ -53,6 +57,18 @@
 	{                        \
 	}
 #endif
+
+#define SDMA_PACKET(op, sub_op, e) ((((e)&0xFFFF) << 16) | (((sub_op)&0xFF) << 8) | (((op)&0xFF) << 0))
+
+#define SDMA_OPCODE_COPY	    1
+#define SDMA_COPY_SUB_OPCODE_LINEAR 0
+#define SDMA_NOP		    0
+#define SDMA_LINEAR_COPY_MAX_SIZE   (1ULL << 21)
+
+enum sdma_op_type {
+	SDMA_OP_VRAM_READ,
+	SDMA_OP_VRAM_WRITE,
+};
 
 struct vma_metadata {
 	struct list_head list;
@@ -560,17 +576,371 @@ int amdgpu_plugin_handle_device_vma(int fd, const struct stat *st_buf)
 }
 CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__HANDLE_DEVICE_VMA, amdgpu_plugin_handle_device_vma)
 
+int alloc_and_map(amdgpu_device_handle h_dev, uint64_t size, uint32_t domain, amdgpu_bo_handle *ph_bo,
+		  amdgpu_va_handle *ph_va, uint64_t *p_gpu_addr, void **p_cpu_addr)
+{
+	struct amdgpu_bo_alloc_request alloc_req;
+	amdgpu_bo_handle h_bo;
+	amdgpu_va_handle h_va;
+	uint64_t gpu_addr;
+	void *cpu_addr;
+	int err;
+
+	memset(&alloc_req, 0, sizeof(alloc_req));
+	alloc_req.alloc_size = size;
+	alloc_req.phys_alignment = 0x1000;
+	alloc_req.preferred_heap = domain;
+	alloc_req.flags = 0;
+	err = amdgpu_bo_alloc(h_dev, &alloc_req, &h_bo);
+	if (err) {
+		pr_perror("failed to alloc BO");
+		return err;
+	}
+	err = amdgpu_va_range_alloc(h_dev, amdgpu_gpu_va_range_general, size, 0x1000, 0, &gpu_addr, &h_va, 0);
+	if (err) {
+		pr_perror("failed to alloc VA");
+		goto err_va;
+	}
+	err = amdgpu_bo_va_op(h_bo, 0, size, gpu_addr, 0, AMDGPU_VA_OP_MAP);
+	if (err) {
+		pr_perror("failed to GPU map BO");
+		goto err_gpu_map;
+	}
+	if (p_cpu_addr) {
+		err = amdgpu_bo_cpu_map(h_bo, &cpu_addr);
+		if (err) {
+			pr_perror("failed to CPU map BO");
+			goto err_cpu_map;
+		}
+		*p_cpu_addr = cpu_addr;
+	}
+
+	*ph_bo = h_bo;
+	*ph_va = h_va;
+	*p_gpu_addr = gpu_addr;
+
+	return 0;
+
+err_cpu_map:
+	amdgpu_bo_va_op(h_bo, 0, size, gpu_addr, 0, AMDGPU_VA_OP_UNMAP);
+err_gpu_map:
+	amdgpu_va_range_free(h_va);
+err_va:
+	amdgpu_bo_free(h_bo);
+	return err;
+}
+
+void free_and_unmap(uint64_t size, amdgpu_bo_handle h_bo, amdgpu_va_handle h_va, uint64_t gpu_addr, void *cpu_addr)
+{
+	if (cpu_addr)
+		amdgpu_bo_cpu_unmap(h_bo);
+	amdgpu_bo_va_op(h_bo, 0, size, gpu_addr, 0, AMDGPU_VA_OP_UNMAP);
+	amdgpu_va_range_free(h_va);
+	amdgpu_bo_free(h_bo);
+}
+
+int sdma_copy_bo(struct kfd_criu_bo_bucket *bo_buckets, BoEntry **bo_info_test, int i, amdgpu_device_handle h_dev,
+		 enum sdma_op_type type)
+{
+	uint64_t size, gpu_addr_src, gpu_addr_dest, gpu_addr_ib;
+	uint64_t gpu_addr_src_orig, gpu_addr_dest_orig;
+	amdgpu_va_handle h_va_src, h_va_dest, h_va_ib;
+	amdgpu_bo_handle h_bo_src, h_bo_dest, h_bo_ib;
+	struct amdgpu_bo_import_result res = { 0 };
+	uint64_t copy_size, bytes_remain, j = 0;
+	struct amdgpu_gpu_info gpu_info = { 0 };
+	uint64_t n_packets, max_copy_size;
+	struct amdgpu_cs_ib_info ib_info;
+	amdgpu_bo_list_handle h_bo_list;
+	struct amdgpu_cs_request cs_req;
+	amdgpu_bo_handle resources[3];
+	struct amdgpu_cs_fence fence;
+	uint32_t family_id, expired;
+	amdgpu_context_handle h_ctx;
+	void *userptr = NULL;
+	uint32_t *ib = NULL;
+	int err, shared_fd;
+
+	err = amdgpu_query_gpu_info(h_dev, &gpu_info);
+	if (err) {
+		pr_perror("failed to query gpuinfo via libdrm");
+		return -EINVAL;
+	}
+
+	family_id = gpu_info.family_id;
+
+	shared_fd = bo_buckets[i].dmabuf_fd;
+	size = bo_buckets[i].size;
+
+	plugin_log_msg("Enter %s\n", __func__);
+
+	/* prepare src buffer */
+	switch (type) {
+	case SDMA_OP_VRAM_WRITE:
+		/* create the userptr BO and prepare the src buffer */
+		posix_memalign(&userptr, sysconf(_SC_PAGE_SIZE), size);
+		if (!userptr) {
+			pr_perror("failed to alloc memory for userptr");
+			return -ENOMEM;
+		}
+
+		memcpy(userptr, bo_info_test[i]->rawdata.data, size);
+		plugin_log_msg("data copied to userptr from protobuf buffer\n");
+
+		err = amdgpu_create_bo_from_user_mem(h_dev, userptr, size, &h_bo_src);
+		if (err) {
+			pr_perror("failed to create userptr for sdma");
+			free(userptr);
+			return -EFAULT;
+		}
+
+		break;
+
+	case SDMA_OP_VRAM_READ:
+		err = amdgpu_bo_import(h_dev, amdgpu_bo_handle_type_dma_buf_fd, shared_fd, &res);
+		if (err) {
+			pr_perror("failed to import dmabuf handle from libdrm");
+			return -EFAULT;
+		}
+
+		h_bo_src = res.buf_handle;
+		plugin_log_msg("closing src fd %d\n", shared_fd);
+		close(shared_fd);
+		break;
+
+	default:
+		pr_perror("Invalid sdma operation");
+		return -EINVAL;
+	}
+
+	err = amdgpu_va_range_alloc(h_dev, amdgpu_gpu_va_range_general, size, 0x1000, 0, &gpu_addr_src, &h_va_src, 0);
+	if (err) {
+		pr_perror("failed to alloc VA for src bo");
+		goto err_src_va;
+	}
+	err = amdgpu_bo_va_op(h_bo_src, 0, size, gpu_addr_src, 0, AMDGPU_VA_OP_MAP);
+	if (err) {
+		pr_perror("failed to GPU map the src BO");
+		goto err_src_bo_map;
+	}
+	plugin_log_msg("Source BO: GPU VA: %lx, size: %lx\n", gpu_addr_src, size);
+	/* prepare dest buffer */
+	switch (type) {
+	case SDMA_OP_VRAM_WRITE:
+		err = amdgpu_bo_import(h_dev, amdgpu_bo_handle_type_dma_buf_fd, shared_fd, &res);
+		if (err) {
+			pr_perror("failed to import dmabuf handle from libdrm");
+			goto err_dest_bo_prep;
+		}
+
+		h_bo_dest = res.buf_handle;
+		plugin_log_msg("closing dest fd %d\n", shared_fd);
+		close(shared_fd);
+		break;
+
+	case SDMA_OP_VRAM_READ:
+		posix_memalign(&userptr, sysconf(_SC_PAGE_SIZE), size);
+		if (!userptr) {
+			pr_perror("failed to alloc memory for userptr");
+			goto err_dest_bo_prep;
+		}
+		memset(userptr, 0, size);
+		err = amdgpu_create_bo_from_user_mem(h_dev, userptr, size, &h_bo_dest);
+		if (err) {
+			pr_perror("failed to create userptr for sdma");
+			free(userptr);
+			goto err_dest_bo_prep;
+		}
+		break;
+
+	default:
+		pr_perror("Invalid sdma operation");
+		goto err_dest_bo_prep;
+	}
+
+	err = amdgpu_va_range_alloc(h_dev, amdgpu_gpu_va_range_general, size, 0x1000, 0, &gpu_addr_dest, &h_va_dest, 0);
+	if (err) {
+		pr_perror("failed to alloc VA for dest bo");
+		goto err_dest_va;
+	}
+	err = amdgpu_bo_va_op(h_bo_dest, 0, size, gpu_addr_dest, 0, AMDGPU_VA_OP_MAP);
+	if (err) {
+		pr_perror("failed to GPU map the dest BO");
+		goto err_dest_bo_map;
+	}
+	plugin_log_msg("Dest BO: GPU VA: %lx, size: %lx\n", gpu_addr_dest, size);
+
+	n_packets = (size + SDMA_LINEAR_COPY_MAX_SIZE) / SDMA_LINEAR_COPY_MAX_SIZE;
+	/* prepare ring buffer/indirect buffer for command submission
+	 * each copy packet is 7 dwords so we need to alloc 28x size for ib
+	 */
+	err = alloc_and_map(h_dev, n_packets * 28, AMDGPU_GEM_DOMAIN_GTT, &h_bo_ib, &h_va_ib, &gpu_addr_ib,
+			    (void **)&ib);
+	if (err) {
+		pr_perror("failed to allocate and map ib/rb");
+		goto err_ib_gpu_alloc;
+	}
+
+	plugin_log_msg("Indirect BO: GPU VA: %lx, size: %lx\n", gpu_addr_ib, n_packets * 28);
+
+	resources[0] = h_bo_src;
+	resources[1] = h_bo_dest;
+	resources[2] = h_bo_ib;
+	err = amdgpu_bo_list_create(h_dev, 3, resources, NULL, &h_bo_list);
+	if (err) {
+		pr_perror("failed to create BO resources list");
+		goto err_bo_list;
+	}
+
+	memset(&cs_req, 0, sizeof(cs_req));
+	memset(&fence, 0, sizeof(fence));
+	memset(ib, 0, n_packets * 28);
+
+	plugin_log_msg("setting up sdma packets for command submission\n");
+	bytes_remain = size;
+	gpu_addr_src_orig = gpu_addr_src;
+	gpu_addr_dest_orig = gpu_addr_dest;
+	max_copy_size = (family_id >= AMDGPU_FAMILY_AI) ? SDMA_LINEAR_COPY_MAX_SIZE : SDMA_LINEAR_COPY_MAX_SIZE - 1;
+	while (bytes_remain > 0) {
+		copy_size = min(bytes_remain, max_copy_size);
+
+		ib[j++] = SDMA_PACKET(SDMA_OPCODE_COPY, SDMA_COPY_SUB_OPCODE_LINEAR, 0);
+		ib[j++] = copy_size;
+		ib[j++] = 0;
+		ib[j++] = 0xffffffff & gpu_addr_src;
+		ib[j++] = (0xffffffff00000000 & gpu_addr_src) >> 32;
+		ib[j++] = 0xffffffff & gpu_addr_dest;
+		ib[j++] = (0xffffffff00000000 & gpu_addr_dest) >> 32;
+
+		gpu_addr_src += copy_size;
+		gpu_addr_dest += copy_size;
+		bytes_remain -= copy_size;
+	}
+
+	gpu_addr_src = gpu_addr_src_orig;
+	gpu_addr_dest = gpu_addr_dest_orig;
+	plugin_log_msg("pad the IB to align on 8 dw boundary\n");
+	/* pad the IB to the required number of dw with SDMA_NOP */
+	while (j & 7)
+		ib[j++] = SDMA_NOP;
+
+	ib_info.ib_mc_address = gpu_addr_ib;
+	ib_info.size = j;
+
+	cs_req.ip_type = AMDGPU_HW_IP_DMA;
+	/* possible future optimization: may use other rings, info available in
+	 * amdgpu_query_hw_ip_info()
+	 */
+	cs_req.ring = 0;
+	cs_req.number_of_ibs = 1;
+	cs_req.ibs = &ib_info;
+	cs_req.resources = h_bo_list;
+	cs_req.fence_info.handle = NULL;
+
+	plugin_log_msg("create the context\n");
+	err = amdgpu_cs_ctx_create(h_dev, &h_ctx);
+	if (err) {
+		pr_perror("failed to create context for SDMA command submission");
+		goto err_ctx;
+	}
+
+	plugin_log_msg("initiate sdma command submission\n");
+	err = amdgpu_cs_submit(h_ctx, 0, &cs_req, 1);
+	if (err) {
+		pr_perror("failed to submit command for SDMA IB");
+		goto err_cs_submit_ib;
+	}
+
+	fence.context = h_ctx;
+	fence.ip_type = AMDGPU_HW_IP_DMA;
+	fence.ip_instance = 0;
+	fence.ring = 0;
+	fence.fence = cs_req.seq_no;
+	err = amdgpu_cs_query_fence_status(&fence, AMDGPU_TIMEOUT_INFINITE, 0, &expired);
+	if (err) {
+		pr_perror("failed to query fence status");
+		goto err_cs_submit_ib;
+	}
+
+	if (!expired) {
+		pr_err("IB execution did not complete\n");
+		err = -EBUSY;
+		goto err_cs_submit_ib;
+	}
+
+	plugin_log_msg("done querying fence status\n");
+
+	if (type == SDMA_OP_VRAM_READ) {
+		memcpy(bo_info_test[i]->rawdata.data, userptr, size);
+		plugin_log_msg("data copied to protobuf buffer\n");
+	}
+
+err_cs_submit_ib:
+	amdgpu_cs_ctx_free(h_ctx);
+err_ctx:
+	amdgpu_bo_list_destroy(h_bo_list);
+err_bo_list:
+	free_and_unmap(n_packets * 28, h_bo_ib, h_va_ib, gpu_addr_ib, ib);
+err_ib_gpu_alloc:
+	err = amdgpu_bo_va_op(h_bo_dest, 0, size, gpu_addr_dest, 0, AMDGPU_VA_OP_UNMAP);
+	if (err)
+		pr_perror("failed to GPU unmap the dest BO %lx, size = %lx", gpu_addr_dest, size);
+err_dest_bo_map:
+	err = amdgpu_va_range_free(h_va_dest);
+	if (err)
+		pr_perror("dest range free failed");
+err_dest_va:
+	err = amdgpu_bo_free(h_bo_dest);
+	if (err)
+		pr_perror("dest bo free failed");
+
+	if (userptr && (type == SDMA_OP_VRAM_READ)) {
+		free(userptr);
+		userptr = NULL;
+	}
+
+err_dest_bo_prep:
+	err = amdgpu_bo_va_op(h_bo_src, 0, size, gpu_addr_src, 0, AMDGPU_VA_OP_UNMAP);
+	if (err)
+		pr_perror("failed to GPU unmap the src BO %lx, size = %lx", gpu_addr_src, size);
+err_src_bo_map:
+	err = amdgpu_va_range_free(h_va_src);
+	if (err)
+		pr_perror("src range free failed");
+err_src_va:
+	err = amdgpu_bo_free(h_bo_src);
+	if (err)
+		pr_perror("src bo free failed");
+
+	if (userptr && (type == SDMA_OP_VRAM_WRITE)) {
+		free(userptr);
+		userptr = NULL;
+	}
+
+	plugin_log_msg("Leaving sdma_copy_bo, err = %d\n", err);
+	return err;
+}
+
 void *dump_bo_contents(void *_thread_data)
 {
-	int i, ret = 0;
-	int num_bos = 0;
 	struct thread_data *thread_data = (struct thread_data *)_thread_data;
 	struct kfd_criu_bo_bucket *bo_buckets = thread_data->bo_buckets;
 	BoEntry **bo_info = thread_data->bo_entries;
-	char *fname;
+	amdgpu_device_handle h_dev;
+	uint32_t major, minor;
 	int mem_fd = -1;
+	int num_bos = 0;
+	int i, ret = 0;
+	char *fname;
 
 	pr_info("amdgpu_plugin: Thread[0x%x] started\n", thread_data->gpu_id);
+
+	ret = amdgpu_device_initialize(thread_data->drm_fd, &major, &minor, &h_dev);
+	if (ret) {
+		pr_perror("failed to initialize device");
+		goto exit;
+	}
+	plugin_log_msg("libdrm initialized successfully\n");
 
 	if (asprintf(&fname, PROCPIDMEM, thread_data->pid) < 0) {
 		pr_perror("failed in asprintf, %s", fname);
@@ -595,6 +965,16 @@ void *dump_bo_contents(void *_thread_data)
 		if (!(bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) &&
 		    !(bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT))
 			continue;
+
+		if (bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) {
+			/* perform sDMA based vram copy */
+			if (!sdma_copy_bo(bo_buckets, bo_info, i, h_dev, SDMA_OP_VRAM_READ)) {
+				plugin_log_msg("** Successfully drained the BO using sDMA: bo_buckets[%d] **\n", i);
+				continue;
+			}
+
+			pr_info("Failed to read the BO using sDMA, retry with HDP: bo_buckets[%d]\n", i);
+		}
 
 		if (bo_info[i]->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
 			void *addr;
@@ -633,24 +1013,34 @@ void *dump_bo_contents(void *_thread_data)
 exit:
 	pr_info("amdgpu_plugin: Thread[0x%x] done num_bos:%d ret:%d\n", thread_data->gpu_id, num_bos, ret);
 
+	amdgpu_device_deinitialize(h_dev);
+
 	if (mem_fd >= 0)
 		close(mem_fd);
-
 	thread_data->ret = ret;
 	return NULL;
 };
 
 void *restore_bo_contents(void *_thread_data)
 {
-	int i, ret = 0;
-	int num_bos = 0;
 	struct thread_data *thread_data = (struct thread_data *)_thread_data;
 	struct kfd_criu_bo_bucket *bo_buckets = thread_data->bo_buckets;
 	BoEntry **bo_info = thread_data->bo_entries;
-	char *fname;
+	amdgpu_device_handle h_dev;
+	uint32_t major, minor;
 	int mem_fd = -1;
+	int num_bos = 0;
+	int i, ret = 0;
+	char *fname;
 
 	pr_info("amdgpu_plugin: Thread[0x%x] started\n", thread_data->gpu_id);
+
+	ret = amdgpu_device_initialize(thread_data->drm_fd, &major, &minor, &h_dev);
+	if (ret) {
+		pr_perror("failed to initialize device");
+		goto exit;
+	}
+	plugin_log_msg("libdrm initialized successfully\n");
 
 	if (asprintf(&fname, PROCPIDMEM, thread_data->pid) < 0) {
 		pr_perror("failed in asprintf, %s", fname);
@@ -679,6 +1069,18 @@ void *restore_bo_contents(void *_thread_data)
 		if (!(bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) &&
 		    !(bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT))
 			continue;
+
+		if (bo_buckets[i].alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM) {
+			/* perform sDMA based VRAM write */
+			if (!sdma_copy_bo(bo_buckets, bo_info, i, h_dev, SDMA_OP_VRAM_WRITE)) {
+				plugin_log_msg("** Successfully filled the BO using sDMA: "
+					       "bo_buckets[%d] **\n",
+					       i);
+				continue;
+			}
+
+			pr_info("Failed to fill the BO using sDMA, retry with HDP: bo_buckets[%d]\n", i);
+		}
 
 		if (bo_info[i]->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
 			plugin_log_msg("amdgpu_plugin: large bar write possible\n");
@@ -731,6 +1133,8 @@ exit:
 
 	if (mem_fd >= 0)
 		close(mem_fd);
+
+	amdgpu_device_deinitialize(h_dev);
 	thread_data->ret = ret;
 	return NULL;
 };

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -1068,3 +1068,29 @@ int amdgpu_plugin_update_vmamap(const char *path, const uint64_t addr, const uin
 	return 0;
 }
 CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, amdgpu_plugin_update_vmamap)
+
+int amdgpu_plugin_resume_devices_late(int target_pid)
+{
+	struct kfd_ioctl_criu_resume_args args = { 0 };
+	int fd, ret = 0;
+
+	pr_info("amdgpu_plugin: Inside %s for target pid = %d\n", __func__, target_pid);
+
+	fd = open(AMDGPU_KFD_DEVICE, O_RDWR | O_CLOEXEC);
+	if (fd < 0) {
+		pr_perror("failed to open kfd in plugin");
+		return -1;
+	}
+
+	args.pid = target_pid;
+	pr_info("amdgpu_plugin: Calling IOCTL to start notifiers and queues\n");
+	if (kmtIoctl(fd, AMDKFD_IOC_CRIU_RESUME, &args) == -1) {
+		pr_perror("restore late ioctl failed");
+		ret = -1;
+	}
+
+	close(fd);
+	return ret;
+}
+
+CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESUME_DEVICES_LATE, amdgpu_plugin_resume_devices_late)

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -23,6 +23,7 @@
 #include "criu-log.h"
 
 #include "common/list.h"
+#include "amdgpu_plugin_topology.h"
 
 #define DRM_FIRST_RENDER_NODE 128
 #define DRM_LAST_RENDER_NODE  255
@@ -54,7 +55,15 @@ struct vma_metadata {
 	uint64_t vma_entry;
 };
 
+/************************************ Global Variables ********************************************/
+struct tp_system src_topology;
+struct tp_system dest_topology;
+
+struct device_maps checkpoint_maps;
+struct device_maps restore_maps;
+
 static LIST_HEAD(update_vma_info_list);
+/**************************************************************************************************/
 
 int open_drm_render_device(int minor)
 {
@@ -198,6 +207,9 @@ static void free_e(CriuKfd *e)
 			if (e->device_entries[i]->private_data.data)
 				xfree(e->device_entries[i]->private_data.data);
 
+			for (int j = 0; j < e->device_entries[i]->n_iolinks; j++)
+				xfree(e->device_entries[i]->iolinks[j]);
+
 			xfree(e->device_entries[i]);
 		}
 	}
@@ -325,15 +337,147 @@ static int allocate_ev_entries(CriuKfd *e, int num_events)
 	return 0;
 }
 
+int topology_to_devinfo(struct tp_system *sys, struct device_maps *maps, DeviceEntry **deviceEntries)
+{
+	uint32_t devinfo_index = 0;
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		DeviceEntry *devinfo = deviceEntries[devinfo_index++];
+
+		devinfo->node_id = node->id;
+
+		if (NODE_IS_GPU(node)) {
+			devinfo->gpu_id = node->gpu_id;
+
+			devinfo->simd_count = node->simd_count;
+			devinfo->mem_banks_count = node->mem_banks_count;
+			devinfo->caches_count = node->caches_count;
+			devinfo->io_links_count = node->io_links_count;
+			devinfo->max_waves_per_simd = node->max_waves_per_simd;
+			devinfo->lds_size_in_kb = node->lds_size_in_kb;
+			devinfo->num_gws = node->num_gws;
+			devinfo->wave_front_size = node->wave_front_size;
+			devinfo->array_count = node->array_count;
+			devinfo->simd_arrays_per_engine = node->simd_arrays_per_engine;
+			devinfo->cu_per_simd_array = node->cu_per_simd_array;
+			devinfo->simd_per_cu = node->simd_per_cu;
+			devinfo->max_slots_scratch_cu = node->max_slots_scratch_cu;
+			devinfo->vendor_id = node->vendor_id;
+			devinfo->device_id = node->device_id;
+			devinfo->domain = node->domain;
+			devinfo->drm_render_minor = node->drm_render_minor;
+			devinfo->hive_id = node->hive_id;
+			devinfo->num_sdma_engines = node->num_sdma_engines;
+			devinfo->num_sdma_xgmi_engines = node->num_sdma_xgmi_engines;
+			devinfo->num_sdma_queues_per_engine = node->num_sdma_queues_per_engine;
+			devinfo->num_cp_queues = node->num_cp_queues;
+			devinfo->fw_version = node->fw_version;
+			devinfo->capability = node->capability;
+			devinfo->sdma_fw_version = node->sdma_fw_version;
+			devinfo->vram_public = node->vram_public;
+			devinfo->vram_size = node->vram_size;
+		} else {
+			devinfo->cpu_cores_count = node->cpu_cores_count;
+		}
+
+		if (node->num_valid_iolinks) {
+			struct tp_iolink *iolink;
+			uint32_t iolink_index = 0;
+
+			devinfo->iolinks = xmalloc(sizeof(DevIolink *) * node->num_valid_iolinks);
+			if (!devinfo->iolinks)
+				return -ENOMEM;
+
+			list_for_each_entry(iolink, &node->iolinks, listm) {
+				if (!iolink->valid)
+					continue;
+
+				devinfo->iolinks[iolink_index] = xmalloc(sizeof(DevIolink));
+				if (!devinfo->iolinks[iolink_index])
+					return -ENOMEM;
+
+				dev_iolink__init(devinfo->iolinks[iolink_index]);
+
+				devinfo->iolinks[iolink_index]->type = iolink->type;
+				devinfo->iolinks[iolink_index]->node_to_id = iolink->node_to_id;
+				iolink_index++;
+			}
+			devinfo->n_iolinks = iolink_index;
+		}
+	}
+	return 0;
+}
+
+int devinfo_to_topology(DeviceEntry *devinfos[], uint32_t num_devices, struct tp_system *sys)
+{
+	for (int i = 0; i < num_devices; i++) {
+		struct tp_node *node;
+		DeviceEntry *devinfo = devinfos[i];
+
+		node = sys_add_node(sys, devinfo->node_id, devinfo->gpu_id);
+		if (!node)
+			return -ENOMEM;
+
+		if (devinfo->cpu_cores_count) {
+			node->cpu_cores_count = devinfo->cpu_cores_count;
+		} else {
+			node->simd_count = devinfo->simd_count;
+			node->mem_banks_count = devinfo->mem_banks_count;
+			node->caches_count = devinfo->caches_count;
+			node->io_links_count = devinfo->io_links_count;
+			node->max_waves_per_simd = devinfo->max_waves_per_simd;
+			node->lds_size_in_kb = devinfo->lds_size_in_kb;
+			node->num_gws = devinfo->num_gws;
+			node->wave_front_size = devinfo->wave_front_size;
+			node->array_count = devinfo->array_count;
+			node->simd_arrays_per_engine = devinfo->simd_arrays_per_engine;
+			node->cu_per_simd_array = devinfo->cu_per_simd_array;
+			node->simd_per_cu = devinfo->simd_per_cu;
+			node->max_slots_scratch_cu = devinfo->max_slots_scratch_cu;
+			node->vendor_id = devinfo->vendor_id;
+			node->device_id = devinfo->device_id;
+			node->domain = devinfo->domain;
+			node->drm_render_minor = devinfo->drm_render_minor;
+			node->hive_id = devinfo->hive_id;
+			node->num_sdma_engines = devinfo->num_sdma_engines;
+			node->num_sdma_xgmi_engines = devinfo->num_sdma_xgmi_engines;
+			node->num_sdma_queues_per_engine = devinfo->num_sdma_queues_per_engine;
+			node->num_cp_queues = devinfo->num_cp_queues;
+			node->fw_version = devinfo->fw_version;
+			node->capability = devinfo->capability;
+			node->sdma_fw_version = devinfo->sdma_fw_version;
+			node->vram_public = devinfo->vram_public;
+			node->vram_size = devinfo->vram_size;
+		}
+
+		for (int j = 0; j < devinfo->n_iolinks; j++) {
+			struct tp_iolink *iolink;
+			DevIolink *devlink = (devinfo->iolinks[j]);
+
+			iolink = node_add_iolink(node, devlink->type, devlink->node_to_id);
+			if (!iolink)
+				return -ENOMEM;
+		}
+	}
+	return 0;
+}
+
 int amdgpu_plugin_init(int stage)
 {
 	pr_info("amdgpu_plugin: initialized:  %s (AMDGPU/KFD)\n", CR_PLUGIN_DESC.name);
+
+	topology_init(&src_topology);
+	topology_init(&dest_topology);
 	return 0;
 }
 
 void amdgpu_plugin_fini(int stage, int ret)
 {
 	pr_info("amdgpu_plugin: finished  %s (AMDGPU/KFD)\n", CR_PLUGIN_DESC.name);
+
+	topology_free(&src_topology);
+	topology_free(&dest_topology);
 }
 
 CR_PLUGIN_REGISTER("amdgpu_plugin", amdgpu_plugin_init, amdgpu_plugin_fini)
@@ -502,14 +646,23 @@ static int dump_devices(int fd, struct kfd_ioctl_criu_process_info_args *info_ar
 	priv_data = (void *)(device_buckets + args.num_objects);
 
 	e->num_of_gpus = info_args->total_devices;
+	e->num_of_cpus = src_topology.num_nodes - info_args->total_devices;
 
-	ret = allocate_device_entries(e, e->num_of_gpus);
+	/* The ioctl will only return entries for GPUs, but we also store entries for CPUs and the
+	 * information for CPUs is obtained from parsing system topology
+	 */
+	ret = allocate_device_entries(e, src_topology.num_nodes);
 	if (ret) {
 		ret = -ENOMEM;
 		goto exit;
 	}
 
-	plugin_log_msg("Number of GPUs:%d\n", e->num_of_gpus);
+	pr_debug("Number of CPUs:%d GPUs:%d\n", e->num_of_cpus, e->num_of_gpus);
+
+	/* Store topology information that was obtained from parsing /sys/class/kfd/kfd/topology/ */
+	ret = topology_to_devinfo(&src_topology, &checkpoint_maps, e->device_entries);
+	if (ret)
+		goto exit;
 
 	/* Add private data obtained from IOCTL for each GPU */
 	for (i = 0; i < args.num_objects; i++) {
@@ -802,6 +955,17 @@ int amdgpu_plugin_dump_file(int fd, int id)
 		return -1;
 	}
 
+	if (topology_parse(&src_topology, "Checkpoint"))
+		return -1;
+
+	/* We call topology_determine_iolinks to validate io_links. If io_links are not valid
+	 * we do not store them inside the checkpointed images
+	 */
+	if (topology_determine_iolinks(&src_topology)) {
+		pr_err("Failed to determine iolinks from topology\n");
+		return -1;
+	}
+
 	/* Check whether this plugin was called for kfd or render nodes */
 	if (major(st.st_rdev) != major(st_kfd.st_rdev) || minor(st.st_rdev) != 0) {
 		/* This is RenderD dumper plugin, for now just save renderD
@@ -960,8 +1124,13 @@ static int restore_devices(int fd, CriuKfd *e)
 
 	pr_debug("Restoring %d devices\n", e->num_of_gpus);
 
-	for (int i = 0; i < e->num_of_gpus; i++)
+	for (int i = 0; i < e->num_of_cpus + e->num_of_gpus; i++) {
+		/* Skip CPUs */
+		if (!e->device_entries[i]->gpu_id)
+			continue;
+
 		objects_size += sizeof(*device_buckets) + e->device_entries[i]->private_data.len;
+	}
 
 	ret = init_restorer_args(&args, KFD_CRIU_OBJECT_TYPE_DEVICE, 0, e->num_of_gpus, objects_size);
 	if (ret)
@@ -970,9 +1139,12 @@ static int restore_devices(int fd, CriuKfd *e)
 	device_buckets = (struct kfd_criu_device_bucket *)args.objects;
 	priv_data = (void *)(device_buckets + args.num_objects);
 
-	for (int i = 0; i < e->num_of_gpus; i++) {
+	for (int entries_i = 0; entries_i < e->num_of_cpus + e->num_of_gpus; entries_i++) {
 		struct kfd_criu_device_bucket *device_bucket;
-		DeviceEntry *devinfo = e->device_entries[i];
+		DeviceEntry *devinfo = e->device_entries[entries_i];
+
+		if (!devinfo->gpu_id)
+			continue;
 
 		device_bucket = &device_buckets[bucket_index++];
 
@@ -986,7 +1158,7 @@ static int restore_devices(int fd, CriuKfd *e)
 
 		device_bucket->user_gpu_id = devinfo->gpu_id;
 
-		device_bucket->drm_fd = open_drm_render_device(i + DRM_FIRST_RENDER_NODE);
+		device_bucket->drm_fd = open_drm_render_device(bucket_index + DRM_FIRST_RENDER_NODE);
 		if (device_bucket->drm_fd < 0) {
 			pr_perror("amdgpu_plugin: Can't pass NULL drm render fd to driver");
 			fd = -EBADFD;
@@ -1357,6 +1529,19 @@ int amdgpu_plugin_restore_file(int id)
 	}
 
 	plugin_log_msg("amdgpu_plugin: read image file data\n");
+
+	ret = devinfo_to_topology(e->device_entries, e->num_of_gpus + e->num_of_cpus, &src_topology);
+	if (ret) {
+		pr_err("Failed to convert stored device information to topology\n");
+		ret = -EINVAL;
+		goto exit;
+	}
+
+	ret = topology_parse(&dest_topology, "Local");
+	if (ret) {
+		pr_err("Failed to parse local system topology\n");
+		goto exit;
+	}
 
 	ret = restore_process(fd, e);
 	if (ret)

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <pthread.h>
+#include <semaphore.h>
 
 #include "criu-plugin.h"
 #include "plugin.h"
@@ -31,6 +32,10 @@
 
 #define AMDGPU_KFD_DEVICE "/dev/kfd"
 #define PROCPIDMEM	  "/proc/%d/mem"
+#define HSAKMT_SHM_PATH	  "/dev/shm/hsakmt_shared_mem"
+#define HSAKMT_SHM	  "/hsakmt_shared_mem"
+#define HSAKMT_SEM_PATH	  "/dev/shm/sem.hsakmt_semaphore"
+#define HSAKMT_SEM	  "hsakmt_semaphore"
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
@@ -730,6 +735,71 @@ exit:
 	return NULL;
 };
 
+int check_hsakmt_shared_mem(uint64_t *shared_mem_size, uint32_t *shared_mem_magic)
+{
+	int ret;
+	struct stat st;
+
+	ret = stat(HSAKMT_SHM_PATH, &st);
+	if (ret) {
+		*shared_mem_size = 0;
+		return 0;
+	}
+
+	*shared_mem_size = st.st_size;
+
+	/* First 4 bytes of shared file is the magic */
+	ret = read_file(HSAKMT_SHM_PATH, shared_mem_magic, sizeof(*shared_mem_magic));
+	if (ret)
+		pr_perror("amdgpu_plugin: Failed to read shared mem magic");
+	else
+		plugin_log_msg("amdgpu_plugin: Shared mem magic:0x%x\n", *shared_mem_magic);
+
+	return 0;
+}
+
+int restore_hsakmt_shared_mem(const uint64_t shared_mem_size, const uint32_t shared_mem_magic)
+{
+	int ret, fd;
+	struct stat st;
+	sem_t *sem = SEM_FAILED;
+
+	if (!shared_mem_size)
+		return 0;
+
+	if (!stat(HSAKMT_SHM_PATH, &st)) {
+		pr_debug("amdgpu_plugin: %s already exists\n", HSAKMT_SHM_PATH);
+	} else {
+		pr_info("Warning:%s was missing. Re-creating new file but we may lose perf counters\n",
+			HSAKMT_SHM_PATH);
+		fd = shm_open(HSAKMT_SHM, O_CREAT | O_RDWR, 0666);
+
+		ret = ftruncate(fd, shared_mem_size);
+		if (ret < 0) {
+			pr_err("amdgpu_plugin: Failed to truncate shared mem %s\n", HSAKMT_SHM);
+			close(fd);
+			return -errno;
+		}
+
+		ret = write(fd, &shared_mem_magic, sizeof(shared_mem_magic));
+		if (ret != sizeof(shared_mem_magic)) {
+			pr_perror("amdgpu_plugin: Failed to restore shared mem magic");
+			close(fd);
+			return -errno;
+		}
+
+		close(fd);
+	}
+
+	sem = sem_open(HSAKMT_SEM, O_CREAT, 0666, 1);
+	if (sem == SEM_FAILED) {
+		pr_perror("Failed to create %s", HSAKMT_SEM);
+		return -EACCES;
+	}
+	sem_close(sem);
+	return 0;
+}
+
 static int init_dumper_args(struct kfd_ioctl_criu_dumper_args *args, __u32 type, __u64 index_start, __u64 num_objects,
 			    __u64 objects_size)
 {
@@ -1266,6 +1336,10 @@ int amdgpu_plugin_dump_file(int fd, int id)
 		goto exit;
 
 	ret = dump_events(fd, &info_args, e);
+	if (ret)
+		goto exit;
+
+	ret = check_hsakmt_shared_mem(&e->shared_mem_size, &e->shared_mem_magic);
 	if (ret)
 		goto exit;
 
@@ -1818,6 +1892,8 @@ int amdgpu_plugin_restore_file(int id)
 	ret = restore_events(fd, e);
 	if (ret)
 		goto exit;
+
+	ret = restore_hsakmt_shared_mem(e->shared_mem_size, e->shared_mem_magic);
 
 exit:
 	sys_close_drm_render_devices(&dest_topology);

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -53,6 +53,8 @@ struct vma_metadata {
 	uint64_t old_pgoff;
 	uint64_t new_pgoff;
 	uint64_t vma_entry;
+	uint32_t new_minor;
+	int fd;
 };
 
 /************************************ Global Variables ********************************************/
@@ -64,31 +66,6 @@ struct device_maps restore_maps;
 
 static LIST_HEAD(update_vma_info_list);
 /**************************************************************************************************/
-
-int open_drm_render_device(int minor)
-{
-	char path[128];
-	int fd;
-
-	if (minor < DRM_FIRST_RENDER_NODE || minor > DRM_LAST_RENDER_NODE) {
-		pr_perror("DRM render minor %d out of range [%d, %d]", minor, DRM_FIRST_RENDER_NODE,
-			  DRM_LAST_RENDER_NODE);
-		return -EINVAL;
-	}
-
-	sprintf(path, "/dev/dri/renderD%d", minor);
-	fd = open(path, O_RDWR | O_CLOEXEC);
-	if (fd < 0) {
-		if (errno != ENOENT && errno != EPERM) {
-			pr_err("Failed to open %s: %s\n", path, strerror(errno));
-			if (errno == EACCES)
-				pr_err("Check user is in \"video\" group\n");
-		}
-		return -EBADFD;
-	}
-
-	return fd;
-}
 
 int write_file(const char *file_path, const void *buf, const size_t buf_len)
 {
@@ -348,7 +325,9 @@ int topology_to_devinfo(struct tp_system *sys, struct device_maps *maps, DeviceE
 		devinfo->node_id = node->id;
 
 		if (NODE_IS_GPU(node)) {
-			devinfo->gpu_id = node->gpu_id;
+			devinfo->gpu_id = maps_get_dest_gpu(&checkpoint_maps, node->gpu_id);
+			if (!devinfo->gpu_id)
+				return -EINVAL;
 
 			devinfo->simd_count = node->simd_count;
 			devinfo->mem_banks_count = node->mem_banks_count;
@@ -469,12 +448,19 @@ int amdgpu_plugin_init(int stage)
 
 	topology_init(&src_topology);
 	topology_init(&dest_topology);
+
+	maps_init(&checkpoint_maps);
+	maps_init(&restore_maps);
+
 	return 0;
 }
 
 void amdgpu_plugin_fini(int stage, int ret)
 {
 	pr_info("amdgpu_plugin: finished  %s (AMDGPU/KFD)\n", CR_PLUGIN_DESC.name);
+
+	maps_free(&checkpoint_maps);
+	maps_free(&restore_maps);
 
 	topology_free(&src_topology);
 	topology_free(&dest_topology);
@@ -645,6 +631,15 @@ static int dump_devices(int fd, struct kfd_ioctl_criu_process_info_args *info_ar
 	/* First private data starts after all buckets */
 	priv_data = (void *)(device_buckets + args.num_objects);
 
+	/* When checkpointing on a node where there was already a checkpoint-restore before, the
+	 * user_gpu_id and actual_gpu_id will be different.
+	 *
+	 * We store the user_gpu_id in the stored image files so that the stored images always have
+	 * the gpu_id's of the node where the application was first launched.
+	 */
+	for (int i = 0; i < args.num_objects; i++)
+		maps_add_gpu_entry(&checkpoint_maps, device_buckets[i].actual_gpu_id, device_buckets[i].user_gpu_id);
+
 	e->num_of_gpus = info_args->total_devices;
 	e->num_of_cpus = src_topology.num_nodes - info_args->total_devices;
 
@@ -666,21 +661,28 @@ static int dump_devices(int fd, struct kfd_ioctl_criu_process_info_args *info_ar
 
 	/* Add private data obtained from IOCTL for each GPU */
 	for (i = 0; i < args.num_objects; i++) {
+		int j;
 		struct kfd_criu_device_bucket *device_bucket = &device_buckets[i];
-		DeviceEntry *devinfo = e->device_entries[i];
+		pr_debug("Device[%d] user_gpu_id:%x actual_gpu_id:%x\n", i, device_bucket->user_gpu_id,
+			 device_bucket->actual_gpu_id);
 
-		pr_debug("Device[%d] user_gpu_id:%x\n", i, device_bucket->user_gpu_id);
+		for (j = 0; j < src_topology.num_nodes; j++) {
+			DeviceEntry *devinfo = e->device_entries[j];
 
-		devinfo->private_data.len = device_bucket->priv_data_size;
-		devinfo->private_data.data = xmalloc(devinfo->private_data.len);
+			if (device_bucket->user_gpu_id != devinfo->gpu_id)
+				continue;
 
-		if (!devinfo->private_data.data) {
-			ret = -ENOMEM;
-			goto exit;
+			devinfo->private_data.len = device_bucket->priv_data_size;
+			devinfo->private_data.data = xmalloc(devinfo->private_data.len);
+
+			if (!devinfo->private_data.data) {
+				ret = -ENOMEM;
+				goto exit;
+			}
+
+			memcpy(devinfo->private_data.data, priv_data + device_bucket->priv_data_offset,
+			       devinfo->private_data.len);
 		}
-
-		memcpy(devinfo->private_data.data, priv_data + device_bucket->priv_data_offset,
-		       devinfo->private_data.len);
 	}
 exit:
 	xfree((void *)args.objects);
@@ -693,10 +695,8 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 	struct kfd_ioctl_criu_dumper_args args = { 0 };
 	struct kfd_criu_bo_bucket *bo_buckets;
 	uint8_t *priv_data;
-	char fd_path[128];
 	int ret = 0, i;
 	char *fname;
-	int drm_fd;
 
 	pr_debug("Dumping %lld BOs\n", info_args->total_bos);
 
@@ -723,13 +723,6 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 		goto exit;
 	}
 
-	sprintf(fd_path, "/dev/dri/renderD%d", DRM_FIRST_RENDER_NODE);
-	drm_fd = open(fd_path, O_RDWR | O_CLOEXEC);
-	if (drm_fd < 0) {
-		pr_perror("amdgpu_plugin: failed to open drm fd for %s", fd_path);
-		return -1;
-	}
-
 	for (i = 0; i < args.num_objects; i++) {
 		struct kfd_criu_bo_bucket *bo_bucket = &bo_buckets[i];
 		BoEntry *boinfo = e->bo_entries[i];
@@ -746,7 +739,11 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 		plugin_log_msg("BO [%d] gpu_id:%x addr:%llx size:%llx offset:%llx dmabuf_fd:%d\n", i, bo_bucket->gpu_id,
 			       bo_bucket->addr, bo_bucket->size, bo_bucket->offset, bo_bucket->dmabuf_fd);
 
-		boinfo->gpu_id = bo_bucket->gpu_id;
+		boinfo->gpu_id = maps_get_dest_gpu(&checkpoint_maps, bo_bucket->gpu_id);
+		if (!boinfo->gpu_id) {
+			ret = -ENODEV;
+			goto exit;
+		}
 		boinfo->addr = bo_bucket->addr;
 		boinfo->size = bo_bucket->size;
 		boinfo->offset = bo_bucket->offset;
@@ -755,9 +752,19 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 		if (bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM ||
 		    bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
 			if (bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC) {
+				int drm_fd;
 				void *addr;
+				struct tp_node *tp_node;
 
-				pr_info("amdgpu_plugin: large bar read possible\n");
+				plugin_log_msg("amdgpu_plugin: large bar read possible\n");
+
+				tp_node = sys_get_node_by_gpu_id(&src_topology, boinfo->gpu_id);
+				if (!tp_node) {
+					ret = -ENODEV;
+					goto exit;
+				}
+
+				drm_fd = node_get_drm_render_device(tp_node);
 
 				addr = mmap(NULL, boinfo->size, PROT_READ, MAP_SHARED, drm_fd, boinfo->offset);
 				if (addr == MAP_FAILED) {
@@ -773,7 +780,7 @@ static int dump_bos(int fd, struct kfd_ioctl_criu_process_info_args *info_args, 
 				size_t bo_size;
 				int mem_fd;
 
-				pr_info("Now try reading BO contents with /proc/pid/mem\n");
+				plugin_log_msg("Now try reading BO contents with /proc/pid/mem\n");
 				if (asprintf(&fname, PROCPIDMEM, info_args->task_pid) < 0) {
 					pr_perror("failed in asprintf, %s", fname);
 					ret = -1;
@@ -857,7 +864,11 @@ static int dump_queues(int fd, struct kfd_ioctl_criu_process_info_args *info_arg
 
 		pr_debug("Queue [%d] gpu_id:%x\n", i, q_bucket->gpu_id);
 
-		qinfo->gpu_id = q_bucket->gpu_id;
+		qinfo->gpu_id = maps_get_dest_gpu(&checkpoint_maps, q_bucket->gpu_id);
+		if (!qinfo->gpu_id) {
+			ret = -ENODEV;
+			goto exit;
+		}
 
 		qinfo->private_data.len = q_bucket->priv_data_size;
 		qinfo->private_data.data = xmalloc(qinfo->private_data.len);
@@ -916,8 +927,13 @@ static int dump_events(int fd, struct kfd_ioctl_criu_process_info_args *info_arg
 
 		pr_debug("Event[%d] gpu_id:%x\n", i, ev_bucket->gpu_id);
 
-		if (ev_bucket->gpu_id)
-			evinfo->gpu_id = ev_bucket->gpu_id;
+		if (ev_bucket->gpu_id) {
+			evinfo->gpu_id = maps_get_dest_gpu(&checkpoint_maps, ev_bucket->gpu_id);
+			if (!evinfo->gpu_id) {
+				ret = -ENODEV;
+				goto exit;
+			}
+		}
 
 		evinfo->private_data.len = ev_bucket->priv_data_size;
 		evinfo->private_data.data = xmalloc(evinfo->private_data.len);
@@ -968,17 +984,24 @@ int amdgpu_plugin_dump_file(int fd, int id)
 
 	/* Check whether this plugin was called for kfd or render nodes */
 	if (major(st.st_rdev) != major(st_kfd.st_rdev) || minor(st.st_rdev) != 0) {
-		/* This is RenderD dumper plugin, for now just save renderD
-		 * minor number to be used during restore. In later phases this
-		 * needs to save more data for video decode etc.
-		 */
+		/* This is RenderD dumper plugin, save the render minor and gpu_id */
 
 		CriuRenderNode rd = CRIU_RENDER_NODE__INIT;
+		struct tp_node *tp_node;
 
 		pr_info("amdgpu_plugin: Dumper called for /dev/dri/renderD%d, FD = %d, ID = %d\n", minor(st.st_rdev),
 			fd, id);
 
-		rd.minor_number = minor(st.st_rdev);
+		tp_node = sys_get_node_by_render_minor(&src_topology, minor(st.st_rdev));
+		if (!tp_node) {
+			pr_err("amdgpu_plugin: Failed to find a device with minor number = %d\n", minor(st.st_rdev));
+
+			return -ENODEV;
+		}
+
+		rd.gpu_id = maps_get_dest_gpu(&checkpoint_maps, tp_node->gpu_id);
+		if (!rd.gpu_id)
+			return -ENODEV;
 
 		len = criu_render_node__get_packed_size(&rd);
 		buf = xmalloc(len);
@@ -994,8 +1017,8 @@ int amdgpu_plugin_dump_file(int fd, int id)
 			return ret;
 		}
 
-		xfree(buf);
 		/* Need to return success here so that criu can call plugins for renderD nodes */
+		xfree(buf);
 		return ret;
 	}
 
@@ -1066,6 +1089,7 @@ exit:
 	/* Restore all queues */
 	pause_process(fd, false);
 
+	sys_close_drm_render_devices(&src_topology);
 	free_e(e);
 
 	if (ret)
@@ -1142,6 +1166,7 @@ static int restore_devices(int fd, CriuKfd *e)
 	for (int entries_i = 0; entries_i < e->num_of_cpus + e->num_of_gpus; entries_i++) {
 		struct kfd_criu_device_bucket *device_bucket;
 		DeviceEntry *devinfo = e->device_entries[entries_i];
+		struct tp_node *tp_node;
 
 		if (!devinfo->gpu_id)
 			continue;
@@ -1157,8 +1182,19 @@ static int restore_devices(int fd, CriuKfd *e)
 		       device_bucket->priv_data_size);
 
 		device_bucket->user_gpu_id = devinfo->gpu_id;
+		device_bucket->actual_gpu_id = maps_get_dest_gpu(&restore_maps, devinfo->gpu_id);
+		if (!device_bucket->actual_gpu_id) {
+			ret = -ENODEV;
+			goto exit;
+		}
 
-		device_bucket->drm_fd = open_drm_render_device(bucket_index + DRM_FIRST_RENDER_NODE);
+		tp_node = sys_get_node_by_gpu_id(&dest_topology, device_bucket->actual_gpu_id);
+		if (!tp_node) {
+			ret = -ENODEV;
+			goto exit;
+		}
+
+		device_bucket->drm_fd = node_get_drm_render_device(tp_node);
 		if (device_bucket->drm_fd < 0) {
 			pr_perror("amdgpu_plugin: Can't pass NULL drm render fd to driver");
 			fd = -EBADFD;
@@ -1172,11 +1208,6 @@ static int restore_devices(int fd, CriuKfd *e)
 	if (ret) {
 		pr_perror("amdgpu_plugin: Failed to call restorer (devices) ioctl");
 		goto exit;
-	}
-
-	for (int i = 0; i < e->num_of_gpus; i++) {
-		if (device_buckets[i].drm_fd >= 0)
-			close(device_buckets[i].drm_fd);
 	}
 exit:
 
@@ -1195,7 +1226,6 @@ static int restore_bos(int fd, CriuKfd *e)
 	int ret = 0;
 	char *fname;
 	void *addr;
-	int drm_fd;
 
 	pr_debug("Restoring %ld BOs\n", e->num_of_bos);
 
@@ -1219,7 +1249,12 @@ static int restore_bos(int fd, CriuKfd *e)
 
 		memcpy(priv_data + bo_bucket->priv_data_offset, bo_entry->private_data.data, bo_bucket->priv_data_size);
 
-		bo_bucket->gpu_id = bo_entry->gpu_id;
+		bo_bucket->gpu_id = maps_get_dest_gpu(&restore_maps, bo_entry->gpu_id);
+		if (!bo_bucket->gpu_id) {
+			ret = -ENODEV;
+			goto exit;
+		}
+
 		bo_bucket->addr = bo_entry->addr;
 		bo_bucket->size = bo_entry->size;
 		bo_bucket->offset = bo_entry->offset;
@@ -1235,24 +1270,37 @@ static int restore_bos(int fd, CriuKfd *e)
 		goto exit;
 	}
 
-	/* This only works for single-gpu, need to fix for multi-gpu */
-	drm_fd = open_drm_render_device(DRM_FIRST_RENDER_NODE);
-
 	for (int i = 0; i < args.num_objects; i++) {
 		struct kfd_criu_bo_bucket *bo_bucket = &bo_buckets[i];
 		BoEntry *bo_entry = e->bo_entries[i];
+
+		struct tp_node *tp_node;
 
 		if (bo_bucket->alloc_flags & (KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_GTT |
 					      KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP | KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL)) {
 			struct vma_metadata *vma_md;
 
 			vma_md = xmalloc(sizeof(*vma_md));
-			if (!vma_md)
-				return -ENOMEM;
+			if (!vma_md) {
+				ret = -ENOMEM;
+				goto exit;
+			}
+
+			memset(vma_md, 0, sizeof(*vma_md));
 
 			vma_md->old_pgoff = bo_bucket->offset;
 			vma_md->vma_entry = bo_bucket->addr;
+
+			tp_node = sys_get_node_by_gpu_id(&dest_topology, bo_bucket->gpu_id);
+			if (!tp_node) {
+				pr_err("Failed to find node with gpu_id:0x%04x\n", bo_bucket->gpu_id);
+				ret = -ENODEV;
+				goto exit;
+			}
+
+			vma_md->new_minor = tp_node->drm_render_minor;
 			vma_md->new_pgoff = bo_bucket->restored_offset;
+			vma_md->fd = node_get_drm_render_device(tp_node);
 
 			plugin_log_msg("amdgpu_plugin: adding vma_entry:addr:0x%lx old-off:0x%lx "
 				       "new_off:0x%lx new_minor:%d\n",
@@ -1262,7 +1310,9 @@ static int restore_bos(int fd, CriuKfd *e)
 		}
 
 		if (bo_bucket->alloc_flags & (KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_GTT)) {
-			pr_info("amdgpu_plugin: Trying mmap in stage 2\n");
+			int drm_fd = node_get_drm_render_device(tp_node);
+
+			plugin_log_msg("amdgpu_plugin: Trying mmap in stage 2\n");
 			if (bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC ||
 			    bo_bucket->alloc_flags & KFD_IOC_ALLOC_MEM_FLAGS_GTT) {
 				plugin_log_msg("amdgpu_plugin: large bar write possible\n");
@@ -1376,7 +1426,12 @@ static int restore_queues(int fd, CriuKfd *e)
 
 		memcpy(priv_data + q_bucket->priv_data_offset, qinfo->private_data.data, q_bucket->priv_data_size);
 
-		q_bucket->gpu_id = qinfo->gpu_id;
+		q_bucket->gpu_id = maps_get_dest_gpu(&restore_maps, qinfo->gpu_id);
+		if (!q_bucket->gpu_id) {
+			ret = -ENODEV;
+			goto exit;
+		}
+
 		pr_debug("Queue [%d] gpu_id:%x\n", i, q_bucket->gpu_id);
 	}
 
@@ -1426,8 +1481,13 @@ static int restore_events(int fd, CriuKfd *e)
 
 		memcpy(priv_data + ev_bucket->priv_data_offset, evinfo->private_data.data, ev_bucket->priv_data_size);
 
-		if (evinfo->gpu_id)
-			ev_bucket->gpu_id = evinfo->gpu_id;
+		if (evinfo->gpu_id) {
+			ev_bucket->gpu_id = maps_get_dest_gpu(&restore_maps, evinfo->gpu_id);
+			if (!ev_bucket->gpu_id) {
+				ret = -ENODEV;
+				goto exit;
+			}
+		}
 
 		plugin_log_msg("Event [%d] gpu_id:%x\n", i, ev_bucket->gpu_id);
 	}
@@ -1458,13 +1518,14 @@ int amdgpu_plugin_restore_file(int id)
 	snprintf(img_path, sizeof(img_path), "kfd.%d.img", id);
 
 	if (stat(img_path, &filestat) == -1) {
+		struct tp_node *tp_node;
+		uint32_t target_gpu_id;
+
 		pr_perror("open(%s)", img_path);
-		/* This is restorer plugin for renderD nodes. Since criu doesn't
-		 * gurantee that they will be called before the plugin is called
-		 * for kfd file descriptor, we need to make sure we open the render
-		 * nodes only once and before /dev/kfd is open, the render nodes
-		 * are open too. Generally, it is seen that during checkpoint and
-		 * restore both, the kfd plugin gets called first.
+		/* This is restorer plugin for renderD nodes. Criu doesn't guarantee that they will
+		 * be called before the plugin is called for kfd file descriptor.
+		 * TODO: Currently, this code will only work if this function is called for /dev/kfd
+		 * first as we assume restore_maps is already filled. Need to fix this later.
 		 */
 		snprintf(img_path, sizeof(img_path), "renderDXXX.%d.img", id);
 
@@ -1493,8 +1554,26 @@ int amdgpu_plugin_restore_file(int id)
 			return -1;
 		}
 
-		pr_info("amdgpu_plugin: render node minor num = %d\n", rd->minor_number);
-		fd = open_drm_render_device(rd->minor_number);
+		pr_info("amdgpu_plugin: render node gpu_id = 0x%04x\n", rd->gpu_id);
+
+		target_gpu_id = maps_get_dest_gpu(&restore_maps, rd->gpu_id);
+		if (!target_gpu_id) {
+			fd = -ENODEV;
+			goto fail;
+		}
+
+		tp_node = sys_get_node_by_gpu_id(&dest_topology, target_gpu_id);
+		if (!tp_node) {
+			fd = -ENODEV;
+			goto fail;
+		}
+
+		pr_info("amdgpu_plugin: render node destination gpu_id = 0x%04x\n", tp_node->gpu_id);
+
+		fd = node_get_drm_render_device(tp_node);
+		if (fd < 0)
+			pr_err("amdgpu_plugin: Failed to open render device (minor:%d)\n", tp_node->drm_render_minor);
+	fail:
 		criu_render_node__free_unpacked(rd, NULL);
 		xfree(buf);
 		return fd;
@@ -1543,6 +1622,12 @@ int amdgpu_plugin_restore_file(int id)
 		goto exit;
 	}
 
+	ret = set_restore_gpu_maps(&src_topology, &dest_topology, &restore_maps);
+	if (ret) {
+		pr_err("Failed to map GPUs\n");
+		goto exit;
+	}
+
 	ret = restore_process(fd, e);
 	if (ret)
 		goto exit;
@@ -1564,6 +1649,8 @@ int amdgpu_plugin_restore_file(int id)
 		goto exit;
 
 exit:
+	sys_close_drm_render_devices(&dest_topology);
+
 	if (e)
 		criu_kfd__free_unpacked(e, NULL);
 
@@ -1582,25 +1669,55 @@ CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESTORE_EXT_FILE, amdgpu_plugin_restore_
  * return -1 for error.
  * return 1 if vmap map must be adjusted.
  */
-int amdgpu_plugin_update_vmamap(const char *path, const uint64_t addr, const uint64_t old_offset, uint64_t *new_offset,
-				int *updated_fd)
+int amdgpu_plugin_update_vmamap(const char *in_path, const uint64_t addr, const uint64_t old_offset,
+				uint64_t *new_offset, int *updated_fd)
 {
 	struct vma_metadata *vma_md;
+	char path[PATH_MAX];
+	char *p_begin;
+	char *p_end;
+	bool is_kfd = false, is_renderD = false;
 
 	plugin_log_msg("amdgpu_plugin: Enter %s\n", __func__);
 
+	strncpy(path, in_path, sizeof(path));
+
+	p_begin = path;
+	p_end = p_begin + strlen(path);
+
 	/*
-	 * On newer versions of AMD KFD driver, only the file descriptor that was used to open the
-	 * device can be used for mmap, so we will have to return the proper file descriptor here
+	 * Paths sometimes have double forward slashes (e.g //dev/dri/renderD*)
+	 * replace all '//' with '/'.
 	 */
-	*updated_fd = -1;
+	while (p_begin < p_end - 1) {
+		if (*p_begin == '/' && *(p_begin + 1) == '/')
+			memmove(p_begin, p_begin + 1, p_end - p_begin);
+		else
+			p_begin++;
+	}
+
+	if (!strncmp(path, "/dev/dri/renderD", strlen("/dev/dri/renderD")))
+		is_renderD = true;
+
+	if (!strcmp(path, AMDGPU_KFD_DEVICE))
+		is_kfd = true;
+
+	if (!is_renderD && !is_kfd) {
+		pr_info("Skipping unsupported path:%s addr:%lx old_offset:%lx\n", in_path, addr, old_offset);
+		return 0;
+	}
 
 	list_for_each_entry(vma_md, &update_vma_info_list, list) {
 		if (addr == vma_md->vma_entry && old_offset == vma_md->old_pgoff) {
 			*new_offset = vma_md->new_pgoff;
 
-			plugin_log_msg("amdgpu_plugin: old_pgoff= 0x%lx new_pgoff = 0x%lx path = %s\n",
-				       vma_md->old_pgoff, vma_md->new_pgoff, path);
+			if (is_renderD)
+				*updated_fd = vma_md->fd;
+			else
+				*updated_fd = -1;
+
+			plugin_log_msg("amdgpu_plugin: old_pgoff=0x%lx new_pgoff=0x%lx fd=%d\n", vma_md->old_pgoff,
+				       vma_md->new_pgoff, *updated_fd);
 
 			return 1;
 		}

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -149,6 +149,17 @@ struct tp_node *sys_get_node_by_render_minor(const struct tp_system *sys, const 
 	return NULL;
 }
 
+struct tp_node *sys_get_node_by_index(const struct tp_system *sys, uint32_t index)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		if (NODE_IS_GPU(node) && index-- == 0)
+			return node;
+	}
+	return NULL;
+}
+
 struct tp_node *sys_get_node_by_gpu_id(const struct tp_system *sys, const uint32_t gpu_id)
 {
 	struct tp_node *node;

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -24,6 +24,19 @@
 #define _GNU_SOURCE 1
 #endif
 
+#ifdef COMPILE_TESTS
+#undef pr_err
+#define pr_err(format, arg...) fprintf(stdout, "%s:%d ERROR:" format, __FILE__, __LINE__, ##arg)
+#undef pr_info
+#define pr_info(format, arg...) fprintf(stdout, "%s:%d INFO:" format, __FILE__, __LINE__, ##arg)
+#undef pr_debug
+#define pr_debug(format, arg...) fprintf(stdout, "%s:%d DBG:" format, __FILE__, __LINE__, ##arg)
+
+#undef pr_perror
+#define pr_perror(format, arg...) \
+	fprintf(stdout, "%s:%d: " format " (errno = %d (%s))\n", __FILE__, __LINE__, ##arg, errno, strerror(errno))
+#endif
+
 #ifdef DEBUG
 #define plugin_log_msg(fmt, ...) pr_debug(fmt, ##__VA_ARGS__)
 #else
@@ -34,17 +47,17 @@
 
 /* User override options */
 /* Skip firmware version check */
-bool kfd_fw_version_check;
+bool kfd_fw_version_check = true;
 /* Skip SDMA firmware version check */
-bool kfd_sdma_fw_version_check;
+bool kfd_sdma_fw_version_check = true;
 /* Skip caches count check */
-bool kfd_caches_count_check;
+bool kfd_caches_count_check = true;
 /* Skip num gws check */
-bool kfd_num_gws_check;
+bool kfd_num_gws_check = true;
 /* Skip vram size check */
-bool kfd_vram_size_check;
+bool kfd_vram_size_check = true;
 /* Preserve NUMA regions */
-bool kfd_numa_check;
+bool kfd_numa_check = true;
 
 static int open_drm_render_device(int minor)
 {

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -1,0 +1,774 @@
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <linux/limits.h>
+
+#include <dirent.h>
+#include "common/list.h"
+
+#include "xmalloc.h"
+#include "kfd_ioctl.h"
+#include "amdgpu_plugin_topology.h"
+
+#define TOPOLOGY_PATH "/sys/class/kfd/kfd/topology/nodes/"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
+#ifdef DEBUG
+#define plugin_log_msg(fmt, ...) pr_debug(fmt, ##__VA_ARGS__)
+#else
+#define plugin_log_msg(fmt, ...) \
+	{                        \
+	}
+#endif
+
+static const char *link_type(uint32_t type)
+{
+	switch (type) {
+	case TOPO_IOLINK_TYPE_PCIE:
+		return "PCIe";
+	case TOPO_IOLINK_TYPE_XGMI:
+		return "XGMI";
+	}
+	return "Unsupported";
+}
+
+static struct tp_node *p2pgroup_get_node_by_gpu_id(const struct tp_p2pgroup *group, const uint32_t gpu_id)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &group->nodes, listm_p2pgroup) {
+		if (node->gpu_id == gpu_id)
+			return node;
+	}
+	return NULL;
+}
+
+struct tp_node *sys_get_node_by_render_minor(const struct tp_system *sys, const int drm_render_minor)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		if (node->drm_render_minor == drm_render_minor)
+			return node;
+	}
+	return NULL;
+}
+
+struct tp_node *sys_get_node_by_gpu_id(const struct tp_system *sys, const uint32_t gpu_id)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		if (node->gpu_id == gpu_id)
+			return node;
+	}
+	return NULL;
+}
+
+static struct tp_node *sys_get_node_by_node_id(const struct tp_system *sys, const uint32_t node_id)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		if (node->id == node_id)
+			return node;
+	}
+	return NULL;
+}
+
+static struct tp_p2pgroup *sys_get_p2pgroup_with_gpu_id(const struct tp_system *sys, const int type,
+							const uint32_t gpu_id)
+{
+	struct tp_p2pgroup *p2pgroup;
+
+	list_for_each_entry(p2pgroup, &sys->xgmi_groups, listm_system) {
+		if (p2pgroup->type != type)
+			continue;
+
+		if (p2pgroup_get_node_by_gpu_id(p2pgroup, gpu_id))
+			return p2pgroup;
+	}
+	return NULL;
+}
+
+static struct tp_iolink *get_tp_peer_iolink(const struct tp_node *from_node, const struct tp_node *to_node,
+					    const uint8_t type)
+{
+	struct tp_iolink *iolink;
+
+	list_for_each_entry(iolink, &from_node->iolinks, listm) {
+		if (iolink->node_to_id == to_node->id && iolink->type == type)
+			return iolink;
+	}
+	return NULL;
+}
+
+uint32_t maps_get_dest_gpu(const struct device_maps *maps, const uint32_t src_id)
+{
+	struct id_map *id_map;
+
+	list_for_each_entry(id_map, &maps->gpu_maps, listm) {
+		if (id_map->src == src_id)
+			return id_map->dest;
+	}
+	return 0;
+}
+
+struct id_map *maps_add_gpu_entry(struct device_maps *maps, const uint32_t src_id, const uint32_t dest_id)
+{
+	struct id_map *id_map = xzalloc(sizeof(*id_map));
+
+	if (!id_map) {
+		pr_err("Failed to allocate memory for id_map\n");
+		return NULL;
+	}
+
+	id_map->src = src_id;
+	id_map->dest = dest_id;
+
+	list_add_tail(&id_map->listm, &maps->gpu_maps);
+
+	maps->tail_gpu = &id_map->listm;
+
+	pr_debug("Added GPU mapping [0x%04X -> 0x%04X]\n", src_id, dest_id);
+	return id_map;
+}
+
+void maps_init(struct device_maps *maps)
+{
+	INIT_LIST_HEAD(&maps->cpu_maps);
+	INIT_LIST_HEAD(&maps->gpu_maps);
+	maps->tail_cpu = 0;
+	maps->tail_gpu = 0;
+}
+
+void maps_free(struct device_maps *maps)
+{
+	while (!list_empty(&maps->cpu_maps)) {
+		struct id_map *map = list_first_entry(&maps->cpu_maps, struct id_map, listm);
+
+		list_del(&map->listm);
+		xfree(map);
+	}
+	while (!list_empty(&maps->gpu_maps)) {
+		struct id_map *map = list_first_entry(&maps->gpu_maps, struct id_map, listm);
+
+		list_del(&map->listm);
+		xfree(map);
+	}
+}
+
+struct tp_iolink *node_add_iolink(struct tp_node *node, uint32_t type, uint32_t node_to_id)
+{
+	struct tp_iolink *iolink = xzalloc(sizeof(*iolink));
+
+	if (!iolink)
+		return NULL;
+
+	iolink->type = type;
+	/* iolink->node_to will be filled in topology_determine_iolinks */
+	iolink->node_to_id = node_to_id;
+	iolink->node_from = node;
+
+	list_add_tail(&iolink->listm, &node->iolinks);
+	return iolink;
+}
+
+struct tp_p2pgroup *sys_add_group(struct tp_system *sys, uint32_t type)
+{
+	struct tp_p2pgroup *group;
+
+	group = xzalloc(sizeof(*group));
+	if (!group)
+		return NULL;
+
+	INIT_LIST_HEAD(&group->nodes);
+	group->type = type;
+	list_add_tail(&group->listm_system, &sys->xgmi_groups);
+	if (type == TOPO_IOLINK_TYPE_XGMI)
+		sys->num_xgmi_groups++;
+
+	return group;
+}
+
+struct tp_node *sys_add_node(struct tp_system *sys, uint32_t id, uint32_t gpu_id)
+{
+	struct tp_node *node = NULL;
+
+	node = xzalloc(sizeof(*node));
+	if (!node)
+		return NULL;
+
+	node->id = id;
+	node->gpu_id = gpu_id;
+	INIT_LIST_HEAD(&node->iolinks);
+	list_add_tail(&node->listm_system, &sys->nodes);
+	sys->num_nodes++;
+
+	return node;
+}
+
+static bool get_prop(char *line, char *name, uint64_t *value)
+{
+	if (sscanf(line, " %29s %lu", name, value) != 2)
+		return false;
+	return true;
+}
+
+/* Parse node properties in /sys/class/kfd/kfd/topology/nodes/N/properties */
+static int parse_topo_node_properties(struct tp_node *dev, const char *dir_path)
+{
+	FILE *file;
+	char path[300];
+	char line[300];
+
+	sprintf(path, "%s/properties", dir_path);
+	file = fopen(path, "r");
+	if (!file) {
+		pr_perror("Failed to access %s", path);
+		return -EFAULT;
+	}
+
+	while (fgets(line, sizeof(line), file)) {
+		char name[30];
+		uint64_t value;
+
+		memset(name, 0, sizeof(name));
+		if (!get_prop(line, name, &value))
+			goto fail;
+
+		if (!strcmp(name, "cpu_cores_count"))
+			dev->cpu_cores_count = (uint32_t)value;
+		else if (!strcmp(name, "simd_count"))
+			dev->simd_count = (uint32_t)value;
+		else if (!strcmp(name, "mem_banks_count"))
+			dev->mem_banks_count = (uint32_t)value;
+		else if (!strcmp(name, "caches_count"))
+			dev->caches_count = (uint32_t)value;
+		else if (!strcmp(name, "io_links_count"))
+			dev->io_links_count = (uint32_t)value;
+		else if (!strcmp(name, "max_waves_per_simd"))
+			dev->max_waves_per_simd = (uint32_t)value;
+		else if (!strcmp(name, "lds_size_in_kb"))
+			dev->lds_size_in_kb = (uint32_t)value;
+		else if (!strcmp(name, "num_gws"))
+			dev->num_gws = (uint32_t)value;
+		else if (!strcmp(name, "wave_front_size"))
+			dev->wave_front_size = (uint32_t)value;
+		else if (!strcmp(name, "array_count"))
+			dev->array_count = (uint32_t)value;
+		else if (!strcmp(name, "simd_arrays_per_engine"))
+			dev->simd_arrays_per_engine = (uint32_t)value;
+		else if (!strcmp(name, "cu_per_simd_array"))
+			dev->cu_per_simd_array = (uint32_t)value;
+		else if (!strcmp(name, "simd_per_cu"))
+			dev->simd_per_cu = (uint32_t)value;
+		else if (!strcmp(name, "max_slots_scratch_cu"))
+			dev->max_slots_scratch_cu = (uint32_t)value;
+		else if (!strcmp(name, "vendor_id"))
+			dev->vendor_id = (uint32_t)value;
+		else if (!strcmp(name, "device_id"))
+			dev->device_id = (uint32_t)value;
+		else if (!strcmp(name, "domain"))
+			dev->domain = (uint32_t)value;
+		else if (!strcmp(name, "drm_render_minor"))
+			dev->drm_render_minor = (uint32_t)value;
+		else if (!strcmp(name, "hive_id"))
+			dev->hive_id = value;
+		else if (!strcmp(name, "num_sdma_engines"))
+			dev->num_sdma_engines = (uint32_t)value;
+		else if (!strcmp(name, "num_sdma_xgmi_engines"))
+			dev->num_sdma_xgmi_engines = (uint32_t)value;
+		else if (!strcmp(name, "num_sdma_queues_per_engine"))
+			dev->num_sdma_queues_per_engine = (uint32_t)value;
+		else if (!strcmp(name, "num_cp_queues"))
+			dev->num_cp_queues = (uint32_t)value;
+		else if (!strcmp(name, "fw_version"))
+			dev->fw_version = (uint32_t)value;
+		else if (!strcmp(name, "capability"))
+			dev->capability = (uint32_t)value;
+		else if (!strcmp(name, "sdma_fw_version"))
+			dev->sdma_fw_version = (uint32_t)value;
+
+		if (!dev->gpu_id && dev->cpu_cores_count >= 1) {
+			/* This is a CPU - we do not need to parse the other information */
+			break;
+		}
+	}
+
+	fclose(file);
+	return 0;
+fail:
+	pr_err("Failed to parse line = %s\n", line);
+	fclose(file);
+	return -EINVAL;
+}
+
+/* Parse node memory properties in /sys/class/kfd/kfd/topology/nodes/N/mem_banks */
+static int parse_topo_node_mem_banks(struct tp_node *node, const char *dir_path)
+{
+	struct dirent *dirent_node;
+	DIR *d_node;
+	char path[300];
+	FILE *file = NULL;
+	uint32_t heap_type = 0;
+	uint64_t mem_size = 0;
+	int ret;
+
+	if (!NODE_IS_GPU(node))
+		return 0;
+
+	sprintf(path, "%s/mem_banks", dir_path);
+
+	d_node = opendir(path);
+	if (!d_node) {
+		pr_perror("Can't open %s", path);
+		return -EACCES;
+	}
+
+	while ((dirent_node = readdir(d_node)) != NULL) {
+		char line[300];
+		char bank_path[1024];
+		struct stat st;
+		int id;
+
+		heap_type = 0;
+		mem_size = 0;
+
+		/* Only parse numeric directories */
+		if (sscanf(dirent_node->d_name, "%d", &id) != 1)
+			continue;
+
+		snprintf(bank_path, sizeof(bank_path), "%s/%s", path, dirent_node->d_name);
+		if (stat(bank_path, &st)) {
+			pr_err("Cannot to access %s\n", path);
+			ret = -EACCES;
+			goto fail;
+		}
+		if ((st.st_mode & S_IFMT) == S_IFDIR) {
+			char properties_path[PATH_MAX];
+
+			snprintf(properties_path, sizeof(properties_path), "%s/properties", bank_path);
+
+			file = fopen(properties_path, "r");
+			if (!file) {
+				pr_perror("Failed to access %s", properties_path);
+				ret = -EACCES;
+				goto fail;
+			}
+
+			while (fgets(line, sizeof(line), file)) {
+				char name[30];
+				uint64_t value;
+
+				memset(name, 0, sizeof(name));
+				if (!get_prop(line, name, &value)) {
+					ret = -EINVAL;
+					goto fail;
+				}
+
+				if (!strcmp(name, "heap_type"))
+					heap_type = (uint32_t)value;
+				if (!strcmp(name, "size_in_bytes"))
+					mem_size = value;
+			}
+
+			fclose(file);
+			file = NULL;
+		}
+
+		if (heap_type == TOPO_HEAP_TYPE_PUBLIC || heap_type == TOPO_HEAP_TYPE_PRIVATE)
+			break;
+	}
+
+	if ((heap_type != TOPO_HEAP_TYPE_PUBLIC && heap_type != TOPO_HEAP_TYPE_PRIVATE) || !mem_size) {
+		pr_err("Failed to determine memory type and size for device in %s\n", dir_path);
+		ret = -EINVAL;
+		goto fail;
+	}
+
+	node->vram_public = (heap_type == TOPO_HEAP_TYPE_PUBLIC);
+	node->vram_size = mem_size;
+	closedir(d_node);
+	return 0;
+fail:
+	if (file)
+		fclose(file);
+	closedir(d_node);
+	return ret;
+}
+
+/* Parse node iolinks properties in /sys/class/kfd/kfd/topology/nodes/N/io_links */
+static int parse_topo_node_iolinks(struct tp_node *node, const char *dir_path)
+{
+	struct dirent *dirent_node;
+	DIR *d_node;
+	char path[300];
+	FILE *file = NULL;
+	int ret = 0;
+
+	snprintf(path, sizeof(path), "%s/io_links", dir_path);
+
+	d_node = opendir(path);
+	if (!d_node) {
+		pr_perror("Can't open %s", path);
+		return -EACCES;
+	}
+
+	while ((dirent_node = readdir(d_node)) != NULL) {
+		char line[300];
+		char iolink_path[1024];
+		struct stat st;
+		int id;
+
+		uint32_t iolink_type = 0;
+		uint32_t node_to_id = 0;
+
+		/* Only parse numeric directories */
+		if (sscanf(dirent_node->d_name, "%d", &id) != 1)
+			continue;
+
+		snprintf(iolink_path, sizeof(iolink_path), "%s/%s", path, dirent_node->d_name);
+		if (stat(iolink_path, &st)) {
+			pr_err("Cannot to access %s\n", path);
+			ret = -EACCES;
+			goto fail;
+		}
+		if ((st.st_mode & S_IFMT) == S_IFDIR) {
+			char properties_path[PATH_MAX];
+
+			snprintf(properties_path, sizeof(properties_path), "%s/properties", iolink_path);
+
+			file = fopen(properties_path, "r");
+			if (!file) {
+				pr_perror("Failed to access %s", properties_path);
+				ret = -EACCES;
+				goto fail;
+			}
+
+			while (fgets(line, sizeof(line), file)) {
+				char name[30];
+				uint64_t value;
+
+				memset(name, 0, sizeof(name));
+				if (!get_prop(line, name, &value)) {
+					ret = -EINVAL;
+					goto fail;
+				}
+
+				if (!strcmp(name, "type"))
+					iolink_type = (uint32_t)value;
+				if (!strcmp(name, "node_to"))
+					node_to_id = (uint32_t)value;
+			}
+			fclose(file);
+			file = NULL;
+		}
+
+		/* We only store the link information for now, then once all topology parsing is
+		 * finished we will confirm iolinks
+		 */
+		if (iolink_type == TOPO_IOLINK_TYPE_PCIE || iolink_type == TOPO_IOLINK_TYPE_XGMI) {
+			if (!node_add_iolink(node, iolink_type, node_to_id)) {
+				ret = -ENOMEM;
+				goto fail;
+			}
+		}
+	}
+	closedir(d_node);
+	return 0;
+fail:
+	if (file)
+		fclose(file);
+
+	closedir(d_node);
+	return ret;
+}
+
+/* Parse a node (CPU or GPU) in /sys/class/kfd/kfd/topology/nodes/N */
+static int parse_topo_node(struct tp_node *node, const char *dir_path)
+{
+	if (parse_topo_node_properties(node, dir_path)) {
+		pr_err("Failed to parse node properties\n");
+		return -EINVAL;
+	}
+	if (parse_topo_node_mem_banks(node, dir_path)) {
+		pr_err("Failed to parse node mem_banks\n");
+		return -EINVAL;
+	}
+	if (parse_topo_node_iolinks(node, dir_path)) {
+		pr_err("Failed to parse node iolinks\n");
+		return -EINVAL;
+	}
+	return 0;
+}
+
+static const char *p2pgroup_to_str(struct tp_p2pgroup *group)
+{
+	static char topology_printstr[200];
+	struct tp_node *node;
+	size_t str_len = 0;
+
+	topology_printstr[0] = '\0';
+	str_len += sprintf(&topology_printstr[str_len], "type:%s:", link_type(group->type));
+
+	list_for_each_entry(node, &group->nodes, listm_p2pgroup) {
+		str_len += sprintf(&topology_printstr[str_len], "0x%04X ", node->gpu_id);
+	}
+	return topology_printstr;
+}
+
+void topology_print(const struct tp_system *sys, const char *message)
+{
+	struct tp_node *node;
+	struct tp_p2pgroup *xgmi_group;
+
+	pr_info("===System Topology=[%12s]==================================\n", message);
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		struct tp_iolink *iolink;
+
+		if (!NODE_IS_GPU(node)) {
+			pr_info("[%d] CPU\n", node->id);
+			pr_info("     cpu_cores_count:%u\n", node->cpu_cores_count);
+		} else {
+			pr_info("[%d] GPU gpu_id:0x%04X\n", node->id, node->gpu_id);
+			pr_info("     vendor_id:%u device_id:%u\n", node->vendor_id, node->device_id);
+			pr_info("     vram_public:%c vram_size:%lu\n", node->vram_public ? 'Y' : 'N', node->vram_size);
+			pr_info("     io_links_count:%u capability:%u\n", node->io_links_count, node->capability);
+			pr_info("     mem_banks_count:%u caches_count:%d lds_size_in_kb:%u\n", node->mem_banks_count,
+				node->caches_count, node->lds_size_in_kb);
+			pr_info("     simd_count:%u max_waves_per_simd:%u\n", node->simd_count,
+				node->max_waves_per_simd);
+			pr_info("     num_gws:%u wave_front_size:%u array_count:%u\n", node->num_gws,
+				node->wave_front_size, node->array_count);
+			pr_info("     simd_arrays_per_engine:%u simd_per_cu:%u\n", node->simd_arrays_per_engine,
+				node->simd_per_cu);
+			pr_info("     max_slots_scratch_cu:%u cu_per_simd_array:%u\n", node->max_slots_scratch_cu,
+				node->cu_per_simd_array);
+			pr_info("     num_sdma_engines:%u\n", node->num_sdma_engines);
+			pr_info("     num_sdma_xgmi_engines:%u num_sdma_queues_per_engine:%u\n",
+				node->num_sdma_xgmi_engines, node->num_sdma_queues_per_engine);
+			pr_info("     num_cp_queues:%u fw_version:%u sdma_fw_version:%u\n", node->num_cp_queues,
+				node->fw_version, node->sdma_fw_version);
+		}
+		list_for_each_entry(iolink, &node->iolinks, listm) {
+			if (!iolink->valid)
+				continue;
+
+			pr_info("     iolink type:%s node-to:%d (0x%04X) node-from:%d bi-dir:%s\n",
+				link_type(iolink->type), iolink->node_to_id, iolink->node_to->gpu_id,
+				iolink->node_from->id, iolink->peer ? "Y" : "N");
+		}
+	}
+
+	pr_info("===Groups==========================================================\n");
+	list_for_each_entry(xgmi_group, &sys->xgmi_groups, listm_system)
+		pr_info("%s\n", p2pgroup_to_str(xgmi_group));
+	pr_info("===================================================================\n");
+}
+
+void topology_init(struct tp_system *sys)
+{
+	memset(sys, 0, sizeof(*sys));
+	INIT_LIST_HEAD(&sys->nodes);
+	INIT_LIST_HEAD(&sys->xgmi_groups);
+}
+
+void topology_free(struct tp_system *sys)
+{
+	while (!list_empty(&sys->nodes)) {
+		struct tp_node *node = list_first_entry(&sys->nodes, struct tp_node, listm_system);
+
+		list_del(&node->listm_system);
+
+		while (!list_empty(&node->iolinks)) {
+			struct tp_iolink *iolink = list_first_entry(&node->iolinks, struct tp_iolink, listm);
+
+			list_del(&iolink->listm);
+			xfree(iolink);
+		}
+		xfree(node);
+	}
+
+	while (!list_empty(&sys->xgmi_groups)) {
+		struct tp_p2pgroup *p2pgroup = list_first_entry(&sys->xgmi_groups, struct tp_p2pgroup, listm_system);
+
+		list_del(&p2pgroup->listm_system);
+		xfree(p2pgroup);
+	}
+}
+
+/**
+ * @brief Validates iolinks and determine XGMI hives in a system topology
+ *
+ * On some systems, some GPUs may not be accessible because they are masked by cgroups, but the
+ * iolinks to these GPUs are still visible. If the peer GPU is not accessible, we consider that link
+ * invalid.
+ * In a XGMI hive, each GPU will have a bi-directional iolink to every other GPU. So we create a
+ * XGMI group (hive) and add all the GPUs in that hive to the group when iterating over the first
+ * GPU in that group.
+ *
+ * @param sys system topology
+ * @return 0 if successful, errno if failed.
+ */
+int topology_determine_iolinks(struct tp_system *sys)
+{
+	int ret = 0;
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		struct tp_iolink *iolink;
+
+		list_for_each_entry(iolink, &node->iolinks, listm) {
+			struct tp_p2pgroup *group = NULL;
+			struct tp_node *peer_node = NULL;
+			struct tp_iolink *peer_iolink = NULL;
+
+			peer_node = sys_get_node_by_node_id(sys, iolink->node_to_id);
+			if (!peer_node) {
+				/* node not accessible, usually because it is masked by cgroups */
+				iolink->valid = false;
+				continue;
+			}
+			iolink->valid = true;
+			node->num_valid_iolinks++;
+
+			iolink->node_to = peer_node;
+			peer_iolink = get_tp_peer_iolink(peer_node, node, iolink->type);
+			if (!peer_iolink)
+				continue; /* This is a one-dir link */
+
+			/* We confirmed both sides have same type of iolink */
+			iolink->peer = peer_iolink;
+			peer_iolink->peer = iolink;
+
+			if (iolink->type == TOPO_IOLINK_TYPE_XGMI) {
+				group = sys_get_p2pgroup_with_gpu_id(sys, iolink->type, node->gpu_id);
+				if (!group) {
+					/* This GPU does not already belong to a group so we create
+					 * a new group
+					 */
+					group = sys_add_group(sys, iolink->type);
+					if (!group) {
+						ret = -ENOMEM;
+						goto fail;
+					}
+					list_add_tail(&node->listm_p2pgroup, &group->nodes);
+				}
+
+				/* Also add peer GPU to this group */
+				if (!p2pgroup_get_node_by_gpu_id(group, peer_node->gpu_id))
+					list_add_tail(&peer_node->listm_p2pgroup, &group->nodes);
+			}
+		}
+	}
+
+fail:
+	/* In case of failure, caller function will call topology_free which will free groups that
+	 * were successfully allocated
+	 */
+	return ret;
+}
+
+/**
+ * @brief Parse system topology
+ *
+ * Parse system topology exposed by the drivers in /sys/class/kfd/kfd/topology and fill in the
+ * system topology structure.
+ *
+ * @param sys system topology structure to be filled by this function
+ * @param message print this message when printing the topology to logs
+ * @return 0 if successful, errno if failed.
+ */
+int topology_parse(struct tp_system *sys, const char *message)
+{
+	struct dirent *dirent_system;
+	DIR *d_system;
+	char path[300];
+	int ret;
+
+	if (sys->parsed)
+		return 0;
+
+	sys->parsed = true;
+	INIT_LIST_HEAD(&sys->nodes);
+	INIT_LIST_HEAD(&sys->xgmi_groups);
+
+	d_system = opendir(TOPOLOGY_PATH);
+	if (!d_system) {
+		pr_perror("Can't open %s", TOPOLOGY_PATH);
+		return -EACCES;
+	}
+
+	while ((dirent_system = readdir(d_system)) != NULL) {
+		struct stat stbuf;
+		int id, fd;
+
+		/* Only parse numeric directories */
+		if (sscanf(dirent_system->d_name, "%d", &id) != 1)
+			continue;
+
+		sprintf(path, "%s%s", TOPOLOGY_PATH, dirent_system->d_name);
+		if (stat(path, &stbuf)) {
+			/* When cgroup is masking some devices, the path exists, but it is not
+			 * accessible, this is not an error
+			 */
+			pr_info("Cannot to access %s\n", path);
+			continue;
+		}
+
+		if ((stbuf.st_mode & S_IFMT) == S_IFDIR) {
+			struct tp_node *node;
+			int len;
+			char gpu_id_path[300];
+			char read_buf[7]; /* Max gpu_id len is 6 chars */
+			unsigned int gpu_id;
+
+			sprintf(gpu_id_path, "%s/%s/gpu_id", TOPOLOGY_PATH, dirent_system->d_name);
+			fd = open(gpu_id_path, O_RDONLY);
+			if (fd < 0) {
+				pr_perror("Failed to access %s", gpu_id_path);
+				continue;
+			}
+
+			len = read(fd, read_buf, sizeof(read_buf) - 1);
+			close(fd);
+			if (len < 0)
+				continue;
+
+			read_buf[len] = '\0';
+
+			if (sscanf(read_buf, "%d", &gpu_id) != 1)
+				continue;
+
+			node = sys_add_node(sys, id, gpu_id);
+			if (!node) {
+				ret = -ENOMEM;
+				goto fail;
+			}
+
+			if (parse_topo_node(node, path)) {
+				pr_err("Failed to parse node %s\n", path);
+				ret = -EINVAL;
+				goto fail;
+			}
+		}
+	}
+	closedir(d_system);
+	return 0;
+
+fail:
+	topology_free(sys);
+	return ret;
+}

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -32,6 +32,20 @@
 	}
 #endif
 
+/* User override options */
+/* Skip firmware version check */
+bool kfd_fw_version_check;
+/* Skip SDMA firmware version check */
+bool kfd_sdma_fw_version_check;
+/* Skip caches count check */
+bool kfd_caches_count_check;
+/* Skip num gws check */
+bool kfd_num_gws_check;
+/* Skip vram size check */
+bool kfd_vram_size_check;
+/* Preserve NUMA regions */
+bool kfd_numa_check;
+
 static int open_drm_render_device(int minor)
 {
 	char path[128];
@@ -962,9 +976,11 @@ static bool device_properties_match(struct tp_node *src, struct tp_node *dest)
 	    src->num_sdma_xgmi_engines == dest->num_sdma_xgmi_engines &&
 	    src->num_sdma_queues_per_engine == dest->num_sdma_queues_per_engine &&
 	    src->num_cp_queues == dest->num_cp_queues && src->capability == dest->capability &&
-	    src->vram_public == dest->vram_public && src->vram_size <= dest->vram_size &&
-	    src->num_gws <= dest->num_gws && src->caches_count <= dest->caches_count &&
-	    src->fw_version <= dest->fw_version && src->sdma_fw_version <= dest->sdma_fw_version) {
+	    src->vram_public == dest->vram_public && (!kfd_vram_size_check || (src->vram_size <= dest->vram_size)) &&
+	    (!kfd_num_gws_check || (src->num_gws <= dest->num_gws)) &&
+	    (!kfd_caches_count_check || (src->caches_count <= dest->caches_count)) &&
+	    (!kfd_fw_version_check || (src->fw_version <= dest->fw_version)) &&
+	    (!kfd_sdma_fw_version_check || (src->sdma_fw_version <= dest->sdma_fw_version))) {
 		return true;
 	}
 	return false;
@@ -1043,40 +1059,48 @@ static bool map_device(struct tp_system *src_sys, struct tp_system *dest_sys, st
 			/* This is a iolink to CPU */
 			pr_debug("Found link to CPU node:%02d\n", src_iolink->node_to->id);
 
-			uint32_t dest_cpu_node_id;
-
-			dest_cpu_node_id = maps_get_dest_cpu(maps, src_iolink->node_to->id);
-			if (dest_cpu_node_id == INVALID_CPU_ID)
-				dest_cpu_node_id = maps_get_dest_cpu(new_maps, src_iolink->node_to->id);
-
-			if (dest_cpu_node_id == INVALID_CPU_ID) {
+			if (!kfd_numa_check) {
 				struct tp_iolink *dest_iolink;
 
 				list_for_each_entry(dest_iolink, &dest_node->iolinks, listm) {
-					if (iolink_match(src_iolink, dest_iolink) &&
-					    !maps_dest_cpu_mapped(maps, dest_iolink->node_to->id) &&
-					    !maps_dest_cpu_mapped(new_maps, dest_iolink->node_to->id)) {
-						if (!maps_add_cpu_entry(new_maps, src_iolink->node_to->id,
-									dest_iolink->node_to->id))
-							/* This is a critical error because we
-							 * are out of memory
-							 */
-							return false;
-
+					if (iolink_match(src_iolink, dest_iolink))
 						matched_iolink = true;
-						break;
-					}
 				}
 			} else {
-				pr_debug("Existing CPU mapping found [%02d-%02d]\n", src_iolink->node_to->id,
-					 dest_cpu_node_id);
-				/* Confirm that the link to this CPU is same or better */
+				uint32_t dest_cpu_node_id;
 
-				struct tp_iolink *dest_iolink =
-					node_get_iolink_to_node_id(dest_node, src_iolink->type, dest_cpu_node_id);
+				dest_cpu_node_id = maps_get_dest_cpu(maps, src_iolink->node_to->id);
+				if (dest_cpu_node_id == INVALID_CPU_ID)
+					dest_cpu_node_id = maps_get_dest_cpu(new_maps, src_iolink->node_to->id);
 
-				if (dest_iolink && iolink_match(src_iolink, dest_iolink))
-					matched_iolink = true;
+				if (dest_cpu_node_id == INVALID_CPU_ID) {
+					struct tp_iolink *dest_iolink;
+					list_for_each_entry(dest_iolink, &dest_node->iolinks, listm) {
+						if (iolink_match(src_iolink, dest_iolink) &&
+						    !maps_dest_cpu_mapped(maps, dest_iolink->node_to->id) &&
+						    !maps_dest_cpu_mapped(new_maps, dest_iolink->node_to->id)) {
+							if (!maps_add_cpu_entry(new_maps, src_iolink->node_to->id,
+										dest_iolink->node_to->id))
+								/* This is a critical error because
+								 * we are out of memory
+								 */
+								return false;
+
+							matched_iolink = true;
+							break;
+						}
+					}
+				} else {
+					pr_debug("Existing CPU mapping found [%02d-%02d]\n", src_iolink->node_to->id,
+						 dest_cpu_node_id);
+					/* Confirm that the link to this CPU is same or better */
+
+					struct tp_iolink *dest_iolink = node_get_iolink_to_node_id(
+						dest_node, src_iolink->type, dest_cpu_node_id);
+
+					if (dest_iolink && iolink_match(src_iolink, dest_iolink))
+						matched_iolink = true;
+				}
 			}
 			if (!matched_iolink) {
 				pr_debug("[0x%04X -> 0x%04X] Mismatch between iolink to CPU\n", src_node->gpu_id,

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -32,6 +32,31 @@
 	}
 #endif
 
+static int open_drm_render_device(int minor)
+{
+	char path[128];
+	int fd;
+
+	if (minor < DRM_FIRST_RENDER_NODE || minor > DRM_LAST_RENDER_NODE) {
+		pr_perror("DRM render minor %d out of range [%d, %d]", minor, DRM_FIRST_RENDER_NODE,
+			  DRM_LAST_RENDER_NODE);
+		return -EINVAL;
+	}
+
+	snprintf(path, sizeof(path), "/dev/dri/renderD%d", minor);
+	fd = open(path, O_RDWR | O_CLOEXEC);
+	if (fd < 0) {
+		if (errno != ENOENT && errno != EPERM) {
+			pr_err("Failed to open %s: %s\n", path, strerror(errno));
+			if (errno == EACCES)
+				pr_err("Check user is in \"video\" group\n");
+		}
+		return -EBADFD;
+	}
+
+	return fd;
+}
+
 static const char *link_type(uint32_t type)
 {
 	switch (type) {
@@ -50,6 +75,38 @@ static struct tp_node *p2pgroup_get_node_by_gpu_id(const struct tp_p2pgroup *gro
 	list_for_each_entry(node, &group->nodes, listm_p2pgroup) {
 		if (node->gpu_id == gpu_id)
 			return node;
+	}
+	return NULL;
+}
+
+int node_get_drm_render_device(struct tp_node *node)
+{
+	if (node->drm_fd < 0)
+		node->drm_fd = open_drm_render_device(node->drm_render_minor);
+
+	return node->drm_fd;
+}
+
+void sys_close_drm_render_devices(struct tp_system *sys)
+{
+	struct tp_node *node;
+
+	list_for_each_entry(node, &sys->nodes, listm_system) {
+		if (node->drm_fd >= 0) {
+			close(node->drm_fd);
+			node->drm_fd = -1;
+		}
+	}
+}
+
+static struct tp_iolink *node_get_iolink_to_node_id(const struct tp_node *node, const uint32_t type,
+						    const uint32_t node_id)
+{
+	struct tp_iolink *iolink;
+
+	list_for_each_entry(iolink, &node->iolinks, listm) {
+		if (iolink->node_to_id == node_id && iolink->type == type)
+			return iolink;
 	}
 	return NULL;
 }
@@ -114,6 +171,39 @@ static struct tp_iolink *get_tp_peer_iolink(const struct tp_node *from_node, con
 	return NULL;
 }
 
+static bool maps_dest_cpu_mapped(const struct device_maps *maps, const uint32_t dest_id)
+{
+	struct id_map *id_map;
+
+	list_for_each_entry(id_map, &maps->cpu_maps, listm) {
+		if (id_map->dest == dest_id)
+			return true;
+	}
+	return false;
+}
+
+static uint32_t maps_get_dest_cpu(const struct device_maps *maps, const uint32_t src_id)
+{
+	struct id_map *id_map;
+
+	list_for_each_entry(id_map, &maps->cpu_maps, listm) {
+		if (id_map->src == src_id)
+			return id_map->dest;
+	}
+	return INVALID_CPU_ID;
+}
+
+bool maps_dest_gpu_mapped(const struct device_maps *maps, const uint32_t dest_id)
+{
+	struct id_map *id_map;
+
+	list_for_each_entry(id_map, &maps->gpu_maps, listm) {
+		if (id_map->dest == dest_id)
+			return true;
+	}
+	return false;
+}
+
 uint32_t maps_get_dest_gpu(const struct device_maps *maps, const uint32_t src_id)
 {
 	struct id_map *id_map;
@@ -123,6 +213,26 @@ uint32_t maps_get_dest_gpu(const struct device_maps *maps, const uint32_t src_id
 			return id_map->dest;
 	}
 	return 0;
+}
+
+static struct id_map *maps_add_cpu_entry(struct device_maps *maps, const uint32_t src_id, const uint32_t dest_id)
+{
+	struct id_map *id_map = xzalloc(sizeof(*id_map));
+
+	if (!id_map) {
+		pr_err("Failed to allocate memory for id_map\n");
+		return NULL;
+	}
+
+	id_map->src = src_id;
+	id_map->dest = dest_id;
+
+	list_add_tail(&id_map->listm, &maps->cpu_maps);
+
+	maps->tail_cpu = &id_map->listm;
+
+	pr_debug("Added CPU mapping [%02d -> %02d]\n", src_id, dest_id);
+	return id_map;
 }
 
 struct id_map *maps_add_gpu_entry(struct device_maps *maps, const uint32_t src_id, const uint32_t dest_id)
@@ -143,6 +253,19 @@ struct id_map *maps_add_gpu_entry(struct device_maps *maps, const uint32_t src_i
 
 	pr_debug("Added GPU mapping [0x%04X -> 0x%04X]\n", src_id, dest_id);
 	return id_map;
+}
+
+static void maps_print(struct device_maps *maps)
+{
+	struct id_map *id_map;
+
+	pr_info("===Maps===============\n");
+	list_for_each_entry(id_map, &maps->gpu_maps, listm)
+		pr_info("GPU: 0x%04X -> 0x%04X\n", id_map->src, id_map->dest);
+
+	list_for_each_entry(id_map, &maps->cpu_maps, listm)
+		pr_info("CPU: %02d -> %02d\n", id_map->src, id_map->dest);
+	pr_info("======================\n");
 }
 
 void maps_init(struct device_maps *maps)
@@ -167,6 +290,46 @@ void maps_free(struct device_maps *maps)
 		list_del(&map->listm);
 		xfree(map);
 	}
+}
+
+static void maps_pop(struct device_maps *maps, struct device_maps *remove)
+{
+	if (remove->tail_cpu)
+		list_cut_position(&remove->cpu_maps, &maps->cpu_maps, remove->tail_cpu);
+
+	if (remove->tail_gpu)
+		list_cut_position(&remove->gpu_maps, &maps->gpu_maps, remove->tail_gpu);
+
+	maps_free(remove);
+}
+
+static int maps_push(struct device_maps *maps, struct device_maps *new)
+{
+	struct id_map *src_id_map, *dest_id_map;
+
+	list_for_each_entry(src_id_map, &new->cpu_maps, listm) {
+		list_for_each_entry(dest_id_map, &maps->cpu_maps, listm) {
+			if (src_id_map->src == dest_id_map->src || src_id_map->dest == dest_id_map->dest) {
+				pr_err("CPU mapping already exists src [%02d->%02d] new [%02d->%02d]\n",
+				       src_id_map->src, src_id_map->dest, dest_id_map->src, dest_id_map->dest);
+				return -EINVAL;
+			}
+		}
+	}
+	list_for_each_entry(src_id_map, &new->gpu_maps, listm) {
+		list_for_each_entry(dest_id_map, &maps->gpu_maps, listm) {
+			if (src_id_map->src == dest_id_map->src || src_id_map->dest == dest_id_map->dest) {
+				pr_err("GPU mapping already exists src [0x%04X -> 0x%04X] new [0x%04X -> 0x%04X]\n",
+				       src_id_map->src, src_id_map->dest, dest_id_map->src, dest_id_map->dest);
+				return -EINVAL;
+			}
+		}
+	}
+
+	list_splice(&new->cpu_maps, &maps->cpu_maps);
+	list_splice(&new->gpu_maps, &maps->gpu_maps);
+
+	return 0;
 }
 
 struct tp_iolink *node_add_iolink(struct tp_node *node, uint32_t type, uint32_t node_to_id)
@@ -212,6 +375,7 @@ struct tp_node *sys_add_node(struct tp_system *sys, uint32_t id, uint32_t gpu_id
 
 	node->id = id;
 	node->gpu_id = gpu_id;
+	node->drm_fd = -1;
 	INIT_LIST_HEAD(&node->iolinks);
 	list_add_tail(&node->listm_system, &sys->nodes);
 	sys->num_nodes++;
@@ -529,6 +693,19 @@ static const char *p2pgroup_to_str(struct tp_p2pgroup *group)
 	return topology_printstr;
 }
 
+static const char *mapping_list_to_str(struct list_head *node_list)
+{
+	static char topology_printstr[200];
+	struct tp_node *node;
+	size_t str_len = 0;
+
+	topology_printstr[0] = '\0';
+	list_for_each_entry(node, node_list, listm_mapping)
+		str_len += sprintf(&topology_printstr[str_len], "0x%04X ", node->gpu_id);
+
+	return topology_printstr;
+}
+
 void topology_print(const struct tp_system *sys, const char *message)
 {
 	struct tp_node *node;
@@ -770,5 +947,450 @@ int topology_parse(struct tp_system *sys, const char *message)
 
 fail:
 	topology_free(sys);
+	return ret;
+}
+
+static bool device_properties_match(struct tp_node *src, struct tp_node *dest)
+{
+	if (src->simd_count == dest->simd_count && src->mem_banks_count == dest->mem_banks_count &&
+	    src->io_links_count == dest->io_links_count && src->max_waves_per_simd == dest->max_waves_per_simd &&
+	    src->lds_size_in_kb == dest->lds_size_in_kb && src->wave_front_size == dest->wave_front_size &&
+	    src->array_count == dest->array_count && src->simd_arrays_per_engine == dest->simd_arrays_per_engine &&
+	    src->cu_per_simd_array == dest->cu_per_simd_array && src->simd_per_cu == dest->simd_per_cu &&
+	    src->max_slots_scratch_cu == dest->max_slots_scratch_cu && src->vendor_id == dest->vendor_id &&
+	    src->device_id == dest->device_id && src->num_sdma_engines == dest->num_sdma_engines &&
+	    src->num_sdma_xgmi_engines == dest->num_sdma_xgmi_engines &&
+	    src->num_sdma_queues_per_engine == dest->num_sdma_queues_per_engine &&
+	    src->num_cp_queues == dest->num_cp_queues && src->capability == dest->capability &&
+	    src->vram_public == dest->vram_public && src->vram_size <= dest->vram_size &&
+	    src->num_gws <= dest->num_gws && src->caches_count <= dest->caches_count &&
+	    src->fw_version <= dest->fw_version && src->sdma_fw_version <= dest->sdma_fw_version) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @brief Determines whether iolink dest can be used to replace src
+ *
+ * @param src source iolink
+ * @param dest destination iolink
+ * @return true if dest can replace src
+ */
+static bool iolink_match(struct tp_iolink *src, struct tp_iolink *dest)
+{
+	if (!src->valid)
+		return true;
+
+	if (!dest->valid)
+		return false;
+
+	if (NODE_IS_GPU(src->node_to) != NODE_IS_GPU(dest->node_to))
+		return false;
+
+	/* XGMI link can replace PCIE links */
+	if (src->type == TOPO_IOLINK_TYPE_XGMI && dest->type == TOPO_IOLINK_TYPE_PCIE)
+		return false;
+
+	/* bi-directional links can replace uni-directional links */
+	if (src->peer != NULL && dest->peer == NULL)
+		return false;
+
+	return true;
+}
+
+/**
+ * @brief Determines whether src_node can be mapped to dest_node
+ *
+ * Nodes compatibility are determined by:
+ * 1. Comparing the node properties
+ * 2. Making sure iolink mappings to CPUs would be compabitle with existing iolink mappings in maps
+ *
+ * If src_node and dest_node are mappable, then map_device will push the new mapping
+ * for src_node -> dest_node into new_maps.
+ * @param src_sys system topology information on source system
+ * @param dest_sys system topology information on destination system
+ * @param src_node source GPU
+ * @param dest_node destination GPU
+ * @param maps list of existing device maps
+ * @param new_maps if nodes are mappable, then GPU and CPU mappings will be added to this list
+ * @return true if src_node and dest_node are mappable
+ */
+static bool map_device(struct tp_system *src_sys, struct tp_system *dest_sys, struct tp_node *src_node,
+		       struct tp_node *dest_node, struct device_maps *maps, struct device_maps *new_maps)
+{
+	struct tp_iolink *src_iolink;
+
+	pr_debug("Evaluating mapping nodes [0x%04X -> 0x%04X]\n", src_node->gpu_id, dest_node->gpu_id);
+
+	/* Compare GPU properties from /sys/class/kfd/kfd/topology/nodes/N/properties */
+	if (!device_properties_match(src_node, dest_node)) {
+		pr_debug("[0x%04X -> 0x%04X] Device properties do not match\n", src_node->gpu_id, dest_node->gpu_id);
+		return false;
+	}
+
+	if (src_node->num_valid_iolinks > dest_node->num_valid_iolinks) {
+		pr_debug("[0x%04X -> 0x%04X] Mismatch between number of iolinks\n", src_node->gpu_id,
+			 dest_node->gpu_id);
+		return false;
+	}
+
+	list_for_each_entry(src_iolink, &src_node->iolinks, listm) {
+		/* Go through list of iolinks to CPU and compare them */
+
+		if (!NODE_IS_GPU(src_iolink->node_to)) {
+			bool matched_iolink = false;
+			/* This is a iolink to CPU */
+			pr_debug("Found link to CPU node:%02d\n", src_iolink->node_to->id);
+
+			uint32_t dest_cpu_node_id;
+
+			dest_cpu_node_id = maps_get_dest_cpu(maps, src_iolink->node_to->id);
+			if (dest_cpu_node_id == INVALID_CPU_ID)
+				dest_cpu_node_id = maps_get_dest_cpu(new_maps, src_iolink->node_to->id);
+
+			if (dest_cpu_node_id == INVALID_CPU_ID) {
+				struct tp_iolink *dest_iolink;
+
+				list_for_each_entry(dest_iolink, &dest_node->iolinks, listm) {
+					if (iolink_match(src_iolink, dest_iolink) &&
+					    !maps_dest_cpu_mapped(maps, dest_iolink->node_to->id) &&
+					    !maps_dest_cpu_mapped(new_maps, dest_iolink->node_to->id)) {
+						if (!maps_add_cpu_entry(new_maps, src_iolink->node_to->id,
+									dest_iolink->node_to->id))
+							/* This is a critical error because we
+							 * are out of memory
+							 */
+							return false;
+
+						matched_iolink = true;
+						break;
+					}
+				}
+			} else {
+				pr_debug("Existing CPU mapping found [%02d-%02d]\n", src_iolink->node_to->id,
+					 dest_cpu_node_id);
+				/* Confirm that the link to this CPU is same or better */
+
+				struct tp_iolink *dest_iolink =
+					node_get_iolink_to_node_id(dest_node, src_iolink->type, dest_cpu_node_id);
+
+				if (dest_iolink && iolink_match(src_iolink, dest_iolink))
+					matched_iolink = true;
+			}
+			if (!matched_iolink) {
+				pr_debug("[0x%04X -> 0x%04X] Mismatch between iolink to CPU\n", src_node->gpu_id,
+					 dest_node->gpu_id);
+
+				return false;
+			}
+		} else {
+			/* If GPUs have P2P-PCIe iolinks to this GPU, then at least one CPU will
+			 * also have a P2P-PCIe iolink to this GPU, so it seems that we do not need
+			 * to consider P2P-PCIe iolinks from GPU to GPU for now. Once P2P-PCIe
+			 * iolinks are exposed via p2p_links we may have to add additional code here
+			 * to validate P2P-PCIe links between GPUs.
+			 */
+		}
+	}
+	pr_debug("[0x%04X -> 0x%04X] Map is possible\n", src_node->gpu_id, dest_node->gpu_id);
+
+	if (!maps_add_gpu_entry(new_maps, src_node->gpu_id, dest_node->gpu_id)) {
+		/* This is a critical error because we are out of memory */
+		return false;
+	}
+	maps_print(new_maps);
+	return true;
+}
+
+/**
+ * @brief Determines whether list of GPUs in src_nodes are mappable to dest_nodes
+ *
+ * This function will pick the first node from src_nodes and iterate through all the nodes in
+ * dest_nodes and call map_device to determine whether the node is mappable.
+ * If a node from dest_nodes is mappable to the first node from src_nodes:
+ * 1. This function will remove the first node from src_nodes and the node from dest_nodes
+ * 2. Push sub-mappings (new_maps) generated by map_device into existing mappings (maps)
+ * 3. Recursively check whether remaining nodes in src_nodes and dest_nodes are mappable.
+ *
+ * Once src_nodes is empty then we have successfully mapped all the nodes and maps contains a full
+ * list of GPU mappings.
+ *
+ * If there are no nodes in dest_nodes that can be mapped to the first node in src_nodes, then this
+ * means we cannot build a full mapping list with the current list of mappings. We backtrack by
+ * popping the newly generated sub-mappings(new_maps) from existing mappings (maps) and add the two
+ * nodes back to src_nodes and dest_nodes and return false. When this function returns false, the
+ * caller function will try a different path by trying to map the first node from src_nodes to the
+ * next node in dest_nodes.
+ *
+ * @param src_sys system topology information on source system
+ * @param dest_sys system topology information on destination system
+ * @param src_node list of source GPUs that need to be mapped
+ * @param dest_node list of destination GPUs that need to be mapped
+ * @param maps list of device maps based on current map path
+ * @return true if all nodes from src_nodes and dest_nodes are mappable
+ */
+static bool map_devices(struct tp_system *src_sys, struct tp_system *dest_sys, struct list_head *src_nodes,
+			struct list_head *dest_nodes, struct device_maps *maps)
+{
+	struct tp_node *src_node, *dest_node, *dest_node_tmp;
+	struct device_maps new_maps;
+
+	/* Pick the first src node from the list of nodes and look for a dest node that is mappable.
+	 * If we find a mappable destination node, then we add src node and dest node mapping to
+	 * device_maps and recursively try to map the remaining nodes in the list.
+	 * If there are no more src nodes in the list, then we have found a successful combination
+	 * of src to dest nodes that are mappable.
+	 */
+	if (list_empty(src_nodes)) {
+		pr_debug("All nodes mapped successfully\n");
+		return true;
+	}
+
+	pr_debug("Mapping list src nodes [%s]\n", mapping_list_to_str(src_nodes));
+	pr_debug("Mapping list dest nodes [%s]\n", mapping_list_to_str(dest_nodes));
+
+	src_node = list_first_entry(src_nodes, struct tp_node, listm_mapping);
+	pr_debug("Looking for match for node 0x%04X\n", src_node->gpu_id);
+
+	list_del(&src_node->listm_mapping);
+
+	list_for_each_entry_safe(dest_node, dest_node_tmp, dest_nodes, listm_mapping) {
+		maps_init(&new_maps);
+		if (map_device(src_sys, dest_sys, src_node, dest_node, maps, &new_maps)) {
+			pr_debug("Matched destination node 0x%04X\n", dest_node->gpu_id);
+
+			/* src node and dest node are mappable, add device_maps generated by
+			 * map_device to list of current valid device_maps, and recursively try to
+			 * map remaining nodes in the list.
+			 */
+
+			list_del(&dest_node->listm_mapping);
+			if (maps_push(maps, &new_maps))
+				return false;
+
+			if (map_devices(src_sys, dest_sys, src_nodes, dest_nodes, maps)) {
+				pr_debug("Matched nodes 0x%04X and after\n", dest_node->gpu_id);
+				return true;
+			} else {
+				/* We could not map remaining nodes in the list. Add dest node back
+				 * to list and try to map next dest ndoe in list to current src
+				 * node.
+				 */
+				pr_debug("Nodes after [0x%04X -> 0x%04X] did not match, "
+					 "adding list back\n",
+					 src_node->gpu_id, dest_node->gpu_id);
+
+				list_add(&dest_node->listm_mapping, dest_nodes);
+				maps_pop(maps, &new_maps);
+			}
+		}
+	}
+	pr_debug("Failed to map nodes 0x%04X and after\n", src_node->gpu_id);
+
+	/* Either: We could not find a mappable dest node for current node, or we could not build a
+	 * combination from the remaining nodes in the lists. Add src node back to the list and
+	 * caller function will try next possible combination.
+	 */
+	list_add(&src_node->listm_mapping, src_nodes);
+
+	return false;
+}
+
+/**
+ * @brief Determines whether list of GPUs in src_xgmi_groups are mappable to list of GPUs in
+ * dest_xgmi_groups
+ *
+ * This function will pick the first XGMI group (hive) from src_xgmi_groups and iterate through the
+ * XGMI groups in dest_xgmi_groups. If the group in dest_xgmi_groups is mappable then this function
+ * will remove the hives from src_xgmi_groups and dest_xgmi_groups and recursively try to map the
+ * remaining hives in src_xgmi_groups and dest_xgmi_groups.
+ *
+ * If src_xgmi_groups is empty, then this means that we have successfully mapped all the XGMI hives
+ * and we have a full list of GPU mappings in maps.
+ *
+ * If we cannot find a hive inside dest_xgmi_groups that is mappable to the first hive from
+ * src_xgmi_groups, then this means that this path is not valid and we need to backtrack. We
+ * backtrack by adding the hives back into src_xgmi_groups and dest_xgmi_groups and returning false.
+ * The caller function will then try a different path by trying to map the first hive in
+ * src_xgmi_groups to the next hive in dest_xgmi_groups.
+ *
+ * @param src_sys system topology information on source system
+ * @param dest_sys system topology information on destination system
+ * @param src_xgmi_groups list of source XGMI hives that need to be mapped
+ * @param dest_xgmi_groups list of destination XGMI hives that need to be mapped
+ * @param maps list of device maps based on current map path
+ * @return true if all nodes from src_nodes and dest_nodes are mappable
+ */
+bool match_xgmi_groups(struct tp_system *src_sys, struct tp_system *dest_sys, struct list_head *src_xgmi_groups,
+		       struct list_head *dest_xgmi_groups, struct device_maps *maps)
+{
+	struct tp_p2pgroup *src_group;
+	struct tp_p2pgroup *dest_group;
+	struct tp_p2pgroup *dest_group_tmp;
+
+	if (list_empty(src_xgmi_groups)) {
+		pr_debug("All groups matched successfully\n");
+		return true;
+	}
+
+	/* Pick the first src XGMI group from the list. Then try to match src XGMI group with a
+	 * dest XGMI group. If we have a dest XGMI group that is mappable, then we try to
+	 * recursively map the next src XGMI group in the list, with remaining dest XGMI groups.
+	 * If there are no more src XGMI groups in the list, then this means we have successfully
+	 * mapped all the groups and we have a valid device_maps
+	 */
+	src_group = list_first_entry(src_xgmi_groups, struct tp_p2pgroup, listm_system);
+	pr_debug("Looking for match for group [%s]\n", p2pgroup_to_str(src_group));
+
+	list_del(&src_group->listm_system);
+
+	list_for_each_entry_safe(dest_group, dest_group_tmp, dest_xgmi_groups, listm_system) {
+		struct tp_node *node;
+
+		LIST_HEAD(src_nodes);
+		LIST_HEAD(dest_nodes);
+
+		if (src_group->num_nodes > dest_group->num_nodes)
+			continue;
+
+		pr_debug("Trying destination group [%s]\n", p2pgroup_to_str(dest_group));
+
+		list_for_each_entry(node, &src_group->nodes, listm_p2pgroup)
+			list_add_tail(&node->listm_mapping, &src_nodes);
+
+		list_for_each_entry(node, &dest_group->nodes, listm_p2pgroup)
+			list_add_tail(&node->listm_mapping, &dest_nodes);
+
+		/* map_devices will populate maps if successful */
+		if (map_devices(src_sys, dest_sys, &src_nodes, &dest_nodes, maps)) {
+			/* All the nodes in current src XGMI group are mappable with nodes in
+			 * current dest XGMI group. Remove the current groups from the lists
+			 * and recursively try to match remaining groups
+			 */
+			list_del(&dest_group->listm_system);
+			pr_debug("Matched destination group [%s]\n", p2pgroup_to_str(dest_group));
+			if (match_xgmi_groups(src_sys, dest_sys, src_xgmi_groups, dest_xgmi_groups, maps)) {
+				pr_debug("Matched subgroups of [%s]\n", p2pgroup_to_str(dest_group));
+
+				xfree(src_group);
+				xfree(dest_group);
+				return true;
+			} else {
+				/* We were not able to map the remaining XGMI groups so we add the
+				 * current dest XGMI group back to the list of unmapped groups, and
+				 * try to map current src XGMI group with the next dest XGMI in the
+				 * list of XGMI groups
+				 */
+				list_add(&dest_group->listm_system, dest_xgmi_groups);
+			}
+		}
+	}
+
+	/* We have not found a mappable dest XGMI group. We discard this combination. If this is
+	 * the first src XGMI group in the list, then it is not possible to match the XGMI groups.
+	 * If this was a recursive call, then the calling instance of function will try the next
+	 * combination of XGMI groups
+	 */
+
+	pr_debug("Failed to match groups [%s]\n", p2pgroup_to_str(src_group));
+	list_add_tail(&src_group->listm_system, src_xgmi_groups);
+
+	return false;
+}
+
+/**
+ * @brief Builds a list of GPU mappings from source topology to destination topology
+ *
+ * The topology on the destination system may not be identical to the topology on the source
+ * system, e.g There can be GPUs with different device ID's and they may be enumerated in a
+ * different order. This function builds a list of GPU mappings from the source topology to the
+ * destination topology and stores it in maps.
+ *
+ * The function will first validate all the iolinks and determine XGMI groups (hives) by calling the
+ * topology_determine_iolinks(). It will then try to match the GPUs that belong to XGMI hives and
+ * after that, match the remaining GPUs.
+ *
+ * @param src_sys system topology information on source system
+ * @param dest_sys system topology information on destination system
+ * @param maps list of device maps that was generated by this function
+ * @return true if we were able to build a full list of GPU mappings.
+ */
+int set_restore_gpu_maps(struct tp_system *src_sys, struct tp_system *dest_sys, struct device_maps *maps)
+{
+	struct tp_node *node;
+	int ret = 0;
+	int src_num_gpus = 0;
+	int dest_num_gpus = 0;
+
+	maps_init(maps);
+
+	ret = topology_determine_iolinks(src_sys);
+	if (ret) {
+		pr_err("Failed to determine iolinks from source (checkpointed) topology\n");
+		return ret;
+	}
+	topology_print(src_sys, "Source    ");
+
+	ret = topology_determine_iolinks(dest_sys);
+	if (ret) {
+		pr_err("Failed to determine iolinks from destination (local) topology\n");
+		return ret;
+	}
+	topology_print(dest_sys, "Destination");
+
+	/* Make sure we have same number of GPUs in src and dest */
+	list_for_each_entry(node, &src_sys->nodes, listm_system) {
+		if (NODE_IS_GPU(node))
+			src_num_gpus++;
+	}
+	list_for_each_entry(node, &dest_sys->nodes, listm_system) {
+		if (NODE_IS_GPU(node))
+			dest_num_gpus++;
+	}
+
+	if (src_num_gpus != dest_num_gpus) {
+		pr_err("Number of devices mismatch (checkpointed:%d local:%d)\n", src_num_gpus, dest_num_gpus);
+		return -EINVAL;
+	}
+
+	if (src_sys->num_xgmi_groups > dest_sys->num_xgmi_groups) {
+		pr_err("Number of xgmi groups mismatch (checkpointed:%d local:%d)\n", src_sys->num_xgmi_groups,
+		       dest_sys->num_xgmi_groups);
+		return -EINVAL;
+	}
+
+	/* First try to match the XGMI hives */
+	if (src_sys->num_xgmi_groups) {
+		if (!match_xgmi_groups(src_sys, dest_sys, &src_sys->xgmi_groups, &dest_sys->xgmi_groups, maps)) {
+			pr_err("Failed to match all GPU groups\n");
+			return -EINVAL;
+		}
+		pr_info("Current maps after XGMI groups matched\n");
+		maps_print(maps);
+	}
+
+	/* We matched all the XGMI hives, now match remaining GPUs */
+	LIST_HEAD(src_nodes);
+	LIST_HEAD(dest_nodes);
+
+	list_for_each_entry(node, &src_sys->nodes, listm_system) {
+		if (NODE_IS_GPU(node) && !maps_get_dest_gpu(maps, node->gpu_id))
+			list_add(&node->listm_mapping, &src_nodes);
+	}
+
+	list_for_each_entry(node, &dest_sys->nodes, listm_system) {
+		if (NODE_IS_GPU(node) && !maps_dest_gpu_mapped(maps, node->gpu_id))
+			list_add(&node->listm_mapping, &dest_nodes);
+	}
+
+	if (!map_devices(src_sys, dest_sys, &src_nodes, &dest_nodes, maps)) {
+		pr_err("Failed to match remaining nodes\n");
+		return -EINVAL;
+	}
+
+	pr_info("Maps after all nodes matched\n");
+	maps_print(maps);
+
 	return ret;
 }

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -59,10 +59,17 @@ bool kfd_vram_size_check = true;
 /* Preserve NUMA regions */
 bool kfd_numa_check = true;
 
+/*
+ * During dump, we can use any fd value so fd_next is always -1.
+ * During restore, we have to use a fd value that does not conflict with fd values in use by the target restore process.
+ * fd_next is initialized as 1 greather than the highest-numbered file descriptor used by the target restore process.
+ */
+int fd_next = -1;
+
 static int open_drm_render_device(int minor)
 {
 	char path[128];
-	int fd;
+	int fd, ret_fd;
 
 	if (minor < DRM_FIRST_RENDER_NODE || minor > DRM_LAST_RENDER_NODE) {
 		pr_perror("DRM render minor %d out of range [%d, %d]", minor, DRM_FIRST_RENDER_NODE,
@@ -81,7 +88,16 @@ static int open_drm_render_device(int minor)
 		return -EBADFD;
 	}
 
-	return fd;
+	if (fd_next < 0)
+		return fd;
+
+	ret_fd = fcntl(fd, F_DUPFD, fd_next++);
+	close(fd);
+
+	if (ret_fd < 0)
+		pr_perror("Failed to duplicate fd for minor:%d (fd_next:%d)", minor, fd_next);
+
+	return ret_fd;
 }
 
 static const char *link_type(uint32_t type)

--- a/plugins/amdgpu/amdgpu_plugin_topology.h
+++ b/plugins/amdgpu/amdgpu_plugin_topology.h
@@ -1,0 +1,119 @@
+#ifndef __KFD_PLUGIN_TOPOLOGY_H__
+#define __KFD_PLUGIN_TOPOLOGY_H__
+
+#define TOPO_HEAP_TYPE_PUBLIC  1 /* HSA_HEAPTYPE_FRAME_BUFFER_PUBLIC */
+#define TOPO_HEAP_TYPE_PRIVATE 2 /* HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE */
+
+#define TOPO_IOLINK_TYPE_ANY  0 /* HSA_IOLINKTYPE_UNDEFINED */
+#define TOPO_IOLINK_TYPE_PCIE 2 /* HSA_IOLINKTYPE_PCIEXPRESS */
+#define TOPO_IOLINK_TYPE_XGMI 11 /* HSA_IOLINK_TYPE_XGMI */
+
+#define NODE_IS_GPU(node) ((node)->gpu_id != 0)
+#define INVALID_CPU_ID	  0xFFFF
+
+/*************************************** Structures ***********************************************/
+struct tp_node;
+
+struct tp_iolink {
+	struct list_head listm;
+	uint32_t type;
+	uint32_t node_to_id;
+	struct tp_node *node_to;
+	struct tp_node *node_from;
+	bool valid; /* Set to false if target node is not accessible */
+	struct tp_iolink *peer; /* If link is bi-directional, peer link */
+};
+
+struct tp_node {
+	uint32_t id;
+	uint32_t gpu_id;
+	uint32_t cpu_cores_count;
+	uint32_t simd_count;
+	uint32_t mem_banks_count;
+	uint32_t caches_count;
+	uint32_t io_links_count;
+	uint32_t max_waves_per_simd;
+	uint32_t lds_size_in_kb;
+	uint32_t num_gws;
+	uint32_t wave_front_size;
+	uint32_t array_count;
+	uint32_t simd_arrays_per_engine;
+	uint32_t cu_per_simd_array;
+	uint32_t simd_per_cu;
+	uint32_t max_slots_scratch_cu;
+	uint32_t vendor_id;
+	uint32_t device_id;
+	uint32_t domain;
+	uint32_t drm_render_minor;
+	uint64_t hive_id;
+	uint32_t num_sdma_engines;
+	uint32_t num_sdma_xgmi_engines;
+	uint32_t num_sdma_queues_per_engine;
+	uint32_t num_cp_queues;
+	uint32_t fw_version;
+	uint32_t capability;
+	uint32_t sdma_fw_version;
+	bool vram_public;
+	uint64_t vram_size;
+
+	struct list_head listm_system;
+	struct list_head listm_p2pgroup;
+	struct list_head listm_mapping; /* Used only during device mapping */
+
+	uint32_t num_valid_iolinks;
+	struct list_head iolinks;
+};
+
+struct tp_p2pgroup {
+	uint32_t type;
+	uint32_t num_nodes;
+	struct list_head listm_system;
+	struct list_head nodes;
+};
+
+struct tp_system {
+	bool parsed;
+	uint32_t num_nodes;
+	struct list_head nodes;
+	uint32_t num_xgmi_groups;
+	struct list_head xgmi_groups;
+};
+
+struct id_map {
+	uint32_t src;
+	uint32_t dest;
+
+	struct list_head listm;
+};
+
+struct device_maps {
+	struct list_head cpu_maps; /* CPUs are mapped using node_id */
+	struct list_head gpu_maps;
+
+	struct list_head *tail_cpu; /* GPUs are mapped using gpu_id */
+	struct list_head *tail_gpu;
+};
+
+/**************************************** Functions ***********************************************/
+void topology_init(struct tp_system *sys);
+void topology_free(struct tp_system *topology);
+
+int topology_parse(struct tp_system *topology, const char *msg);
+int topology_determine_iolinks(struct tp_system *sys);
+void topology_print(const struct tp_system *sys, const char *msg);
+
+struct id_map *maps_add_gpu_entry(struct device_maps *maps, const uint32_t src_id, const uint32_t dest_id);
+
+struct tp_node *sys_add_node(struct tp_system *sys, uint32_t id, uint32_t gpu_id);
+struct tp_iolink *node_add_iolink(struct tp_node *node, uint32_t type, uint32_t node_to_id);
+
+struct tp_node *sys_get_node_by_gpu_id(const struct tp_system *sys, const uint32_t gpu_id);
+struct tp_node *sys_get_node_by_render_minor(const struct tp_system *sys, const int drm_render_minor);
+int set_restore_gpu_maps(struct tp_system *tp_checkpoint, struct tp_system *tp_local, struct device_maps *maps);
+
+uint32_t maps_get_dest_gpu(const struct device_maps *maps, const uint32_t src_id);
+
+void maps_init(struct device_maps *maps);
+void maps_free(struct device_maps *maps);
+
+#endif /* __KFD_PLUGIN_TOPOLOGY_H__ */

--- a/plugins/amdgpu/amdgpu_plugin_topology.h
+++ b/plugins/amdgpu/amdgpu_plugin_topology.h
@@ -1,6 +1,9 @@
 #ifndef __KFD_PLUGIN_TOPOLOGY_H__
 #define __KFD_PLUGIN_TOPOLOGY_H__
 
+#define DRM_FIRST_RENDER_NODE 128
+#define DRM_LAST_RENDER_NODE  255
+
 #define TOPO_HEAP_TYPE_PUBLIC  1 /* HSA_HEAPTYPE_FRAME_BUFFER_PUBLIC */
 #define TOPO_HEAP_TYPE_PRIVATE 2 /* HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE */
 
@@ -62,6 +65,8 @@ struct tp_node {
 
 	uint32_t num_valid_iolinks;
 	struct list_head iolinks;
+
+	int drm_fd;
 };
 
 struct tp_p2pgroup {
@@ -109,6 +114,10 @@ struct tp_iolink *node_add_iolink(struct tp_node *node, uint32_t type, uint32_t 
 
 struct tp_node *sys_get_node_by_gpu_id(const struct tp_system *sys, const uint32_t gpu_id);
 struct tp_node *sys_get_node_by_render_minor(const struct tp_system *sys, const int drm_render_minor);
+
+int node_get_drm_render_device(struct tp_node *node);
+void sys_close_drm_render_devices(struct tp_system *sys);
+
 int set_restore_gpu_maps(struct tp_system *tp_checkpoint, struct tp_system *tp_local, struct device_maps *maps);
 
 uint32_t maps_get_dest_gpu(const struct device_maps *maps, const uint32_t src_id);

--- a/plugins/amdgpu/amdgpu_plugin_topology.h
+++ b/plugins/amdgpu/amdgpu_plugin_topology.h
@@ -114,6 +114,7 @@ struct tp_iolink *node_add_iolink(struct tp_node *node, uint32_t type, uint32_t 
 
 struct tp_node *sys_get_node_by_gpu_id(const struct tp_system *sys, const uint32_t gpu_id);
 struct tp_node *sys_get_node_by_render_minor(const struct tp_system *sys, const int drm_render_minor);
+struct tp_node *sys_get_node_by_index(const struct tp_system *sys, uint32_t index);
 
 int node_get_drm_render_device(struct tp_node *node);
 void sys_close_drm_render_devices(struct tp_system *sys);

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -4,9 +4,45 @@ message process_entry {
 	required bytes private_data = 1;
 }
 
+message dev_iolink {
+	required uint32 type = 1;
+	required uint32 node_to_id = 2;
+}
+
 message device_entry {
-	required uint32 gpu_id = 1;
-	required bytes private_data = 2;
+	required uint32 node_id = 1;
+	required uint32 gpu_id = 2;
+	required uint32 cpu_cores_count = 3;
+	required uint32 simd_count = 4;
+	required uint32 mem_banks_count = 5;
+	required uint32 caches_count = 6;
+	required uint32 io_links_count = 7;
+	required uint32 max_waves_per_simd = 8;
+	required uint32 lds_size_in_kb = 9;
+	required uint32 gds_size_in_kb = 10;
+	required uint32 num_gws = 11;
+	required uint32 wave_front_size = 12;
+	required uint32 array_count = 13;
+	required uint32 simd_arrays_per_engine = 14;
+	required uint32 cu_per_simd_array = 15;
+	required uint32 simd_per_cu = 16;
+	required uint32 max_slots_scratch_cu = 17;
+	required uint32 vendor_id = 18;
+	required uint32 device_id = 19;
+	required uint32 domain = 20;
+	required uint32 drm_render_minor = 21;
+	required uint64 hive_id = 22;
+	required uint32 num_sdma_engines = 23;
+	required uint32 num_sdma_xgmi_engines = 24;
+	required uint32 num_sdma_queues_per_engine = 25;
+	required uint32 num_cp_queues = 26;
+	required uint32 fw_version = 27;
+	required uint32 capability = 28;
+	required uint32 sdma_fw_version = 29;
+	required uint32 vram_public = 30;
+	required uint64 vram_size = 31;
+	repeated dev_iolink iolinks = 32;
+	required bytes private_data = 33;
 }
 
 message bo_entry {
@@ -33,14 +69,15 @@ message criu_kfd {
 	required uint32 pid = 1;
 	required process_entry process_entry = 2;
 	required uint32 num_of_gpus = 3;
-	repeated device_entry device_entries = 4;
-	required uint64	num_of_bos = 5;
-	repeated bo_entry bo_entries = 6;
-	required uint32	num_of_queues = 7;
-	repeated q_entry q_entries = 8;
-	required uint64 event_page_offset = 9;
-	required uint32 num_of_events = 10;
-	repeated ev_entry ev_entries = 11;
+	required uint32 num_of_cpus = 4;
+	repeated device_entry device_entries = 5;
+	required uint64	num_of_bos = 6;
+	repeated bo_entry bo_entries = 7;
+	required uint32	num_of_queues = 8;
+	repeated q_entry q_entries = 9;
+	required uint64 event_page_offset = 10;
+	required uint32 num_of_events = 11;
+	repeated ev_entry ev_entries = 12;
 }
 
 message criu_render_node {

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -24,6 +24,11 @@ message q_entry {
 	required bytes private_data = 2;
 }
 
+message ev_entry {
+	required uint32 gpu_id = 1;
+	required bytes private_data = 2;
+}
+
 message criu_kfd {
 	required uint32 pid = 1;
 	required process_entry process_entry = 2;
@@ -33,6 +38,9 @@ message criu_kfd {
 	repeated bo_entry bo_entries = 6;
 	required uint32	num_of_queues = 7;
 	repeated q_entry q_entries = 8;
+	required uint64 event_page_offset = 9;
+	required uint32 num_of_events = 10;
+	repeated ev_entry ev_entries = 11;
 }
 
 message criu_render_node {

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -81,5 +81,5 @@ message criu_kfd {
 }
 
 message criu_render_node {
-	required uint32 minor_number = 1;
+	required uint32 gpu_id = 1;
 }

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -1,0 +1,33 @@
+syntax = "proto2";
+
+message process_entry {
+	required bytes private_data = 1;
+}
+
+message device_entry {
+	required uint32 gpu_id = 1;
+	required bytes private_data = 2;
+}
+
+message bo_entry {
+	required uint64	addr = 1;
+	required uint64	size = 2;
+	required uint64	offset = 3;
+	required uint32 alloc_flags = 4;
+	required uint32 gpu_id = 5;
+	required bytes rawdata = 6;
+	required bytes private_data = 7;
+}
+
+message criu_kfd {
+	required uint32 pid = 1;
+	required process_entry process_entry = 2;
+	required uint32 num_of_gpus = 3;
+	repeated device_entry device_entries = 4;
+	required uint64	num_of_bos = 5;
+	repeated bo_entry bo_entries = 6;
+}
+
+message criu_render_node {
+	required uint32 minor_number = 1;
+}

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -19,6 +19,11 @@ message bo_entry {
 	required bytes private_data = 7;
 }
 
+message q_entry {
+	required uint32 gpu_id = 1;
+	required bytes private_data = 2;
+}
+
 message criu_kfd {
 	required uint32 pid = 1;
 	required process_entry process_entry = 2;
@@ -26,6 +31,8 @@ message criu_kfd {
 	repeated device_entry device_entries = 4;
 	required uint64	num_of_bos = 5;
 	repeated bo_entry bo_entries = 6;
+	required uint32	num_of_queues = 7;
+	repeated q_entry q_entries = 8;
 }
 
 message criu_render_node {

--- a/plugins/amdgpu/criu-amdgpu.proto
+++ b/plugins/amdgpu/criu-amdgpu.proto
@@ -78,6 +78,8 @@ message criu_kfd {
 	required uint64 event_page_offset = 10;
 	required uint32 num_of_events = 11;
 	repeated ev_entry ev_entries = 12;
+	required uint64 shared_mem_size = 13;
+	required uint32 shared_mem_magic = 14;
 }
 
 message criu_render_node {

--- a/plugins/amdgpu/kfd_ioctl.h
+++ b/plugins/amdgpu/kfd_ioctl.h
@@ -1,0 +1,852 @@
+/*
+ * Copyright 2014 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef KFD_IOCTL_H_INCLUDED
+#define KFD_IOCTL_H_INCLUDED
+
+#include <drm/drm.h>
+#include <linux/ioctl.h>
+
+/*
+ * - 1.1 - initial version
+ * - 1.3 - Add SMI events support
+ * - 1.4 - Indicate new SRAM EDC bit in device properties
+ * - 1.5 - Add SVM API
+ */
+#define KFD_IOCTL_MAJOR_VERSION 1
+#define KFD_IOCTL_MINOR_VERSION 5
+
+struct kfd_ioctl_get_version_args {
+	__u32 major_version;	/* from KFD */
+	__u32 minor_version;	/* from KFD */
+};
+
+/* For kfd_ioctl_create_queue_args.queue_type. */
+#define KFD_IOC_QUEUE_TYPE_COMPUTE		0x0
+#define KFD_IOC_QUEUE_TYPE_SDMA			0x1
+#define KFD_IOC_QUEUE_TYPE_COMPUTE_AQL		0x2
+#define KFD_IOC_QUEUE_TYPE_SDMA_XGMI		0x3
+
+#define KFD_MAX_QUEUE_PERCENTAGE	100
+#define KFD_MAX_QUEUE_PRIORITY		15
+
+struct kfd_ioctl_create_queue_args {
+	__u64 ring_base_address;	/* to KFD */
+	__u64 write_pointer_address;	/* from KFD */
+	__u64 read_pointer_address;	/* from KFD */
+	__u64 doorbell_offset;	/* from KFD */
+
+	__u32 ring_size;		/* to KFD */
+	__u32 gpu_id;		/* to KFD */
+	__u32 queue_type;		/* to KFD */
+	__u32 queue_percentage;	/* to KFD */
+	__u32 queue_priority;	/* to KFD */
+	__u32 queue_id;		/* from KFD */
+
+	__u64 eop_buffer_address;	/* to KFD */
+	__u64 eop_buffer_size;	/* to KFD */
+	__u64 ctx_save_restore_address; /* to KFD */
+	__u32 ctx_save_restore_size;	/* to KFD */
+	__u32 ctl_stack_size;		/* to KFD */
+};
+
+struct kfd_ioctl_destroy_queue_args {
+	__u32 queue_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_update_queue_args {
+	__u64 ring_base_address;	/* to KFD */
+
+	__u32 queue_id;		/* to KFD */
+	__u32 ring_size;		/* to KFD */
+	__u32 queue_percentage;	/* to KFD */
+	__u32 queue_priority;	/* to KFD */
+};
+
+struct kfd_ioctl_set_cu_mask_args {
+	__u32 queue_id;		/* to KFD */
+	__u32 num_cu_mask;		/* to KFD */
+	__u64 cu_mask_ptr;		/* to KFD */
+};
+
+struct kfd_ioctl_get_queue_wave_state_args {
+	__u64 ctl_stack_address;	/* to KFD */
+	__u32 ctl_stack_used_size;	/* from KFD */
+	__u32 save_area_used_size;	/* from KFD */
+	__u32 queue_id;			/* to KFD */
+	__u32 pad;
+};
+
+/* For kfd_ioctl_set_memory_policy_args.default_policy and alternate_policy */
+#define KFD_IOC_CACHE_POLICY_COHERENT 0
+#define KFD_IOC_CACHE_POLICY_NONCOHERENT 1
+
+struct kfd_ioctl_set_memory_policy_args {
+	__u64 alternate_aperture_base;	/* to KFD */
+	__u64 alternate_aperture_size;	/* to KFD */
+
+	__u32 gpu_id;			/* to KFD */
+	__u32 default_policy;		/* to KFD */
+	__u32 alternate_policy;		/* to KFD */
+	__u32 pad;
+};
+
+/*
+ * All counters are monotonic. They are used for profiling of compute jobs.
+ * The profiling is done by userspace.
+ *
+ * In case of GPU reset, the counter should not be affected.
+ */
+
+struct kfd_ioctl_get_clock_counters_args {
+	__u64 gpu_clock_counter;	/* from KFD */
+	__u64 cpu_clock_counter;	/* from KFD */
+	__u64 system_clock_counter;	/* from KFD */
+	__u64 system_clock_freq;	/* from KFD */
+
+	__u32 gpu_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_process_device_apertures {
+	__u64 lds_base;		/* from KFD */
+	__u64 lds_limit;		/* from KFD */
+	__u64 scratch_base;		/* from KFD */
+	__u64 scratch_limit;		/* from KFD */
+	__u64 gpuvm_base;		/* from KFD */
+	__u64 gpuvm_limit;		/* from KFD */
+	__u32 gpu_id;		/* from KFD */
+	__u32 pad;
+};
+
+/*
+ * AMDKFD_IOC_GET_PROCESS_APERTURES is deprecated. Use
+ * AMDKFD_IOC_GET_PROCESS_APERTURES_NEW instead, which supports an
+ * unlimited number of GPUs.
+ */
+#define NUM_OF_SUPPORTED_GPUS 7
+struct kfd_ioctl_get_process_apertures_args {
+	struct kfd_process_device_apertures
+			process_apertures[NUM_OF_SUPPORTED_GPUS];/* from KFD */
+
+	/* from KFD, should be in the range [1 - NUM_OF_SUPPORTED_GPUS] */
+	__u32 num_of_nodes;
+	__u32 pad;
+};
+
+struct kfd_ioctl_get_process_apertures_new_args {
+	/* User allocated. Pointer to struct kfd_process_device_apertures
+	 * filled in by Kernel
+	 */
+	__u64 kfd_process_device_apertures_ptr;
+	/* to KFD - indicates amount of memory present in
+	 *  kfd_process_device_apertures_ptr
+	 * from KFD - Number of entries filled by KFD.
+	 */
+	__u32 num_of_nodes;
+	__u32 pad;
+};
+
+#define MAX_ALLOWED_NUM_POINTS    100
+#define MAX_ALLOWED_AW_BUFF_SIZE 4096
+#define MAX_ALLOWED_WAC_BUFF_SIZE  128
+
+struct kfd_ioctl_dbg_register_args {
+	__u32 gpu_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_dbg_unregister_args {
+	__u32 gpu_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_dbg_address_watch_args {
+	__u64 content_ptr;		/* a pointer to the actual content */
+	__u32 gpu_id;		/* to KFD */
+	__u32 buf_size_in_bytes;	/*including gpu_id and buf_size */
+};
+
+struct kfd_ioctl_dbg_wave_control_args {
+	__u64 content_ptr;		/* a pointer to the actual content */
+	__u32 gpu_id;		/* to KFD */
+	__u32 buf_size_in_bytes;	/*including gpu_id and buf_size */
+};
+
+/* Matching HSA_EVENTTYPE */
+#define KFD_IOC_EVENT_SIGNAL			0
+#define KFD_IOC_EVENT_NODECHANGE		1
+#define KFD_IOC_EVENT_DEVICESTATECHANGE		2
+#define KFD_IOC_EVENT_HW_EXCEPTION		3
+#define KFD_IOC_EVENT_SYSTEM_EVENT		4
+#define KFD_IOC_EVENT_DEBUG_EVENT		5
+#define KFD_IOC_EVENT_PROFILE_EVENT		6
+#define KFD_IOC_EVENT_QUEUE_EVENT		7
+#define KFD_IOC_EVENT_MEMORY			8
+
+#define KFD_IOC_WAIT_RESULT_COMPLETE		0
+#define KFD_IOC_WAIT_RESULT_TIMEOUT		1
+#define KFD_IOC_WAIT_RESULT_FAIL		2
+
+#define KFD_SIGNAL_EVENT_LIMIT			4096
+
+/* For kfd_event_data.hw_exception_data.reset_type. */
+#define KFD_HW_EXCEPTION_WHOLE_GPU_RESET	0
+#define KFD_HW_EXCEPTION_PER_ENGINE_RESET	1
+
+/* For kfd_event_data.hw_exception_data.reset_cause. */
+#define KFD_HW_EXCEPTION_GPU_HANG	0
+#define KFD_HW_EXCEPTION_ECC		1
+
+/* For kfd_hsa_memory_exception_data.ErrorType */
+#define KFD_MEM_ERR_NO_RAS		0
+#define KFD_MEM_ERR_SRAM_ECC		1
+#define KFD_MEM_ERR_POISON_CONSUMED	2
+#define KFD_MEM_ERR_GPU_HANG		3
+
+struct kfd_ioctl_create_event_args {
+	__u64 event_page_offset;	/* from KFD */
+	__u32 event_trigger_data;	/* from KFD - signal events only */
+	__u32 event_type;		/* to KFD */
+	__u32 auto_reset;		/* to KFD */
+	__u32 node_id;		/* to KFD - only valid for certain event types */
+	__u32 event_id;		/* from KFD */
+	__u32 event_slot_index;	/* from KFD */
+};
+
+struct kfd_ioctl_destroy_event_args {
+	__u32 event_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_set_event_args {
+	__u32 event_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_reset_event_args {
+	__u32 event_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_memory_exception_failure {
+	__u32 NotPresent;	/* Page not present or supervisor privilege */
+	__u32 ReadOnly;	/* Write access to a read-only page */
+	__u32 NoExecute;	/* Execute access to a page marked NX */
+	__u32 imprecise;	/* Can't determine the	exact fault address */
+};
+
+/* memory exception data */
+struct kfd_hsa_memory_exception_data {
+	struct kfd_memory_exception_failure failure;
+	__u64 va;
+	__u32 gpu_id;
+	__u32 ErrorType; /* 0 = no RAS error,
+			  * 1 = ECC_SRAM,
+			  * 2 = Link_SYNFLOOD (poison),
+			  * 3 = GPU hang (not attributable to a specific cause),
+			  * other values reserved
+			  */
+};
+
+/* hw exception data */
+struct kfd_hsa_hw_exception_data {
+	__u32 reset_type;
+	__u32 reset_cause;
+	__u32 memory_lost;
+	__u32 gpu_id;
+};
+
+/* Event data */
+struct kfd_event_data {
+	union {
+		struct kfd_hsa_memory_exception_data memory_exception_data;
+		struct kfd_hsa_hw_exception_data hw_exception_data;
+	};				/* From KFD */
+	__u64 kfd_event_data_ext;	/* pointer to an extension structure
+					 * for future exception types */
+	__u32 event_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_wait_events_args {
+	__u64 events_ptr;		/* pointed to struct kfd_event_data array, to KFD */
+	__u32 num_events;		/* to KFD */
+	__u32 wait_for_all;		/* to KFD */
+	__u32 timeout;		/* to KFD */
+	__u32 wait_result;		/* from KFD */
+};
+
+struct kfd_ioctl_set_scratch_backing_va_args {
+	__u64 va_addr;	/* to KFD */
+	__u32 gpu_id;	/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_get_tile_config_args {
+	/* to KFD: pointer to tile array */
+	__u64 tile_config_ptr;
+	/* to KFD: pointer to macro tile array */
+	__u64 macro_tile_config_ptr;
+	/* to KFD: array size allocated by user mode
+	 * from KFD: array size filled by kernel
+	 */
+	__u32 num_tile_configs;
+	/* to KFD: array size allocated by user mode
+	 * from KFD: array size filled by kernel
+	 */
+	__u32 num_macro_tile_configs;
+
+	__u32 gpu_id;		/* to KFD */
+	__u32 gb_addr_config;	/* from KFD */
+	__u32 num_banks;		/* from KFD */
+	__u32 num_ranks;		/* from KFD */
+	/* struct size can be extended later if needed
+	 * without breaking ABI compatibility
+	 */
+};
+
+struct kfd_ioctl_set_trap_handler_args {
+	__u64 tba_addr;		/* to KFD */
+	__u64 tma_addr;		/* to KFD */
+	__u32 gpu_id;		/* to KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_acquire_vm_args {
+	__u32 drm_fd;	/* to KFD */
+	__u32 gpu_id;	/* to KFD */
+};
+
+/* Allocation flags: memory types */
+#define KFD_IOC_ALLOC_MEM_FLAGS_VRAM		(1 << 0)
+#define KFD_IOC_ALLOC_MEM_FLAGS_GTT		(1 << 1)
+#define KFD_IOC_ALLOC_MEM_FLAGS_USERPTR		(1 << 2)
+#define KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL	(1 << 3)
+#define KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP	(1 << 4)
+/* Allocation flags: attributes/access options */
+#define KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE	(1 << 31)
+#define KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE	(1 << 30)
+#define KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC		(1 << 29)
+#define KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE	(1 << 28)
+#define KFD_IOC_ALLOC_MEM_FLAGS_AQL_QUEUE_MEM	(1 << 27)
+#define KFD_IOC_ALLOC_MEM_FLAGS_COHERENT	(1 << 26)
+#define KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED	(1 << 25)
+
+/* Allocate memory for later SVM (shared virtual memory) mapping.
+ *
+ * @va_addr:     virtual address of the memory to be allocated
+ *               all later mappings on all GPUs will use this address
+ * @size:        size in bytes
+ * @handle:      buffer handle returned to user mode, used to refer to
+ *               this allocation for mapping, unmapping and freeing
+ * @mmap_offset: for CPU-mapping the allocation by mmapping a render node
+ *               for userptrs this is overloaded to specify the CPU address
+ * @gpu_id:      device identifier
+ * @flags:       memory type and attributes. See KFD_IOC_ALLOC_MEM_FLAGS above
+ */
+struct kfd_ioctl_alloc_memory_of_gpu_args {
+	__u64 va_addr;		/* to KFD */
+	__u64 size;		/* to KFD */
+	__u64 handle;		/* from KFD */
+	__u64 mmap_offset;	/* to KFD (userptr), from KFD (mmap offset) */
+	__u32 gpu_id;		/* to KFD */
+	__u32 flags;
+};
+
+/* Free memory allocated with kfd_ioctl_alloc_memory_of_gpu
+ *
+ * @handle: memory handle returned by alloc
+ */
+struct kfd_ioctl_free_memory_of_gpu_args {
+	__u64 handle;		/* to KFD */
+};
+
+/* Map memory to one or more GPUs
+ *
+ * @handle:                memory handle returned by alloc
+ * @device_ids_array_ptr:  array of gpu_ids (__u32 per device)
+ * @n_devices:             number of devices in the array
+ * @n_success:             number of devices mapped successfully
+ *
+ * @n_success returns information to the caller how many devices from
+ * the start of the array have mapped the buffer successfully. It can
+ * be passed into a subsequent retry call to skip those devices. For
+ * the first call the caller should initialize it to 0.
+ *
+ * If the ioctl completes with return code 0 (success), n_success ==
+ * n_devices.
+ */
+struct kfd_ioctl_map_memory_to_gpu_args {
+	__u64 handle;			/* to KFD */
+	__u64 device_ids_array_ptr;	/* to KFD */
+	__u32 n_devices;		/* to KFD */
+	__u32 n_success;		/* to/from KFD */
+};
+
+/* Unmap memory from one or more GPUs
+ *
+ * same arguments as for mapping
+ */
+struct kfd_ioctl_unmap_memory_from_gpu_args {
+	__u64 handle;			/* to KFD */
+	__u64 device_ids_array_ptr;	/* to KFD */
+	__u32 n_devices;		/* to KFD */
+	__u32 n_success;		/* to/from KFD */
+};
+
+/* Allocate GWS for specific queue
+ *
+ * @queue_id:    queue's id that GWS is allocated for
+ * @num_gws:     how many GWS to allocate
+ * @first_gws:   index of the first GWS allocated.
+ *               only support contiguous GWS allocation
+ */
+struct kfd_ioctl_alloc_queue_gws_args {
+	__u32 queue_id;		/* to KFD */
+	__u32 num_gws;		/* to KFD */
+	__u32 first_gws;	/* from KFD */
+	__u32 pad;
+};
+
+struct kfd_ioctl_get_dmabuf_info_args {
+	__u64 size;		/* from KFD */
+	__u64 metadata_ptr;	/* to KFD */
+	__u32 metadata_size;	/* to KFD (space allocated by user)
+				 * from KFD (actual metadata size)
+				 */
+	__u32 gpu_id;	/* from KFD */
+	__u32 flags;		/* from KFD (KFD_IOC_ALLOC_MEM_FLAGS) */
+	__u32 dmabuf_fd;	/* to KFD */
+};
+
+struct kfd_ioctl_import_dmabuf_args {
+	__u64 va_addr;	/* to KFD */
+	__u64 handle;	/* from KFD */
+	__u32 gpu_id;	/* to KFD */
+	__u32 dmabuf_fd;	/* to KFD */
+};
+
+/*
+ * KFD SMI(System Management Interface) events
+ */
+enum kfd_smi_event {
+	KFD_SMI_EVENT_NONE = 0, /* not used */
+	KFD_SMI_EVENT_VMFAULT = 1, /* event start counting at 1 */
+	KFD_SMI_EVENT_THERMAL_THROTTLE = 2,
+	KFD_SMI_EVENT_GPU_PRE_RESET = 3,
+	KFD_SMI_EVENT_GPU_POST_RESET = 4,
+};
+
+#define KFD_SMI_EVENT_MASK_FROM_INDEX(i) (1ULL << ((i) - 1))
+
+struct kfd_ioctl_smi_events_args {
+	__u32 gpuid;	/* to KFD */
+	__u32 anon_fd;	/* from KFD */
+};
+
+struct kfd_criu_process_bucket {
+	__u64 priv_data_offset;
+	__u64 priv_data_size;
+};
+
+struct kfd_criu_device_bucket {
+	__u64 priv_data_offset;
+	__u64 priv_data_size;
+	__u32 user_gpu_id;
+	__u32 actual_gpu_id;
+	__u32 drm_fd;
+	__u32 pad;
+};
+
+struct kfd_criu_bo_bucket {
+	__u64 priv_data_offset;
+	__u64 priv_data_size;
+	__u64 addr;
+	__u64 size;
+	__u64 offset;
+	__u64 restored_offset;
+	__u32 gpu_id;
+	__u32 alloc_flags;
+	__u32 dmabuf_fd;
+	__u32 pad;
+};
+
+struct kfd_criu_queue_bucket {
+	__u64 priv_data_offset;
+	__u64 priv_data_size;
+	__u32 gpu_id;
+	__u32 pad;
+};
+
+struct kfd_criu_event_bucket {
+	__u64 priv_data_offset;
+	__u64 priv_data_size;
+	__u32 gpu_id;
+	__u32 pad;
+};
+
+struct kfd_ioctl_criu_process_info_args {
+	__u64 process_priv_data_size;
+	__u64 bos_priv_data_size;
+	__u64 devices_priv_data_size;
+	__u64 queues_priv_data_size;
+	__u64 events_priv_data_size;
+	__u64 svm_ranges_priv_data_size;
+	__u64 total_bos;
+	__u64 total_svm_ranges;
+	__u32 total_devices;
+	__u32 total_queues;
+	__u32 total_events;
+	__u32 task_pid;
+};
+
+struct kfd_ioctl_criu_pause_args {
+	__u32 pause;
+	__u32 pad;
+};
+
+enum kfd_criu_object_type {
+	KFD_CRIU_OBJECT_TYPE_PROCESS	= 0,
+	KFD_CRIU_OBJECT_TYPE_DEVICE	= 1,
+	KFD_CRIU_OBJECT_TYPE_BO		= 2,
+	KFD_CRIU_OBJECT_TYPE_QUEUE	= 3,
+	KFD_CRIU_OBJECT_TYPE_EVENT	= 4,
+	KFD_CRIU_OBJECT_TYPE_SVM_RANGE	= 5,
+};
+
+struct kfd_ioctl_criu_dumper_args {
+	__u64 num_objects;
+	__u64 objects;
+	__u64 objects_size;
+	__u64 objects_index_start;
+	__u32 type; /* enum kfd_criu_object_type */
+	__u32 pad;
+};
+
+struct kfd_ioctl_criu_restorer_args {
+	__u64 num_objects;
+	__u64 objects;
+	__u64 objects_size;
+	__u64 objects_index_start;
+	__u32 type; /* enum kfd_criu_object_type */
+	__u32 pad;
+};
+
+struct kfd_ioctl_criu_resume_args {
+	__u32 pid;	/* to KFD */
+	__u32 pad;
+};
+
+/* Register offset inside the remapped mmio page
+ */
+enum kfd_mmio_remap {
+	KFD_MMIO_REMAP_HDP_MEM_FLUSH_CNTL = 0,
+	KFD_MMIO_REMAP_HDP_REG_FLUSH_CNTL = 4,
+};
+
+/* Guarantee host access to memory */
+#define KFD_IOCTL_SVM_FLAG_HOST_ACCESS 0x00000001
+/* Fine grained coherency between all devices with access */
+#define KFD_IOCTL_SVM_FLAG_COHERENT    0x00000002
+/* Use any GPU in same hive as preferred device */
+#define KFD_IOCTL_SVM_FLAG_HIVE_LOCAL  0x00000004
+/* GPUs only read, allows replication */
+#define KFD_IOCTL_SVM_FLAG_GPU_RO      0x00000008
+/* Allow execution on GPU */
+#define KFD_IOCTL_SVM_FLAG_GPU_EXEC    0x00000010
+/* GPUs mostly read, may allow similar optimizations as RO, but writes fault */
+#define KFD_IOCTL_SVM_FLAG_GPU_READ_MOSTLY     0x00000020
+
+/**
+ * kfd_ioctl_svm_op - SVM ioctl operations
+ *
+ * @KFD_IOCTL_SVM_OP_SET_ATTR: Modify one or more attributes
+ * @KFD_IOCTL_SVM_OP_GET_ATTR: Query one or more attributes
+ */
+enum kfd_ioctl_svm_op {
+	KFD_IOCTL_SVM_OP_SET_ATTR,
+	KFD_IOCTL_SVM_OP_GET_ATTR
+};
+
+/** kfd_ioctl_svm_location - Enum for preferred and prefetch locations
+ *
+ * GPU IDs are used to specify GPUs as preferred and prefetch locations.
+ * Below definitions are used for system memory or for leaving the preferred
+ * location unspecified.
+ */
+enum kfd_ioctl_svm_location {
+	KFD_IOCTL_SVM_LOCATION_SYSMEM = 0,
+	KFD_IOCTL_SVM_LOCATION_UNDEFINED = 0xffffffff
+};
+
+/**
+ * kfd_ioctl_svm_attr_type - SVM attribute types
+ *
+ * @KFD_IOCTL_SVM_ATTR_PREFERRED_LOC: gpuid of the preferred location, 0 for
+ *                                    system memory
+ * @KFD_IOCTL_SVM_ATTR_PREFETCH_LOC: gpuid of the prefetch location, 0 for
+ *                                   system memory. Setting this triggers an
+ *                                   immediate prefetch (migration).
+ * @KFD_IOCTL_SVM_ATTR_ACCESS:
+ * @KFD_IOCTL_SVM_ATTR_ACCESS_IN_PLACE:
+ * @KFD_IOCTL_SVM_ATTR_NO_ACCESS: specify memory access for the gpuid given
+ *                                by the attribute value
+ * @KFD_IOCTL_SVM_ATTR_SET_FLAGS: bitmask of flags to set (see
+ *                                KFD_IOCTL_SVM_FLAG_...)
+ * @KFD_IOCTL_SVM_ATTR_CLR_FLAGS: bitmask of flags to clear
+ * @KFD_IOCTL_SVM_ATTR_GRANULARITY: migration granularity
+ *                                  (log2 num pages)
+ */
+enum kfd_ioctl_svm_attr_type {
+	KFD_IOCTL_SVM_ATTR_PREFERRED_LOC,
+	KFD_IOCTL_SVM_ATTR_PREFETCH_LOC,
+	KFD_IOCTL_SVM_ATTR_ACCESS,
+	KFD_IOCTL_SVM_ATTR_ACCESS_IN_PLACE,
+	KFD_IOCTL_SVM_ATTR_NO_ACCESS,
+	KFD_IOCTL_SVM_ATTR_SET_FLAGS,
+	KFD_IOCTL_SVM_ATTR_CLR_FLAGS,
+	KFD_IOCTL_SVM_ATTR_GRANULARITY
+};
+
+/**
+ * kfd_ioctl_svm_attribute - Attributes as pairs of type and value
+ *
+ * The meaning of the @value depends on the attribute type.
+ *
+ * @type: attribute type (see enum @kfd_ioctl_svm_attr_type)
+ * @value: attribute value
+ */
+struct kfd_ioctl_svm_attribute {
+	__u32 type;
+	__u32 value;
+};
+
+/**
+ * kfd_ioctl_svm_args - Arguments for SVM ioctl
+ *
+ * @op specifies the operation to perform (see enum
+ * @kfd_ioctl_svm_op).  @start_addr and @size are common for all
+ * operations.
+ *
+ * A variable number of attributes can be given in @attrs.
+ * @nattr specifies the number of attributes. New attributes can be
+ * added in the future without breaking the ABI. If unknown attributes
+ * are given, the function returns -EINVAL.
+ *
+ * @KFD_IOCTL_SVM_OP_SET_ATTR sets attributes for a virtual address
+ * range. It may overlap existing virtual address ranges. If it does,
+ * the existing ranges will be split such that the attribute changes
+ * only apply to the specified address range.
+ *
+ * @KFD_IOCTL_SVM_OP_GET_ATTR returns the intersection of attributes
+ * over all memory in the given range and returns the result as the
+ * attribute value. If different pages have different preferred or
+ * prefetch locations, 0xffffffff will be returned for
+ * @KFD_IOCTL_SVM_ATTR_PREFERRED_LOC or
+ * @KFD_IOCTL_SVM_ATTR_PREFETCH_LOC resepctively. For
+ * @KFD_IOCTL_SVM_ATTR_SET_FLAGS, flags of all pages will be
+ * aggregated by bitwise AND. The minimum  migration granularity
+ * throughout the range will be returned for
+ * @KFD_IOCTL_SVM_ATTR_GRANULARITY.
+ *
+ * Querying of accessibility attributes works by initializing the
+ * attribute type to @KFD_IOCTL_SVM_ATTR_ACCESS and the value to the
+ * GPUID being queried. Multiple attributes can be given to allow
+ * querying multiple GPUIDs. The ioctl function overwrites the
+ * attribute type to indicate the access for the specified GPU.
+ *
+ * @KFD_IOCTL_SVM_ATTR_CLR_FLAGS is invalid for
+ * @KFD_IOCTL_SVM_OP_GET_ATTR.
+ */
+struct kfd_ioctl_svm_args {
+	__u64 start_addr;
+	__u64 size;
+	__u32 op;
+	__u32 nattr;
+	/* Variable length array of attributes */
+	struct kfd_ioctl_svm_attribute attrs[0];
+};
+
+/**
+ * kfd_ioctl_set_xnack_mode_args - Arguments for set_xnack_mode
+ *
+ * @xnack_enabled:       [in/out] Whether to enable XNACK mode for this process
+ *
+ * @xnack_enabled indicates whether recoverable page faults should be
+ * enabled for the current process. 0 means disabled, positive means
+ * enabled, negative means leave unchanged. If enabled, virtual address
+ * translations on GFXv9 and later AMD GPUs can return XNACK and retry
+ * the access until a valid PTE is available. This is used to implement
+ * device page faults.
+ *
+ * On output, @xnack_enabled returns the (new) current mode (0 or
+ * positive). Therefore, a negative input value can be used to query
+ * the current mode without changing it.
+ *
+ * The XNACK mode fundamentally changes the way SVM managed memory works
+ * in the driver, with subtle effects on application performance and
+ * functionality.
+ *
+ * Enabling XNACK mode requires shader programs to be compiled
+ * differently. Furthermore, not all GPUs support changing the mode
+ * per-process. Therefore changing the mode is only allowed while no
+ * user mode queues exist in the process. This ensure that no shader
+ * code is running that may be compiled for the wrong mode. And GPUs
+ * that cannot change to the requested mode will prevent the XNACK
+ * mode from occurring. All GPUs used by the process must be in the
+ * same XNACK mode.
+ *
+ * GFXv8 or older GPUs do not support 48 bit virtual addresses or SVM.
+ * Therefore those GPUs are not considered for the XNACK mode switch.
+ *
+ * Return: 0 on success, -errno on failure
+ */
+struct kfd_ioctl_set_xnack_mode_args {
+	__s32 xnack_enabled;
+};
+
+#define AMDKFD_IOCTL_BASE 'K'
+#define AMDKFD_IO(nr)			_IO(AMDKFD_IOCTL_BASE, nr)
+#define AMDKFD_IOR(nr, type)		_IOR(AMDKFD_IOCTL_BASE, nr, type)
+#define AMDKFD_IOW(nr, type)		_IOW(AMDKFD_IOCTL_BASE, nr, type)
+#define AMDKFD_IOWR(nr, type)		_IOWR(AMDKFD_IOCTL_BASE, nr, type)
+
+#define AMDKFD_IOC_GET_VERSION			\
+		AMDKFD_IOR(0x01, struct kfd_ioctl_get_version_args)
+
+#define AMDKFD_IOC_CREATE_QUEUE			\
+		AMDKFD_IOWR(0x02, struct kfd_ioctl_create_queue_args)
+
+#define AMDKFD_IOC_DESTROY_QUEUE		\
+		AMDKFD_IOWR(0x03, struct kfd_ioctl_destroy_queue_args)
+
+#define AMDKFD_IOC_SET_MEMORY_POLICY		\
+		AMDKFD_IOW(0x04, struct kfd_ioctl_set_memory_policy_args)
+
+#define AMDKFD_IOC_GET_CLOCK_COUNTERS		\
+		AMDKFD_IOWR(0x05, struct kfd_ioctl_get_clock_counters_args)
+
+#define AMDKFD_IOC_GET_PROCESS_APERTURES	\
+		AMDKFD_IOR(0x06, struct kfd_ioctl_get_process_apertures_args)
+
+#define AMDKFD_IOC_UPDATE_QUEUE			\
+		AMDKFD_IOW(0x07, struct kfd_ioctl_update_queue_args)
+
+#define AMDKFD_IOC_CREATE_EVENT			\
+		AMDKFD_IOWR(0x08, struct kfd_ioctl_create_event_args)
+
+#define AMDKFD_IOC_DESTROY_EVENT		\
+		AMDKFD_IOW(0x09, struct kfd_ioctl_destroy_event_args)
+
+#define AMDKFD_IOC_SET_EVENT			\
+		AMDKFD_IOW(0x0A, struct kfd_ioctl_set_event_args)
+
+#define AMDKFD_IOC_RESET_EVENT			\
+		AMDKFD_IOW(0x0B, struct kfd_ioctl_reset_event_args)
+
+#define AMDKFD_IOC_WAIT_EVENTS			\
+		AMDKFD_IOWR(0x0C, struct kfd_ioctl_wait_events_args)
+
+#define AMDKFD_IOC_DBG_REGISTER			\
+		AMDKFD_IOW(0x0D, struct kfd_ioctl_dbg_register_args)
+
+#define AMDKFD_IOC_DBG_UNREGISTER		\
+		AMDKFD_IOW(0x0E, struct kfd_ioctl_dbg_unregister_args)
+
+#define AMDKFD_IOC_DBG_ADDRESS_WATCH		\
+		AMDKFD_IOW(0x0F, struct kfd_ioctl_dbg_address_watch_args)
+
+#define AMDKFD_IOC_DBG_WAVE_CONTROL		\
+		AMDKFD_IOW(0x10, struct kfd_ioctl_dbg_wave_control_args)
+
+#define AMDKFD_IOC_SET_SCRATCH_BACKING_VA	\
+		AMDKFD_IOWR(0x11, struct kfd_ioctl_set_scratch_backing_va_args)
+
+#define AMDKFD_IOC_GET_TILE_CONFIG                                      \
+		AMDKFD_IOWR(0x12, struct kfd_ioctl_get_tile_config_args)
+
+#define AMDKFD_IOC_SET_TRAP_HANDLER		\
+		AMDKFD_IOW(0x13, struct kfd_ioctl_set_trap_handler_args)
+
+#define AMDKFD_IOC_GET_PROCESS_APERTURES_NEW	\
+		AMDKFD_IOWR(0x14,		\
+			struct kfd_ioctl_get_process_apertures_new_args)
+
+#define AMDKFD_IOC_ACQUIRE_VM			\
+		AMDKFD_IOW(0x15, struct kfd_ioctl_acquire_vm_args)
+
+#define AMDKFD_IOC_ALLOC_MEMORY_OF_GPU		\
+		AMDKFD_IOWR(0x16, struct kfd_ioctl_alloc_memory_of_gpu_args)
+
+#define AMDKFD_IOC_FREE_MEMORY_OF_GPU		\
+		AMDKFD_IOW(0x17, struct kfd_ioctl_free_memory_of_gpu_args)
+
+#define AMDKFD_IOC_MAP_MEMORY_TO_GPU		\
+		AMDKFD_IOWR(0x18, struct kfd_ioctl_map_memory_to_gpu_args)
+
+#define AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU	\
+		AMDKFD_IOWR(0x19, struct kfd_ioctl_unmap_memory_from_gpu_args)
+
+#define AMDKFD_IOC_SET_CU_MASK		\
+		AMDKFD_IOW(0x1A, struct kfd_ioctl_set_cu_mask_args)
+
+#define AMDKFD_IOC_GET_QUEUE_WAVE_STATE		\
+		AMDKFD_IOWR(0x1B, struct kfd_ioctl_get_queue_wave_state_args)
+
+#define AMDKFD_IOC_GET_DMABUF_INFO		\
+		AMDKFD_IOWR(0x1C, struct kfd_ioctl_get_dmabuf_info_args)
+
+#define AMDKFD_IOC_IMPORT_DMABUF		\
+		AMDKFD_IOWR(0x1D, struct kfd_ioctl_import_dmabuf_args)
+
+#define AMDKFD_IOC_ALLOC_QUEUE_GWS		\
+		AMDKFD_IOWR(0x1E, struct kfd_ioctl_alloc_queue_gws_args)
+
+#define AMDKFD_IOC_SMI_EVENTS			\
+		AMDKFD_IOWR(0x1F, struct kfd_ioctl_smi_events_args)
+
+#define AMDKFD_IOC_SVM	AMDKFD_IOWR(0x20, struct kfd_ioctl_svm_args)
+
+#define AMDKFD_IOC_SET_XNACK_MODE		\
+		AMDKFD_IOWR(0x21, struct kfd_ioctl_set_xnack_mode_args)
+
+#define AMDKFD_IOC_CRIU_DUMPER			\
+		AMDKFD_IOWR(0x22, struct kfd_ioctl_criu_dumper_args)
+
+#define AMDKFD_IOC_CRIU_RESTORER			\
+		AMDKFD_IOWR(0x23, struct kfd_ioctl_criu_restorer_args)
+
+#define AMDKFD_IOC_CRIU_PROCESS_INFO			\
+		AMDKFD_IOWR(0x24, struct kfd_ioctl_criu_process_info_args)
+
+#define AMDKFD_IOC_CRIU_RESUME			\
+		AMDKFD_IOWR(0x25, struct kfd_ioctl_criu_resume_args)
+
+#define AMDKFD_IOC_CRIU_PAUSE			\
+		AMDKFD_IOW(0x26, struct kfd_ioctl_criu_pause_args)
+
+#define AMDKFD_COMMAND_START		0x01
+#define AMDKFD_COMMAND_END		0x26
+
+#endif

--- a/plugins/amdgpu/kfd_ioctl.h
+++ b/plugins/amdgpu/kfd_ioctl.h
@@ -36,78 +36,78 @@
 #define KFD_IOCTL_MINOR_VERSION 5
 
 struct kfd_ioctl_get_version_args {
-	__u32 major_version;	/* from KFD */
-	__u32 minor_version;	/* from KFD */
+	__u32 major_version; /* from KFD */
+	__u32 minor_version; /* from KFD */
 };
 
 /* For kfd_ioctl_create_queue_args.queue_type. */
-#define KFD_IOC_QUEUE_TYPE_COMPUTE		0x0
-#define KFD_IOC_QUEUE_TYPE_SDMA			0x1
-#define KFD_IOC_QUEUE_TYPE_COMPUTE_AQL		0x2
-#define KFD_IOC_QUEUE_TYPE_SDMA_XGMI		0x3
+#define KFD_IOC_QUEUE_TYPE_COMPUTE     0x0
+#define KFD_IOC_QUEUE_TYPE_SDMA	       0x1
+#define KFD_IOC_QUEUE_TYPE_COMPUTE_AQL 0x2
+#define KFD_IOC_QUEUE_TYPE_SDMA_XGMI   0x3
 
-#define KFD_MAX_QUEUE_PERCENTAGE	100
-#define KFD_MAX_QUEUE_PRIORITY		15
+#define KFD_MAX_QUEUE_PERCENTAGE 100
+#define KFD_MAX_QUEUE_PRIORITY	 15
 
 struct kfd_ioctl_create_queue_args {
-	__u64 ring_base_address;	/* to KFD */
-	__u64 write_pointer_address;	/* from KFD */
-	__u64 read_pointer_address;	/* from KFD */
-	__u64 doorbell_offset;	/* from KFD */
+	__u64 ring_base_address; /* to KFD */
+	__u64 write_pointer_address; /* from KFD */
+	__u64 read_pointer_address; /* from KFD */
+	__u64 doorbell_offset; /* from KFD */
 
-	__u32 ring_size;		/* to KFD */
-	__u32 gpu_id;		/* to KFD */
-	__u32 queue_type;		/* to KFD */
-	__u32 queue_percentage;	/* to KFD */
-	__u32 queue_priority;	/* to KFD */
-	__u32 queue_id;		/* from KFD */
+	__u32 ring_size; /* to KFD */
+	__u32 gpu_id; /* to KFD */
+	__u32 queue_type; /* to KFD */
+	__u32 queue_percentage; /* to KFD */
+	__u32 queue_priority; /* to KFD */
+	__u32 queue_id; /* from KFD */
 
-	__u64 eop_buffer_address;	/* to KFD */
-	__u64 eop_buffer_size;	/* to KFD */
+	__u64 eop_buffer_address; /* to KFD */
+	__u64 eop_buffer_size; /* to KFD */
 	__u64 ctx_save_restore_address; /* to KFD */
-	__u32 ctx_save_restore_size;	/* to KFD */
-	__u32 ctl_stack_size;		/* to KFD */
+	__u32 ctx_save_restore_size; /* to KFD */
+	__u32 ctl_stack_size; /* to KFD */
 };
 
 struct kfd_ioctl_destroy_queue_args {
-	__u32 queue_id;		/* to KFD */
+	__u32 queue_id; /* to KFD */
 	__u32 pad;
 };
 
 struct kfd_ioctl_update_queue_args {
-	__u64 ring_base_address;	/* to KFD */
+	__u64 ring_base_address; /* to KFD */
 
-	__u32 queue_id;		/* to KFD */
-	__u32 ring_size;		/* to KFD */
-	__u32 queue_percentage;	/* to KFD */
-	__u32 queue_priority;	/* to KFD */
+	__u32 queue_id; /* to KFD */
+	__u32 ring_size; /* to KFD */
+	__u32 queue_percentage; /* to KFD */
+	__u32 queue_priority; /* to KFD */
 };
 
 struct kfd_ioctl_set_cu_mask_args {
-	__u32 queue_id;		/* to KFD */
-	__u32 num_cu_mask;		/* to KFD */
-	__u64 cu_mask_ptr;		/* to KFD */
+	__u32 queue_id; /* to KFD */
+	__u32 num_cu_mask; /* to KFD */
+	__u64 cu_mask_ptr; /* to KFD */
 };
 
 struct kfd_ioctl_get_queue_wave_state_args {
-	__u64 ctl_stack_address;	/* to KFD */
-	__u32 ctl_stack_used_size;	/* from KFD */
-	__u32 save_area_used_size;	/* from KFD */
-	__u32 queue_id;			/* to KFD */
+	__u64 ctl_stack_address; /* to KFD */
+	__u32 ctl_stack_used_size; /* from KFD */
+	__u32 save_area_used_size; /* from KFD */
+	__u32 queue_id; /* to KFD */
 	__u32 pad;
 };
 
 /* For kfd_ioctl_set_memory_policy_args.default_policy and alternate_policy */
-#define KFD_IOC_CACHE_POLICY_COHERENT 0
+#define KFD_IOC_CACHE_POLICY_COHERENT	 0
 #define KFD_IOC_CACHE_POLICY_NONCOHERENT 1
 
 struct kfd_ioctl_set_memory_policy_args {
-	__u64 alternate_aperture_base;	/* to KFD */
-	__u64 alternate_aperture_size;	/* to KFD */
+	__u64 alternate_aperture_base; /* to KFD */
+	__u64 alternate_aperture_size; /* to KFD */
 
-	__u32 gpu_id;			/* to KFD */
-	__u32 default_policy;		/* to KFD */
-	__u32 alternate_policy;		/* to KFD */
+	__u32 gpu_id; /* to KFD */
+	__u32 default_policy; /* to KFD */
+	__u32 alternate_policy; /* to KFD */
 	__u32 pad;
 };
 
@@ -119,23 +119,23 @@ struct kfd_ioctl_set_memory_policy_args {
  */
 
 struct kfd_ioctl_get_clock_counters_args {
-	__u64 gpu_clock_counter;	/* from KFD */
-	__u64 cpu_clock_counter;	/* from KFD */
-	__u64 system_clock_counter;	/* from KFD */
-	__u64 system_clock_freq;	/* from KFD */
+	__u64 gpu_clock_counter; /* from KFD */
+	__u64 cpu_clock_counter; /* from KFD */
+	__u64 system_clock_counter; /* from KFD */
+	__u64 system_clock_freq; /* from KFD */
 
-	__u32 gpu_id;		/* to KFD */
+	__u32 gpu_id; /* to KFD */
 	__u32 pad;
 };
 
 struct kfd_process_device_apertures {
-	__u64 lds_base;		/* from KFD */
-	__u64 lds_limit;		/* from KFD */
-	__u64 scratch_base;		/* from KFD */
-	__u64 scratch_limit;		/* from KFD */
-	__u64 gpuvm_base;		/* from KFD */
-	__u64 gpuvm_limit;		/* from KFD */
-	__u32 gpu_id;		/* from KFD */
+	__u64 lds_base; /* from KFD */
+	__u64 lds_limit; /* from KFD */
+	__u64 scratch_base; /* from KFD */
+	__u64 scratch_limit; /* from KFD */
+	__u64 gpuvm_base; /* from KFD */
+	__u64 gpuvm_limit; /* from KFD */
+	__u32 gpu_id; /* from KFD */
 	__u32 pad;
 };
 
@@ -146,8 +146,7 @@ struct kfd_process_device_apertures {
  */
 #define NUM_OF_SUPPORTED_GPUS 7
 struct kfd_ioctl_get_process_apertures_args {
-	struct kfd_process_device_apertures
-			process_apertures[NUM_OF_SUPPORTED_GPUS];/* from KFD */
+	struct kfd_process_device_apertures process_apertures[NUM_OF_SUPPORTED_GPUS]; /* from KFD */
 
 	/* from KFD, should be in the range [1 - NUM_OF_SUPPORTED_GPUS] */
 	__u32 num_of_nodes;
@@ -167,93 +166,93 @@ struct kfd_ioctl_get_process_apertures_new_args {
 	__u32 pad;
 };
 
-#define MAX_ALLOWED_NUM_POINTS    100
-#define MAX_ALLOWED_AW_BUFF_SIZE 4096
-#define MAX_ALLOWED_WAC_BUFF_SIZE  128
+#define MAX_ALLOWED_NUM_POINTS	  100
+#define MAX_ALLOWED_AW_BUFF_SIZE  4096
+#define MAX_ALLOWED_WAC_BUFF_SIZE 128
 
 struct kfd_ioctl_dbg_register_args {
-	__u32 gpu_id;		/* to KFD */
+	__u32 gpu_id; /* to KFD */
 	__u32 pad;
 };
 
 struct kfd_ioctl_dbg_unregister_args {
-	__u32 gpu_id;		/* to KFD */
+	__u32 gpu_id; /* to KFD */
 	__u32 pad;
 };
 
 struct kfd_ioctl_dbg_address_watch_args {
-	__u64 content_ptr;		/* a pointer to the actual content */
-	__u32 gpu_id;		/* to KFD */
-	__u32 buf_size_in_bytes;	/*including gpu_id and buf_size */
+	__u64 content_ptr; /* a pointer to the actual content */
+	__u32 gpu_id; /* to KFD */
+	__u32 buf_size_in_bytes; /*including gpu_id and buf_size */
 };
 
 struct kfd_ioctl_dbg_wave_control_args {
-	__u64 content_ptr;		/* a pointer to the actual content */
-	__u32 gpu_id;		/* to KFD */
-	__u32 buf_size_in_bytes;	/*including gpu_id and buf_size */
+	__u64 content_ptr; /* a pointer to the actual content */
+	__u32 gpu_id; /* to KFD */
+	__u32 buf_size_in_bytes; /*including gpu_id and buf_size */
 };
 
 /* Matching HSA_EVENTTYPE */
-#define KFD_IOC_EVENT_SIGNAL			0
-#define KFD_IOC_EVENT_NODECHANGE		1
-#define KFD_IOC_EVENT_DEVICESTATECHANGE		2
-#define KFD_IOC_EVENT_HW_EXCEPTION		3
-#define KFD_IOC_EVENT_SYSTEM_EVENT		4
-#define KFD_IOC_EVENT_DEBUG_EVENT		5
-#define KFD_IOC_EVENT_PROFILE_EVENT		6
-#define KFD_IOC_EVENT_QUEUE_EVENT		7
-#define KFD_IOC_EVENT_MEMORY			8
+#define KFD_IOC_EVENT_SIGNAL		0
+#define KFD_IOC_EVENT_NODECHANGE	1
+#define KFD_IOC_EVENT_DEVICESTATECHANGE 2
+#define KFD_IOC_EVENT_HW_EXCEPTION	3
+#define KFD_IOC_EVENT_SYSTEM_EVENT	4
+#define KFD_IOC_EVENT_DEBUG_EVENT	5
+#define KFD_IOC_EVENT_PROFILE_EVENT	6
+#define KFD_IOC_EVENT_QUEUE_EVENT	7
+#define KFD_IOC_EVENT_MEMORY		8
 
-#define KFD_IOC_WAIT_RESULT_COMPLETE		0
-#define KFD_IOC_WAIT_RESULT_TIMEOUT		1
-#define KFD_IOC_WAIT_RESULT_FAIL		2
+#define KFD_IOC_WAIT_RESULT_COMPLETE 0
+#define KFD_IOC_WAIT_RESULT_TIMEOUT  1
+#define KFD_IOC_WAIT_RESULT_FAIL     2
 
-#define KFD_SIGNAL_EVENT_LIMIT			4096
+#define KFD_SIGNAL_EVENT_LIMIT 4096
 
 /* For kfd_event_data.hw_exception_data.reset_type. */
-#define KFD_HW_EXCEPTION_WHOLE_GPU_RESET	0
-#define KFD_HW_EXCEPTION_PER_ENGINE_RESET	1
+#define KFD_HW_EXCEPTION_WHOLE_GPU_RESET  0
+#define KFD_HW_EXCEPTION_PER_ENGINE_RESET 1
 
 /* For kfd_event_data.hw_exception_data.reset_cause. */
-#define KFD_HW_EXCEPTION_GPU_HANG	0
-#define KFD_HW_EXCEPTION_ECC		1
+#define KFD_HW_EXCEPTION_GPU_HANG 0
+#define KFD_HW_EXCEPTION_ECC	  1
 
 /* For kfd_hsa_memory_exception_data.ErrorType */
-#define KFD_MEM_ERR_NO_RAS		0
-#define KFD_MEM_ERR_SRAM_ECC		1
-#define KFD_MEM_ERR_POISON_CONSUMED	2
-#define KFD_MEM_ERR_GPU_HANG		3
+#define KFD_MEM_ERR_NO_RAS	    0
+#define KFD_MEM_ERR_SRAM_ECC	    1
+#define KFD_MEM_ERR_POISON_CONSUMED 2
+#define KFD_MEM_ERR_GPU_HANG	    3
 
 struct kfd_ioctl_create_event_args {
-	__u64 event_page_offset;	/* from KFD */
-	__u32 event_trigger_data;	/* from KFD - signal events only */
-	__u32 event_type;		/* to KFD */
-	__u32 auto_reset;		/* to KFD */
-	__u32 node_id;		/* to KFD - only valid for certain event types */
-	__u32 event_id;		/* from KFD */
-	__u32 event_slot_index;	/* from KFD */
+	__u64 event_page_offset; /* from KFD */
+	__u32 event_trigger_data; /* from KFD - signal events only */
+	__u32 event_type; /* to KFD */
+	__u32 auto_reset; /* to KFD */
+	__u32 node_id; /* to KFD - only valid for certain event types */
+	__u32 event_id; /* from KFD */
+	__u32 event_slot_index; /* from KFD */
 };
 
 struct kfd_ioctl_destroy_event_args {
-	__u32 event_id;		/* to KFD */
+	__u32 event_id; /* to KFD */
 	__u32 pad;
 };
 
 struct kfd_ioctl_set_event_args {
-	__u32 event_id;		/* to KFD */
+	__u32 event_id; /* to KFD */
 	__u32 pad;
 };
 
 struct kfd_ioctl_reset_event_args {
-	__u32 event_id;		/* to KFD */
+	__u32 event_id; /* to KFD */
 	__u32 pad;
 };
 
 struct kfd_memory_exception_failure {
-	__u32 NotPresent;	/* Page not present or supervisor privilege */
-	__u32 ReadOnly;	/* Write access to a read-only page */
-	__u32 NoExecute;	/* Execute access to a page marked NX */
-	__u32 imprecise;	/* Can't determine the	exact fault address */
+	__u32 NotPresent; /* Page not present or supervisor privilege */
+	__u32 ReadOnly; /* Write access to a read-only page */
+	__u32 NoExecute; /* Execute access to a page marked NX */
+	__u32 imprecise; /* Can't determine the	exact fault address */
 };
 
 /* memory exception data */
@@ -282,24 +281,24 @@ struct kfd_event_data {
 	union {
 		struct kfd_hsa_memory_exception_data memory_exception_data;
 		struct kfd_hsa_hw_exception_data hw_exception_data;
-	};				/* From KFD */
-	__u64 kfd_event_data_ext;	/* pointer to an extension structure
+	}; /* From KFD */
+	__u64 kfd_event_data_ext; /* pointer to an extension structure
 					 * for future exception types */
-	__u32 event_id;		/* to KFD */
+	__u32 event_id; /* to KFD */
 	__u32 pad;
 };
 
 struct kfd_ioctl_wait_events_args {
-	__u64 events_ptr;		/* pointed to struct kfd_event_data array, to KFD */
-	__u32 num_events;		/* to KFD */
-	__u32 wait_for_all;		/* to KFD */
-	__u32 timeout;		/* to KFD */
-	__u32 wait_result;		/* from KFD */
+	__u64 events_ptr; /* pointed to struct kfd_event_data array, to KFD */
+	__u32 num_events; /* to KFD */
+	__u32 wait_for_all; /* to KFD */
+	__u32 timeout; /* to KFD */
+	__u32 wait_result; /* from KFD */
 };
 
 struct kfd_ioctl_set_scratch_backing_va_args {
-	__u64 va_addr;	/* to KFD */
-	__u32 gpu_id;	/* to KFD */
+	__u64 va_addr; /* to KFD */
+	__u32 gpu_id; /* to KFD */
 	__u32 pad;
 };
 
@@ -317,41 +316,41 @@ struct kfd_ioctl_get_tile_config_args {
 	 */
 	__u32 num_macro_tile_configs;
 
-	__u32 gpu_id;		/* to KFD */
-	__u32 gb_addr_config;	/* from KFD */
-	__u32 num_banks;		/* from KFD */
-	__u32 num_ranks;		/* from KFD */
+	__u32 gpu_id; /* to KFD */
+	__u32 gb_addr_config; /* from KFD */
+	__u32 num_banks; /* from KFD */
+	__u32 num_ranks; /* from KFD */
 	/* struct size can be extended later if needed
 	 * without breaking ABI compatibility
 	 */
 };
 
 struct kfd_ioctl_set_trap_handler_args {
-	__u64 tba_addr;		/* to KFD */
-	__u64 tma_addr;		/* to KFD */
-	__u32 gpu_id;		/* to KFD */
+	__u64 tba_addr; /* to KFD */
+	__u64 tma_addr; /* to KFD */
+	__u32 gpu_id; /* to KFD */
 	__u32 pad;
 };
 
 struct kfd_ioctl_acquire_vm_args {
-	__u32 drm_fd;	/* to KFD */
-	__u32 gpu_id;	/* to KFD */
+	__u32 drm_fd; /* to KFD */
+	__u32 gpu_id; /* to KFD */
 };
 
 /* Allocation flags: memory types */
-#define KFD_IOC_ALLOC_MEM_FLAGS_VRAM		(1 << 0)
-#define KFD_IOC_ALLOC_MEM_FLAGS_GTT		(1 << 1)
-#define KFD_IOC_ALLOC_MEM_FLAGS_USERPTR		(1 << 2)
-#define KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL	(1 << 3)
-#define KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP	(1 << 4)
+#define KFD_IOC_ALLOC_MEM_FLAGS_VRAM	   (1 << 0)
+#define KFD_IOC_ALLOC_MEM_FLAGS_GTT	   (1 << 1)
+#define KFD_IOC_ALLOC_MEM_FLAGS_USERPTR	   (1 << 2)
+#define KFD_IOC_ALLOC_MEM_FLAGS_DOORBELL   (1 << 3)
+#define KFD_IOC_ALLOC_MEM_FLAGS_MMIO_REMAP (1 << 4)
 /* Allocation flags: attributes/access options */
-#define KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE	(1 << 31)
-#define KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE	(1 << 30)
-#define KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC		(1 << 29)
-#define KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE	(1 << 28)
-#define KFD_IOC_ALLOC_MEM_FLAGS_AQL_QUEUE_MEM	(1 << 27)
-#define KFD_IOC_ALLOC_MEM_FLAGS_COHERENT	(1 << 26)
-#define KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED	(1 << 25)
+#define KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE      (1 << 31)
+#define KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE    (1 << 30)
+#define KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC	      (1 << 29)
+#define KFD_IOC_ALLOC_MEM_FLAGS_NO_SUBSTITUTE (1 << 28)
+#define KFD_IOC_ALLOC_MEM_FLAGS_AQL_QUEUE_MEM (1 << 27)
+#define KFD_IOC_ALLOC_MEM_FLAGS_COHERENT      (1 << 26)
+#define KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED      (1 << 25)
 
 /* Allocate memory for later SVM (shared virtual memory) mapping.
  *
@@ -366,11 +365,11 @@ struct kfd_ioctl_acquire_vm_args {
  * @flags:       memory type and attributes. See KFD_IOC_ALLOC_MEM_FLAGS above
  */
 struct kfd_ioctl_alloc_memory_of_gpu_args {
-	__u64 va_addr;		/* to KFD */
-	__u64 size;		/* to KFD */
-	__u64 handle;		/* from KFD */
-	__u64 mmap_offset;	/* to KFD (userptr), from KFD (mmap offset) */
-	__u32 gpu_id;		/* to KFD */
+	__u64 va_addr; /* to KFD */
+	__u64 size; /* to KFD */
+	__u64 handle; /* from KFD */
+	__u64 mmap_offset; /* to KFD (userptr), from KFD (mmap offset) */
+	__u32 gpu_id; /* to KFD */
 	__u32 flags;
 };
 
@@ -379,7 +378,7 @@ struct kfd_ioctl_alloc_memory_of_gpu_args {
  * @handle: memory handle returned by alloc
  */
 struct kfd_ioctl_free_memory_of_gpu_args {
-	__u64 handle;		/* to KFD */
+	__u64 handle; /* to KFD */
 };
 
 /* Map memory to one or more GPUs
@@ -398,10 +397,10 @@ struct kfd_ioctl_free_memory_of_gpu_args {
  * n_devices.
  */
 struct kfd_ioctl_map_memory_to_gpu_args {
-	__u64 handle;			/* to KFD */
-	__u64 device_ids_array_ptr;	/* to KFD */
-	__u32 n_devices;		/* to KFD */
-	__u32 n_success;		/* to/from KFD */
+	__u64 handle; /* to KFD */
+	__u64 device_ids_array_ptr; /* to KFD */
+	__u32 n_devices; /* to KFD */
+	__u32 n_success; /* to/from KFD */
 };
 
 /* Unmap memory from one or more GPUs
@@ -409,10 +408,10 @@ struct kfd_ioctl_map_memory_to_gpu_args {
  * same arguments as for mapping
  */
 struct kfd_ioctl_unmap_memory_from_gpu_args {
-	__u64 handle;			/* to KFD */
-	__u64 device_ids_array_ptr;	/* to KFD */
-	__u32 n_devices;		/* to KFD */
-	__u32 n_success;		/* to/from KFD */
+	__u64 handle; /* to KFD */
+	__u64 device_ids_array_ptr; /* to KFD */
+	__u32 n_devices; /* to KFD */
+	__u32 n_success; /* to/from KFD */
 };
 
 /* Allocate GWS for specific queue
@@ -423,28 +422,28 @@ struct kfd_ioctl_unmap_memory_from_gpu_args {
  *               only support contiguous GWS allocation
  */
 struct kfd_ioctl_alloc_queue_gws_args {
-	__u32 queue_id;		/* to KFD */
-	__u32 num_gws;		/* to KFD */
-	__u32 first_gws;	/* from KFD */
+	__u32 queue_id; /* to KFD */
+	__u32 num_gws; /* to KFD */
+	__u32 first_gws; /* from KFD */
 	__u32 pad;
 };
 
 struct kfd_ioctl_get_dmabuf_info_args {
-	__u64 size;		/* from KFD */
-	__u64 metadata_ptr;	/* to KFD */
-	__u32 metadata_size;	/* to KFD (space allocated by user)
+	__u64 size; /* from KFD */
+	__u64 metadata_ptr; /* to KFD */
+	__u32 metadata_size; /* to KFD (space allocated by user)
 				 * from KFD (actual metadata size)
 				 */
-	__u32 gpu_id;	/* from KFD */
-	__u32 flags;		/* from KFD (KFD_IOC_ALLOC_MEM_FLAGS) */
-	__u32 dmabuf_fd;	/* to KFD */
+	__u32 gpu_id; /* from KFD */
+	__u32 flags; /* from KFD (KFD_IOC_ALLOC_MEM_FLAGS) */
+	__u32 dmabuf_fd; /* to KFD */
 };
 
 struct kfd_ioctl_import_dmabuf_args {
-	__u64 va_addr;	/* to KFD */
-	__u64 handle;	/* from KFD */
-	__u32 gpu_id;	/* to KFD */
-	__u32 dmabuf_fd;	/* to KFD */
+	__u64 va_addr; /* to KFD */
+	__u64 handle; /* from KFD */
+	__u32 gpu_id; /* to KFD */
+	__u32 dmabuf_fd; /* to KFD */
 };
 
 /*
@@ -458,11 +457,11 @@ enum kfd_smi_event {
 	KFD_SMI_EVENT_GPU_POST_RESET = 4,
 };
 
-#define KFD_SMI_EVENT_MASK_FROM_INDEX(i) (1ULL << ((i) - 1))
+#define KFD_SMI_EVENT_MASK_FROM_INDEX(i) (1ULL << ((i)-1))
 
 struct kfd_ioctl_smi_events_args {
-	__u32 gpuid;	/* to KFD */
-	__u32 anon_fd;	/* from KFD */
+	__u32 gpuid; /* to KFD */
+	__u32 anon_fd; /* from KFD */
 };
 
 struct kfd_criu_process_bucket {
@@ -527,12 +526,12 @@ struct kfd_ioctl_criu_pause_args {
 };
 
 enum kfd_criu_object_type {
-	KFD_CRIU_OBJECT_TYPE_PROCESS	= 0,
-	KFD_CRIU_OBJECT_TYPE_DEVICE	= 1,
-	KFD_CRIU_OBJECT_TYPE_BO		= 2,
-	KFD_CRIU_OBJECT_TYPE_QUEUE	= 3,
-	KFD_CRIU_OBJECT_TYPE_EVENT	= 4,
-	KFD_CRIU_OBJECT_TYPE_SVM_RANGE	= 5,
+	KFD_CRIU_OBJECT_TYPE_PROCESS = 0,
+	KFD_CRIU_OBJECT_TYPE_DEVICE = 1,
+	KFD_CRIU_OBJECT_TYPE_BO = 2,
+	KFD_CRIU_OBJECT_TYPE_QUEUE = 3,
+	KFD_CRIU_OBJECT_TYPE_EVENT = 4,
+	KFD_CRIU_OBJECT_TYPE_SVM_RANGE = 5,
 };
 
 struct kfd_ioctl_criu_dumper_args {
@@ -554,7 +553,7 @@ struct kfd_ioctl_criu_restorer_args {
 };
 
 struct kfd_ioctl_criu_resume_args {
-	__u32 pid;	/* to KFD */
+	__u32 pid; /* to KFD */
 	__u32 pad;
 };
 
@@ -568,15 +567,15 @@ enum kfd_mmio_remap {
 /* Guarantee host access to memory */
 #define KFD_IOCTL_SVM_FLAG_HOST_ACCESS 0x00000001
 /* Fine grained coherency between all devices with access */
-#define KFD_IOCTL_SVM_FLAG_COHERENT    0x00000002
+#define KFD_IOCTL_SVM_FLAG_COHERENT 0x00000002
 /* Use any GPU in same hive as preferred device */
-#define KFD_IOCTL_SVM_FLAG_HIVE_LOCAL  0x00000004
+#define KFD_IOCTL_SVM_FLAG_HIVE_LOCAL 0x00000004
 /* GPUs only read, allows replication */
-#define KFD_IOCTL_SVM_FLAG_GPU_RO      0x00000008
+#define KFD_IOCTL_SVM_FLAG_GPU_RO 0x00000008
 /* Allow execution on GPU */
-#define KFD_IOCTL_SVM_FLAG_GPU_EXEC    0x00000010
+#define KFD_IOCTL_SVM_FLAG_GPU_EXEC 0x00000010
 /* GPUs mostly read, may allow similar optimizations as RO, but writes fault */
-#define KFD_IOCTL_SVM_FLAG_GPU_READ_MOSTLY     0x00000020
+#define KFD_IOCTL_SVM_FLAG_GPU_READ_MOSTLY 0x00000020
 
 /**
  * kfd_ioctl_svm_op - SVM ioctl operations
@@ -584,10 +583,7 @@ enum kfd_mmio_remap {
  * @KFD_IOCTL_SVM_OP_SET_ATTR: Modify one or more attributes
  * @KFD_IOCTL_SVM_OP_GET_ATTR: Query one or more attributes
  */
-enum kfd_ioctl_svm_op {
-	KFD_IOCTL_SVM_OP_SET_ATTR,
-	KFD_IOCTL_SVM_OP_GET_ATTR
-};
+enum kfd_ioctl_svm_op { KFD_IOCTL_SVM_OP_SET_ATTR, KFD_IOCTL_SVM_OP_GET_ATTR };
 
 /** kfd_ioctl_svm_location - Enum for preferred and prefetch locations
  *
@@ -595,10 +591,7 @@ enum kfd_ioctl_svm_op {
  * Below definitions are used for system memory or for leaving the preferred
  * location unspecified.
  */
-enum kfd_ioctl_svm_location {
-	KFD_IOCTL_SVM_LOCATION_SYSMEM = 0,
-	KFD_IOCTL_SVM_LOCATION_UNDEFINED = 0xffffffff
-};
+enum kfd_ioctl_svm_location { KFD_IOCTL_SVM_LOCATION_SYSMEM = 0, KFD_IOCTL_SVM_LOCATION_UNDEFINED = 0xffffffff };
 
 /**
  * kfd_ioctl_svm_attr_type - SVM attribute types
@@ -726,127 +719,89 @@ struct kfd_ioctl_set_xnack_mode_args {
 	__s32 xnack_enabled;
 };
 
-#define AMDKFD_IOCTL_BASE 'K'
-#define AMDKFD_IO(nr)			_IO(AMDKFD_IOCTL_BASE, nr)
-#define AMDKFD_IOR(nr, type)		_IOR(AMDKFD_IOCTL_BASE, nr, type)
-#define AMDKFD_IOW(nr, type)		_IOW(AMDKFD_IOCTL_BASE, nr, type)
-#define AMDKFD_IOWR(nr, type)		_IOWR(AMDKFD_IOCTL_BASE, nr, type)
+#define AMDKFD_IOCTL_BASE     'K'
+#define AMDKFD_IO(nr)	      _IO(AMDKFD_IOCTL_BASE, nr)
+#define AMDKFD_IOR(nr, type)  _IOR(AMDKFD_IOCTL_BASE, nr, type)
+#define AMDKFD_IOW(nr, type)  _IOW(AMDKFD_IOCTL_BASE, nr, type)
+#define AMDKFD_IOWR(nr, type) _IOWR(AMDKFD_IOCTL_BASE, nr, type)
 
-#define AMDKFD_IOC_GET_VERSION			\
-		AMDKFD_IOR(0x01, struct kfd_ioctl_get_version_args)
+#define AMDKFD_IOC_GET_VERSION AMDKFD_IOR(0x01, struct kfd_ioctl_get_version_args)
 
-#define AMDKFD_IOC_CREATE_QUEUE			\
-		AMDKFD_IOWR(0x02, struct kfd_ioctl_create_queue_args)
+#define AMDKFD_IOC_CREATE_QUEUE AMDKFD_IOWR(0x02, struct kfd_ioctl_create_queue_args)
 
-#define AMDKFD_IOC_DESTROY_QUEUE		\
-		AMDKFD_IOWR(0x03, struct kfd_ioctl_destroy_queue_args)
+#define AMDKFD_IOC_DESTROY_QUEUE AMDKFD_IOWR(0x03, struct kfd_ioctl_destroy_queue_args)
 
-#define AMDKFD_IOC_SET_MEMORY_POLICY		\
-		AMDKFD_IOW(0x04, struct kfd_ioctl_set_memory_policy_args)
+#define AMDKFD_IOC_SET_MEMORY_POLICY AMDKFD_IOW(0x04, struct kfd_ioctl_set_memory_policy_args)
 
-#define AMDKFD_IOC_GET_CLOCK_COUNTERS		\
-		AMDKFD_IOWR(0x05, struct kfd_ioctl_get_clock_counters_args)
+#define AMDKFD_IOC_GET_CLOCK_COUNTERS AMDKFD_IOWR(0x05, struct kfd_ioctl_get_clock_counters_args)
 
-#define AMDKFD_IOC_GET_PROCESS_APERTURES	\
-		AMDKFD_IOR(0x06, struct kfd_ioctl_get_process_apertures_args)
+#define AMDKFD_IOC_GET_PROCESS_APERTURES AMDKFD_IOR(0x06, struct kfd_ioctl_get_process_apertures_args)
 
-#define AMDKFD_IOC_UPDATE_QUEUE			\
-		AMDKFD_IOW(0x07, struct kfd_ioctl_update_queue_args)
+#define AMDKFD_IOC_UPDATE_QUEUE AMDKFD_IOW(0x07, struct kfd_ioctl_update_queue_args)
 
-#define AMDKFD_IOC_CREATE_EVENT			\
-		AMDKFD_IOWR(0x08, struct kfd_ioctl_create_event_args)
+#define AMDKFD_IOC_CREATE_EVENT AMDKFD_IOWR(0x08, struct kfd_ioctl_create_event_args)
 
-#define AMDKFD_IOC_DESTROY_EVENT		\
-		AMDKFD_IOW(0x09, struct kfd_ioctl_destroy_event_args)
+#define AMDKFD_IOC_DESTROY_EVENT AMDKFD_IOW(0x09, struct kfd_ioctl_destroy_event_args)
 
-#define AMDKFD_IOC_SET_EVENT			\
-		AMDKFD_IOW(0x0A, struct kfd_ioctl_set_event_args)
+#define AMDKFD_IOC_SET_EVENT AMDKFD_IOW(0x0A, struct kfd_ioctl_set_event_args)
 
-#define AMDKFD_IOC_RESET_EVENT			\
-		AMDKFD_IOW(0x0B, struct kfd_ioctl_reset_event_args)
+#define AMDKFD_IOC_RESET_EVENT AMDKFD_IOW(0x0B, struct kfd_ioctl_reset_event_args)
 
-#define AMDKFD_IOC_WAIT_EVENTS			\
-		AMDKFD_IOWR(0x0C, struct kfd_ioctl_wait_events_args)
+#define AMDKFD_IOC_WAIT_EVENTS AMDKFD_IOWR(0x0C, struct kfd_ioctl_wait_events_args)
 
-#define AMDKFD_IOC_DBG_REGISTER			\
-		AMDKFD_IOW(0x0D, struct kfd_ioctl_dbg_register_args)
+#define AMDKFD_IOC_DBG_REGISTER AMDKFD_IOW(0x0D, struct kfd_ioctl_dbg_register_args)
 
-#define AMDKFD_IOC_DBG_UNREGISTER		\
-		AMDKFD_IOW(0x0E, struct kfd_ioctl_dbg_unregister_args)
+#define AMDKFD_IOC_DBG_UNREGISTER AMDKFD_IOW(0x0E, struct kfd_ioctl_dbg_unregister_args)
 
-#define AMDKFD_IOC_DBG_ADDRESS_WATCH		\
-		AMDKFD_IOW(0x0F, struct kfd_ioctl_dbg_address_watch_args)
+#define AMDKFD_IOC_DBG_ADDRESS_WATCH AMDKFD_IOW(0x0F, struct kfd_ioctl_dbg_address_watch_args)
 
-#define AMDKFD_IOC_DBG_WAVE_CONTROL		\
-		AMDKFD_IOW(0x10, struct kfd_ioctl_dbg_wave_control_args)
+#define AMDKFD_IOC_DBG_WAVE_CONTROL AMDKFD_IOW(0x10, struct kfd_ioctl_dbg_wave_control_args)
 
-#define AMDKFD_IOC_SET_SCRATCH_BACKING_VA	\
-		AMDKFD_IOWR(0x11, struct kfd_ioctl_set_scratch_backing_va_args)
+#define AMDKFD_IOC_SET_SCRATCH_BACKING_VA AMDKFD_IOWR(0x11, struct kfd_ioctl_set_scratch_backing_va_args)
 
-#define AMDKFD_IOC_GET_TILE_CONFIG                                      \
-		AMDKFD_IOWR(0x12, struct kfd_ioctl_get_tile_config_args)
+#define AMDKFD_IOC_GET_TILE_CONFIG AMDKFD_IOWR(0x12, struct kfd_ioctl_get_tile_config_args)
 
-#define AMDKFD_IOC_SET_TRAP_HANDLER		\
-		AMDKFD_IOW(0x13, struct kfd_ioctl_set_trap_handler_args)
+#define AMDKFD_IOC_SET_TRAP_HANDLER AMDKFD_IOW(0x13, struct kfd_ioctl_set_trap_handler_args)
 
-#define AMDKFD_IOC_GET_PROCESS_APERTURES_NEW	\
-		AMDKFD_IOWR(0x14,		\
-			struct kfd_ioctl_get_process_apertures_new_args)
+#define AMDKFD_IOC_GET_PROCESS_APERTURES_NEW AMDKFD_IOWR(0x14, struct kfd_ioctl_get_process_apertures_new_args)
 
-#define AMDKFD_IOC_ACQUIRE_VM			\
-		AMDKFD_IOW(0x15, struct kfd_ioctl_acquire_vm_args)
+#define AMDKFD_IOC_ACQUIRE_VM AMDKFD_IOW(0x15, struct kfd_ioctl_acquire_vm_args)
 
-#define AMDKFD_IOC_ALLOC_MEMORY_OF_GPU		\
-		AMDKFD_IOWR(0x16, struct kfd_ioctl_alloc_memory_of_gpu_args)
+#define AMDKFD_IOC_ALLOC_MEMORY_OF_GPU AMDKFD_IOWR(0x16, struct kfd_ioctl_alloc_memory_of_gpu_args)
 
-#define AMDKFD_IOC_FREE_MEMORY_OF_GPU		\
-		AMDKFD_IOW(0x17, struct kfd_ioctl_free_memory_of_gpu_args)
+#define AMDKFD_IOC_FREE_MEMORY_OF_GPU AMDKFD_IOW(0x17, struct kfd_ioctl_free_memory_of_gpu_args)
 
-#define AMDKFD_IOC_MAP_MEMORY_TO_GPU		\
-		AMDKFD_IOWR(0x18, struct kfd_ioctl_map_memory_to_gpu_args)
+#define AMDKFD_IOC_MAP_MEMORY_TO_GPU AMDKFD_IOWR(0x18, struct kfd_ioctl_map_memory_to_gpu_args)
 
-#define AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU	\
-		AMDKFD_IOWR(0x19, struct kfd_ioctl_unmap_memory_from_gpu_args)
+#define AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU AMDKFD_IOWR(0x19, struct kfd_ioctl_unmap_memory_from_gpu_args)
 
-#define AMDKFD_IOC_SET_CU_MASK		\
-		AMDKFD_IOW(0x1A, struct kfd_ioctl_set_cu_mask_args)
+#define AMDKFD_IOC_SET_CU_MASK AMDKFD_IOW(0x1A, struct kfd_ioctl_set_cu_mask_args)
 
-#define AMDKFD_IOC_GET_QUEUE_WAVE_STATE		\
-		AMDKFD_IOWR(0x1B, struct kfd_ioctl_get_queue_wave_state_args)
+#define AMDKFD_IOC_GET_QUEUE_WAVE_STATE AMDKFD_IOWR(0x1B, struct kfd_ioctl_get_queue_wave_state_args)
 
-#define AMDKFD_IOC_GET_DMABUF_INFO		\
-		AMDKFD_IOWR(0x1C, struct kfd_ioctl_get_dmabuf_info_args)
+#define AMDKFD_IOC_GET_DMABUF_INFO AMDKFD_IOWR(0x1C, struct kfd_ioctl_get_dmabuf_info_args)
 
-#define AMDKFD_IOC_IMPORT_DMABUF		\
-		AMDKFD_IOWR(0x1D, struct kfd_ioctl_import_dmabuf_args)
+#define AMDKFD_IOC_IMPORT_DMABUF AMDKFD_IOWR(0x1D, struct kfd_ioctl_import_dmabuf_args)
 
-#define AMDKFD_IOC_ALLOC_QUEUE_GWS		\
-		AMDKFD_IOWR(0x1E, struct kfd_ioctl_alloc_queue_gws_args)
+#define AMDKFD_IOC_ALLOC_QUEUE_GWS AMDKFD_IOWR(0x1E, struct kfd_ioctl_alloc_queue_gws_args)
 
-#define AMDKFD_IOC_SMI_EVENTS			\
-		AMDKFD_IOWR(0x1F, struct kfd_ioctl_smi_events_args)
+#define AMDKFD_IOC_SMI_EVENTS AMDKFD_IOWR(0x1F, struct kfd_ioctl_smi_events_args)
 
-#define AMDKFD_IOC_SVM	AMDKFD_IOWR(0x20, struct kfd_ioctl_svm_args)
+#define AMDKFD_IOC_SVM AMDKFD_IOWR(0x20, struct kfd_ioctl_svm_args)
 
-#define AMDKFD_IOC_SET_XNACK_MODE		\
-		AMDKFD_IOWR(0x21, struct kfd_ioctl_set_xnack_mode_args)
+#define AMDKFD_IOC_SET_XNACK_MODE AMDKFD_IOWR(0x21, struct kfd_ioctl_set_xnack_mode_args)
 
-#define AMDKFD_IOC_CRIU_DUMPER			\
-		AMDKFD_IOWR(0x22, struct kfd_ioctl_criu_dumper_args)
+#define AMDKFD_IOC_CRIU_DUMPER AMDKFD_IOWR(0x22, struct kfd_ioctl_criu_dumper_args)
 
-#define AMDKFD_IOC_CRIU_RESTORER			\
-		AMDKFD_IOWR(0x23, struct kfd_ioctl_criu_restorer_args)
+#define AMDKFD_IOC_CRIU_RESTORER AMDKFD_IOWR(0x23, struct kfd_ioctl_criu_restorer_args)
 
-#define AMDKFD_IOC_CRIU_PROCESS_INFO			\
-		AMDKFD_IOWR(0x24, struct kfd_ioctl_criu_process_info_args)
+#define AMDKFD_IOC_CRIU_PROCESS_INFO AMDKFD_IOWR(0x24, struct kfd_ioctl_criu_process_info_args)
 
-#define AMDKFD_IOC_CRIU_RESUME			\
-		AMDKFD_IOWR(0x25, struct kfd_ioctl_criu_resume_args)
+#define AMDKFD_IOC_CRIU_RESUME AMDKFD_IOWR(0x25, struct kfd_ioctl_criu_resume_args)
 
-#define AMDKFD_IOC_CRIU_PAUSE			\
-		AMDKFD_IOW(0x26, struct kfd_ioctl_criu_pause_args)
+#define AMDKFD_IOC_CRIU_PAUSE AMDKFD_IOW(0x26, struct kfd_ioctl_criu_pause_args)
 
-#define AMDKFD_COMMAND_START		0x01
-#define AMDKFD_COMMAND_END		0x26
+#define AMDKFD_COMMAND_START 0x01
+#define AMDKFD_COMMAND_END   0x26
 
 #endif

--- a/plugins/amdgpu/tests/test_topology_remap.c
+++ b/plugins/amdgpu/tests/test_topology_remap.c
@@ -1,0 +1,1119 @@
+/**************************************************************************************************
+ * GPU groups remapping unit tests
+ *
+ * Test cases for GPU topology group remapping when there are P2P iolinks between the GPUs. GPUs are
+ * considered to be grouped when they are connected via a XGMI bridge.
+ *
+ * When a GPU has large BAR enabled and its full address space can be accessed by another GPU (i.e
+ * its address is within 40/44/48-bits address limitation of the other GPU), then
+ * the other GPU will have an P2P-PCIe to this GPU.
+ *
+ * When GPUs have large BAR, but one GPU cannot address the full address another, then there is no
+ * iolink-PCIe from this GPU to the other GPU. This GPU still has to be remapped to a GPU with
+ * large BAR on restore. The other GPU could still have an iolink-PCIe to this GPU. This would
+ * result in a uni-directional P2P-PCIe.
+ *
+ *
+ * In general, the GPU ID's have the following format to ease debugging:
+ * WXYZ where:
+ * W = A in the source topology, B in the destination topology
+ * X = Unused
+ * Y = Hive number
+ * Z = GPU number
+ *
+ * e.g A017 = GPU in source topology, Hive number 1 (2nd hive), GPU number 7 (8th GPU)
+ *
+ *
+ * Test 0: 8 GPUs in 2 XGMI hives (full P2P-PCIe)
+ *	2 XGMI hives of 4 GPUs
+ *	Each hives have different type of GPUs
+ *	All 8 GPUs have P2P-PCIe links
+ *	2 CPU's - each cpu can access alternate GPUs
+ *
+ *	Src Topology:
+ *	  Hive-0 has 4 GPUs device-id 0xD000
+ *	  Hive-1 has 4 GPUs device-id 0xD001
+ *
+ *	Dest Topology:
+ *	  Hive-0 has 4 GPUs device-id 0xD001
+ *	  Hive-1 has 4 GPUs device-id 0xD000
+ *
+ *      EXPECT: SUCCESS
+ *	  GPUs in Hive-0 in Src Topology should be mapped to GPUs in Hive-1 in Dest Topology and
+ *	  GPUs in Hive-1 in Src Topology should be mapped to GPUs in Hive-0. So that the device-id's
+ *	  match.
+ *
+ *
+ * Test 1: 8 GPUs in 2 XGMI hives (partial P2P-PCIe case 1)
+ *	2 XGMI hives of 4 GPUs
+ *	All 8 GPUs have the same device-id
+ *
+ *	Src Topology:
+ *	  Hive-0 has 4 GPUs
+ *	  Hive-1 has 4 GPUs
+ *	  GPUs 0, 1, 2, 3, 4, 5 have P2P-PCIe links
+ *	  GPUs 7, 8 do not have P2P-PCIe links
+ *
+ *	Dest Topology:
+ *	  Same as Src Topology
+ *
+ *	EXPECT: SUCCESS
+ *
+ *
+ * Test 2: 8 GPUs in 2 XGMI hives (partial P2P-PCIe case 1)
+ *	Same as test 1 but each hive have different device-id's for each hive.
+ *
+ *	Src Topology:
+ *	  Hive-0 has 4 GPUs with device-id 0xD000
+ *	  Hive-1 has 4 GPUs with device-id 0xD001
+ *	  GPUs 0, 1, 2, 3, 4, 5 have P2P-PCIe links
+ *	  GPUs 7, 8 do not have P2P-PCIe links
+ *
+ *	Dest Topology:
+ *	  Hive-0 has 4 GPUs with device-id 0xD001
+ *	  Hive-1 has 4 GPUs with device-id 0xD000
+ *	  GPUs 0, 1, 2, 3, 4, 5 have P2P-PCIe links
+ *	  GPUs 7, 8 do not have P2P-PCIe links
+ *
+ *	EXPECT: FAIL
+ *	  It is not possible to map the GPUs because Src:Hive-0 would have to be mapped to
+ *	  Dest:Hive-1 to be able to match the P2P-PCIe links, but Src:Hive-0 and Dest:Hive-1 have
+ *	  different device-id's.
+ *
+ *
+ * Test 3:8 GPUs in 2 XGMI hives (partial P2P-PCIe case 2)
+ *	2 XGMI hives of 4 GPUs
+ *	1 GPU in each hive has a P2P-PCIe link but at different indexes within the hive.
+ *
+ *	Src Topology:
+ *	  Hive-0: Has 4 GPUs with device-id 0xD000.
+ *		  Only GPU-2(A002) has bi-directional P2P-PCIe link.
+ *
+ *	  Hive-1: Has 4 GPUs with device-id 0xD001.
+ *		  Only GPU-7(A017) has bi-directional P2P-PCIe link.
+ *
+ *	Dest Topology:
+ *	  Hive-0: Has 4 GPUs with device-id 0xD000.
+ *		  Only GPU-0(B000) has bi-directional P2P-PCIe link.
+ *
+ *	  Hive-1: Has 4 GPUs with device-id 0xD001.
+ *		  Only GPU-5(B015) has bi-directional P2P-PCIe link.
+ *
+ *
+ *	EXPECT: SUCCESS
+ *	  Only possible map for A002 is B000 because B000 is the only dest GPU with device-id 0xD000
+ *	  that has a P2P-PCIe link.
+ *	  Only possible map for A017 is B015 because B015 is the only dest GPU with device-id 0xD001
+ *	  that has a P2P-PCIe link.
+ *
+ *
+ * Test 4:8 GPU's in 2 XGMI hives (partial P2P-PCIe case 2)
+ *	Similar to Test 3 but not possible to map because one CPU iolink is uni-directional
+ *
+ *	Src Topology:
+ *	  Hive-0: Has 4 GPUs with device-id 0xD000.
+ *		  Only GPU-2(A002) has bi-directional P2P-PCIe link.
+ *
+ *	  Hive-1: Has 4 GPUs with device-id 0xD001.
+ *		  Only GPU-7(A017) has bi-directional P2P-PCIe link.
+ *
+ *	Dest Topology:
+ *	  Hive-0: Has 4 GPUs with device-id 0xD000.
+ *		  Only GPU-0(B000) has bi-directional P2P-PCIe link.
+ *
+ *	  Hive-1: Has 4 GPUs with device-id 0xD001.
+ *		  Only GPU-5(B014) has uni-directional P2P-PCIe link.
+ *
+ *	EXPECT: FAIL
+ *
+ *
+ * Test 5: 8 GPUs with 1 XGMI hive
+ *	4 GPUs in 1 XGMI hive, 4 GPUs have no XGMI bridge. Tests combination of XGMI and non-XGMI.
+ *	All 8 GPUs have P2P-PCIe links
+ *
+ *	Src Topology:
+ *	  Hive-0: Has 4 GPUs
+ *	  4 Other GPUs are not part of a XGMI hive
+ *
+ *	Dest Topology:
+ *	   Same as src topology
+ *
+ *	EXPECT: SUCCESS
+ *
+ *
+ * Test 6: 5 GPUs (mix and match GPU types and partial P2P-PCIe links)
+ *	No XGMI bridges
+ *	First 4 GPUs have P2P-PCIe links
+ *	1 GPU has different device-id's at different locations
+ *
+ *	Src Topology:
+ *	  GPU-0, GPU-1, GPU-3 has device-id 0xD000
+ *	  GPU-2, GPU-4 has device-id 0xD001
+ *
+ *	Dest Topology:
+ *	  GPU-0, GPU-2, GPU-3 has device-id 0xD000
+ *	  GPU-1, GPU-4 has device-id 0xD001
+ *
+ *	EXPECT: SUCCESS
+ *	  Mapping needs to be able to map A001->B002 and A002->B001.
+ *
+ *
+ **************************************************************************************************
+ * Tests where restore node is more capable than checkpointed node
+ * In the following tests, the destination topology is more P2P-links than the source topology, so
+ * the mapping should succeed, even though the user application will probably not be able to take
+ * advantage of the extra links.
+ *
+ * Test 7: 8 GPUs (ignore XGMI bridge on restore node)
+ *
+ *	Src Topology:
+ *	  Hive-0: GPU-0, GPU-1, GPU-2, GPU-3
+ *	  No XGMI bridge: GPU-4, GPU-5, GPU-6, GPU-7
+ *
+ *	Dest Topology:
+ *	  Hive-0: GPU-0, GPU-1, GPU-2, GPU-3
+ *	  Hive-1: GPU-4, GPU-5, GPU-6, GPU-7
+ *
+ *	EXPECT: SUCCESS
+ *	  Mapping should succeed, because destination GPUs GPU-4, GPU-5, GPU-6, GPU-7 are more
+ *	  capable than source GPUs GPU-4, GPU-5, GPU-6, GPU-7.
+ *	  User application will probably not take advantage of XGMI links in Hive-1.
+ *
+ *
+ * Test 8: 5 GPUs (4 GPUs with P2P-PCIe links vs 3 GPUs with P2P-PCIe links)
+ *
+ *	Src Topology:
+ *	  GPU-0, GPU-1, GPU-2 have bi-directional links
+ *	  GPU-3, GPU-4 have unidirectional links
+ *
+ *	Dest Topology:
+ *	  GPU-0, GPU-1, GPU-2, GPU-3 have bi-directional links
+ *	  GPU-4 have unidirectional links
+ *
+ *	EXPECT: SUCCESS
+ *	  Mapping should succeed because destination GPU-3 can replace source GPU-3.
+ *
+ **************************************************************************************************/
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <errno.h>
+#include "common/list.h"
+
+#include "amdgpu_plugin_topology.h"
+
+#define pr_err(...)   fprintf(stdout, "ERR:" __VA_ARGS__)
+#define pr_info(...)  fprintf(stdout, "INFO:" __VA_ARGS__)
+#define pr_debug(...) fprintf(stdout, "DBG:" __VA_ARGS__)
+
+int verify_maps(const struct device_maps *maps, uint32_t num_cpus, uint32_t num_gpus)
+{
+	struct id_map *map;
+
+	/* TODO: This merely checks that all nodes have been mapped. We should add individual
+	 * verification functions for each test to tests the mappings are correct
+	 */
+
+	list_for_each_entry(map, &maps->cpu_maps, listm) {
+		if (num_cpus-- == 0) {
+			pr_err("Results had more mappings than number of CPUs\n");
+			return -EINVAL;
+		}
+	}
+	if (num_cpus > 0) {
+		pr_err("Results did not map all CPUs\n");
+		return -EINVAL;
+	}
+
+	list_for_each_entry(map, &maps->gpu_maps, listm) {
+		if (num_gpus-- == 0) {
+			pr_err("Results had more mappings than number of GPUs\n");
+			return -EINVAL;
+		}
+	}
+	if (num_gpus > 0) {
+		pr_err("Results did not map all GPUs\n");
+		return -EINVAL;
+	}
+	return 0;
+}
+
+int test_0(void)
+{
+	int ret = 0;
+	struct device_maps maps;
+
+	struct tp_node *node_gpus[8];
+	struct tp_node *node_cpus[2];
+
+	struct tp_system tp_src = { 0 };
+	struct tp_system tp_dest = { 0 };
+
+	/* Fill src struct */
+	topology_init(&tp_src);
+	tp_src.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+		for (int j = 6; j < 10; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+		node_gpus[i]->device_id = 0xD001;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+		for (int j = 2; j < 6; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	/* Fill dest struct */
+	topology_init(&tp_dest);
+	tp_dest.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+		node_gpus[i]->device_id = 0xD001;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+		for (int j = 6; j < 10; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+		for (int j = 2; j < 6; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+	if (!ret) {
+		if (verify_maps(&maps, ARRAY_SIZE(node_cpus), ARRAY_SIZE(node_gpus))) {
+			pr_err("Mapping returned success, but results had errors\n");
+			ret = -1;
+		}
+	}
+	topology_free(&tp_src);
+	topology_free(&tp_dest);
+	maps_free(&maps);
+	return ret;
+}
+
+int test_1(void)
+{
+	int ret = 0;
+	struct device_maps maps;
+
+	struct tp_node *node_gpus[8];
+	struct tp_node *node_cpus[2];
+
+	struct tp_system tp_src = { 0 };
+	struct tp_system tp_dest = { 0 };
+
+	/* Fill src struct */
+	topology_init(&tp_src);
+	tp_src.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+		for (int j = 6; j < 8; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+		node_gpus[i]->device_id = 0xD000;
+
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		if (i < 6)
+			node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+
+		for (int j = 2; j < 6; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	/* Fill dest struct */
+	topology_init(&tp_dest);
+	tp_dest.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+		for (int j = 6; j < 8; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+		node_gpus[i]->device_id = 0xD000;
+
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		if (i < 6)
+			node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+		for (int j = 2; j < 6; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+	if (!ret) {
+		if (verify_maps(&maps, ARRAY_SIZE(node_cpus), ARRAY_SIZE(node_gpus))) {
+			pr_err("Mapping returned success, but results had errors\n");
+			ret = -1;
+		}
+	}
+	topology_free(&tp_src);
+	topology_free(&tp_dest);
+	maps_free(&maps);
+	return ret;
+}
+
+int test_2(void)
+{
+	int ret = 0;
+	struct device_maps maps;
+
+	struct tp_node *node_gpus[8];
+	struct tp_node *node_cpus[2];
+
+	struct tp_system tp_src = { 0 };
+	struct tp_system tp_dest = { 0 };
+
+	/* Fill src struct */
+	topology_init(&tp_src);
+	tp_src.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+		for (int j = 6; j < 8; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+		node_gpus[i]->device_id = 0xD001;
+
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		if (i < 6)
+			node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+		for (int j = 2; j < 6; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	/* Fill dest struct */
+	topology_init(&tp_dest);
+	tp_dest.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+		node_gpus[i]->device_id = 0xD001;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+		for (int j = 6; j < 8; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+		node_gpus[i]->device_id = 0xD000;
+
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		if (i < 6)
+			node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+		for (int j = 2; j < 6; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+	if (!ret) {
+		if (verify_maps(&maps, ARRAY_SIZE(node_cpus), ARRAY_SIZE(node_gpus))) {
+			pr_err("Mapping returned success, but results had errors\n");
+			ret = -1;
+		}
+	}
+	topology_free(&tp_src);
+	topology_free(&tp_dest);
+	maps_free(&maps);
+	return ret;
+}
+
+int test_3(void)
+{
+	int ret = 0;
+	struct device_maps maps;
+
+	struct tp_node *node_gpus[8];
+	struct tp_node *node_cpus[2];
+
+	struct tp_system tp_src = { 0 };
+	struct tp_system tp_dest = { 0 };
+
+	/* Fill src struct */
+	topology_init(&tp_src);
+	tp_src.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+		node_gpus[i]->device_id = 0xD001;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+	}
+
+	node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, 4);
+	node_add_iolink(node_cpus[1], TOPO_IOLINK_TYPE_PCIE, 9);
+
+	/* Fill dest struct */
+	topology_init(&tp_dest);
+	tp_dest.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+		node_gpus[i]->device_id = 0xD001;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+	}
+
+	node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_cpus[1], TOPO_IOLINK_TYPE_PCIE, 7);
+
+	ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+	if (!ret) {
+		if (verify_maps(&maps, ARRAY_SIZE(node_cpus), ARRAY_SIZE(node_gpus))) {
+			pr_err("Mapping returned success, but results had errors\n");
+			ret = -1;
+		}
+	}
+	topology_free(&tp_src);
+	topology_free(&tp_dest);
+	maps_free(&maps);
+	return ret;
+}
+
+int test_4(void)
+{
+	int ret = 0;
+	struct device_maps maps;
+
+	struct tp_node *node_gpus[8];
+	struct tp_node *node_cpus[2];
+
+	struct tp_system tp_src = { 0 };
+	struct tp_system tp_dest = { 0 };
+
+	/* Fill src struct */
+	topology_init(&tp_src);
+	tp_src.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+		node_gpus[i]->device_id = 0xD001;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+	}
+
+	node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, 4);
+	node_add_iolink(node_cpus[1], TOPO_IOLINK_TYPE_PCIE, 9);
+
+	/* Fill dest struct */
+	topology_init(&tp_dest);
+	tp_dest.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+		node_gpus[i]->device_id = 0xD001;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+	}
+
+	node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_cpus[1], TOPO_IOLINK_TYPE_PCIE, 6);
+
+	ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+	if (!ret) {
+		if (verify_maps(&maps, ARRAY_SIZE(node_cpus), ARRAY_SIZE(node_gpus))) {
+			pr_err("Mapping returned success, but results had errors\n");
+			ret = -1;
+		}
+	}
+	topology_free(&tp_src);
+	topology_free(&tp_dest);
+	maps_free(&maps);
+	return ret;
+}
+
+int test_5(void)
+{
+	int ret = 0;
+	struct device_maps maps;
+
+	struct tp_node *node_gpus[8];
+	struct tp_node *node_cpus[2];
+
+	struct tp_system tp_src = { 0 };
+	struct tp_system tp_dest = { 0 };
+
+	/* Fill src struct */
+	topology_init(&tp_src);
+	tp_src.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+		for (int j = 6; j < 10; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+		for (int j = 2; j < 6; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	/* Fill dest struct */
+	topology_init(&tp_dest);
+	tp_dest.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+		for (int j = 6; j < 10; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+		node_add_iolink(node_cpus[i & 1], TOPO_IOLINK_TYPE_PCIE, i + 2);
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, ((i + j) % 4) + 6);
+		for (int j = 2; j < 6; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, j);
+	}
+
+	ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+	if (!ret) {
+		if (verify_maps(&maps, ARRAY_SIZE(node_cpus), ARRAY_SIZE(node_gpus))) {
+			pr_err("Mapping returned success, but results had errors\n");
+			ret = -1;
+		}
+	}
+	topology_free(&tp_src);
+	topology_free(&tp_dest);
+	maps_free(&maps);
+	return ret;
+}
+
+int test_6(void)
+{
+	int ret = 0;
+	struct device_maps maps;
+
+	struct tp_node *node_gpus[5];
+	struct tp_node *node_cpus[1];
+
+	struct tp_system tp_src = { 0 };
+	struct tp_system tp_dest = { 0 };
+
+	/* Fill src struct */
+	topology_init(&tp_src);
+	tp_src.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 5; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 1, 0xA000 + i);
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, 0);
+		node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, i + 1);
+	}
+	node_gpus[0]->device_id = 0xD000;
+	node_gpus[1]->device_id = 0xD000;
+	node_gpus[2]->device_id = 0xD001;
+	node_gpus[3]->device_id = 0xD000;
+	node_gpus[4]->device_id = 0xD001;
+
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 3);
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 3);
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 3);
+
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 3);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	/* Fill dest struct */
+	topology_init(&tp_dest);
+	tp_dest.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 5; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 1, 0xB000 + i);
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, 0);
+		node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, i + 1);
+	}
+	node_gpus[0]->device_id = 0xD000;
+	node_gpus[1]->device_id = 0xD001;
+	node_gpus[2]->device_id = 0xD000;
+	node_gpus[3]->device_id = 0xD000;
+	node_gpus[4]->device_id = 0xD001;
+
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 3);
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 3);
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 3);
+
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 3);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+	if (!ret) {
+		if (verify_maps(&maps, ARRAY_SIZE(node_cpus), ARRAY_SIZE(node_gpus))) {
+			pr_err("Mapping returned success, but results had errors\n");
+			ret = -1;
+		}
+	}
+	topology_free(&tp_src);
+	topology_free(&tp_dest);
+	maps_free(&maps);
+	return ret;
+}
+
+int test_7(void)
+{
+	int ret = 0;
+	struct device_maps maps;
+
+	struct tp_node *node_gpus[8];
+	struct tp_node *node_cpus[2];
+
+	struct tp_system tp_src = { 0 };
+	struct tp_system tp_dest = { 0 };
+
+	/* Fill src struct */
+	topology_init(&tp_src);
+	tp_src.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_src, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 2, 0xA010 + i);
+		node_gpus[i]->device_id = 0xD000;
+	}
+
+	/* Fill dest struct */
+	topology_init(&tp_dest);
+	tp_dest.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+	node_cpus[1] = sys_add_node(&tp_dest, 1, 0);
+	node_cpus[1]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 4; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, i & 1);
+	}
+	for (int i = 0; i < 4; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 2);
+	}
+
+	for (int i = 4; i < 8; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 2, 0xB010 + i);
+		node_gpus[i]->device_id = 0xD000;
+	}
+	for (int i = 4; i < 8; i++) {
+		for (int j = 1; j < 4; j++)
+			node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_XGMI, ((i + j) % 4) + 6);
+	}
+
+	ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+
+	if (!ret) {
+		if (verify_maps(&maps, ARRAY_SIZE(node_cpus), ARRAY_SIZE(node_gpus))) {
+			pr_err("Mapping returned success, but results had errors\n");
+			ret = -1;
+		}
+	}
+	topology_free(&tp_src);
+	topology_free(&tp_dest);
+	maps_free(&maps);
+	return ret;
+}
+
+int test_8(void)
+{
+	int ret = 0;
+	struct device_maps maps;
+
+	struct tp_node *node_gpus[5];
+	struct tp_node *node_cpus[1];
+
+	struct tp_system tp_src = { 0 };
+	struct tp_system tp_dest = { 0 };
+
+	/* Fill src struct */
+	topology_init(&tp_src);
+	tp_src.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_src, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 5; i++) {
+		node_gpus[i] = sys_add_node(&tp_src, i + 1, 0xA000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, 0);
+		node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, i + 1);
+	}
+
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 3);
+
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 3);
+
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 2);
+
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 3);
+
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 3);
+
+	/* Fill dest struct */
+	topology_init(&tp_dest);
+	tp_dest.parsed = true;
+
+	node_cpus[0] = sys_add_node(&tp_dest, 0, 0);
+	node_cpus[0]->cpu_cores_count = 1;
+
+	for (int i = 0; i < 5; i++) {
+		node_gpus[i] = sys_add_node(&tp_dest, i + 1, 0xB000 + i);
+		node_gpus[i]->device_id = 0xD000;
+		node_add_iolink(node_gpus[i], TOPO_IOLINK_TYPE_PCIE, 0);
+		node_add_iolink(node_cpus[0], TOPO_IOLINK_TYPE_PCIE, i + 1);
+	}
+
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 3);
+	node_add_iolink(node_gpus[0], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 3);
+	node_add_iolink(node_gpus[1], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[2], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[3], TOPO_IOLINK_TYPE_PCIE, 3);
+
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 1);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 2);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 3);
+	node_add_iolink(node_gpus[4], TOPO_IOLINK_TYPE_PCIE, 4);
+
+	ret = set_restore_gpu_maps(&tp_src, &tp_dest, &maps);
+
+	if (!ret) {
+		if (verify_maps(&maps, ARRAY_SIZE(node_cpus), ARRAY_SIZE(node_gpus))) {
+			pr_err("Mapping returned success, but results had errors\n");
+			ret = -1;
+		}
+	}
+	topology_free(&tp_src);
+	topology_free(&tp_dest);
+	maps_free(&maps);
+	return ret;
+}
+
+struct test {
+	int (*test_func)(void);
+	bool success; /* true if we expect function to return 0 */
+};
+
+int main(int argc, char **argv)
+{
+	int ret;
+	int result = 0;
+
+	struct test tests[] = {
+		{ test_0, true }, { test_1, true }, { test_2, false }, { test_3, true }, { test_4, false },
+		{ test_5, true }, { test_6, true }, { test_7, true },  { test_8, true },
+	};
+
+	if (argc > 1) {
+		int run;
+
+		if (sscanf(argv[1], "%d", &run) != 1 || (run >= ARRAY_SIZE(tests))) {
+			pr_err("Usage: test_topology_remap [test_number]\n");
+			pr_err("       Test number range:0-%ld\n", ARRAY_SIZE(tests) - 1);
+			pr_err("       Return codes:\n");
+			pr_err("         0 All tests pass\n");
+			pr_err("         1 At least one test failed\n");
+			pr_err("         2 Invalid parameters\n");
+			return 2;
+		}
+		pr_info("======================================================================\n");
+		pr_info("Starting test %d\n", run);
+		ret = tests[run].test_func();
+		pr_info("\n\nTest %d: %s\n", run, (!ret == tests[run].success) ? "PASS" : "FAILED");
+		pr_info("======================================================================\n");
+		return (!ret == tests[run].success) ? 0 : 1;
+	}
+
+	for (int i = 0; i < ARRAY_SIZE(tests); i++) {
+		pr_info("======================================================================\n");
+		pr_info("Starting test %d\n", i);
+		ret = tests[i].test_func();
+		pr_info("\n\nTest %d: %s\n", i, (!ret == tests[i].success) ? "PASS" : "FAILED");
+		pr_info("======================================================================\n");
+		if (!ret != tests[i].success)
+			result = 1;
+	}
+	return result;
+}

--- a/scripts/build/Dockerfile.amd-rocm
+++ b/scripts/build/Dockerfile.amd-rocm
@@ -1,0 +1,97 @@
+FROM rocm/pytorch:rocm4.0.1_ubuntu18.04_py3.6_pytorch
+
+ARG CC=gcc
+
+# Environment
+ENV BRANCH=$BRANCH \
+    DEBIAN_FRONTEND=noninteractive \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
+
+#
+# Package installation
+#
+RUN apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-install-recommends \
+	--no-upgrade -yq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+	apt-utils \
+	apt-transport-https\
+	gnupg \
+	gnupg2 \
+	gettext \
+	locales \
+	iproute2 \
+	iputils-ping \
+	moreutils \
+	net-tools \
+	psmisc\
+	supervisor \
+	cifs-utils \
+	nfs-common \
+	systemd \
+	fuse \
+	xmlto \
+	autossh \
+	netbase \
+	libnet-dev \
+	libnl-route-3-dev \
+	$CC \
+	bsdmainutils \
+	ca-certificates \
+	build-essential \
+	git-core \
+	iptables \
+	libaio-dev \
+	libbsd-dev \
+	libcap-dev \
+	libgnutls28-dev \
+	libgnutls30 \
+	libnl-3-dev \
+	libprotobuf-c-dev \
+	libprotobuf-dev \
+	libselinux-dev \
+	pkg-config \
+	protobuf-c-compiler \
+	protobuf-compiler \
+	python-protobuf \
+	python3-minimal \
+	python3-future \
+	python-ipaddress \
+	curl \
+	wget \
+	vim \
+	openssl \
+	openssh-server \
+	python \
+	sudo \
+	libnuma1 \
+	libdrm-dev \
+	libdrm-amdgpu1 \
+	asciidoc \
+	&& \
+	rm -rf /var/lib/apt/lists/* && \
+	apt-get purge --auto-remove && \
+	apt-get clean
+
+# Clone latest criu code
+COPY . /criu
+WORKDIR /criu
+
+RUN make mrproper && date && \
+# Check single object build
+	make -j $(nproc) CC="$CC" criu/parasite-syscall.o && \
+# Compile criu
+	make -j $(nproc) CC="$CC" && \
+	date && echo BUILD_OK && \
+# Install criu
+	make -j $(nproc) install && \
+	date && echo INSTALL_OK
+
+WORKDIR /root/criu_build_dir
+RUN	git clone --recursive -b  cl/rocm-transformers https://github.com/lcskrishna/transformers.git && \
+	cd transformers && wget https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json && \
+	wget https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json && \
+	wget https://github.com/allenai/bi-att-flow/blob/master/squad/evaluate-v1.1.py
+ENV SQUAD_DIR=/root/criu_build_dir/transformers
+WORKDIR /root/criu_build_dir/transformers
+RUN pip3 install tensorboard tensorboardX && pip3 install .


### PR DESCRIPTION
Hi @checkpoint-restore/maintainers ,

This is part 2 of the amdgpu_plugin RFC PR based on the basic foundation setup by the part 1 PR #1556  that brought in CRIU specific changes.

This PR :
 *  Addresses review feedback received on #1519.
 *  Fixes for Lint, Build errors and sets up CI for some x86 based Linux flavors
 *  Updates dummy plugin hook implementation to actual amdgpu_plugin.
 *  Auto detect build dependencies, for amdgpu_plugin
 *  Doesn't impact CRIU and other component build due to missing dependencies
 *  Skip building amdgpu_plugin for non-x86 arch in CI automation
 *  Multi GPU support
 *  Fast Checkpoint Restore with sDMA engines (depends on a kernel change) 

Kernel: https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/commits/fxkamd/criu-wip 

* Note *
-   sDMA change will be updated after some more ongoing stability testing and other recently identified optimizations. 
-   Our IOCTL API definitions are still evolving along with our kernel mode changes.
- Kernel change required for sDMA https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/commit/99d888b3b7f2592786dd2731451437a3d2fe8340 

This work is tested(limited) with single/multi-gpu system with Pytorch Microbenchmark and BERT Transformers training model with AMD Vega10. Detailed testing is underway with various other combinations of workloads and gpu hierarchies.

Thank you
