### PR TITLE
ci: fix Fedora Rawhide

### DIFF
--- a/.github/workflows/fedora-rawhide-test.yml
+++ b/.github/workflows/fedora-rawhide-test.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run Fedora Rawhide Test
-      run: sudo -E make -C scripts/ci fedora-rawhide
+      run: sudo -E make -C scripts/ci fedora-rawhide CONTAINER_RUNTIME=podman BUILD_OPTIONS="--security-opt seccomp=unconfined"

--- a/scripts/build/Makefile
+++ b/scripts/build/Makefile
@@ -19,7 +19,7 @@ Dockerfile.%: Dockerfile.%.hdr Dockerfile.%.tmpl
 	cat $^ > $@
 
 $(CONTAINER_TARGETS):
-	$(CONTAINER_RUNTIME) build  -t criu-$@ -f Dockerfile.$@ $(DB_CC) ../..
+	$(CONTAINER_RUNTIME) build $(BUILD_OPTIONS) -t criu-$@ -f Dockerfile.$@ $(DB_CC) ../..
 .PHONY: $(CONTAINER_TARGETS)
 
 # Clang builds add some Docker build env

--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -14,8 +14,9 @@ endif
 TARGETS := alpine fedora-rawhide centos7 centos8 archlinux
 ZDTM_OPTIONS :=
 UNAME := $(shell uname -m)
-
 export UNAME
+CONTAINER_RUNTIME := docker
+export CONTAINER_RUNTIME
 
 alpine: ZDTM_OPTIONS=-x zdtm/static/binfmt_misc -x zdtm/static/netns-nf -x zdtm/static/sched_policy00 -x zdtm/static/seccomp_strict -x zdtm/static/sigaltstack -x zdtm/static/signalfd00 -x zdtm/static/config_inotify_irmap
 
@@ -45,8 +46,19 @@ else
 	CONTAINER_OPTS := --rm -v /lib/modules:/lib/modules --tmpfs /run
 endif
 
+ifeq ($(CONTAINER_RUNTIME),podman)
+	# Just as Docker needs to use devicemapper Podman needs vfs
+	# as graphdriver as overlayfs does not support all test cases
+	STORAGE_DRIVER := vfs
+	# Podman limits the number of processes in a container using cgroups.
+	# Disable it as it breaks the thread-bomb test
+	CONTAINER_OPTS += --pids-limit=0
+endif
+
+export STORAGE_DRIVER
+
 restart-docker:
-	if [ "$$UNAME" = "x86_64" ]; then \
+	if [ "$$UNAME" = "x86_64" ] && [ "$$CONTAINER_RUNTIME" = "docker" ]; then \
 		echo "$$DOCKER_JSON" > /etc/docker/daemon.json; \
 		cat /etc/docker/daemon.json; \
 		systemctl status docker; \
@@ -56,11 +68,11 @@ restart-docker:
 
 $(TARGETS): restart-docker
 	$(MAKE) -C ../build $@$(target-suffix)
-	docker run --env-file docker.env $(CONTAINER_OPTS) criu-$@ scripts/ci/run-ci-tests.sh
+	$(CONTAINER_RUNTIME) run --env-file docker.env $(CONTAINER_OPTS) criu-$@ scripts/ci/run-ci-tests.sh
 
 fedora-asan: restart-docker
 	$(MAKE) -C ../build $@$(target-suffix)
-	docker run $(CONTAINER_OPTS) criu-$@ ./scripts/ci/asan.sh $(ZDTM_OPTIONS)
+	$(CONTAINER_RUNTIME) run $(CONTAINER_OPTS) criu-$@ ./scripts/ci/asan.sh $(ZDTM_OPTIONS)
 
 docker-test:
 	./docker-test.sh


### PR DESCRIPTION
Fedora Rawhide updated to a glibc using clone3(). clone3() is, however, not yet part of the seccomp filter. Unfortunately 'docker build' does not allow dropping seccomp but luckily 'podman build' does.

This switches the Fedora Rawhide test to use Podman. Podman is part of GitHub Actions and no additional packages need to be installed.