### PR TITLE
ci: use pre-installed Podman

### DIFF
--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -1,30 +1,6 @@
 #!/bin/bash
 set -x -e -o pipefail
 
-if [ ! -e /etc/lsb-release ]; then
-       # This expects to run on Ubuntu
-       exit 1
-fi
-
-#shellcheck disable=SC1091
-. /etc/lsb-release
-
-echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${DISTRIB_RELEASE}/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-
-curl -sL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${DISTRIB_RELEASE}/Release.key" | apt-key add -
-
-# podman conflicts with a man page from docker-ce
-# this is a podman packaging bug (https://github.com/containers/libpod/issues/4747)
-apt-get -y purge docker-ce || :
-
-./apt-install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    software-properties-common
-
-./apt-install podman containernetworking-plugins
-
 export SKIP_CI_TEST=1
 
 ./run-ci-tests.sh


### PR DESCRIPTION
GitHub Actions already has Podman installed. No need to install it a second time.