### PR TITLE
criu-ns: add man page and install target

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -12,6 +12,7 @@ endif
 
 FOOTER		:= footer.txt
 SRC1		+= crit.txt
+SRC1		+= criu-ns.txt
 SRC1		+= compel.txt
 SRC8		+= criu.txt
 SRC		:= $(SRC1) $(SRC8)

--- a/Documentation/criu-ns.txt
+++ b/Documentation/criu-ns.txt
@@ -14,6 +14,8 @@ SYNOPSIS
 
 *criu-ns* 'restore' [<options>]
 
+*criu-ns* 'check' [<options>]
+
 DESCRIPTION
 -----------
 The *criu-ns* command executes 'criu' in a new PID and mount namespace.

--- a/Documentation/criu-ns.txt
+++ b/Documentation/criu-ns.txt
@@ -1,0 +1,30 @@
+CRIU-NS(1)
+==========
+include::footer.txt[]
+
+NAME
+----
+criu-ns - run criu in different namespaces
+
+SYNOPSIS
+--------
+*criu-ns* 'dump' -t PID [<options>]
+
+*criu-ns* 'pre-dump' -t PID [<options>]
+
+*criu-ns* 'restore' [<options>]
+
+DESCRIPTION
+-----------
+The *criu-ns* command executes 'criu' in a new PID and mount namespace.
+The purpose of this wrapper script is to enable restoring a process tree
+that might require a specific PID that is already used on the system;
+so called "PID mismatch" problem.
+
+SEE ALSO
+--------
+nsenter(1) namespaces(7) criu(8)
+
+AUTHOR
+------
+The CRIU team

--- a/criu/Makefile
+++ b/criu/Makefile
@@ -144,11 +144,13 @@ install: $(obj)/criu
 	$(Q) install -m 644 $(UAPI_HEADERS) $(DESTDIR)$(INCLUDEDIR)/criu/
 	$(Q) mkdir -p $(DESTDIR)$(LIBEXECDIR)/criu/scripts
 	$(Q) install -m 755 scripts/systemd-autofs-restart.sh $(DESTDIR)$(LIBEXECDIR)/criu/scripts
+	$(Q) install -m 755 scripts/criu-ns $(DESTDIR)$(SBINDIR)
 .PHONY: install
 
 uninstall:
 	$(E) " UNINSTALL" criu
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(SBINDIR)/,criu)
+	$(Q) $(RM) $(addprefix $(DESTDIR)$(SBINDIR)/,criu-ns)
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(INCLUDEDIR)/criu/,$(notdir $(UAPI_HEADERS)))
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBEXECDIR)/criu/scripts/,systemd-autofs-restart.sh)
 .PHONY: uninstall

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -224,7 +224,7 @@ if action == 'restore':
 elif action in ['dump', 'pre-dump']:
     res = wrap_dump()
 else:
-    print('Unsupported action {} for nswrap'.format(action))
+    print('Unsupported action {} for criu-ns'.format(action))
     res = -1
 
 sys.exit(res)

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -205,7 +205,7 @@ def wrap_dump():
     return _wait_for_process_status(pid)
 
 
-if len(sys.argv) == 1:
+def show_usage():
     print("""
 Usage:
   {0} dump|pre-dump -t PID [<options>]
@@ -215,16 +215,20 @@ Usage:
   pre-dump       pre-dump task(s) minimizing their frozen time
   restore        restore a process/tree
 """.format(sys.argv[0]))
-    exit(1)
 
-action = sys.argv[1]
 
-if action == 'restore':
-    res = wrap_restore()
-elif action in ['dump', 'pre-dump']:
-    res = wrap_dump()
-else:
-    print('Unsupported action {} for criu-ns'.format(action))
-    res = -1
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        show_usage()
+        exit(1)
 
-sys.exit(res)
+    action = sys.argv[1]
+    if action == 'restore':
+        res = wrap_restore()
+    elif action in ['dump', 'pre-dump']:
+        res = wrap_dump()
+    else:
+        print('Unsupported action {} for criu-ns'.format(action))
+        res = -1
+
+    sys.exit(res)

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -214,6 +214,7 @@ Usage:
   dump           checkpoint a process/tree identified by pid
   pre-dump       pre-dump task(s) minimizing their frozen time
   restore        restore a process/tree
+  check          checks whether the kernel support is up-to-date
 """.format(sys.argv[0]))
 
 
@@ -227,6 +228,8 @@ if __name__ == "__main__":
         res = wrap_restore()
     elif action in ['dump', 'pre-dump']:
         res = wrap_dump()
+    elif action == 'check':
+        run_criu(sys.argv[1:])
     else:
         print('Unsupported action {} for criu-ns'.format(action))
         res = -1


### PR DESCRIPTION
This pull request adds a man page for the [`criu-ns`](https://criu.org/CR_in_namespace) script and includes it in the install/uninstall criu makefile targets.