### PR TITLE
posix-timers: fix getoverrun error handling

### DIFF
--- a/criu/pie/parasite.c
+++ b/criu/pie/parasite.c
@@ -157,12 +157,13 @@ static int dump_posix_timers(struct parasite_dump_posix_timers_args *args)
 			pr_err("sys_timer_gettime failed (%d)\n", ret);
 			return ret;
 		}
-		args->timer[i].overrun = sys_timer_getoverrun(args->timer[i].it_id);
-		ret = args->timer[i].overrun;
+		ret = sys_timer_getoverrun(args->timer[i].it_id);
 		if (ret < 0) {
 			pr_err("sys_timer_getoverrun failed (%d)\n", ret);
 			return ret;
 		}
+		args->timer[i].overrun = ret;
+		ret = 0;
 	}
 
 	return ret;


### PR DESCRIPTION
If retcode of dump_posix_timers is not zero it is treated as an error in
compel_rpc_sync. And currently we can return positive overrun of last
timer (if we are lucky and it is not zero) as retcode of function
dump_posix_timers, let's fix it. Also I don't see any point in putting
negative value into .overrun on error path, fix it too.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
