### PR TITLE
Socket bufs lock support (tcp perfomance decrease after migration fix)

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1372,6 +1372,14 @@ static int check_network_lock_nftables(void)
 	return 0;
 }
 
+static int check_sockopt_buf_lock(void)
+{
+	if (!kdat.has_sockopt_buf_lock)
+		return -1;
+
+	return 0;
+}
+
 static int (*chk_feature)(void);
 
 /*
@@ -1490,6 +1498,7 @@ int cr_check(void)
 		ret |= check_ns_pid();
 		ret |= check_apparmor_stacking();
 		ret |= check_network_lock_nftables();
+		ret |= check_sockopt_buf_lock();
 	}
 
 	/*
@@ -1602,6 +1611,7 @@ static struct feature_list feature_list[] = {
 	{ "ns_pid", check_ns_pid },
 	{ "apparmor_stacking", check_apparmor_stacking },
 	{ "network_lock_nftables", check_network_lock_nftables },
+	{ "sockopt_buf_lock", check_sockopt_buf_lock },
 	{ NULL, NULL },
 };
 

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -74,6 +74,7 @@ struct kerndat_s {
 	bool has_pidfd_getfd;
 	bool has_nspid;
 	bool has_nftables_concat;
+	bool has_sockopt_buf_lock;
 };
 
 extern struct kerndat_s kdat;

--- a/criu/include/sockets.h
+++ b/criu/include/sockets.h
@@ -123,4 +123,8 @@ extern const char *socket_proto_name(unsigned int proto, char *nm, size_t size);
 #define ___socket_family_name(family) __socket_info_helper(socket_family_name, family)
 #define ___socket_proto_name(proto)   __socket_info_helper(socket_proto_name, proto)
 
+#ifndef SO_BUF_LOCK
+#define SO_BUF_LOCK 72
+#endif
+
 #endif /* __CR_SOCKETS_H__ */

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -519,6 +519,10 @@ int restore_socket_opts(int sk, SkOptsEntry *soe)
 	/* setsockopt() multiplies the input values by 2 */
 	ret |= userns_call(sk_setbufs, 0, bufs, sizeof(bufs), sk);
 
+	if (soe->has_so_buf_lock) {
+		pr_debug("\trestore buf_lock %d for socket\n", soe->so_buf_lock);
+		ret |= restore_opt(sk, SOL_SOCKET, SO_BUF_LOCK, &soe->so_buf_lock);
+	}
 	if (soe->has_so_priority) {
 		pr_debug("\trestore priority %d for socket\n", soe->so_priority);
 		ret |= restore_opt(sk, SOL_SOCKET, SO_PRIORITY, &soe->so_priority);
@@ -619,6 +623,10 @@ int dump_socket_opts(int sk, SkOptsEntry *soe)
 
 	ret |= dump_opt(sk, SOL_SOCKET, SO_SNDBUF, &soe->so_sndbuf);
 	ret |= dump_opt(sk, SOL_SOCKET, SO_RCVBUF, &soe->so_rcvbuf);
+	if (kdat.has_sockopt_buf_lock) {
+		soe->has_so_buf_lock = true;
+		ret |= dump_opt(sk, SOL_SOCKET, SO_BUF_LOCK, &soe->so_buf_lock);
+	}
 	soe->has_so_priority = true;
 	ret |= dump_opt(sk, SOL_SOCKET, SO_PRIORITY, &soe->so_priority);
 	soe->has_so_rcvlowat = true;

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -517,7 +517,7 @@ int restore_socket_opts(int sk, SkOptsEntry *soe)
 	pr_info("%d restore sndbuf %d rcv buf %d\n", sk, soe->so_sndbuf, soe->so_rcvbuf);
 
 	/* setsockopt() multiplies the input values by 2 */
-	ret |= userns_call(sk_setbufs, UNS_ASYNC, bufs, sizeof(bufs), sk);
+	ret |= userns_call(sk_setbufs, 0, bufs, sizeof(bufs), sk);
 
 	if (soe->has_so_priority) {
 		pr_debug("\trestore priority %d for socket\n", soe->so_priority);

--- a/images/sk-opts.proto
+++ b/images/sk-opts.proto
@@ -31,6 +31,8 @@ message sk_opts_entry {
 	optional uint32		tcp_keepintvl	= 22;
 	optional uint32		so_oobinline	= 23;
 	optional uint32		so_linger	= 24;
+
+	optional uint32		so_buf_lock	= 25;
 }
 
 enum sk_shutdown {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -116,6 +116,7 @@ TST_NOFILE	:=				\
 		socket-linger			\
 		sock_opts00			\
 		sock_opts01			\
+		sock_opts02			\
 		sk-unix-unconn			\
 		ipc_namespace			\
 		selfexe00			\

--- a/test/zdtm/static/sock_opts02.c
+++ b/test/zdtm/static/sock_opts02.c
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check that SO_BUF_LOCK option dumped";
+const char *test_author = "Pavel Tikhomirov <ptikhomirov@virtuozzo.com>";
+
+#ifndef SO_BUF_LOCK
+#define SO_BUF_LOCK 72
+#endif
+
+#define NSOCK 4
+
+int main(int argc, char **argv)
+{
+	int sock[NSOCK];
+	uint32_t val[NSOCK];
+	int ret, i;
+	int exit_code = 1;
+
+	test_init(argc, argv);
+
+	for (i = 0; i < NSOCK; i++) {
+		sock[i] = -1;
+		val[i] = i;
+	}
+
+	for (i = 0; i < NSOCK; i++) {
+		sock[i] = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+		if (sock[i] < 0) {
+			pr_perror("can't create socket %d", i);
+			goto err;
+		}
+
+		ret = setsockopt(sock[i], SOL_SOCKET, SO_BUF_LOCK, &val[i], sizeof(val[i]));
+		if (ret < 0) {
+			pr_perror("can't set SO_BUF_LOCK (%u) on socket %d", val[i], i);
+			goto err;
+		}
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	for (i = 0; i < NSOCK; i++) {
+		uint32_t tmp;
+		socklen_t len;
+
+		len = sizeof(tmp);
+		ret = getsockopt(sock[i], SOL_SOCKET, SO_BUF_LOCK, &tmp, &len);
+		if (ret < 0) {
+			pr_perror("can't get SO_BUF_LOCK from socket %d", i);
+			goto err;
+		}
+
+		if (tmp != val[i]) {
+			fail("SO_BUF_LOCK missmatch %u != %u", tmp, val[i]);
+			goto err;
+		}
+	}
+
+	pass();
+	exit_code = 0;
+err:
+	for (i = 0; i < NSOCK; i++)
+		close(sock[i]);
+
+	return exit_code;
+}

--- a/test/zdtm/static/sock_opts02.c
+++ b/test/zdtm/static/sock_opts02.c
@@ -13,32 +13,77 @@ const char *test_author = "Pavel Tikhomirov <ptikhomirov@virtuozzo.com>";
 #define SO_BUF_LOCK 72
 #endif
 
-#define NSOCK 4
+#ifndef SOCK_SNDBUF_LOCK
+#define SOCK_SNDBUF_LOCK 1
+#endif
+#ifndef SOCK_RCVBUF_LOCK
+#define SOCK_RCVBUF_LOCK 2
+#endif
+
+#define BUFSIZE 16384
+
+struct sk_opt {
+	int type;
+	uint32_t val;
+	uint32_t lock;
+} sk_opts[] = { { SO_BUF_LOCK, 0, 0 },
+		{ SO_BUF_LOCK, SOCK_SNDBUF_LOCK, SOCK_SNDBUF_LOCK },
+		{ SO_BUF_LOCK, SOCK_RCVBUF_LOCK, SOCK_RCVBUF_LOCK },
+		{ SO_BUF_LOCK, SOCK_SNDBUF_LOCK | SOCK_RCVBUF_LOCK, SOCK_SNDBUF_LOCK | SOCK_RCVBUF_LOCK },
+		{ SO_SNDBUF, BUFSIZE, SOCK_SNDBUF_LOCK },
+		{ SO_RCVBUF, BUFSIZE, SOCK_RCVBUF_LOCK } };
+
+#define NSOCK ARRAY_SIZE(sk_opts)
+
+char *type_to_str(int type)
+{
+	switch (type) {
+	case SO_BUF_LOCK:
+		return "SO_BUF_LOCK";
+	case SO_SNDBUFFORCE:
+		return "SO_SNDBUFFORCE";
+	case SO_RCVBUFFORCE:
+		return "SO_RCVBUFFORCE";
+	}
+	return NULL;
+}
 
 int main(int argc, char **argv)
 {
 	int sock[NSOCK];
-	uint32_t val[NSOCK];
 	int ret, i;
 	int exit_code = 1;
 
 	test_init(argc, argv);
 
-	for (i = 0; i < NSOCK; i++) {
+	for (i = 0; i < NSOCK; i++)
 		sock[i] = -1;
-		val[i] = i;
-	}
 
 	for (i = 0; i < NSOCK; i++) {
+		uint32_t tmp;
+		socklen_t len;
+
 		sock[i] = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
 		if (sock[i] < 0) {
 			pr_perror("can't create socket %d", i);
 			goto err;
 		}
 
-		ret = setsockopt(sock[i], SOL_SOCKET, SO_BUF_LOCK, &val[i], sizeof(val[i]));
+		ret = setsockopt(sock[i], SOL_SOCKET, sk_opts[i].type, &sk_opts[i].val, sizeof(sk_opts[i].val));
 		if (ret < 0) {
-			pr_perror("can't set SO_BUF_LOCK (%u) on socket %d", val[i], i);
+			pr_perror("can't set %s (%u) on socket %d", type_to_str(sk_opts[i].type), sk_opts[i].val, i);
+			goto err;
+		}
+
+		len = sizeof(tmp);
+		ret = getsockopt(sock[i], SOL_SOCKET, SO_BUF_LOCK, &tmp, &len);
+		if (ret < 0) {
+			pr_perror("can't get SO_BUF_LOCK from socket %d", i);
+			goto err;
+		}
+
+		if (tmp != sk_opts[i].lock) {
+			fail("SO_BUF_LOCK missmatch %u != %u", tmp, sk_opts[i].lock);
 			goto err;
 		}
 	}
@@ -57,8 +102,8 @@ int main(int argc, char **argv)
 			goto err;
 		}
 
-		if (tmp != val[i]) {
-			fail("SO_BUF_LOCK missmatch %u != %u", tmp, val[i]);
+		if (tmp != sk_opts[i].lock) {
+			fail("SO_BUF_LOCK missmatch %u != %u", tmp, sk_opts[i].lock);
 			goto err;
 		}
 	}

--- a/test/zdtm/static/sock_opts02.desc
+++ b/test/zdtm/static/sock_opts02.desc
@@ -1,0 +1,1 @@
+{'flags': 'suid', 'feature': 'sockopt_buf_lock'}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->

When one sets socket buffer sizes with setsockopt(SO_{SND,RCV}BUF*), kernel sets corresponding SOCK_SNDBUF_LOCK or SOCK_RCVBUF_LOCK flags on struct sock. It means that such a socket with explicitly changed buffer size can not be auto-adjusted by kernel (e.g. if there is free memory kernel can auto-increase default socket buffers to improve performance). (see tcp_fixup_rcvbuf() and tcp_sndbuf_expand())  
 
CRIU is always changing buf sizes on restore, that means that all sockets receive lock flags on struct sock and become non-auto-adjusted after migration. In some cases it can decrease performance of network connections quite a lot.  
 
So let's c/r socket buf locks (SO_BUF_LOCKS), so that sockets for which auto-adjustment is available does not lose it.  
 
Origin of the problem: 
 
We have a customer in Virtuozzo who mentioned that nginx server becomes slower after migration. Especially it is easy to mention when you wget some big file via localhost from the same container which was just migrated. 
 
By strace-ing all nginx processes I see that nginx worker process before c/r sends data to local wget with big chunks ~1.5Mb, but after c/r it only succeeds to send by small chunks ~64Kb (also to remote wget it is around ~128Kb). That can explain the decrease in download speed. 
 
Before: 
sendfile(12, 13, [7984974] => [9425600], 11479629) = 1440626 <0.000180> 
 
After: 
sendfile(8, 13, [1507275] => [1568768], 17957328) = 61493 <0.000675> 
 
As a POC (this way one can check it without a kernel patch) I just commented out all buffer setting manipulations. I managed to get big chunks after c/r and download speed became the same (fast) as before migration.

This is yet a draft as a kernel patch does not hit mainstream kernel. See https://lkml.org/lkml/2021/7/30/346