### PR TITLE
zdtm: fix indentation in Makefile wait_stop target

### DIFF
--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -495,8 +495,8 @@ WAIT_TIME=240
 	[ $$i -lt $(WAIT_TIME) ]
 
 wait_stop:
-		i=0; \
-		while [ $$i -lt $(WAIT_TIME) ] ; do \
+	i=0; \
+	while [ $$i -lt $(WAIT_TIME) ] ; do \
 		kill -0 `awk '{print}' *.pid 2>/dev/null` 2>/dev/null || break; \
 		sleep 1; \
 		i=`expr $$i + 1`; \


### PR DESCRIPTION
Improves while loop readability.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
