### PR TITLE
lsm: do not print a warning if no LSM has been detected

### DIFF
--- a/criu/lsm.c
+++ b/criu/lsm.c
@@ -324,8 +324,10 @@ int collect_and_suspend_lsm(void)
 		break;
 	case LSMTYPE__SELINUX:
 		break;
+	case LSMTYPE__NO_LSM:
+		break;
 	default:
-		pr_warn("don't know how to suspend LSM %d\n", kdat.lsm);
+		pr_debug("don't know how to suspend LSM %d\n", kdat.lsm);
 	}
 
 	return 0;


### PR DESCRIPTION
Without any LSM detected CRIU would print a warning for every run:

 Warn  (criu/lsm.c:328): don't know how to suspend LSM 0

Which clutters up the CI logs.

Change the message to a debug message.

CC: @avagin @brauner 