### PR TITLE
ci: fix 'crit.sh: 3: source: not found'

### DIFF
--- a/test/jenkins/_run_ct
+++ b/test/jenkins/_run_ct
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 mount --make-rslave /

--- a/test/jenkins/run_ct
+++ b/test/jenkins/run_ct
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
 unshare --mount --pid --fork -- $(readlink -f `dirname $0`/_run_ct) "$@"


### PR DESCRIPTION
Jenkins test runs are failing with:

 ./test/jenkins/run_ct ./test/jenkins/crit.sh
 ./test/jenkins/crit.sh: 3: source: not found

Switch to bash which has 'source'.

Fixes: https://ci.kernoops.org/job/CRIU/view/CRIU-devel/job/CRIU-crit/job/criu-dev/627/console

CC: @mihalicyn 