### PR TITLE
files-reg: do not print a warning if a file has no build_id

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1365,7 +1365,7 @@ static int get_build_id_32(Elf32_Ehdr *file_header, unsigned char **build_id, co
 	}
 
 	if (!note_header) {
-		pr_warn("Couldn't find the build-id note for file with fd %d\n", fd);
+		pr_debug("Couldn't find the build-id note for file with fd %d\n", fd);
 		return -1;
 	}
 
@@ -1455,7 +1455,7 @@ static int get_build_id_64(Elf64_Ehdr *file_header, unsigned char **build_id, co
 	}
 
 	if (!note_header) {
-		pr_warn("Couldn't find the build-id note for file with fd %d\n", fd);
+		pr_debug("Couldn't find the build-id note for file with fd %d\n", fd);
 		return -1;
 	}
 


### PR DESCRIPTION
On systems where there is no build_id we get a warning for each run

 Warn  (criu/files-reg.c:1458): Couldn't find the build-id note for file with fd 15

Change the log level to debug for this message as the file just does not have
a build_id and printing a warning clutters the CI logs.