### PR TITLE
zdtm/pthread_timers: make sure glibc allocated SIGEV_THREAD's stack

### DIFF
--- a/test/zdtm/static/pthread_timers.c
+++ b/test/zdtm/static/pthread_timers.c
@@ -54,6 +54,12 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
+	/* Read one event to make sure glibc allocated SIGEV_THREAD's stack */
+	if (read(efd, &val, sizeof(val)) != sizeof(val)) {
+		pr_perror("read");
+		return 1;
+	}
+
 	test_daemon();
 	test_waitsig();
 


### PR DESCRIPTION
On Virtuozzo7 jenkins we see a fail of criu-dev zdtm:

  ===================== Run zdtm/static/pthread_timers in ns =====================
  Start test
  ./pthread_timers --pidfile=pthread_timers.pid --outfile=pthread_timers.out
  Run criu dump
  =[log]=> dump/zdtm/static/pthread_timers/112/1/dump.log
  ------------------------ grep Error ------------------------
  (00.004817) netlink: Collect netlink sock 0x1cad6e21
  (00.004821) netlink: Collect netlink sock 0x1cad6e22
  (00.004831) Collecting pidns 9/112
  (00.004886) No parent images directory provided
  (00.004903) Warn  (criu/lsm.c:328): don't know how to suspend LSM 0
  ------------------------ ERROR OVER ------------------------
  Run criu restore
  4: Old maps lost: set([])
  4: New maps appeared: set([u'7fe4c54ca000-7fe4c54cb000 ---p', u'7fe4c0000000-7fe4c0021000 rw-p', u'7fe4c0021000-7fe4c4000000 ---p', u'7fe4c54cb000-7fe4c5ccb000 rw-p'])
  ############# Test zdtm/static/pthread_timers FAIL at maps compare #############

https://ci.openvz.org/job/CRIU/job/CRIU-virtuozzo/job/criu-dev/8032/consoleFull

First thing to mention is that this is not related to criu. I can manage
to reproduce it with "--nocr", problem is that some mapping appears a
bit later when we do pre-cr get_visible_state().

By debugging SIGEV_THREAD thread with gdb I can see that addresses from
this unexpectedly appearing mapping are used by glibc here as "struct
pthread *pd":

 clone()
  start_thread()
   timer_helper_thread()
    __pthread_create_2_1()

So the mapping looks allocated by allocate_stack(), and it is only
gets done after first timer trigger (we have glibc-2.17 on vz7):

https://github.com/bminor/glibc/blob/release/2.17/master/nptl/sysdeps/unix/sysv/linux/timer_routines.c#L92

So let's wait at least 1 timer trigger so that memory outfit of the test
become permanent and our check_visible_state zdtm check would not be
false negative.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
