### PR TITLE
configs: fix used after free cases

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
         if [ ! -z "$STATUS" ]; then
           echo "FAIL: some files are not correctly formatted.";
           echo "$STATUS"
+          git diff
           echo "FAIL: please run 'make indent'";
           exit 1;
         fi

--- a/criu/action-scripts.c
+++ b/criu/action-scripts.c
@@ -147,9 +147,13 @@ int add_script(char *path)
 
 	script = xmalloc(sizeof(struct script));
 	if (script == NULL)
-		return 1;
+		return -1;
 
-	script->path = path;
+	script->path = xstrdup(path);
+	if (!script->path) {
+		xfree(script);
+		return -1;
+	}
 	list_add(&script->node, &scripts);
 
 	return 0;

--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -1994,10 +1994,20 @@ int new_cg_root_add(char *controller, char *newroot)
 	if (!o)
 		return -1;
 
-	o->controller = controller;
-	o->newroot = newroot;
+	o->controller = xstrdup(controller);
+	if (!o->controller)
+		goto err_ctrl;
+	o->newroot = xstrdup(newroot);
+	if (!o->newroot)
+		goto err_newroot;
 	list_add(&o->node, &opts.new_cgroup_roots);
+
 	return 0;
+err_newroot:
+	xfree(o->controller);
+err_ctrl:
+	xfree(o);
+	return -1;
 }
 
 struct ns_desc cgroup_ns_desc = NS_DESC_ENTRY(CLONE_NEWCGROUP, "cgroup");

--- a/criu/config.c
+++ b/criu/config.c
@@ -548,8 +548,13 @@ static size_t parse_size(char *optarg)
 static int parse_join_ns(const char *ptr)
 {
 	char *aux, *ns_file, *extra_opts = NULL;
+	char *ns;
 
-	aux = strchr(ptr, ':');
+	ns = xstrdup(ptr);
+	if (ns == NULL)
+		return -1;
+
+	aux = strchr(ns, ':');
 	if (aux == NULL)
 		return -1;
 	*aux = '\0';
@@ -562,7 +567,7 @@ static int parse_join_ns(const char *ptr)
 	} else {
 		extra_opts = NULL;
 	}
-	if (join_ns_add(ptr, ns_file, extra_opts))
+	if (join_ns_add(ns, ns_file, extra_opts))
 		return -1;
 
 	return 0;

--- a/criu/config.c
+++ b/criu/config.c
@@ -854,7 +854,6 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 			return 1;
 		case 'L':
 			SET_CHAR_OPTS(libdir, optarg);
-			opts.libdir = optarg;
 			break;
 		case 1059:
 			*has_exec_cmd = true;

--- a/criu/filesystems.c
+++ b/criu/filesystems.c
@@ -829,9 +829,11 @@ bool add_fsname_auto(const char *names)
 
 	if (css_contains(names, fsauto_all))
 		fsauto_names = fsauto_all;
-	else if (!old)
+	else if (!old) {
 		fsauto_names = xstrdup(names);
-	else {
+		if (!fsauto_names)
+			abort();
+	} else {
 		if (asprintf(&fsauto_names, "%s,%s", old, names) < 0)
 			fsauto_names = NULL;
 	}

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -18,7 +18,9 @@
 #define SET_CHAR_OPTS(__dest, __src)              \
 	do {                                      \
 		char *__src_dup = xstrdup(__src); \
-		free(opts.__dest);                \
+		if (!__src_dup)                   \
+			abort();                  \
+		xfree(opts.__dest);               \
 		opts.__dest = __src_dup;          \
 	} while (0)
 

--- a/criu/include/plugin.h
+++ b/criu/include/plugin.h
@@ -24,22 +24,22 @@ typedef struct {
 	struct list_head link[CR_PLUGIN_HOOK__MAX];
 } plugin_desc_t;
 
-#define run_plugins(__hook, ...)                                                                          \
-	({                                                                                                \
-		plugin_desc_t *this;                                                                      \
-		int __ret = -ENOTSUP;                                                                     \
-                                                                                                          \
-		list_for_each_entry(this, &cr_plugin_ctl.hook_chain[CR_PLUGIN_HOOK__##__hook],            \
-				    link[CR_PLUGIN_HOOK__##__hook]) {                                     \
-			pr_debug("plugin: `%s' hook %u -> %p\n", this->d->name, CR_PLUGIN_HOOK__##__hook, \
-				 this->d->hooks[CR_PLUGIN_HOOK__##__hook]);                               \
-			__ret = ((CR_PLUGIN_HOOK__##__hook##_t *)this->d                                  \
-					 ->hooks[CR_PLUGIN_HOOK__##__hook])(__VA_ARGS__);                 \
-			if (__ret == -ENOTSUP)                                                            \
-				continue;                                                                 \
-			break;                                                                            \
-		}                                                                                         \
-		__ret;                                                                                    \
+#define run_plugins(__hook, ...)                                                                            \
+	({                                                                                                  \
+		plugin_desc_t *this;                                                                        \
+		int __ret = -ENOTSUP;                                                                       \
+                                                                                                            \
+		list_for_each_entry(this, &cr_plugin_ctl.hook_chain[CR_PLUGIN_HOOK__##__hook],              \
+				    link[CR_PLUGIN_HOOK__##__hook]) {                                       \
+			pr_debug("plugin: `%s' hook %u -> %p\n", this->d->name, CR_PLUGIN_HOOK__##__hook,   \
+				 this->d->hooks[CR_PLUGIN_HOOK__##__hook]);                                 \
+			__ret = ((CR_PLUGIN_HOOK__##__hook##_t *)this->d->hooks[CR_PLUGIN_HOOK__##__hook])( \
+				__VA_ARGS__);                                                               \
+			if (__ret == -ENOTSUP)                                                              \
+				continue;                                                                   \
+			break;                                                                              \
+		}                                                                                           \
+		__ret;                                                                                      \
 	})
 
 #endif

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -147,7 +147,12 @@ int join_ns_add(const char *type, char *ns_file, char *extra_opts)
 	if (!jn)
 		return -1;
 
-	jn->ns_file = ns_file;
+	jn->ns_file = xstrdup(ns_file);
+	if (!jn->ns_file) {
+		xfree(jn);
+		return -1;
+	}
+
 	if (!strncmp(type, "net", 4)) {
 		jn->nd = &net_ns_desc;
 		join_ns_flags |= CLONE_NEWNET;
@@ -182,6 +187,7 @@ int join_ns_add(const char *type, char *ns_file, char *extra_opts)
 	pr_info("Added %s:%s join namespace\n", type, ns_file);
 	return 0;
 err:
+	xfree(jn->ns_file);
 	xfree(jn);
 	return -1;
 }


### PR DESCRIPTION
We have some code written with the assumption that argv is never
destroyed, but when we handle configs, we construct an argv-like array
for each config, parse it and release it.

I am still not sure that we need to release the memory of per-config argv
arrays... The current scheme is going to be a source of used-after-free
bugs. When we will add the non-privileged mode, all these bugs will be
serious security issues.