### PR TITLE
tcp: Skip restoring TCP state when dumping with --tcp-close

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -334,7 +334,8 @@ mount -t cgroup -o devices,freezer none devices,freezer
     Checkpoint established TCP connections.
 
 *--tcp-close*::
-    Don't dump the state of, or block, established tcp connections.
+    Don't dump the state of, or block, established tcp connections
+    (including the connection is once established but now closed).
     This is useful when tcp connections are not going to be restored.
 
 *--skip-in-flight*::

--- a/criu/sk-tcp.c
+++ b/criu/sk-tcp.c
@@ -451,7 +451,7 @@ int restore_one_tcp(int fd, struct inet_sk_info *ii)
 
 	pr_info("Restoring TCP connection\n");
 
-	if (opts.tcp_close && ii->ie->state != TCP_LISTEN && ii->ie->state != TCP_CLOSE) {
+	if (opts.tcp_close) {
 		if (shutdown(fd, SHUT_RDWR) && errno != ENOTCONN) {
 			pr_perror("Unable to shutdown the socket id %x ino %x", ii->ie->id, ii->ie->ino);
 		}

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -107,6 +107,7 @@ TST_NOFILE	:=				\
 		socket-tcp4v6-closed		\
 		socket-tcp-close0 		\
 		socket-tcp-close1 		\
+		socket-tcp-close2		\
 		socket-dump-tcp-close 		\
 		socket-tcp-unconn		\
 		socket-tcp6-unconn		\

--- a/test/zdtm/static/socket-tcp-close2.c
+++ b/test/zdtm/static/socket-tcp-close2.c
@@ -1,0 +1,67 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <linux/types.h>
+#include <signal.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check both dump and restore with tcp_close on TCP_CLOSE sockets";
+const char *test_author = "Bui Quang Minh <minhquangbui99@gmail.com>";
+
+static int port = 8880;
+
+int main(int argc, char **argv)
+{
+	int fd_s, fd, client;
+	char c;
+
+	test_init(argc, argv);
+	signal(SIGPIPE, SIG_IGN);
+
+	fd_s = tcp_init_server(AF_INET, &port);
+	if (fd_s < 0) {
+		pr_err("Server initializations failed\n");
+		return 1;
+	}
+
+	client = tcp_init_client(AF_INET, "localhost", port);
+	if (client < 0) {
+		pr_err("Client initializations failed\n");
+		return 1;
+	}
+
+	fd = tcp_accept_server(fd_s);
+	if (fd < 0) {
+		pr_err("Can't accept client\n");
+		return 1;
+	}
+	close(fd_s);
+
+	shutdown(client, SHUT_WR);
+	shutdown(fd, SHUT_WR);
+
+	test_daemon();
+	test_waitsig();
+
+	if (read(fd, &c, 1) != 0) {
+		fail("read server");
+		return 1;
+	}
+	if (read(client, &c, 1) != 0) {
+		fail("read client");
+		return 1;
+	}
+	if (write(client, &c, 1) != -1) {
+		fail("write client");
+		return 1;
+	}
+	if (write(fd, &c, 1) != -1) {
+		fail("write server");
+		return 1;
+	}
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/socket-tcp-close2.desc
+++ b/test/zdtm/static/socket-tcp-close2.desc
@@ -1,0 +1,1 @@
+{'opts': '--tcp-close', 'flags': 'reqrst '}


### PR DESCRIPTION
Since commit e42f5e0 ("tcp: allow to specify --tcp-close on dump"),
--tcp-close option can be used when checkpointing. This option skips
checkpointing TCP_CLOSE socket's state. However, when restoring, we
still try to restore TCP_CLOSE socket's state. As a result, a
non-existent protobuf image is opened.

This commit allows dumping TCP_CLOSE socket's state in --tcp-close case.
This commit also removes a redundant check for TCP_LISTEN state in
restore_one_tcp as TCP_LISTEN socket cannot reach this function

Fixes: #1523 