### PR TITLE
zdtm: fix network lock tests when run with --norst

### DIFF
--- a/test/zdtm/static/net_lock_socket_iptables.desc
+++ b/test/zdtm/static/net_lock_socket_iptables.desc
@@ -1,6 +1,6 @@
 {
     'flavor': 'h',
-    'flags': 'suid excl',
+    'flags': 'suid excl reqrst',
     'dopts': '--tcp-established --network-lock iptables',
     'ropts': '--tcp-established',
 }

--- a/test/zdtm/static/net_lock_socket_iptables6.desc
+++ b/test/zdtm/static/net_lock_socket_iptables6.desc
@@ -1,6 +1,6 @@
 {
     'flavor': 'h',
-    'flags': 'suid excl',
+    'flags': 'suid excl reqrst',
     'dopts': '--tcp-established --network-lock iptables',
     'ropts': '--tcp-established',
 }

--- a/test/zdtm/static/net_lock_socket_nftables.desc
+++ b/test/zdtm/static/net_lock_socket_nftables.desc
@@ -1,6 +1,6 @@
 {
     'flavor': 'h',
-    'flags': 'suid excl',
+    'flags': 'suid excl reqrst',
     'feature': 'network_lock_nftables',
     'dopts': '--tcp-established --network-lock nftables',
     'ropts': '--tcp-established',

--- a/test/zdtm/static/net_lock_socket_nftables6.desc
+++ b/test/zdtm/static/net_lock_socket_nftables6.desc
@@ -1,6 +1,6 @@
 {
     'flavor': 'h',
-    'flags': 'suid excl',
+    'flags': 'suid excl reqrst',
     'feature': 'network_lock_nftables',
     'dopts': '--tcp-established --network-lock nftables',
     'ropts': '--tcp-established',

--- a/test/zdtm/static/netns_lock_iptables.desc
+++ b/test/zdtm/static/netns_lock_iptables.desc
@@ -1,6 +1,6 @@
 {
     'flavor': 'h',
-    'flags': 'suid excl',
+    'flags': 'suid excl reqrst',
     'opts': '--tcp-established',
     'dopts': '--network-lock iptables',
     'ropts': '--join-ns net:/var/run/netns/criu-net-lock-test'

--- a/test/zdtm/static/netns_lock_nftables.desc
+++ b/test/zdtm/static/netns_lock_nftables.desc
@@ -1,6 +1,6 @@
 {
     'flavor': 'h',
-    'flags': 'suid excl',
+    'flags': 'suid excl reqrst',
     'feature': 'network_lock_nftables',
     'opts': '--tcp-established',
     'dopts': '--network-lock nftables',


### PR DESCRIPTION
In test/jenkins/{crit.sh,criu-dump}, ZDTM is run with --norst,
Causing tests to only go through dump wihtout restoring.

The network locking tests are highly dependant on dump/restore hooks
causing them to hang when run with --norst.

We just add a reqrst flag to all network lock tests.

Signed-off-by: Zeyad Yasser <zeyady98@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
