### PR TITLE
restore cwd when restore mnt namespace

### DIFF
--- a/criu/autofs.c
+++ b/criu/autofs.c
@@ -391,7 +391,7 @@ static int access_autofs_mount(struct mount_info *pm)
 	const char *mnt_path = pm->mountpoint + 1;
 	dev_t dev_id = pm->s_dev;
 	int new_pid_ns = -1, old_pid_ns = -1;
-	int old_mnt_ns;
+	int old_mnt_ns, old_cwd_fd;
 	int autofs_mnt;
 	int err = -1;
 	int pid, status;
@@ -409,7 +409,7 @@ static int access_autofs_mount(struct mount_info *pm)
 	if (old_pid_ns < 0)
 		goto close_new_pid_ns;
 
-	if (switch_ns(pm->nsid->ns_pid, &mnt_ns_desc, &old_mnt_ns)) {
+	if (switch_mnt_ns(pm->nsid->ns_pid, &old_mnt_ns, &old_cwd_fd)) {
 		pr_err("failed to switch to mount namespace\n");
 		goto close_old_pid_ns;
 	}
@@ -451,7 +451,7 @@ restore_pid_ns:
 	}
 	old_pid_ns = -1;
 restore_mnt_ns:
-	if (restore_ns(old_mnt_ns, &mnt_ns_desc)) {
+	if (restore_mnt_ns(old_mnt_ns, &old_cwd_fd)) {
 		pr_err("failed to restore mount namespace\n");
 		err = -1;
 	}

--- a/criu/include/namespaces.h
+++ b/criu/include/namespaces.h
@@ -165,8 +165,10 @@ extern int prepare_namespace(struct pstree_item *item, unsigned long clone_flags
 extern int prepare_userns_creds(void);
 
 extern int switch_ns(int pid, struct ns_desc *nd, int *rst);
+extern int switch_mnt_ns(int pid, int *rst, int *cwd_fd);
 extern int switch_ns_by_fd(int nsfd, struct ns_desc *nd, int *rst);
 extern int restore_ns(int rst, struct ns_desc *nd);
+extern int restore_mnt_ns(int rst, int *cwd_fd);
 
 extern int dump_task_ns_ids(struct pstree_item *);
 extern int predump_task_ns_ids(struct pstree_item *);

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -1511,10 +1511,10 @@ err:
 static __maybe_unused int mount_cr_time_mount(struct ns_id *ns, unsigned int *s_dev, const char *source,
 					      const char *target, const char *type)
 {
-	int mnt_fd, ret, exit_code = 0;
+	int mnt_fd, cwd_fd, ret, exit_code = 0;
 	struct stat st;
 
-	ret = switch_ns(ns->ns_pid, &mnt_ns_desc, &mnt_fd);
+	ret = switch_mnt_ns(ns->ns_pid, &mnt_fd, &cwd_fd);
 	if (ret < 0) {
 		pr_err("Can't switch mnt_ns\n");
 		goto out;
@@ -1536,7 +1536,7 @@ static __maybe_unused int mount_cr_time_mount(struct ns_id *ns, unsigned int *s_
 	}
 
 restore_ns:
-	ret = restore_ns(mnt_fd, &mnt_ns_desc);
+	ret = restore_mnt_ns(mnt_fd, &cwd_fd);
 out:
 	return ret < 0 ? 0 : exit_code;
 }

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -282,6 +282,51 @@ int restore_ns(int rst, struct ns_desc *nd)
 	return ret;
 }
 
+int switch_mnt_ns(int pid, int *rst, int *cwd_fd)
+{
+	int ret;
+	int fd;
+
+	if (!cwd_fd)
+		return switch_ns(pid, &mnt_ns_desc, rst);
+
+	fd = open(".", O_PATH);
+	if (fd < 0) {
+		pr_perror("unable to open current directory");
+		return fd;
+	}
+
+	ret = switch_ns(pid, &mnt_ns_desc, rst);
+	if (ret < 0) {
+		close(fd);
+		return ret;
+	}
+
+	*cwd_fd = fd;
+	return 0;
+}
+
+int restore_mnt_ns(int rst, int *cwd_fd)
+{
+	int ret = -1;
+
+	ret = restore_ns(rst, &mnt_ns_desc);
+	if (ret < 0)
+		goto err_restore;
+
+	if (cwd_fd) {
+		ret = fchdir(*cwd_fd);
+		if (ret)
+			pr_perror("unable to restore current directory");
+	}
+
+err_restore:
+	if (cwd_fd)
+		close_safe(cwd_fd);
+
+	return ret;
+}
+
 struct ns_id *ns_ids = NULL;
 static unsigned int ns_next_id = 1;
 unsigned long root_ns_mask = 0;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;
-->
When CONFIG_BINFMT_MISC_VIRTUALIZED is enabled, I found stats-dump is write to /, but not  work directory in dump  process. Finaly I found criu do not restore cwd when restoring mnt ns. The patch series do the following:

-  add helpers to switch/restore mnt ns
-  restore current work directory after restoring mnt ns in cr_dump_task
- use swich_mnt_ns/restore_mnt_ns helpers to simplify code in open_mountpoint
