### PR TITLE
Fix some locking errors due to the unreleased locks

### DIFF
--- a/test/zdtm/static/clone_fs.c
+++ b/test/zdtm/static/clone_fs.c
@@ -76,6 +76,8 @@ int main(int argc, char **argv)
 
 	if (pthread_create(&th, NULL, thread_func, &tid)) {
 		fail("Can't pthread_create");
+		pthread_mutex_unlock(&init_lock);
+		pthread_mutex_unlock(&exit_lock);
 		return 1;
 	}
 
@@ -83,6 +85,7 @@ int main(int argc, char **argv)
 
 	ret = kcmp(KCMP_FS, gettid(), tid, 0, 0);
 	if (ret)
+		pthread_mutex_unlock(&exit_lock);
 		exit(1);
 
 	test_daemon();
@@ -91,6 +94,7 @@ int main(int argc, char **argv)
 	ret = kcmp(KCMP_FS, gettid(), tid, 0, 0);
 	if (ret) {
 		fail();
+		pthread_mutex_unlock(&exit_lock);
 		exit(1);
 	}
 

--- a/test/zdtm/static/seccomp_filter_tsync.c
+++ b/test/zdtm/static/seccomp_filter_tsync.c
@@ -145,11 +145,13 @@ int main(int argc, char **argv)
 
 		if (write(sk, &c, 1) != 1) {
 			pr_perror("write");
+			pthread_mutex_unlock(&getpid_wait);
 			_exit(1);
 		}
 
 		if (read(sk, &c, 1) != 1) {
 			pr_perror("read");
+			pthread_mutex_unlock(&getpid_wait);
 			_exit(1);
 		}
 
@@ -158,6 +160,7 @@ int main(int argc, char **argv)
 		 * inherited.
 		 */
 		if (filter_syscall(__NR_ptrace, SECCOMP_FILTER_FLAG_TSYNC) < 0)
+			pthread_mutex_unlock(&getpid_wait);
 			_exit(1);
 
 		pthread_mutex_unlock(&getpid_wait);

--- a/test/zdtm/static/sigpending.c
+++ b/test/zdtm/static/sigpending.c
@@ -242,9 +242,10 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
-	if (child == 0)
+	if (child == 0){
 		pthread_mutex_unlock(&exit_lock);
 		return 5; /* SIGCHLD */
+	}
 	if (waitid(P_PID, child, &infop, WNOWAIT | WEXITED)) {
 		pr_perror("waitid");
 		pthread_mutex_unlock(&exit_lock);


### PR DESCRIPTION
Fix some (small) locking errors due to the unreleased locks before program exit for better resource management and good code symmetry reported in #1600 #1601 #1602. 

