### PR TITLE
bfd: use lockless ringbuffer to rewrite bfd

### DIFF
--- a/criu/include/bfd.h
+++ b/criu/include/bfd.h
@@ -3,28 +3,22 @@
 
 #include "common/err.h"
 
-struct bfd_buf;
-struct xbuf {
-	char *mem; /* buffer */
-	char *data; /* position we see bytes at */
-	unsigned int sz; /* bytes sitting after b->pos */
-	struct bfd_buf *buf;
-};
-
+struct iovec;
+struct rb_buffer;
 struct bfd {
-	int fd;
-	bool writable;
-	struct xbuf b;
+    int fd;
+    bool writable;
+    struct rb_buffer *rb_data;
 };
 
 static inline bool bfd_buffered(struct bfd *b)
 {
-	return b->b.mem != NULL;
+	return b->rb_data != NULL;
 }
 
 static inline void bfd_setraw(struct bfd *b)
 {
-	b->b.mem = NULL;
+	b->rb_data = NULL;
 }
 
 int bfdopenr(struct bfd *f);


### PR DESCRIPTION
Hi guys. I am trying to optimize performances of read/write of proc file in criu since my proc file has the size of 42M. It is really big.
And I found criu uses bfd to handle proc read/write. I think it is a little complicated to use. So I wonder if it will be better to use lockless ring buffer. 

So according to the usage of bfd in criu, I wrote a new version that used ring buffer. In my testing environment, it almost has no effect on performance, but I think ring buffer is easier to maintain. And also, I am trying to use two threads to handle proc at the same time to see if I can have a better performance. Does anyone has tried this before?
