### PR TITLE
bfd: avoid memory move by using ring buffer in bfd

### DIFF
--- a/criu/include/bfd.h
+++ b/criu/include/bfd.h
@@ -6,8 +6,9 @@
 struct bfd_buf;
 struct xbuf {
 	char *mem; /* buffer */
-	char *data; /* position we see bytes at */
-	unsigned int sz; /* bytes sitting after b->pos */
+	unsigned long size;
+	unsigned long write;
+	unsigned long read;
 	struct bfd_buf *buf;
 };
 


### PR DESCRIPTION
By using ring buffer in bfd, we can avoid moving memory.
And the implementation will be more simple.

And, lockless ring buffer also supports two threads work
at the same time which is helpful to deal with the situation
when the size of the proc file is up to tens of megabytes.

Signed-off-by: anatasluo <luolongjuna@gmail.com>

