### PR TITLE
gitignore: add build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ lib/.crit-setup.files
 compel/include/asm
 include/common/asm
 include/common/config.h
+build/


### PR DESCRIPTION
The build directory is generated when running make install.