### PR TITLE
mount: fix double-dump file system bug

### DIFF
--- a/criu/mount.c
+++ b/criu/mount.c
@@ -1565,6 +1565,7 @@ static int dump_one_fs(struct mount_info *mi)
 		if (ret < 0)
 			return ret;
 
+		pm->dumped = true;
 		list_for_each_entry(t, &pm->mnt_bind, mnt_bind)
 			t->dumped = true;
 		return 0;


### PR DESCRIPTION
In the function dump_one_fs(), there's a comment that says "mnt_bind is
a cycled list, so list_for_each can't be used here." That means that the
list head of the list is also a node of the list.

The subsequent list_for_each_entry() marks all the mount info nodes as
dumped, except it skips the list head, which is also a mount info.
This is the bug we fix.

This bug made CRIU dump a file system twice.
See https://github.com/checkpoint-restore/criu-image-streamer/issues/8