### PR TITLE
ci: Update openj9 container images

### DIFF
--- a/scripts/build/Dockerfile.openj9-alpine
+++ b/scripts/build/Dockerfile.openj9-alpine
@@ -1,3 +1,5 @@
+# FIXME: Replace with eclipse-temurin once Alpine support has been added.
+# https://github.com/adoptium/containers/pull/60
 FROM adoptopenjdk/openjdk8-openj9:alpine
 ARG CC=gcc
 

--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8-openj9:latest
+FROM docker.io/library/eclipse-temurin:8-focal
 ARG CC=gcc
 
 COPY scripts/ci/apt-install /bin/apt-install


### PR DESCRIPTION
The AdoptOpenJDK docker images have been deprecated in favor of
eclipse-temurin.

https://github.com/AdoptOpenJDK/openjdk-docker/pull/604