### PR TITLE
libcriu: add API for join-ns option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,6 +431,7 @@ lint:
 	shellcheck scripts/*.sh
 	shellcheck scripts/ci/*.sh scripts/ci/apt-install
 	shellcheck test/others/crit/*.sh
+	shellcheck test/others/libcriu/*.sh
 	shellcheck test/others/config-file/*.sh
 	# Do not append \n to pr_perror or fail
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*\\n"'

--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -28,6 +28,13 @@
 extern "C" {
 #endif
 
+#define CRIU_LOG_UNSET (-1)
+#define CRIU_LOG_MSG   (0) /* Print message regardless of log level */
+#define CRIU_LOG_ERROR (1) /* Errors only */
+#define CRIU_LOG_WARN  (2) /* Warnings */
+#define CRIU_LOG_INFO  (3) /* Informative */
+#define CRIU_LOG_DEBUG (4) /* Debug only */
+
 enum criu_service_comm { CRIU_COMM_SK, CRIU_COMM_FD, CRIU_COMM_BIN };
 
 enum criu_cg_mode {

--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -103,6 +103,7 @@ int criu_set_page_server_address_port(const char *address, int port);
 int criu_set_pre_dump_mode(enum criu_pre_dump_mode mode);
 void criu_set_pidfd_store_sk(int sk);
 int criu_set_network_lock(enum criu_network_lock_method method);
+int criu_join_ns_add(const char *ns, const char *ns_file, const char *extra_opt);
 
 /*
  * The criu_notify_arg_t na argument is an opaque
@@ -263,6 +264,7 @@ int criu_local_set_page_server_address_port(criu_opts *opts, const char *address
 int criu_local_set_pre_dump_mode(criu_opts *opts, enum criu_pre_dump_mode mode);
 void criu_local_set_pidfd_store_sk(criu_opts *opts, int sk);
 int criu_local_set_network_lock(criu_opts *opts, enum criu_network_lock_method method);
+int criu_local_join_ns_add(criu_opts *opts, const char *ns, const char *ns_file, const char *extra_opt);
 
 void criu_local_set_notify_cb(criu_opts *opts, int (*cb)(char *action, criu_notify_arg_t na));
 

--- a/test/others/libcriu/.gitignore
+++ b/test/others/libcriu/.gitignore
@@ -3,4 +3,6 @@ test_iters
 test_notify
 test_self
 test_sub
+test_join_ns
 wdir
+libcriu.so.*

--- a/test/others/libcriu/.gitignore
+++ b/test/others/libcriu/.gitignore
@@ -4,5 +4,5 @@ test_notify
 test_self
 test_sub
 test_join_ns
-wdir
+output/
 libcriu.so.*

--- a/test/others/libcriu/Makefile
+++ b/test/others/libcriu/Makefile
@@ -1,10 +1,11 @@
 include ../../../../criu/Makefile.versions
 
-TESTS += test_sub 
+TESTS += test_sub
 TESTS += test_self
 TESTS += test_notify
 TESTS += test_iters
 TESTS += test_errno
+TESTS += test_join_ns
 
 all: $(TESTS)
 .PHONY: all

--- a/test/others/libcriu/run.sh
+++ b/test/others/libcriu/run.sh
@@ -53,6 +53,7 @@ if [ "$(uname -m)" == "x86_64" ]; then
 	run_test test_iters
 fi
 run_test test_errno
+run_test test_join_ns
 
 echo "== Tests done"
 make libcriu_clean

--- a/test/others/libcriu/run.sh
+++ b/test/others/libcriu/run.sh
@@ -9,6 +9,7 @@ TEST_LOG="${TEST_DIR}/test.log"
 DUMP_LOG="${TEST_DIR}/dump.log"
 RESTORE_LOG="${TEST_DIR}/restore.log"
 
+# shellcheck disable=1091
 source "${MAIN_DIR}/../env.sh" || exit 1
 
 echo "== Clean"

--- a/test/others/libcriu/test_iters.c
+++ b/test/others/libcriu/test_iters.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 	criu_set_service_binary(argv[1]);
 	criu_set_pid(pid);
 	criu_set_log_file("dump.log");
-	criu_set_log_level(4);
+	criu_set_log_level(CRIU_LOG_DEBUG);
 
 	open_imgdir();
 	ret = criu_dump_iters(next_iter);
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
 
 	printf("--- Restore loop ---\n");
 	criu_init_opts();
-	criu_set_log_level(4);
+	criu_set_log_level(CRIU_LOG_DEBUG);
 	criu_set_log_file("restore.log");
 	criu_set_images_dir_fd(cur_imgdir);
 

--- a/test/others/libcriu/test_join_ns.c
+++ b/test/others/libcriu/test_join_ns.c
@@ -1,0 +1,243 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "criu.h"
+#include "lib.h"
+
+#ifndef CLONE_NEWTIME
+#define CLONE_NEWTIME 0x00000080 /* New time namespace */
+#endif
+
+static pid_t child_pid;
+static int pipefd[2];
+
+static int dir_fd;
+static char *criu_bin;
+
+static bool timens_support(void)
+{
+	return access("/proc/self/ns/time", F_OK) == 0;
+}
+
+static void create_child_process(void)
+{
+	pid_t pid = fork();
+	if (pid < 0) {
+		perror("fork failed");
+		exit(1);
+	}
+
+	if (pid == 0) {
+		if (setsid() < 0)
+			exit(1);
+		pid = getpid();
+		write(pipefd[1], &pid, sizeof(pid));
+		while (1)
+			sleep(1);
+	}
+}
+
+static void unshare_namespaces(void)
+{
+	int flags = CLONE_NEWIPC | CLONE_NEWUTS;
+	if (unshare(flags)) {
+		perror("Can't unshare namespaces");
+		exit(1);
+	}
+
+	if (timens_support() && unshare(CLONE_NEWTIME)) {
+		perror("unshare(CLONE_NEWTIME) failed");
+		exit(1);
+	}
+}
+
+static void init_criu_request(void)
+{
+	if (criu_init_opts()) {
+		fprintf(stderr, "failed to initialise request options\n");
+		exit(1);
+	}
+	criu_set_service_binary(criu_bin);
+	criu_set_images_dir_fd(dir_fd);
+	criu_set_log_level(CRIU_LOG_DEBUG);
+}
+
+static void checkpoint_test(void)
+{
+	int pid, ret;
+
+	pipe(pipefd);
+
+	pid = fork();
+	if (pid < 0) {
+		perror("fork failed");
+		exit(1);
+	}
+
+	if (pid == 0) {
+		unshare_namespaces();
+		/* Close unused read end */
+		close(pipefd[0]);
+		create_child_process();
+		exit(0);
+	}
+
+	/* Close unused write end */
+	close(pipefd[1]);
+	/* Read child PID */
+	read(pipefd[0], &child_pid, sizeof(child_pid));
+
+	init_criu_request();
+	criu_set_log_file("dump.log");
+	criu_set_pid(child_pid);
+
+	ret = criu_dump();
+	if (ret < 0) {
+		what_err_ret_mean(ret);
+		exit(1);
+	}
+
+	kill(pid, SIGKILL);
+	if (waitpid(pid, NULL, 0) < 0) {
+		perror("Can't wait pid");
+		exit(1);
+	}
+}
+
+static void join_ns(const char *ns, pid_t pid)
+{
+	char ns_file[PATH_MAX];
+	snprintf(ns_file, sizeof(ns_file), "/proc/%d/ns/%s", pid, ns);
+	criu_join_ns_add(ns, ns_file, NULL);
+}
+
+static pid_t create_namespaces(void)
+{
+	pid_t pid = fork();
+	if (pid < 0) {
+		perror("fork failed");
+		exit(1);
+	}
+
+	if (pid == 0) {
+		unshare_namespaces();
+		while (1)
+			sleep(1);
+	}
+
+	return pid;
+}
+
+static int get_ns_ino(pid_t pid, const char *nsname, ino_t *ino)
+{
+	struct stat st;
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path), "/proc/%d/ns/%s", pid, nsname);
+	printf("Stat %s\n", path);
+	if (stat(path, &st))
+		return -errno;
+	*ino = st.st_ino;
+
+	return 0;
+}
+
+static int compare_namespace(const char *nsname, pid_t parent_pid)
+{
+	ino_t child_ns_ino, parent_ns_ino;
+
+	printf("Compare %s ns for %d and %d\n", nsname, child_pid, parent_pid);
+
+	if (get_ns_ino(child_pid, nsname, &child_ns_ino)) {
+		perror("Failed to get child ns inode");
+		return -1;
+	}
+
+	if (get_ns_ino(parent_pid, nsname, &parent_ns_ino)) {
+		perror("Failed to get parent ns inode");
+		return -1;
+	}
+
+	return child_ns_ino != parent_ns_ino;
+}
+
+static int restore_test(void)
+{
+	int ret;
+	pid_t parent_pid = create_namespaces();
+
+	init_criu_request();
+	criu_set_log_file("restore.log");
+
+	join_ns("ipc", parent_pid);
+	join_ns("uts", parent_pid);
+	if (timens_support())
+		join_ns("time", parent_pid);
+
+	ret = criu_restore_child();
+	if (ret < 0) {
+		what_err_ret_mean(ret);
+		exit(1);
+	}
+
+	/* Verify that the child process has joined correct namespaces */
+
+	if (compare_namespace("ipc", parent_pid)) {
+		fprintf(stderr, "Error: IPC ns doesn't match\n");
+		exit(1);
+	}
+
+	if (compare_namespace("uts", parent_pid)) {
+		fprintf(stderr, "Error: UTS ns doesn't match\n");
+		exit(1);
+	}
+
+	if (timens_support() && compare_namespace("time", parent_pid)) {
+		fprintf(stderr, "Error: Time ns doesn't match\n");
+		exit(1);
+	}
+
+	kill(child_pid, SIGKILL);
+	if (waitpid(child_pid, NULL, 0) < 0) {
+		perror("Can't wait child pid");
+		exit(1);
+	}
+
+	kill(parent_pid, SIGKILL);
+	if (waitpid(parent_pid, NULL, 0) < 0) {
+		perror("Can't wait parent pid");
+		exit(1);
+	}
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	int exit_code;
+
+	criu_bin = argv[1];
+	dir_fd = open(argv[2], O_DIRECTORY);
+	if (dir_fd < 0) {
+		perror("Can't open images dir");
+		return -1;
+	}
+
+	checkpoint_test();
+	exit_code = restore_test();
+
+	close(dir_fd);
+	return exit_code;
+}

--- a/test/others/libcriu/test_notify.c
+++ b/test/others/libcriu/test_notify.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
 	criu_set_service_binary(argv[1]);
 	criu_set_pid(pid);
 	criu_set_log_file("dump.log");
-	criu_set_log_level(4);
+	criu_set_log_level(CRIU_LOG_DEBUG);
 	criu_set_notify_cb(notify);
 	fd = open(argv[2], O_DIRECTORY);
 	criu_set_images_dir_fd(fd);

--- a/test/others/libcriu/test_self.c
+++ b/test/others/libcriu/test_self.c
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 	}
 
 	criu_set_images_dir_fd(fd);
-	criu_set_log_level(4);
+	criu_set_log_level(CRIU_LOG_DEBUG);
 
 	printf("--- Start child ---\n");
 	pid = fork();

--- a/test/others/libcriu/test_sub.c
+++ b/test/others/libcriu/test_sub.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
 	criu_set_service_binary(argv[1]);
 	criu_set_pid(pid);
 	criu_set_log_file("dump.log");
-	criu_set_log_level(4);
+	criu_set_log_level(CRIU_LOG_DEBUG);
 	fd = open(argv[2], O_DIRECTORY);
 	criu_set_images_dir_fd(fd);
 
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
 
 	printf("--- Restore loop ---\n");
 	criu_init_opts();
-	criu_set_log_level(4);
+	criu_set_log_level(CRIU_LOG_DEBUG);
 	criu_set_log_file("restore.log");
 	criu_set_images_dir_fd(fd);
 


### PR DESCRIPTION
We use the join-ns RPC API in runc to enable checkpoint/restore of containers with shared namespaces. Shared namespaces are often used when containers run inside Kubernetes Pod. However, crun is using libcriu to interface with CRIU and libcriu currently doesn't provide an API for join-ns. This pull request adds the libcriu API necessary to enable checkpoint/restore of containers with shared namespaces with crun.