### PR TITLE
criu-ns: change python shebang to python3

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -12,7 +12,9 @@ endif
 
 FOOTER		:= footer.txt
 SRC1		+= crit.txt
+ifeq ($(PYTHON),python3)
 SRC1		+= criu-ns.txt
+endif
 SRC1		+= compel.txt
 SRC8		+= criu.txt
 SRC		:= $(SRC1) $(SRC8)

--- a/criu/Makefile
+++ b/criu/Makefile
@@ -144,7 +144,9 @@ install: $(obj)/criu
 	$(Q) install -m 644 $(UAPI_HEADERS) $(DESTDIR)$(INCLUDEDIR)/criu/
 	$(Q) mkdir -p $(DESTDIR)$(LIBEXECDIR)/criu/scripts
 	$(Q) install -m 755 scripts/systemd-autofs-restart.sh $(DESTDIR)$(LIBEXECDIR)/criu/scripts
+ifeq ($(PYTHON),python3)
 	$(Q) install -m 755 scripts/criu-ns $(DESTDIR)$(SBINDIR)
+endif
 .PHONY: install
 
 uninstall:

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import ctypes
 import ctypes.util
 import errno


### PR DESCRIPTION
[PEP 394](https://www.python.org/dev/peps/pep-0394/) recommends changing `python` shebangs to `python3` when Python 3.x is supported. This is similar to `crit-python3`.