### PR TITLE
criu.pc: Add libprotobuf-c as a dependency

### DIFF
--- a/lib/c/criu.pc.in
+++ b/lib/c/criu.pc.in
@@ -4,5 +4,6 @@ includedir=@includedir@
 Name: CRIU
 Description: RPC library for userspace checkpoint and restore
 Version: @version@
+Requires.private: protobuf-c
 Libs: -L${libdir} -lcriu
 Cflags: -I${includedir}


### PR DESCRIPTION
CRIU has a dependency on protobuf-c-devel. We express this dependency in pkgconfig to be auto-detected when building a package.