### PR TITLE
criu-ns: make pidns init first do setsid

### DIFF
--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -102,6 +102,7 @@ def wrap_restore():
 
     criu_pid = os.fork()
     if criu_pid == 0:
+        os.setsid()
         _mount_new_proc()
         run_criu(restore_args)
 


### PR DESCRIPTION
We see that on criu-ns dump/restore/dump of the process which initially
was not a session leader (with --shell-job option) we see sid == 0 for
it and fail with something like:

Error (criu/cr-dump.c:1333): A session leader of 41585(41585) is outside of its pid namespace

Note: We should not dump processes with sid 0 (even with --shell-job) as
on restore we can can put such processes from multiple sessions into
one, which is wrong.

Fixes: #232

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
