### PR TITLE
pie/restorer: remove excess hash printf specifier

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1013,7 +1013,7 @@ static int timerfd_arm(struct task_restore_args *args)
 
 			t->val.it_value.tv_sec += (time_t)ts.tv_sec;
 
-			pr_debug("Adjust id %#x it_value(%llu, %llu) -> it_value(%llu, %llu)\n", t->id,
+			pr_debug("Adjust id %x it_value(%llu, %llu) -> it_value(%llu, %llu)\n", t->id,
 				 (unsigned long long)ts.tv_sec, (unsigned long long)ts.tv_nsec,
 				 (unsigned long long)t->val.it_value.tv_sec,
 				 (unsigned long long)t->val.it_value.tv_nsec);


### PR DESCRIPTION
We use here "%#x" printf specifier in pie code, but sbuf_printf core pie
printing function knows nothing about '#' specifier. More over simple
"%x" in pie does same as "%#x" in stdio printf, see print_hex* functions
add "0x" before hex numbers.

We've got this error on vzt-cpt runs in Virtuozzo:

(04.750271) pie: 158: Adjust id
Error: Unknown printf format %#

So to fix it we can just remove '#'.

Fixes: ecd432fe2 ("timerfd: Implement c/r procedure")
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
