### PR TITLE
util: use nftw in rmrf helper

### DIFF
--- a/criu/apparmor.c
+++ b/criu/apparmor.c
@@ -630,7 +630,7 @@ int suspend_aa(void)
 	}
 
 	ret = do_suspend(true);
-	if (rm_rf(policydir) < 0)
+	if (rmrf(policydir) < 0)
 		pr_err("failed removing policy dir %s\n", policydir);
 
 	return ret;

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -284,8 +284,8 @@ int setup_tcp_server(char *type, char *addr, unsigned short *port);
 int run_tcp_server(bool daemon_mode, int *ask, int cfd, int sk);
 int setup_tcp_client(char *hostname);
 
-/* *dir should be writable and at least PATH_MAX long */
-int rm_rf(char *dir);
+/* path should be writable and no more than PATH_MAX long */
+int rmrf(char *path);
 
 #define LAST_PID_PATH "sys/kernel/ns_last_pid"
 #define PID_MAX_PATH  "sys/kernel/pid_max"


### PR DESCRIPTION
This simplifies the code by removing excess recursion and reusing
standard function to walk over file-tree instead of opencoding it.

This addresses problem mentioned in my review comment:
https://github.com/checkpoint-restore/criu/pull/1495#discussion_r677554523

Fixes: 0db135ac4 ("util: add rm -rf function")

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
