### PR TITLE
ci: replace deprecated codecov bash uploader

### DIFF
--- a/.github/workflows/gcov-test.yml
+++ b/.github/workflows/gcov-test.yml
@@ -10,5 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run Coverage Tests
       run: sudo -E make -C scripts/ci local GCOV=1
+    - name: Run gcov
+      run: sudo -E find . -name '*gcda' -type f -print0 | sudo -E xargs --null --max-args 128 --max-procs 4 gcov
     - name: Run Coverage Analysis
       run: sudo -E make codecov

--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,9 @@ lint:
 
 codecov: SHELL := $(shell which bash)
 codecov:
-	bash <(curl -s https://codecov.io/bash)
+	curl -Os https://uploader.codecov.io/latest/linux/codecov
+	chmod +x codecov
+	./codecov
 .PHONY: codecov
 
 fetch-clang-format: .FORCE


### PR DESCRIPTION
Replace deprecated codecov bash uploader with new version:

https://about.codecov.io/blog/introducing-codecovs-new-uploader/