### PR TITLE
Replace CONFIG_ARMV* with CONFIG_CPU_V*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ifeq ($(ARCH),arm)
                 ARMV := 7
         endif
 
-        DEFINES		:= -DCONFIG_ARMV$(ARMV) -DCONFIG_VDSO_32
+        DEFINES		:= -DCONFIG_CPU_V$(ARMV) -DCONFIG_VDSO_32
 
         PROTOUFIX	:= y
 	# For simplicity - compile code in Arm mode without interwork.

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ endif
 ifeq ($(ARCH),arm)
         ARMV		:= $(shell echo $(SUBARCH) | sed -nr 's/armv([[:digit:]]).*/\1/p; t; i7')
 
+        ifneq ($(filter-out 6 7 8,$(ARMV)),)
+                $(error "ARM platform subversion undetected. SUBARCH is $(SUBARCH))
+        endif
+
         ifeq ($(ARMV),6)
                 USERCFLAGS += -march=armv6
         endif

--- a/compel/src/main.c
+++ b/compel/src/main.c
@@ -44,7 +44,7 @@ static const flags_t flags = {
 #elif defined CONFIG_AARCH64
 	.arch = "aarch64",
 	.cflags = COMPEL_CFLAGS_PIE,
-#elif defined(CONFIG_ARMV6) || defined(CONFIG_ARMV7)
+#elif defined(CONFIG_CPU_V6) || defined(CONFIG_CPU_V7)
 	.arch = "arm",
 	.cflags = COMPEL_CFLAGS_PIE,
 #elif defined CONFIG_PPC64

--- a/include/common/arch/arm/asm/atomic.h
+++ b/include/common/arch/arm/asm/atomic.h
@@ -9,7 +9,7 @@ typedef struct {
 
 /* Copied from the Linux kernel header arch/arm/include/asm/atomic.h */
 
-#if defined(CONFIG_ARMV7)
+#if defined(CONFIG_CPU_V7)
 
 #define smp_mb() __asm__ __volatile__("dmb" : : : "memory")
 
@@ -38,7 +38,7 @@ static inline int atomic_cmpxchg(atomic_t *ptr, int old, int new)
 	return oldval;
 }
 
-#elif defined(CONFIG_ARMV6)
+#elif defined(CONFIG_CPU_V6)
 
 /* SMP isn't supported for ARMv6 */
 
@@ -57,7 +57,7 @@ static inline int atomic_cmpxchg(atomic_t *v, int old, int new)
 
 #else
 
-#error ARM architecture version (CONFIG_ARMV*) not set or unsupported.
+#error ARM architecture version (CONFIG_CPU_V*) not set or unsupported.
 
 #endif
 


### PR DESCRIPTION
This pull request is a rebase of https://github.com/checkpoint-restore/criu/pull/1071.

We have seen this problem reported in https://bugs.debian.org/918229 as well.