### PR TITLE
ci: fix userfaultfd and clang-format test failures

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:latest
+      image: registry.fedoraproject.org/fedora:34
     steps:
     - name: Install tools
       run: sudo dnf -y install git make python3-flake8 ShellCheck clang-tools-extra which findutils

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -197,6 +197,12 @@ fi
 # shellcheck disable=SC2086
 ./test/zdtm.py run -a -p 2 --keep-going $ZDTM_OPTS
 
+# Newer kernels are blocking access to userfaultfd:
+# uffd: Set unprivileged_userfaultfd sysctl knob to 1 if kernel faults must be handled without obtaining CAP_SYS_PTRACE capability
+if [ -e /proc/sys/vm/unprivileged_userfaultfd ]; then
+	echo 1 > /proc/sys/vm/unprivileged_userfaultfd
+fi
+
 LAZY_EXCLUDE="-x maps04 -x cmdlinenv00 -x maps007"
 
 LAZY_TESTS='.*(maps0|uffd-events|lazy-thp|futex|fork).*'


### PR DESCRIPTION
Newer kernels (5.11) require echo 1 > /proc/sys/vm/unprivileged_userfaultfd

Without the 'echo 1' the kernel prints a message like this:

 uffd: Set unprivileged_userfaultfd sysctl knob to 1 if kernel faults must be handled without obtaining CAP_SYS_PTRACE capability

I also pinned the clang-format to Fedora 34 which comes with clang 12. Fedora 35 has clang 13 which formats the code differently.