### PR TITLE
ci: disable socket-raw test on centos8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,7 +47,7 @@ task:
     pip3 install junit_xml
 
   build_script: |
-    make -C scripts/ci local SKIP_CI_PREP=1 CC=gcc CD_TO_TOP=1
+    make -C scripts/ci local SKIP_CI_PREP=1 CC=gcc CD_TO_TOP=1 ZDTM_OPTS="-x zdtm/static/socket-raw"
 
 task:
   name: CentOS 7 based test


### PR DESCRIPTION
We see error in centos8 ci on restore of socket-raw test:

  inet: \tRestore: family AF_INET type SOCK_RAW proto 66
  port 66 state TCP_CLOSE src_addr 0.0.0.0
  Error (criu/sk-inet.c:834): inet: Can't create inet socket:
  Protocol not supported

Centos 8 kernel replaces IPPROTO_MPTCP(262) with "in-kernel" value
IPPROTO_MPTCP_KERN(66) on inet_create(), but later shows this inkernel
value to criu when listing sockets info. Same code in inet_create()
returns EPROTONOSUPPORT on the attempr to create socket with
IPPROTO_MPTCP_KERN. So this ci error is completely rh8 kernel related.
Kernel should not show "in-kernel" value to userspace. But anyway this
is already changed in Centos 9 kernel, so we can just skip socket-raw
test on Centos 8.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
