### PR TITLE
clang-format/zdtm: fix clang complains about strange elseifs

### DIFF
--- a/test/zdtm/static/mprotect00.c
+++ b/test/zdtm/static/mprotect00.c
@@ -44,10 +44,12 @@ static int check_prot(char *ptr, int prot)
 			fail("PROT_READ bypassed");
 			return -1;
 		}
-	} else /* we come here on return from SIGSEGV handler */
+	} else {
+		/* we come here on return from SIGSEGV handler */
 		if (prot & PROT_READ) {
-		fail("PROT_READ rejected");
-		return -1;
+			fail("PROT_READ rejected");
+			return -1;
+		}
 	}
 
 	if (!sigsetjmp(segv_ret, 1)) {
@@ -56,10 +58,12 @@ static int check_prot(char *ptr, int prot)
 			fail("PROT_WRITE bypassed");
 			return -1;
 		}
-	} else /* we come here on return from SIGSEGV handler */
+	} else {
+		/* we come here on return from SIGSEGV handler */
 		if (prot & PROT_WRITE) {
-		fail("PROT_WRITE rejected");
-		return -1;
+			fail("PROT_WRITE rejected");
+			return -1;
+		}
 	}
 
 	if (signal(SIGSEGV, SIG_DFL) == SIG_ERR) {

--- a/test/zdtm/static/shm-mp.c
+++ b/test/zdtm/static/shm-mp.c
@@ -33,10 +33,12 @@ static int check_prot(char *ptr, char val, int prot)
 			fail("PROT_READ bypassed");
 			return -1;
 		}
-	} else /* we come here on return from SIGSEGV handler */
+	} else {
+		/* we come here on return from SIGSEGV handler */
 		if (prot & PROT_READ) {
-		fail("PROT_READ rejected");
-		return -1;
+			fail("PROT_READ rejected");
+			return -1;
+		}
 	}
 
 	if (!sigsetjmp(segv_ret, 1)) {
@@ -45,10 +47,12 @@ static int check_prot(char *ptr, char val, int prot)
 			fail("PROT_WRITE bypassed");
 			return -1;
 		}
-	} else /* we come here on return from SIGSEGV handler */
+	} else {
+		/* we come here on return from SIGSEGV handler */
 		if (prot & PROT_WRITE) {
-		fail("PROT_WRITE rejected");
-		return -1;
+			fail("PROT_WRITE rejected");
+			return -1;
+		}
 	}
 
 	if (signal(SIGSEGV, SIG_DFL) == SIG_ERR) {


### PR DESCRIPTION
Clang-format v13 on my Fedora 35 complains about these hunks, more over
reading the formating we had before is a pain:

```
} else /* comment */
	if (smth) {
	fail("")
	return -1;
}
```

Let's make explicit {} braces for else, this way it looks much better.

Fixes: 93dd984ca ("Run 'make indent' on all C files")
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
