### PR TITLE
ci: switch to centos-stream-8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ task:
 
   compute_engine_instance:
     image_project: centos-cloud
-    image: family/centos-8
+    image: family/centos-stream-8
     platform: linux
     cpu: 4
     memory: 8G


### PR DESCRIPTION
CentOS 8 goes EOL at the end of 2021. This switches our CentOS 8 based tests to CentOS Stream 8 which should be supported until 2024.