### PR TITLE
clang-format: disable wrong struct pointer declaration format

### DIFF
--- a/criu/fdstore.c
+++ b/criu/fdstore.c
@@ -13,10 +13,12 @@
 #include "rst-malloc.h"
 #include "log.h"
 
+/* clang-format off */
 static struct fdstore_desc {
 	int next_id;
 	mutex_t lock; /* to protect a peek offset */
-} * desc;
+} *desc;
+/* clang-format on */
 
 int fdstore_init(void)
 {

--- a/test/zdtm/lib/test.c
+++ b/test/zdtm/lib/test.c
@@ -20,9 +20,11 @@
 #include "ns.h"
 
 futex_t sig_received;
+/* clang-format off */
 static struct {
 	futex_t stage;
-} * test_shared_state;
+} *test_shared_state;
+/* clang-format on */
 
 enum {
 	TEST_INIT_STAGE = 0,

--- a/test/zdtm/static/child_subreaper_and_reparent.c
+++ b/test/zdtm/static/child_subreaper_and_reparent.c
@@ -19,11 +19,13 @@ enum {
 	TEST_EXIT,
 };
 
+/* clang-format off */
 struct shared {
 	futex_t fstate;
 	int parent_before_cr;
 	int parent_after_cr;
-} * sh;
+} *sh;
+/* clang-format on */
 
 int orphan(void)
 {

--- a/test/zdtm/static/child_subreaper_existing_child.c
+++ b/test/zdtm/static/child_subreaper_existing_child.c
@@ -18,10 +18,12 @@ enum {
 	TEST_EXIT,
 };
 
+/* clang-format off */
 struct shared {
 	futex_t fstate;
 	int ppid_after_reparent;
-} * sh;
+} *sh;
+/* clang-format on */
 
 int orphan(void)
 {

--- a/test/zdtm/static/file_fown.c
+++ b/test/zdtm/static/file_fown.c
@@ -22,12 +22,14 @@
 const char *test_doc = "Check for signal delivery on file owners";
 const char *test_author = "Cyrill Gorcunov <gorcunov@openvz.org>";
 
+/* clang-format off */
 struct params {
 	int sigio;
 	int pipe_flags[2];
 	int pipe_pid[2];
 	int pipe_sig[2];
-} * shared;
+} *shared;
+/* clang-format on */
 
 static void signal_handler_io(int status)
 {


### PR DESCRIPTION
When we declare struct and at the same time declare variable pointer of
this struct type, it looks like clang-format threats "*" as a
multiplication operator instead of indirection (pointer declaration)
operator and puts spaces on both sides, which looks wrong.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

I decided to just disable clang, other ideas are welcome. Also I considered the idea to separate structure declaration from pointer declaration, but it would not work for unnamed structures, disabling clang looks more universal.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
