### PR TITLE
libcriu: add single pre-dump support

### DIFF
--- a/images/rpc.proto
+++ b/images/rpc.proto
@@ -172,6 +172,8 @@ enum criu_req_type {
 
 	WAIT_PID	= 11;
 	PAGE_SERVER_CHLD = 12;
+
+	SINGLE_PRE_DUMP = 13;
 }
 
 /*

--- a/lib/c/criu.c
+++ b/lib/c/criu.c
@@ -1512,7 +1512,7 @@ int criu_check(void)
 	return criu_local_check(global_opts);
 }
 
-int criu_local_dump(criu_opts *opts)
+static int dump(bool pre_dump, criu_opts *opts)
 {
 	int ret = -1;
 	CriuReq req = CRIU_REQ__INIT;
@@ -1520,7 +1520,7 @@ int criu_local_dump(criu_opts *opts)
 
 	saved_errno = 0;
 
-	req.type = CRIU_REQ_TYPE__DUMP;
+	req.type = pre_dump ? CRIU_REQ_TYPE__SINGLE_PRE_DUMP : CRIU_REQ_TYPE__DUMP;
 	req.opts = opts->rpc;
 
 	ret = send_req_and_recv_resp(opts, &req, &resp);
@@ -1528,7 +1528,7 @@ int criu_local_dump(criu_opts *opts)
 		goto exit;
 
 	if (resp->success) {
-		if (resp->dump->has_restored && resp->dump->restored)
+		if (!pre_dump && resp->dump->has_restored && resp->dump->restored)
 			ret = 1;
 		else
 			ret = 0;
@@ -1546,9 +1546,24 @@ exit:
 	return ret;
 }
 
+int criu_local_dump(criu_opts *opts)
+{
+	return dump(false, opts);
+}
+
 int criu_dump(void)
 {
 	return criu_local_dump(global_opts);
+}
+
+int criu_local_pre_dump(criu_opts *opts)
+{
+	return dump(true, opts);
+}
+
+int criu_pre_dump(void)
+{
+	return criu_local_pre_dump(global_opts);
 }
 
 int criu_local_dump_iters(criu_opts *opts, int (*more)(criu_predump_info pi))

--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -160,6 +160,7 @@ int criu_get_orphan_pts_master_fd(void);
  */
 int criu_check(void);
 int criu_dump(void);
+int criu_pre_dump(void);
 int criu_restore(void);
 int criu_restore_child(void);
 
@@ -277,6 +278,7 @@ void criu_local_set_notify_cb(criu_opts *opts, int (*cb)(char *action, criu_noti
 
 int criu_local_check(criu_opts *opts);
 int criu_local_dump(criu_opts *opts);
+int criu_local_pre_dump(criu_opts *opts);
 int criu_local_restore(criu_opts *opts);
 int criu_local_restore_child(criu_opts *opts);
 int criu_local_dump_iters(criu_opts *opts, int (*more)(criu_predump_info pi));

--- a/test/others/libcriu/.gitignore
+++ b/test/others/libcriu/.gitignore
@@ -4,5 +4,6 @@ test_notify
 test_self
 test_sub
 test_join_ns
+test_pre_dump
 output/
 libcriu.so.*

--- a/test/others/libcriu/Makefile
+++ b/test/others/libcriu/Makefile
@@ -6,6 +6,7 @@ TESTS += test_notify
 TESTS += test_iters
 TESTS += test_errno
 TESTS += test_join_ns
+TESTS += test_pre_dump
 
 all: $(TESTS)
 .PHONY: all

--- a/test/others/libcriu/lib.h
+++ b/test/others/libcriu/lib.h
@@ -1,3 +1,5 @@
 void what_err_ret_mean(int ret);
 int chk_exit(int status, int want);
 int get_version(void);
+
+#define SUCC_ECODE 42

--- a/test/others/libcriu/run.sh
+++ b/test/others/libcriu/run.sh
@@ -58,6 +58,7 @@ run_test test_notify
 if [ "$(uname -m)" = "x86_64" ]; then
 	# Skip this on aarch64 as aarch64 has no dirty page tracking
 	run_test test_iters
+	run_test test_pre_dump
 fi
 run_test test_errno
 run_test test_join_ns

--- a/test/others/libcriu/test_iters.c
+++ b/test/others/libcriu/test_iters.c
@@ -46,8 +46,6 @@ static int next_iter(criu_predump_info pi)
 	return cur_iter < MAX_ITERS;
 }
 
-#define SUCC_ECODE 42
-
 int main(int argc, char **argv)
 {
 	int pid, ret, p[2];

--- a/test/others/libcriu/test_notify.c
+++ b/test/others/libcriu/test_notify.c
@@ -10,8 +10,6 @@
 
 #include "lib.h"
 
-#define SUCC_ECODE 42
-
 static int actions_called = 0;
 static int notify(char *action, criu_notify_arg_t na)
 {


### PR DESCRIPTION
In contrast to the CLI it is not possible to do a single pre-dump via
RPC and thus libcriu. In cr-service.c pre-dump always goes into a
pre-dump loop followed by a final dump. runc already works around this
to only do a single pre-dump by killing the CRIU process waiting for the
message for the final dump.

Trying to implement pre-dump in crun via libcriu it is not as easy to
work around CRIU's pre-dump loop expectations as with runc that directly
talks to CRIU via RPC.

We know that LXC/LXD also does single pre-dumps using the CLI and runc
also only does single pre-dumps by misusing the pre-dump loop interface.

With this commit it is possible to trigger a single pre-dump via RPC and
libcriu without misusing the interface provided via cr-service.c. So
this commit basically updates CRIU to the existing use cases.

The existing pre-dump loop still sounds like a very good idea, but so
far most tools have decided to implement the pre-dump loop themselves.

With this change we can implement pre-dump in crun to match what is
currently implemented in runc.