### PR TITLE
ci: disable broken tests until fixed

### DIFF
--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -50,9 +50,9 @@ fedora-no-vdso() {
 	vagrant reload
 	ssh default cat /proc/cmdline
 	ssh default 'cd /vagrant; tar xf criu.tar; cd criu; make -j 4'
-	# BPF tests are failing see: https://github.com/checkpoint-restore/criu/issues/1354
-	# Needs to be fixed, skip for now
-	ssh default 'cd /vagrant/criu/test; sudo ./zdtm.py run -a --keep-going -x zdtm/static/bpf_hash -x zdtm/static/bpf_array'
+	# Disabling tests which are broken on 5.15
+	# https://github.com/checkpoint-restore/criu/issues/1669
+	ssh default 'cd /vagrant/criu/test; sudo ./zdtm.py run -a --keep-going -x zdtm/static/socket_close_data -x zdtm/static/socket_close_data01 -x zdtm/static/fifo_upon_unix_socket01 -x zdtm/static/sk-unix-mntns -x zdtm/static/fifo_upon_unix_socket00 -x zdtm/static/socket-ext -x zdtm/static/sk-unix01 -x zdtm/static/socket_dgram_data -x zdtm/static/sockets_dgram -x zdtm/static/sk-unix-dgram-ghost'
 	# This test (pidfd_store_sk) requires pidfd_getfd syscall which is guaranteed in Fedora 33.
 	# It is also skipped from -a because it runs in RPC mode only
 	ssh default 'cd /vagrant/criu/test; sudo ./zdtm.py run -t zdtm/transition/pidfd_store_sk --rpc --pre 2'

--- a/test/jenkins/criu-fault.sh
+++ b/test/jenkins/criu-fault.sh
@@ -28,6 +28,14 @@ fi
 ./test/zdtm.py run -t zdtm/static/maps04 --fault 131 --keep-going --report report --pre 2:1 || fail
 ./test/zdtm.py run -t zdtm/transition/maps008 --fault 131 --keep-going --report report --pre 2:1 || fail
 ./test/zdtm.py run -t zdtm/static/maps01 --fault 132 -f h || fail
+
+# Error injection with --fault 134 fails on newer CPUs used in Circle CI on EC2
+# Skip the --fault 134 tests
+# https://github.com/checkpoint-restore/criu/issues/1635
+if [ -n "$CIRCLECI" ]; then
+	exit 0
+fi
+
 # 134 is corrupting extended registers set, should run in a sub-thread (fpu03)
 # without restore (that will check if parasite corrupts extended registers)
 ./test/zdtm.py run -t zdtm/static/fpu03 --fault 134 -f h --norst || fail


### PR DESCRIPTION
This disables know broken tests and enables fixed tests. The disabled tests are tracked in the mentioned tickets.

The disabled tests are still being run on older kernels and this helps us to easily detect is something else than the already known broken tests does not work.

Broken tests are being tracked at

 * https://github.com/checkpoint-restore/criu/issues/1669
 * https://github.com/checkpoint-restore/criu/issues/1635

This also enables previously disabled BPF related tests:

 * https://github.com/checkpoint-restore/criu/issues/1354