### PR TITLE
test: another try to correctly fix the kernel version

### DIFF
--- a/test/zdtm_ct.c
+++ b/test/zdtm_ct.c
@@ -61,7 +61,7 @@ static int create_timens()
 	if (sscanf(buf.release, "%u.%u", &major, &minor) != 2)
 		return -1;
 
-	if ((major <= 5) || (major == 5 && minor < 11)) {
+	if ((major < 5) || (major == 5 && minor < 11)) {
 		fprintf(stderr, "timens isn't supported on %s\n", buf.release);
 		return 0;
 	}


### PR DESCRIPTION
We try to disable time namespace based testing for kernels older than 5.11. But we fail to come up with the correct if condition.

This changes (major <= 5) to (major < 5). There are no kernels with major > 5 so currently the time namespace based are never run. This should finally change it to run time namespace based tests on kernel versions newer than 5.10.