### PR TITLE
test: do not use --keep-going for single zdtm tests

### DIFF
--- a/test/jenkins/criu-dedup.sh
+++ b/test/jenkins/criu-dedup.sh
@@ -9,8 +9,8 @@ prep
 # Additionally run these tests as they touch a lot of
 # memory and it makes sense to additionally check it
 # with delays between iterations
-./test/zdtm.py run -t zdtm/transition/maps007 --keep-going --report report -f h --pre 8:.1 --dedup || fail
-./test/zdtm.py run -t zdtm/static/mem-touch   --keep-going --report report -f h --pre 8:.1 --dedup || fail
-./test/zdtm.py run -t zdtm/transition/maps008 --keep-going --report report -f h --pre 8:.1 --dedup || fail
-./test/zdtm.py run -t zdtm/transition/maps007 --keep-going --report report -f h --pre 8:.1 --noauto-dedup || fail
-./test/zdtm.py run -t zdtm/static/mem-touch   --keep-going --report report -f h --pre 8:.1 --noauto-dedup || fail
+./test/zdtm.py run -t zdtm/transition/maps007 --report report -f h --pre 8:.1 --dedup || fail
+./test/zdtm.py run -t zdtm/static/mem-touch   --report report -f h --pre 8:.1 --dedup || fail
+./test/zdtm.py run -t zdtm/transition/maps008 --report report -f h --pre 8:.1 --dedup || fail
+./test/zdtm.py run -t zdtm/transition/maps007 --report report -f h --pre 8:.1 --noauto-dedup || fail
+./test/zdtm.py run -t zdtm/static/mem-touch   --report report -f h --pre 8:.1 --noauto-dedup || fail

--- a/test/jenkins/criu-fault.sh
+++ b/test/jenkins/criu-fault.sh
@@ -4,10 +4,10 @@
 set -e
 source `dirname $0`/criu-lib.sh
 prep
-./test/zdtm.py run -t zdtm/static/env00 --fault 1 --keep-going --report report -f h || fail
-./test/zdtm.py run -t zdtm/static/unlink_fstat00 --fault 2 --keep-going --report report -f h || fail
-./test/zdtm.py run -t zdtm/static/maps00 --fault 3 --keep-going --report report -f h || fail
-./test/zdtm.py run -t zdtm/static/inotify_irmap --fault 128 --keep-going --pre 2 -f uns || fail
+./test/zdtm.py run -t zdtm/static/env00 --fault 1 --report report -f h || fail
+./test/zdtm.py run -t zdtm/static/unlink_fstat00 --fault 2 --report report -f h || fail
+./test/zdtm.py run -t zdtm/static/maps00 --fault 3 --report report -f h || fail
+./test/zdtm.py run -t zdtm/static/inotify_irmap --fault 128 --pre 2 -f uns || fail
 ./test/zdtm.py run -t zdtm/static/env00 --fault 129 -f uns || fail
 ./test/zdtm.py run -t zdtm/transition/fork --fault 130 -f h || fail
 ./test/zdtm.py run -t zdtm/static/vdso01 --fault 127 || fail
@@ -17,16 +17,16 @@ if [ "${COMPAT_TEST}" != "y" ] ; then
 	./test/zdtm.py run -t zdtm/static/vdso01 --fault 133 -f h || fail
 fi
 
-./test/zdtm.py run -t zdtm/static/mntns_ghost --fault 2 --keep-going --report report || fail
-./test/zdtm.py run -t zdtm/static/mntns_ghost --fault 4 --keep-going --report report || fail
+./test/zdtm.py run -t zdtm/static/mntns_ghost --fault 2 --report report || fail
+./test/zdtm.py run -t zdtm/static/mntns_ghost --fault 4 --report report || fail
 
 ./test/zdtm.py run -t zdtm/static/mntns_ghost --fault 6 --report report || fail
 ./test/zdtm.py run -t zdtm/static/mntns_link_remap --fault 6 --report report || fail
 ./test/zdtm.py run -t zdtm/static/unlink_fstat03 --fault 6 --report report || fail
 
-./test/zdtm.py run -t zdtm/static/env00 --fault 5 --keep-going --report report || fail
-./test/zdtm.py run -t zdtm/static/maps04 --fault 131 --keep-going --report report --pre 2:1 || fail
-./test/zdtm.py run -t zdtm/transition/maps008 --fault 131 --keep-going --report report --pre 2:1 || fail
+./test/zdtm.py run -t zdtm/static/env00 --fault 5 --report report || fail
+./test/zdtm.py run -t zdtm/static/maps04 --fault 131 --report report --pre 2:1 || fail
+./test/zdtm.py run -t zdtm/transition/maps008 --fault 131 --report report --pre 2:1 || fail
 ./test/zdtm.py run -t zdtm/static/maps01 --fault 132 -f h || fail
 
 # Error injection with --fault 134 fails on newer CPUs used in Circle CI on EC2

--- a/test/jenkins/criu-fcg.sh
+++ b/test/jenkins/criu-fcg.sh
@@ -6,10 +6,10 @@ source `dirname $0`/criu-lib.sh
 prep
 mount_tmpfs_to_dump
 
-./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --keep-going --report report --freezecg zdtm:f || fail
-./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --keep-going --report report --freezecg zdtm:f --pre 3 || fail
-./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --keep-going --report report --freezecg zdtm:f --norst || fail
+./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --report report --freezecg zdtm:f || fail
+./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --report report --freezecg zdtm:f --pre 3 || fail
+./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --report report --freezecg zdtm:f --norst || fail
 
-./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --keep-going --report report --freezecg zdtm:t || fail
-./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --keep-going --report report --freezecg zdtm:t --pre 3 || fail
-./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --keep-going --report report --freezecg zdtm:t --norst || fail
+./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --report report --freezecg zdtm:t || fail
+./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --report report --freezecg zdtm:t --pre 3 || fail
+./test/zdtm.py run -t zdtm/transition/thread-bomb -f h --report report --freezecg zdtm:t --norst || fail


### PR DESCRIPTION
Looking at CI logs there are often messages like:

 "[WARNING] Option --keep-going is more useful when running multiple tests"

This commit removes '--keep-going' from single zdtm test runs.