### PR TITLE
sk-unix: Fix TCP_ESTABLISHED checks in unix sockets

### DIFF
--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -460,7 +460,7 @@ static int dump_one_unix_fd(int lfd, uint32_t id, const struct fd_parms *p)
 			pr_warn("Shutdown mismatch %u:%d -> %u:%d\n", ue->ino, ue->shutdown, peer->sd.ino,
 				peer->shutdown);
 		}
-	} else if (ue->state == TCP_ESTABLISHED) {
+	} else if (ue->state == TCP_ESTABLISHED && ue->type != SOCK_DGRAM) {
 		const struct unix_sk_listen_icon *e;
 
 		e = lookup_unix_listen_icons(ue->ino);
@@ -1851,13 +1851,9 @@ static int open_unixsk_standalone(struct unix_sk_info *ui, int *new_fd)
 
 		close(sks[1]);
 		sk = sks[0];
-	} else if (ui->ue->state == TCP_ESTABLISHED && queuer && queuer->ue->ino == FAKE_INO) {
+	} else if ((ui->ue->state == TCP_ESTABLISHED && ui->ue->type == SOCK_STREAM) && queuer &&
+		   queuer->ue->ino == FAKE_INO) {
 		int ret, sks[2];
-
-		if (ui->ue->type != SOCK_STREAM) {
-			pr_err("Non-stream socket %u in established state\n", ui->ue->ino);
-			return -1;
-		}
 
 		if (ui->ue->shutdown != SK_SHUTDOWN__BOTH) {
 			pr_err("Wrong shutdown/peer state for %u\n", ui->ue->ino);

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -50,9 +50,7 @@ fedora-no-vdso() {
 	vagrant reload
 	ssh default cat /proc/cmdline
 	ssh default 'cd /vagrant; tar xf criu.tar; cd criu; make -j 4'
-	# Disabling tests which are broken on 5.15
-	# https://github.com/checkpoint-restore/criu/issues/1669
-	ssh default 'cd /vagrant/criu/test; sudo ./zdtm.py run -a --keep-going -x zdtm/static/socket_close_data -x zdtm/static/socket_close_data01 -x zdtm/static/fifo_upon_unix_socket01 -x zdtm/static/sk-unix-mntns -x zdtm/static/fifo_upon_unix_socket00 -x zdtm/static/socket-ext -x zdtm/static/sk-unix01 -x zdtm/static/socket_dgram_data -x zdtm/static/sockets_dgram -x zdtm/static/sk-unix-dgram-ghost'
+	ssh default 'cd /vagrant/criu/test; sudo ./zdtm.py run -a --keep-going'
 	# This test (pidfd_store_sk) requires pidfd_getfd syscall which is guaranteed in Fedora 33.
 	# It is also skipped from -a because it runs in RPC mode only
 	ssh default 'cd /vagrant/criu/test; sudo ./zdtm.py run -t zdtm/transition/pidfd_store_sk --rpc --pre 2'


### PR DESCRIPTION
Since commit 83301b5367a98 ("af_unix: Set TCP_ESTABLISHED for datagram sockets
too") in Linux kernel, SOCK_DGRAM unix sockets can have TCP_ESTABLISHED state
when connected. So we need to fix checks that assume SOCK_DRAM sockets cannot
have TCP_ESTABLISHED state.

I look around for TCP_ESTABLISHED usages in sk-unix and there is one place I'm not 
sure about

```
diff --git a/criu/sk-unix.c b/criu/sk-unix.c
index 8037d9cf2..d3402c3ac 100644
--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -460,7 +460,7 @@ static int dump_one_unix_fd(int lfd, uint32_t id, const struct fd_parms *p)
                        pr_warn("Shutdown mismatch %u:%d -> %u:%d\n", ue->ino, ue->shutdown, peer->sd.ino,
                                peer->shutdown);
                }
-       } else if (ue->state == TCP_ESTABLISHED) {
+       } else if (ue->state == TCP_ESTABLISHED && ue->type != SOCK_DGRAM) {
                const struct unix_sk_listen_icon *e;
 
                e = lookup_unix_listen_icons(ue->ino);

```
I don't know if the additional check is necessary. AFAIK, SOCK_DGRAM socket sets 
TCP_ESTABLISHED state for itself and the peer socket connect() is called. At that time,
the socket's peer will be set too. So I think we cannot get 
`ue->type == SOCK_DGRAM && ue->state == TCP_ESTABLISHED)`

Fixes: #1669