### PR TITLE
lib: introduce feature check in libcriu

### DIFF
--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -288,6 +288,35 @@ int criu_local_dump_iters(criu_opts *opts, int (*more)(criu_predump_info pi));
 int criu_local_get_version(criu_opts *opts);
 int criu_local_check_version(criu_opts *opts, int minimum);
 
+/*
+ * Feature checking allows the user to check if CRIU supports
+ * certain features. There are CRIU features which do not depend
+ * on the version of CRIU but on kernel features or architecture.
+ *
+ * One example is memory tracking. Memory tracking can be disabled
+ * in the kernel or there are architectures which do not support
+ * it (aarch64 for example). By using the feature check a libcriu
+ * user can easily query CRIU if a certain feature is available.
+ *
+ * The features which should be checked can be marked in the
+ * structure 'struct criu_feature_check'. Each structure member
+ * that is set to true will result in CRIU checking for the
+ * availability of that feature in the current combination of
+ * CRIU/kernel/architecture.
+ *
+ * Available features will be set to true when the function
+ * returns successfully. Missing features will be set to false.
+ */
+
+struct criu_feature_check {
+	bool mem_track;
+	bool lazy_pages;
+	bool pidfd_store;
+};
+
+int criu_feature_check(struct criu_feature_check *features, size_t size);
+int criu_local_feature_check(criu_opts *opts, struct criu_feature_check *features, size_t size);
+
 #ifdef __GNUG__
 }
 #endif

--- a/test/others/libcriu/.gitignore
+++ b/test/others/libcriu/.gitignore
@@ -5,5 +5,6 @@ test_self
 test_sub
 test_join_ns
 test_pre_dump
+test_feature_check
 output/
 libcriu.so.*

--- a/test/others/libcriu/Makefile
+++ b/test/others/libcriu/Makefile
@@ -7,6 +7,7 @@ TESTS += test_iters
 TESTS += test_errno
 TESTS += test_join_ns
 TESTS += test_pre_dump
+TESTS += test_feature_check
 
 all: $(TESTS)
 .PHONY: all

--- a/test/others/libcriu/run.sh
+++ b/test/others/libcriu/run.sh
@@ -62,6 +62,16 @@ if [ "$(uname -m)" = "x86_64" ]; then
 fi
 run_test test_errno
 run_test test_join_ns
+if criu check --feature mem_dirty_track > /dev/null; then
+	export CRIU_FEATURE_MEM_TRACK=1
+fi
+if criu check --feature uffd-noncoop > /dev/null; then
+	export CRIU_FEATURE_LAZY_PAGES=1
+fi
+if criu check --feature pidfd_store > /dev/null; then
+	export CRIU_FEATURE_PIDFD_STORE=1
+fi
+run_test test_feature_check
 
 echo "== Tests done"
 make libcriu_clean

--- a/test/others/libcriu/test_feature_check.c
+++ b/test/others/libcriu/test_feature_check.c
@@ -1,0 +1,65 @@
+#include "criu.h"
+#include <fcntl.h>
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "lib.h"
+
+int main(int argc, char **argv)
+{
+	int ret;
+	char *env;
+	bool mem_track = 0;
+	bool lazy_pages = 0;
+	bool pidfd_store = 0;
+	struct criu_feature_check features = {
+		.mem_track = true,
+		.lazy_pages = true,
+		.pidfd_store = true,
+	};
+
+	printf("--- Start feature check ---\n");
+	criu_init_opts();
+	criu_set_service_binary(argv[1]);
+
+	env = getenv("CRIU_FEATURE_MEM_TRACK");
+	if (env) {
+		mem_track = true;
+	}
+	env = getenv("CRIU_FEATURE_LAZY_PAGES");
+	if (env) {
+		lazy_pages = true;
+	}
+	env = getenv("CRIU_FEATURE_PIDFD_STORE");
+	if (env) {
+		pidfd_store = true;
+	}
+
+	ret = criu_feature_check(&features, sizeof(features) + 1);
+	printf("   `- passing too large structure to libcriu should return -1: %d\n", ret);
+	if (ret != -1)
+		return -1;
+
+	ret = criu_feature_check(&features, sizeof(features));
+	if (ret < 0) {
+		what_err_ret_mean(ret);
+		return ret;
+	}
+
+	printf("   `- mem_track  : %d - expected : %d\n", features.mem_track, mem_track);
+	if (features.mem_track != mem_track)
+		return -1;
+	printf("   `- lazy_pages : %d - expected : %d\n", features.lazy_pages, lazy_pages);
+	if (features.lazy_pages != lazy_pages)
+		return -1;
+	printf("   `- pidfd_store: %d - expected : %d\n", features.pidfd_store, pidfd_store);
+	if (features.pidfd_store != pidfd_store)
+		return -1;
+
+	return 0;
+}


### PR DESCRIPTION
This commit adds feature check support to libcriu. It already exists in the CLI and RPC and this just extends it to libcriu.

This commit provides one function to do all possible feature checks in one call. The parameter to the feature check function is a structure and the user can enable which features should be checked.

Using a structure makes the function extensible without the need to break the API/ABI in the future.