### PR TITLE
Export current criu mode to opts

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -735,6 +735,7 @@ static int dump_using_req(int sk, CriuOpts *req)
 	bool success = false;
 	bool self_dump = !req->pid;
 
+	opts.mode = CR_DUMP;
 	if (setup_opts_from_req(sk, req))
 		goto exit;
 
@@ -777,6 +778,7 @@ static int restore_using_req(int sk, CriuOpts *req)
 
 	opts.restore_detach = true;
 
+	opts.mode = CR_RESTORE;
 	if (setup_opts_from_req(sk, req))
 		goto exit;
 
@@ -828,6 +830,7 @@ static int check(int sk, CriuOpts *req)
 	if (pid == 0) {
 		setproctitle("check --rpc");
 
+		opts.mode = CR_CHECK;
 		if (setup_opts_from_req(sk, req))
 			exit(1);
 
@@ -859,6 +862,7 @@ static int pre_dump_using_req(int sk, CriuOpts *req, bool single)
 	if (pid == 0) {
 		int ret = 1;
 
+		opts.mode = CR_PRE_DUMP;
 		if (setup_opts_from_req(sk, req))
 			goto cout;
 
@@ -936,6 +940,7 @@ static int start_page_server_req(int sk, CriuOpts *req, bool daemon_mode)
 	if (pid == 0) {
 		close(start_pipe[0]);
 
+		opts.mode = CR_PAGE_SERVER;
 		if (setup_opts_from_req(sk, req))
 			goto out_ch;
 
@@ -1182,6 +1187,7 @@ static int handle_cpuinfo(int sk, CriuReq *msg)
 	if (pid == 0) {
 		int ret = 1;
 
+		opts.mode = CR_CPUINFO;
 		if (setup_opts_from_req(sk, msg->opts))
 			goto cout;
 
@@ -1231,6 +1237,8 @@ int cr_service_work(int sk)
 	CriuReq *msg = 0;
 
 more:
+	opts.mode = CR_SWRK;
+
 	if (recv_criu_msg(sk, &msg) != 0) {
 		pr_perror("Can't recv request");
 		goto err;

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -222,6 +222,9 @@ int main(int argc, char *argv[], char *envp[])
 		if (opts.mode != CR_CPUINFO && has_sub_command) {
 			pr_err("excessive parameter%s for command %s\n", (argc - optind) > 2 ? "s" : "", argv[optind]);
 			goto usage;
+		} else if (opts.mode == CR_CPUINFO && !has_sub_command) {
+			pr_err("cpuinfo requires an action: dump or check\n");
+			goto usage;
 		}
 	}
 

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -124,7 +124,7 @@ int main(int argc, char *argv[], char *envp[])
 		return 1;
 	}
 
-	if (optind < argc && !strcmp(argv[optind], "swrk")) {
+	if (!strcmp(argv[optind], "swrk")) {
 		if (argc != optind + 2) {
 			fprintf(stderr, "Usage: criu swrk <fd>\n");
 			return 1;

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -56,14 +56,23 @@ void flush_early_log_to_stderr(void)
 
 static int image_dir_mode(char *argv[], int optind)
 {
-	if (!strcmp(argv[optind], "dump") || !strcmp(argv[optind], "pre-dump") ||
-	    (!strcmp(argv[optind], "cpuinfo") && !strcmp(argv[optind + 1], "dump")))
+	switch (opts.mode) {
+	case CR_DUMP:
+		/* fallthrough */
+	case CR_PRE_DUMP:
 		return O_DUMP;
-
-	if (!strcmp(argv[optind], "restore") ||
-	    (!strcmp(argv[optind], "cpuinfo") && !strcmp(argv[optind + 1], "restore")))
+	case CR_RESTORE:
 		return O_RSTR;
+	case CR_CPUINFO:
+		if (!strcmp(argv[optind + 1], "dump"))
+			return O_DUMP;
+		/* fallthrough */
+	default:
+		return -1;
+	}
 
+	/* never reached */
+	BUG();
 	return -1;
 }
 

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -100,6 +100,22 @@ struct irmap_path_opt {
 	struct irmap *ir;
 };
 
+enum criu_mode {
+	CR_UNSET = 0,
+	CR_DUMP,
+	CR_PRE_DUMP,
+	CR_RESTORE,
+	CR_LAZY_PAGES,
+	CR_CHECK,
+	CR_PAGE_SERVER,
+	CR_SERVICE,
+	CR_SWRK,
+	CR_DEDUP,
+	CR_CPUINFO,
+	CR_EXEC_DEPRECATED,
+	CR_SHOW_DEPRECATED,
+};
+
 struct cr_options {
 	int final_state;
 	int check_extra_features;
@@ -188,6 +204,9 @@ struct cr_options {
 
 	/* This stores which method to use for file validation. */
 	int file_validation_method;
+
+	/* Shows the mode criu is running at the moment: dump/pre-dump/restore/... */
+	enum criu_mode mode;
 };
 
 extern struct cr_options opts;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
We have multiple options which are valid only on restore or only on dump or in any other specific criu mode, so it would be useful to have info about current mode in opts so that we can validate other options against current mode.

Plan is to use it for mount-v2 (switch from current restore mount engine to a new one) option as it is only valid on restore, and this would make handling of different types of mountpoints much easier.

- When criu mode is set from main() we just parse mode from argv[optind] just after parse_options() found optind of the command. Note that opts.mode is available before check_options().

- For rpc service we reset opts.mode to CR_SWRK each time we restart cr_service_work(), in the original service process we still have CR_SERVICE to differentiate between them, and each request handling function which does setup_opts_from_req sets opts.mode in accordance with the processed request type. And it is also available before check_options().
    
Now in check_options we can add filters on one mode only options.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

Note: I chose to call this "mode" as in rpc we have a request type and on cli we have command, so "mode" should unify these two similar terms in one.