### PR TITLE
page-server: don't set TCP_CORK for tls sockets

### DIFF
--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -1389,6 +1389,11 @@ int cr_page_server(bool daemon_mode, bool lazy_dump, int cfd)
 	if (init_stats(DUMP_STATS))
 		return -1;
 
+	/*
+	 * We might need a lot of pipes to fetch huge number of pages.
+	 */
+	rlimit_unlimit_nofile();
+
 	if (!opts.lazy_pages)
 		up_page_ids_base();
 	else if (!lazy_dump)

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -1178,7 +1178,8 @@ static int page_server_serve(int sk)
 		pr_debug("Created xfer pipe size %u\n", cxfer.pipe_size);
 	} else {
 		pipe_read_dest_init(&pipe_read_dest);
-		tcp_cork(sk, true);
+		if (!opts.tls)
+			tcp_cork(sk, true);
 	}
 
 	while (1) {
@@ -1259,7 +1260,7 @@ static int page_server_serve(int sk)
 		ret = -1;
 	}
 
-	if (ret == 0 && opts.ps_socket == -1) {
+	if (ret == 0 && opts.ps_socket == -1 && !opts.tls) {
 		char c;
 
 		/*
@@ -1466,7 +1467,8 @@ out:
 	 * the corked by default socket with sporadic NODELAY-s
 	 * on urgent data is the smartest mode ever.
 	 */
-	tcp_cork(page_server_sk, true);
+	if (!opts.tls)
+		tcp_cork(page_server_sk, true);
 	return 0;
 }
 

--- a/criu/tls.c
+++ b/criu/tls.c
@@ -53,7 +53,7 @@ void tls_terminate_session(void)
 
 ssize_t tls_send(const void *buf, size_t len, int flags)
 {
-	int ret;
+	ssize_t ret;
 
 	tls_sk_flags = flags;
 	ret = gnutls_record_send(session, buf, len);
@@ -95,7 +95,7 @@ int tls_send_data_from_fd(int fd, unsigned long len)
 		return -1;
 
 	while (len > 0) {
-		int ret, sent;
+		ssize_t ret, sent;
 
 		copied = read(fd, buf, min(len, buf_size));
 		if (copied <= 0) {
@@ -119,7 +119,7 @@ err:
 
 ssize_t tls_recv(void *buf, size_t len, int flags)
 {
-	int ret;
+	ssize_t ret;
 
 	tls_sk_flags = flags;
 	ret = gnutls_record_recv(session, buf, len);
@@ -163,7 +163,7 @@ int tls_recv_data_to_fd(int fd, unsigned long len)
 	gnutls_packet_t packet;
 
 	while (len > 0) {
-		int ret, w;
+		ssize_t ret, w;
 		gnutls_datum_t pdata;
 
 		ret = gnutls_record_recv_packet(session, &packet);
@@ -301,7 +301,7 @@ static int tls_x509_setup_creds(void)
 static ssize_t _tls_push_cb(void *p, const void *data, size_t sz)
 {
 	int fd = *(int *)(p);
-	int ret = send(fd, data, sz, tls_sk_flags);
+	ssize_t ret = send(fd, data, sz, tls_sk_flags);
 	if (ret < 0 && errno != EAGAIN) {
 		int _errno = errno;
 		pr_perror("Push callback send failed");
@@ -313,7 +313,7 @@ static ssize_t _tls_push_cb(void *p, const void *data, size_t sz)
 static ssize_t _tls_pull_cb(void *p, void *data, size_t sz)
 {
 	int fd = *(int *)(p);
-	int ret = recv(fd, data, sz, tls_sk_flags);
+	ssize_t ret = recv(fd, data, sz, tls_sk_flags);
 	if (ret < 0 && errno != EAGAIN) {
 		int _errno = errno;
 		pr_perror("Pull callback recv failed");

--- a/criu/tls.c
+++ b/criu/tls.c
@@ -8,7 +8,7 @@
 #include "cr_options.h"
 #include "xmalloc.h"
 
-/* Compatability with GnuTLS verson <3.5 */
+/* Compatability with GnuTLS version < 3.5 */
 #ifndef GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR
 #define GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR GNUTLS_E_CERTIFICATE_ERROR
 #endif

--- a/criu/tls.c
+++ b/criu/tls.c
@@ -70,6 +70,8 @@ ssize_t tls_send(const void *buf, size_t len, int flags)
 		case GNUTLS_E_UNEXPECTED_PACKET_LENGTH:
 			errno = ENOMSG;
 			break;
+		case GNUTLS_E_PREMATURE_TERMINATION:
+			return 0;
 		default:
 			tls_perror("Failed to send data", ret);
 			errno = EIO;
@@ -142,6 +144,8 @@ ssize_t tls_recv(void *buf, size_t len, int flags)
 		case GNUTLS_E_INTERRUPTED:
 			errno = EINTR;
 			break;
+		case GNUTLS_E_PREMATURE_TERMINATION:
+			return 0;
 		default:
 			tls_perror("Failed receiving data", ret);
 			errno = EIO;

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -6,6 +6,7 @@ RUN apk update && apk add \
 	bash \
 	build-base \
 	coreutils \
+	procps \
 	git \
 	gnutls-dev \
 	libaio-dev \

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -212,10 +212,8 @@ LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $ZDTM_OPTS"
 ./test/zdtm.py run $LAZY_OPTS --lazy-pages
 # shellcheck disable=SC2086
 ./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages
-# FIXME: post-copy migration of THP over TLS (sometimes) fails with:
-#     Error (criu/tls.c:321): tls: Pull callback recv failed: Connection reset by peer
 # shellcheck disable=SC2086
-./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls -x lazy-thp
+./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls
 
 bash -x ./test/jenkins/criu-fault.sh
 if [ "$UNAME_M" == "x86_64" ]; then


### PR DESCRIPTION
Setting TCP_CORK with a value of 1, aka "corking the socket", tells TCP to wait to remove the cork before sending any packets. 
As a results, we block the underlying channel, but still send data to gnutls which then produces multiple encryption packets.
This PR also makes sure that gnutls properly terminates the TLS connection and handles the case when socket is unexpectedly closed.

Fixes: #1380