### PR TITLE
ci: install procps in alpine

### DIFF
--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -6,6 +6,7 @@ RUN apk update && apk add \
 	bash \
 	build-base \
 	coreutils \
+	procps \
 	git \
 	gnutls-dev \
 	libaio-dev \


### PR DESCRIPTION
The default version of ps in Alpine image is very limited. It is based on the one from busybox and doesn't support options used in zdtm such as `-p`.
```
ps --help
BusyBox v1.34.1 (2021-11-23 00:57:35 UTC) multi-call binary.

Usage: ps [-o COL1,COL2=HEADER] [-T]

Show list of processes

	-o COL1,COL2=HEADER	Select columns for display
	-T
```

