### PR TITLE
x86/compel/fault-inject: bound features to test

### DIFF
--- a/compel/arch/x86/src/lib/include/uapi/asm/fpu.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/fpu.h
@@ -80,6 +80,11 @@ enum xfeature {
 	(XFEATURE_MASK_FP | XFEATURE_MASK_SSE | XFEATURE_MASK_YMM | XFEATURE_MASK_OPMASK | XFEATURE_MASK_ZMM_Hi256 | \
 	 XFEATURE_MASK_Hi16_ZMM | XFEATURE_MASK_PKRU | XFEATURE_MASK_BNDREGS | XFEATURE_MASK_BNDCSR)
 
+/* xsave structure features which is safe to fill with garbage (see validate_random_xstate()) */
+#define XFEATURE_MASK_FAULTINJ                                                                                       \
+	(XFEATURE_MASK_FP | XFEATURE_MASK_SSE | XFEATURE_MASK_YMM | XFEATURE_MASK_OPMASK | XFEATURE_MASK_ZMM_Hi256 | \
+	 XFEATURE_MASK_Hi16_ZMM)
+
 struct fpx_sw_bytes {
 	uint32_t magic1;
 	uint32_t extended_size;

--- a/compel/arch/x86/src/lib/infect.c
+++ b/compel/arch/x86/src/lib/infect.c
@@ -254,6 +254,7 @@ static void validate_random_xstate(struct xsave_struct *xsave)
 	/* No unknown or supervisor features may be set */
 	hdr->xstate_bv &= XFEATURE_MASK_USER;
 	hdr->xstate_bv &= ~XFEATURE_MASK_SUPERVISOR;
+	hdr->xstate_bv &= XFEATURE_MASK_FAULTINJ;
 
 	for (i = 0; i < XFEATURE_MAX; i++) {
 		if (!compel_fpu_has_feature(i))

--- a/compel/arch/x86/src/lib/infect.c
+++ b/compel/arch/x86/src/lib/infect.c
@@ -283,10 +283,10 @@ static int corrupt_extregs(pid_t pid)
 	bool use_xsave = compel_cpu_has_feature(X86_FEATURE_OSXSAVE);
 	user_fpregs_struct_t ext_regs;
 	int *rand_to = (int *)&ext_regs;
-	unsigned int seed;
+	unsigned int seed, init_seed;
 	size_t i;
 
-	seed = time(NULL);
+	init_seed = seed = time(NULL);
 	for (i = 0; i < sizeof(ext_regs) / sizeof(int); i++)
 		*rand_to++ = rand_r(&seed);
 
@@ -296,7 +296,7 @@ static int corrupt_extregs(pid_t pid)
 	 *  - zdtm.py will grep it auto-magically from logs
 	 *    (and the seed will be known from an automatical testing)
 	 */
-	pr_err("Corrupting %s for %d, seed %u\n", use_xsave ? "xsave" : "fpuregs", pid, seed);
+	pr_err("Corrupting %s for %d, seed %u\n", use_xsave ? "xsave" : "fpuregs", pid, init_seed);
 
 	if (!use_xsave) {
 		if (ptrace(PTRACE_SETFPREGS, pid, NULL, &ext_regs)) {

--- a/test/jenkins/criu-fault.sh
+++ b/test/jenkins/criu-fault.sh
@@ -28,14 +28,6 @@ fi
 ./test/zdtm.py run -t zdtm/static/maps04 --fault 131 --report report --pre 2:1 || fail
 ./test/zdtm.py run -t zdtm/transition/maps008 --fault 131 --report report --pre 2:1 || fail
 ./test/zdtm.py run -t zdtm/static/maps01 --fault 132 -f h || fail
-
-# Error injection with --fault 134 fails on newer CPUs used in Circle CI on EC2
-# Skip the --fault 134 tests
-# https://github.com/checkpoint-restore/criu/issues/1635
-if [ -n "$CIRCLECI" ]; then
-	exit 0
-fi
-
 # 134 is corrupting extended registers set, should run in a sub-thread (fpu03)
 # without restore (that will check if parasite corrupts extended registers)
 ./test/zdtm.py run -t zdtm/static/fpu03 --fault 134 -f h --norst || fail


### PR DESCRIPTION
Hi there :)

These patches aimed to fix the problem from the https://github.com/checkpoint-restore/criu/issues/1635 issue.

I've grabbed VM from Amazon and tested that it's working fine now. The problem was that after putting garbage into the pkru registers our victim's processes catch segfaults because they lose access to their own VMAs (see `arch_vma_access_permitted` function https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/arch/x86/include/asm/mmu_context.h#L207).

Thanks,
Alex