### PR TITLE
Add documentation for --timeout option

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -367,6 +367,10 @@ mount -t cgroup -o devices,freezer none devices,freezer
     Allows to link unlinked files back, if possible (modifies filesystem
     during *restore*).
 
+*--timeout* 'number'::
+    Set a time limit in seconds for collecting tasks during the
+    dump operation. The timeout is 10 seconds by default.
+
 *--ghost-limit* 'size'::
     Set the maximum size of deleted file to be carried inside image.
     By default, up to 1M file is allowed. Using this

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -391,6 +391,8 @@ usage:
 	       "  -j|--" OPT_SHELL_JOB "        allow one to dump and restore shell jobs\n"
 	       "  -l|--" OPT_FILE_LOCKS "       handle file locks, for safety, only used for container\n"
 	       "  -L|--libdir           path to a plugin directory (by default " CR_PLUGIN_DEFAULT ")\n"
+	       "  --timeout NUM         a timeout (in seconds) on collecting tasks during dump\n"
+	       "                        (default 10 seconds)\n"
 	       "  --force-irmap         force resolving names for inotify/fsnotify watches\n"
 	       "  --irmap-scan-path FILE\n"
 	       "                        add a path the irmap hints to scan\n"


### PR DESCRIPTION
A timeout was introduced in https://github.com/checkpoint-restore/criu/commit/d0ff730 to prevent criu dump from being able to hang indefinitely. The `--timeout` option allows users to adjust the time limit in seconds for collecting tasks during the dump operation.