### PR TITLE
usernsd: UNS_FDOUT should not require an input descriptor

### DIFF
--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -1330,11 +1330,6 @@ static int usernsd(int sk)
 		unsc_msg_pid_fd(&um, &pid, &fd);
 		pr_debug("uns: daemon calls %p (%d, %d, %x)\n", call, pid, fd, flags);
 
-		if (fd < 0 && flags & UNS_FDOUT) {
-			pr_err("uns: bad flags/fd %p %d %x\n", call, fd, flags);
-			BUG();
-		}
-
 		/*
 		 * Caller has sent us bare address of the routine it
 		 * wants to call. Since the caller is fork()-ed from the


### PR DESCRIPTION
UNS_FDOUT means only that a userns call will return a file descriptor.

