### PR TITLE
mount/btrfs: make __open_mountpoint fallback to get_sdev_from_fd

### DIFF
--- a/criu/fsnotify.c
+++ b/criu/fsnotify.c
@@ -132,7 +132,7 @@ static char *alloc_openable(unsigned int s_dev, unsigned long i_ino, FhEntry *f_
 		if (!mnt_is_dir(m))
 			continue;
 
-		mntfd = __open_mountpoint(m, -1);
+		mntfd = __open_mountpoint(m);
 		pr_debug("\t\tTrying via mntid %d root %s ns_mountpoint @%s (%d)\n", m->mnt_id, m->root,
 			 m->ns_mountpoint, mntfd);
 		if (mntfd < 0)
@@ -206,7 +206,7 @@ static int open_handle(unsigned int s_dev, unsigned long i_ino, FhEntry *f_handl
 		if (m->s_dev != s_dev || !mnt_is_dir(m))
 			continue;
 
-		mntfd = __open_mountpoint(m, -1);
+		mntfd = __open_mountpoint(m);
 		if (mntfd < 0) {
 			pr_warn("Can't open mount for s_dev %x, continue\n", s_dev);
 			continue;

--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -109,6 +109,7 @@ extern int mntns_get_root_by_mnt_id(int mnt_id);
 extern struct ns_id *lookup_nsid_by_mnt_id(int mnt_id);
 
 extern int open_mount(unsigned int s_dev);
+extern int __check_mountpoint_fd(struct mount_info *pm, int mnt_fd, bool parse_mountinfo);
 extern int check_mountpoint_fd(struct mount_info *pm, int mnt_fd);
 extern int __open_mountpoint(struct mount_info *pm);
 extern int mnt_is_dir(struct mount_info *pm);

--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -140,6 +140,7 @@ extern void clean_cr_time_mounts(void);
 
 extern bool add_skip_mount(const char *mountpoint);
 struct ns_id;
+extern int get_sdev_from_fd(int fd, unsigned int *sdev, bool parse_mountinfo);
 extern struct mount_info *parse_mountinfo(pid_t pid, struct ns_id *nsid, bool for_dump);
 
 extern int check_mnt_id(void);

--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -109,6 +109,7 @@ extern int mntns_get_root_by_mnt_id(int mnt_id);
 extern struct ns_id *lookup_nsid_by_mnt_id(int mnt_id);
 
 extern int open_mount(unsigned int s_dev);
+extern int check_mountpoint_fd(struct mount_info *pm, int mnt_fd);
 extern int __open_mountpoint(struct mount_info *pm, int mnt_fd);
 extern int mnt_is_dir(struct mount_info *pm);
 extern int open_mountpoint(struct mount_info *pm);

--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -110,7 +110,7 @@ extern struct ns_id *lookup_nsid_by_mnt_id(int mnt_id);
 
 extern int open_mount(unsigned int s_dev);
 extern int check_mountpoint_fd(struct mount_info *pm, int mnt_fd);
-extern int __open_mountpoint(struct mount_info *pm, int mnt_fd);
+extern int __open_mountpoint(struct mount_info *pm);
 extern int mnt_is_dir(struct mount_info *pm);
 extern int open_mountpoint(struct mount_info *pm);
 


### PR DESCRIPTION
We face that btrfs returns anonymous device in stat instead of real
superblock dev for volumes, thus __open_mountpoint can't open btrfs
mountpoint due to dev missmatch between stat and mountinfo. We can use
special helper get_sdev_from_fd instead of stat to get real dev of fd.

New get_sdev_from_fd helper first gets mnt_id from fd using fdinfo and
then converts mnt_id to sdev using mountinfo.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
