### PR TITLE
zdtm: stop process after migration

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -212,10 +212,8 @@ LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $ZDTM_OPTS"
 ./test/zdtm.py run $LAZY_OPTS --lazy-pages
 # shellcheck disable=SC2086
 ./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages
-# FIXME: post-copy migration of THP over TLS (sometimes) fails with:
-#     Error (criu/tls.c:321): tls: Pull callback recv failed: Connection reset by peer
 # shellcheck disable=SC2086
-./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls -x lazy-thp
+./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls
 
 bash -x ./test/jenkins/criu-fault.sh
 if [ "$UNAME_M" == "x86_64" ]; then

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1886,8 +1886,8 @@ def do_run_test(tname, tdesc, flavs, opts):
                 check_visible_state(t, s, opts)
                 if opts['join_ns']:
                     check_joinns_state(t)
-                t.stop()
                 cr_api.fini()
+                t.stop()
                 try_run_hook(t, ["--clean"])
                 if t.blocking():
                     raise test_fail_exc("unexpected success")


### PR DESCRIPTION
The `--remote-lazy-pages` option of zdtm allows to run a test with simulated post-copy (also know as "lazy") migration. When running tests with this option zdtm starts two additional processes (1) page-server and (2) lazy-pages. For example, a zdtm test would look like:

1. `criu dump ...`
2. `criu page-server --port 12345 --lazy-pages ...`
3. `criu lazy-pages --page-server --port 12345 --address 127.0.0.1 ...`
4. `criu restore --lazy-pages --restore-detached ...`

The `--restore-detached` would cause criu to detach itself once restore is complete.

Then zdtm would send a `SIGTERM` to the restored process (in `t.stop()`) and wait for the lazy-pages process and the page-server process to exit.

However, `criu restore --lazy-pages --restore-detached` would exit before all memory pages have been migrated. Thus, zdtm would terminate `criu restore`  before page-server and lazy-pages have completed.

As a result, the TCP socket between page-server and lazy-pages would close unexpectedly and when TLS encryption is enabled we sometimes see error messages like:

    (00.065013) Error (criu/tls.c:319): tls: Pull callback recv failed: Connection reset by peer
    (00.065038) Error (criu/tls.c:146): tls: Failed receiving data: Error in the pull function.
    (00.065048) Error (criu/page-xfer.c:1193): page-xfer: Can't read pagemap from socket: I/O error
    (00.065062) Error (criu/tls.c:307): tls: Push callback send failed: Broken pipe

Moving cr_api.fini() before t.stop() would make sure that zdtm waits for the page-server and lazy-pages processes to complete the transfer of memory pages, and only then send `SIGTERM` to `criu restore`.

Fixes #1380
