### PR TITLE
Fix `make test` compile failure

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -607,9 +607,11 @@ class zdtm_test:
     @staticmethod
     def available():
         if not os.access("umount2", os.X_OK):
-            subprocess.check_call(["make", "umount2"])
+            subprocess.check_call(
+                ["make", "umount2"], env=dict(os.environ, MAKEFLAGS=""))
         if not os.access("zdtm_ct", os.X_OK):
-            subprocess.check_call(["make", "zdtm_ct"])
+            subprocess.check_call(
+                ["make", "zdtm_ct"], env=dict(os.environ, MAKEFLAGS=""))
         if not os.access("zdtm/lib/libzdtmtst.a", os.F_OK):
             subprocess.check_call(["make", "-C", "zdtm/"])
         subprocess.check_call(

--- a/test/zdtm_ct.c
+++ b/test/zdtm_ct.c
@@ -41,7 +41,7 @@ static inline int _settime(clockid_t clk_id, time_t offset)
 	return 0;
 }
 
-static int create_timens()
+static int create_timens(void)
 {
 	struct utsname buf;
 	unsigned major, minor;


### PR DESCRIPTION
This PR addresses the issue from https://github.com/checkpoint-restore/criu/issues/1699

We use implicit make rules to produce `test/umount2` and `test/zdtm_ct` binaries, but when `make umount2`
is called from zdtm.py which is called from `make test` (under the CRIU tree root) this nested make inherits `MAKEFLAGS`
variable with the value `rR --no-print-directory` and that's the problem because `-r` means "no builtin rules".
Let's just drop this variable value for `make umount2` and `make zdtm_ct` this is safe.