### PR TITLE
tls: handle ECONNRESET in recv callback

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -212,10 +212,8 @@ LAZY_OPTS="-p 2 -T $LAZY_TESTS $LAZY_EXCLUDE $ZDTM_OPTS"
 ./test/zdtm.py run $LAZY_OPTS --lazy-pages
 # shellcheck disable=SC2086
 ./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages
-# FIXME: post-copy migration of THP over TLS (sometimes) fails with:
-#     Error (criu/tls.c:321): tls: Pull callback recv failed: Connection reset by peer
 # shellcheck disable=SC2086
-./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls -x lazy-thp
+./test/zdtm.py run $LAZY_OPTS --remote-lazy-pages --tls
 
 bash -x ./test/jenkins/criu-fault.sh
 if [ "$UNAME_M" == "x86_64" ]; then


### PR DESCRIPTION
The --remote-lazy-pages option of zdtm allows to run a test with simulated post-copy (also know as "lazy") migration. When running tests with this option zdtm starts two additional processes (1) page-server and (2) lazy-pages.

For example, a zdtm test would look like:

    1. criu dump ...
    2. criu page-server --port 12345 --lazy-pages ...
    3. criu lazy-pages --page-server --port 12345 --address 127.0.0.1 ...
    4. criu restore --lazy-pages --restore-detached ...

The `--restore-detached` would result in criu to detach itself once restore is complete, but not all memory pages have been migrated. Then zdtm would send a `SIGTERM` to the restored process and wait for the lazy-pages process and the page-server process to exit.

As a result, the TCP socket between page-server and lazy-pages could close unexpectedly and when TLS encryption is enabled we sometimes see error messages like:

    Error (criu/tls.c:319): tls: Pull callback recv failed: Connection reset by peer
    Error (criu/tls.c:146): tls: Failed receiving data: Error in the pull function.
    Error (criu/page-xfer.c:1193): page-xfer: Can't read pagemap from socket: I/O error
    Error (criu/tls.c:307): tls: Push callback send failed: Broken pipe

This patch updates the recv callback used with gnutls to handle `ECONNRESET` when the connection was not properly terminated (`man 3 gnutls_transport_set_pull_function`).