### PR TITLE
page-server: increase nr_open limit

### DIFF
--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -1389,6 +1389,11 @@ int cr_page_server(bool daemon_mode, bool lazy_dump, int cfd)
 	if (init_stats(DUMP_STATS))
 		return -1;
 
+	/*
+	 * We might need a lot of pipes to fetch huge number of pages.
+	 */
+	rlimit_unlimit_nofile();
+
 	if (!opts.lazy_pages)
 		up_page_ids_base();
 	else if (!lazy_dump)


### PR DESCRIPTION
Starting a page server for checkpoint that contains large number of memory pages currently fails with "Too many open files".

To replicate this problem use the following steps:

1. Start a test process with memhog:
```bash
memhog -r1000 2G
```
2. Checkpoint the process:
```bash
mkdir /tmp/test
sudo criu dump -t `pidof memhog` -D /tmp/test/ -j
```

3. Start page-server:
```bash
sudo criu page-server -D /tmp/test/ --lazy-pages --address 0.0.0.0 --port 12345 --tls -v4 --tls-no-cn-verify
```

page-server would exit with the following error message:

```
(00.025930) Error (criu/page-pipe.c:117): page-pipe: Can't make pipe for page-pipe: Too many open files
(00.025936) Error (criu/page-xfer.c:1303): page-xfer: Failed adding page at 7fd5a6cef000
(00.025940) Error (criu/page-xfer.c:1370): page-xfer: 107433: failed to open page-read
```