### PR TITLE
ci: added .lgtm.yml file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,30 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+      - "protobuf-c-compiler"
+      - "libprotobuf-c-dev"
+      - "libprotobuf-dev"
+      - "build-essential"
+      - "libprotobuf-dev"
+      - "libprotobuf-c-dev"
+      - "protobuf-c-compiler"
+      - "protobuf-compiler"
+      - "python3-protobuf"
+      - "libnet-dev"
+      - "pkg-config"
+      - "libnl-3-dev"
+      - "libbsd0"
+      - "libbsd-dev"
+      - "iproute2"
+      - "libcap-dev"
+      - "libaio-dev"
+      - "python3-yaml"
+      - "libnl-route-3-dev"
+      - "python-future"
+      - "gnutls-dev"
+    configure:
+      command:
+      - "ls -laR images/google"
+      - "ln -s /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto"
+      - "ls -laR images/google"


### PR DESCRIPTION
A couple of months (or years) ago I looked into lgtm.com for CRIU. Today on a pull request I saw result from lgtm.com for the first time and it failed. Not sure what triggered the lgtm.com message into the CRIU repository, but with the .lgtm.yml file in this commit lgtm.com can actually build CRIU.