### PR TITLE
fix GCC 12 failures

### DIFF
--- a/compel/plugins/std/string.c
+++ b/compel/plugins/std/string.c
@@ -151,7 +151,12 @@ static unsigned int __conv_val(unsigned char c)
 	if (__isdigit(c))
 		return c - '0';
 	else if (__isalpha(c))
-		return &conv_tab[__tolower(c)] - conv_tab;
+		/**
+		 * If we want the value of something which __isalpha() == true
+		 * it has to be base > 10. 'A' = 10, 'B' = 11 ... 'Z' = 35
+		 */
+		return __tolower(c) - 'a' + 10;
+
 	return -1u;
 }
 

--- a/compel/src/main.c
+++ b/compel/src/main.c
@@ -19,6 +19,7 @@
 
 #define CFLAGS_DEFAULT_SET     \
 	"-Wstrict-prototypes " \
+	"-ffreestanding "      \
 	"-fno-stack-protector -nostdlib -fomit-frame-pointer "
 
 #define COMPEL_CFLAGS_PIE   CFLAGS_DEFAULT_SET "-fpie"

--- a/criu/config.c
+++ b/criu/config.c
@@ -229,7 +229,7 @@ out:
 		tmp_string[0] = 0;
 
 	/* Check for unsupported configuration file entries */
-	if (configuration[i] + offset + 1 != 0 && strchr(configuration[i] + offset, ' ')) {
+	if (strchr(configuration[i] + offset, ' ')) {
 		int j;
 		len = strlen(configuration[i] + offset);
 		for (j = 0; j < len - 1; j++) {


### PR DESCRIPTION
This is a confusing change as it seems the original code was just wrong.
GCC 12 complains with:
```
In function ‘__conv_val’,
    inlined from ‘std_strtoul’ at compel/plugins/std/string.c:202:7:
compel/plugins/std/string.c:154:24: error: array subscript 97 is above array bounds of ‘const char[37]’ [-Werror=array-bounds]
  154 |                 return &conv_tab[__tolower(c)] - conv_tab;
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
compel/plugins/std/string.c: In function ‘std_strtoul’:
compel/plugins/std/string.c:10:19: note: while referencing ‘conv_tab’
   10 | static const char conv_tab[] = "0123456789abcdefghijklmnopqrstuvwxyz";
      |                   ^~~~~~~~
cc1: all warnings being treated as errors
```
Which sounds correct. The array conv_tab has just 37 elements.

If I understand the code correctly we are trying to convert anything
that is character between a-z and A-Z to a number for cases where
the base is larger than 10. For a base 11 conversion b|B should return 11.
For a base 35 conversion z|Z should return 35. This is all for a strtoul()
implementation.

The original code was:

  static const char conv_tab[] = "0123456789abcdefghijklmnopqrstuvwxyz";

  return &conv_tab[__tolower(c)] - conv_tab;

and that seems wrong. If conv_tab would have been some kind of hash it could
have worked, but '__tolower()' will always return something larger than
97 ('a') which will always overflow the array.

But maybe I just don't get that part of the code.

I replaced it with

  return __tolower(c) - 'a' + 10;

which does the right thing: 'A' = 10, 'B' = 11 ... 'Z' = 35