### PR TITLE
pstree: when updating sid for shell job also update matching pgid

### DIFF
--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -382,6 +382,9 @@ static int prepare_pstree_for_shell_job(pid_t pid)
 		for_each_pstree_item(pi) {
 			if (pi->sid == old_sid)
 				pi->sid = current_sid;
+
+			if (pi->pgid == old_sid)
+				pi->pgid = current_sid;
 		}
 
 		if (lookup_create_item(current_sid) == NULL)


### PR DESCRIPTION
If we replace old_sid with current_sid we should also do same
replacement for matching pgid (=old_sid).

 Reported in CRIU gitter by Younes Manton (@ymanton)

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
