### PR TITLE
Modularize zdtm

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,16 @@ jobs:
     steps:
     - name: Install tools
       run: sudo dnf -y install git make python3-flake8 ShellCheck clang-tools-extra which findutils codespell
+
     - uses: actions/checkout@v2
+
+    - name: Set git safe directory
+      # https://github.com/actions/checkout/issues/760
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
     - name: Run make lint
       run: make lint
+
     - name: Run make indent
       run: >
         make indent &&

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ HOSTCFLAGS		+= $(WARNINGS) $(DEFINES) -iquote include/
 export AFLAGS CFLAGS USERCLFAGS HOSTCFLAGS
 
 # Default target
-all: criu lib crit
+all: flog criu lib crit
 .PHONY: all
 
 #
@@ -233,6 +233,15 @@ soccr/built-in.o: $(CONFIG_HEADER) .FORCE
 $(SOCCR_A): |soccr/built-in.o
 criu-deps	+= $(SOCCR_A)
 
+#flog gets used by criu, build it earlier
+
+flogMakefile: ;
+flog%:
+	$(Q) $(MAKE) $(build)=flog $@
+flog:
+	$(Q) $(MAKE) $(build)=flog all
+.PHONY: flog
+
 #
 # CRIU building done in own directory
 # with slightly different rules so we
@@ -275,6 +284,7 @@ lib: crit
 
 clean mrproper:
 	$(Q) $(MAKE) $(build)=images $@
+	$(Q) $(MAKE) $(build)=flog $@
 	$(Q) $(MAKE) $(build)=criu $@
 	$(Q) $(MAKE) $(build)=soccr $@
 	$(Q) $(MAKE) $(build)=lib $@

--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,7 @@ lint:
 	flake8 --config=scripts/flake8.cfg test/others/rpc/config_file.py
 	flake8 --config=scripts/flake8.cfg lib/py/images/pb2dict.py
 	flake8 --config=scripts/flake8.cfg scripts/criu-ns
+	flake8 --config=scripts/flake8.cfg scripts/crit-setup.py
 	flake8 --config=scripts/flake8.cfg coredump/
 	shellcheck --version
 	shellcheck scripts/*.sh

--- a/Makefile
+++ b/Makefile
@@ -424,6 +424,7 @@ help:
 lint:
 	flake8 --version
 	flake8 --config=scripts/flake8.cfg test/zdtm.py
+	flake8 --config=scripts/flake8.cfg test/zdtm/*.py
 	flake8 --config=scripts/flake8.cfg test/inhfd/*.py
 	flake8 --config=scripts/flake8.cfg test/others/rpc/config_file.py
 	flake8 --config=scripts/flake8.cfg lib/py/images/pb2dict.py

--- a/Makefile.install
+++ b/Makefile.install
@@ -7,7 +7,7 @@ MANDIR		?= $(PREFIX)/share/man
 INCLUDEDIR	?= $(PREFIX)/include
 LIBEXECDIR	?= $(PREFIX)/libexec
 RUNDIR		?= /run
-PLUGINDIR	?= /var/lib/criu
+PLUGINDIR	?= $(PREFIX)/lib/criu
 
 #
 # For recent Debian/Ubuntu with multiarch support.

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -2049,7 +2049,7 @@ static int cr_dump_finish(int ret)
 	close_service_fd(CR_PROC_FD_OFF);
 	close_image_dir();
 
-	if (ret) {
+	if (ret || post_dump_ret) {
 		pr_err("Dumping FAILED.\n");
 	} else {
 		write_stats(DUMP_STATS);

--- a/criu/include/page-xfer.h
+++ b/criu/include/page-xfer.h
@@ -10,7 +10,7 @@ struct ps_info {
 extern int cr_page_server(bool daemon_mode, bool lazy_dump, int cfd);
 
 /* User buffer for read-mode pre-dump*/
-#define BUFFER_SIZE (PIPE_MAX_SIZE << PAGE_SHIFT)
+#define PIPE_MAX_BUFFER_SIZE (PIPE_MAX_SIZE << PAGE_SHIFT)
 
 /*
  * page_xfer -- transfer pages into image file.

--- a/criu/include/plugin.h
+++ b/criu/include/plugin.h
@@ -5,7 +5,9 @@
 #include "common/compiler.h"
 #include "common/list.h"
 
-#define CR_PLUGIN_DEFAULT "/var/lib/criu/"
+#ifndef CR_PLUGIN_DEFAULT
+#define CR_PLUGIN_DEFAULT "/usr/lib/criu/"
+#endif
 
 void cr_plugin_fini(int stage, int err);
 int cr_plugin_init(int stage);

--- a/criu/page-pipe.c
+++ b/criu/page-pipe.c
@@ -56,7 +56,7 @@ static inline int ppb_resize_pipe(struct page_pipe_buf *ppb)
 
 	if (new_size > PIPE_MAX_SIZE) {
 		if (ppb->pipe_size < PIPE_MAX_SIZE)
-			ppb->pipe_size = PIPE_MAX_SIZE;
+			new_size = PIPE_MAX_SIZE;
 		else
 			return 1;
 	}

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -736,7 +736,7 @@ static long fill_userbuf(int pid, struct page_pipe_buf *ppb, struct iovec *bufve
 				continue;
 			} else if (errno == ESRCH) {
 				pr_debug("Target process PID:%d not found\n", pid);
-				return ESRCH;
+				return -ESRCH;
 			}
 		}
 
@@ -798,7 +798,7 @@ int page_xfer_predump_pages(int pid, struct page_xfer *xfer, struct page_pipe *p
 
 		bytes_read = fill_userbuf(pid, ppb, &bufvec, aux_iov, &aux_len);
 
-		if (bytes_read == ESRCH) {
+		if (bytes_read == -ESRCH) {
 			munmap(userbuf, BUFFER_SIZE);
 			return -1;
 		}

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -822,7 +822,7 @@ int page_xfer_predump_pages(int pid, struct page_xfer *xfer, struct page_pipe *p
 
 		bufvec.iov_base = userbuf;
 		bufvec.iov_len = bytes_read;
-		ret = vmsplice(ppb->p[1], &bufvec, 1, SPLICE_F_NONBLOCK);
+		ret = vmsplice(ppb->p[1], &bufvec, 1, SPLICE_F_NONBLOCK | SPLICE_F_GIFT);
 
 		if (ret == -1 || ret != bytes_read) {
 			pr_err("vmsplice: Failed to splice user buffer to pipe %ld\n", ret);

--- a/flog/Makefile
+++ b/flog/Makefile
@@ -1,0 +1,29 @@
+OPTS=-ggdb3 -Wall -Werror
+export OPTS
+
+CFLAGS			+= -iquote include
+CFLAGS			+= -iquote flog/include
+CFLAGS			+= -iquote flog/include/uapi
+
+include $(__nmk_dir)msg.mk
+
+$(eval $(call gen-built-in,src))
+
+flog:
+	$(Q) $(MAKE) $(build)=$(obj)/src all
+.PHONY: flog
+
+clean-flog:
+	$(call msg-gen, $@)
+	$(Q) $(MAKE) $(build)=$(obj)/src clean
+	$(Q) $(RM) built-in.o
+.PHONY: clean-flog
+
+clean: clean-flog
+mrproper: clean
+
+test:
+	./tests/test00
+
+all-y += flog
+

--- a/flog/built-in.S
+++ b/flog/built-in.S
@@ -1,0 +1,4 @@
+SECTIONS
+{
+	.rodata : { _rodata_start = . ; *(.rodata*) ; _rodata_end = . ;}
+}

--- a/flog/include/compiler.h
+++ b/flog/include/compiler.h
@@ -1,0 +1,71 @@
+#ifndef __COMPILER_H__
+#define __COMPILER_H__
+
+/*
+ * Various definitions for success build,
+ * picked from various places, mostly from
+ * the linux kernel.
+ */
+
+#define ARRAY_SIZE(x)		(sizeof(x) / sizeof((x)[0]))
+#define BUILD_BUG_ON(condition)	((void)sizeof(char[1 - 2*!!(condition)]))
+
+#define __stringify_1(x...)	#x
+#define __stringify(x...)	__stringify_1(x)
+
+#define NORETURN		__attribute__((__noreturn__))
+#define __packed		__attribute__((__packed__))
+#define __used			__attribute__((__used__))
+#define __maybe_unused		__attribute__((unused))
+#define __always_unused		__attribute__((unused))
+
+#define __section(S)		__attribute__ ((__section__(#S)))
+
+#ifndef __always_inline
+# define __always_inline	inline __attribute__((always_inline))
+#endif
+
+#define likely(x)		__builtin_expect(!!(x), 1)
+#define unlikely(x)		__builtin_expect(!!(x), 0)
+
+#ifndef always_inline
+# define always_inline		__always_inline
+#endif
+
+#ifndef noinline
+# define noinline		__attribute__((noinline))
+#endif
+
+#define __aligned(x)		__attribute__((aligned(x)))
+
+#ifndef offsetof
+# define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#endif
+
+#define barrier()		asm volatile("" ::: "memory")
+
+#define container_of(ptr, type, member) ({			\
+	const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
+	(type *)( (char *)__mptr - offsetof(type,member) );})
+
+#define __round_mask(x, y)	((__typeof__(x))((y) - 1))
+#define round_up(x, y)		((((x) - 1) | __round_mask(x, y)) + 1)
+#define round_down(x, y)	((x) & ~__round_mask(x, y))
+#define DIV_ROUND_UP(n,d)	(((n) + (d) - 1) / (d))
+#define ALIGN(x, a)		(((x) + (a) - 1) & ~((a) - 1))
+
+#define min(x, y) ({				\
+	typeof(x) _min1 = (x);			\
+	typeof(y) _min2 = (y);			\
+	(void) (&_min1 == &_min2);		\
+	_min1 < _min2 ? _min1 : _min2; })
+
+#define max(x, y) ({				\
+	typeof(x) _max1 = (x);			\
+	typeof(y) _max2 = (y);			\
+	(void) (&_max1 == &_max2);		\
+	_max1 > _max2 ? _max1 : _max2; })
+
+#define is_log2(v)		(((v) & ((v) - 1)) == 0)
+
+#endif /* __COMPILER_H__ */

--- a/flog/include/compiler.h
+++ b/flog/include/compiler.h
@@ -8,64 +8,70 @@
  */
 
 #define ARRAY_SIZE(x)		(sizeof(x) / sizeof((x)[0]))
-#define BUILD_BUG_ON(condition)	((void)sizeof(char[1 - 2*!!(condition)]))
+#define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2 * !!(condition)]))
 
-#define __stringify_1(x...)	#x
-#define __stringify(x...)	__stringify_1(x)
+#define __stringify_1(x...) #x
+#define __stringify(x...)   __stringify_1(x)
 
-#define NORETURN		__attribute__((__noreturn__))
-#define __packed		__attribute__((__packed__))
-#define __used			__attribute__((__used__))
-#define __maybe_unused		__attribute__((unused))
-#define __always_unused		__attribute__((unused))
+#define NORETURN	__attribute__((__noreturn__))
+#define __packed	__attribute__((__packed__))
+#define __used		__attribute__((__used__))
+#define __maybe_unused	__attribute__((unused))
+#define __always_unused __attribute__((unused))
 
-#define __section(S)		__attribute__ ((__section__(#S)))
+#define __section(S) __attribute__((__section__(#S)))
 
 #ifndef __always_inline
-# define __always_inline	inline __attribute__((always_inline))
+#define __always_inline inline __attribute__((always_inline))
 #endif
 
-#define likely(x)		__builtin_expect(!!(x), 1)
-#define unlikely(x)		__builtin_expect(!!(x), 0)
+#define likely(x)   __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
 
 #ifndef always_inline
-# define always_inline		__always_inline
+#define always_inline __always_inline
 #endif
 
 #ifndef noinline
-# define noinline		__attribute__((noinline))
+#define noinline __attribute__((noinline))
 #endif
 
-#define __aligned(x)		__attribute__((aligned(x)))
+#define __aligned(x) __attribute__((aligned(x)))
 
 #ifndef offsetof
-# define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#define offsetof(TYPE, MEMBER) ((size_t) & ((TYPE *)0)->MEMBER)
 #endif
 
-#define barrier()		asm volatile("" ::: "memory")
+#define barrier() asm volatile("" ::: "memory")
 
-#define container_of(ptr, type, member) ({			\
-	const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
-	(type *)( (char *)__mptr - offsetof(type,member) );})
+#define container_of(ptr, type, member)                            \
+	({                                                         \
+		const typeof(((type *)0)->member) *__mptr = (ptr); \
+		(type *)((char *)__mptr - offsetof(type, member)); \
+	})
 
-#define __round_mask(x, y)	((__typeof__(x))((y) - 1))
-#define round_up(x, y)		((((x) - 1) | __round_mask(x, y)) + 1)
-#define round_down(x, y)	((x) & ~__round_mask(x, y))
-#define DIV_ROUND_UP(n,d)	(((n) + (d) - 1) / (d))
-#define ALIGN(x, a)		(((x) + (a) - 1) & ~((a) - 1))
+#define __round_mask(x, y) ((__typeof__(x))((y)-1))
+#define round_up(x, y)	   ((((x)-1) | __round_mask(x, y)) + 1)
+#define round_down(x, y)   ((x) & ~__round_mask(x, y))
+#define DIV_ROUND_UP(n, d) (((n) + (d)-1) / (d))
+#define ALIGN(x, a)	   (((x) + (a)-1) & ~((a)-1))
 
-#define min(x, y) ({				\
-	typeof(x) _min1 = (x);			\
-	typeof(y) _min2 = (y);			\
-	(void) (&_min1 == &_min2);		\
-	_min1 < _min2 ? _min1 : _min2; })
+#define min(x, y)                              \
+	({                                     \
+		typeof(x) _min1 = (x);         \
+		typeof(y) _min2 = (y);         \
+		(void)(&_min1 == &_min2);      \
+		_min1 < _min2 ? _min1 : _min2; \
+	})
 
-#define max(x, y) ({				\
-	typeof(x) _max1 = (x);			\
-	typeof(y) _max2 = (y);			\
-	(void) (&_max1 == &_max2);		\
-	_max1 > _max2 ? _max1 : _max2; })
+#define max(x, y)                              \
+	({                                     \
+		typeof(x) _max1 = (x);         \
+		typeof(y) _max2 = (y);         \
+		(void)(&_max1 == &_max2);      \
+		_max1 > _max2 ? _max1 : _max2; \
+	})
 
-#define is_log2(v)		(((v) & ((v) - 1)) == 0)
+#define is_log2(v) (((v) & ((v)-1)) == 0)
 
 #endif /* __COMPILER_H__ */

--- a/flog/include/flog.h
+++ b/flog/include/flog.h
@@ -1,0 +1,9 @@
+#ifndef __FLOG_H__
+#define __FLOG_H__
+
+#include <string.h>
+#include <errno.h>
+
+#include "uapi/flog.h"
+
+#endif /* __FLOG_H__ */

--- a/flog/include/log.h
+++ b/flog/include/log.h
@@ -1,0 +1,17 @@
+#ifndef __LOG_H__
+#define __LOG_H__
+
+#include <stdio.h>
+
+#define pr_out(fmt, ...)	fprintf(stdout, fmt, ##__VA_ARGS__)
+
+#if 1
+# define pr_debug(fmt, ...)	fprintf(stderr, fmt, ##__VA_ARGS__)
+#else
+# define pr_debug(fmt, ...)
+#endif
+
+#define pr_err(fmt, ...)	fprintf(stderr, "Error (%s:%d): "fmt, __FILE__, __LINE__, ##__VA_ARGS__)
+#define pr_perror(fmt, ...)	fprintf(stderr, "Error (%s:%d): "fmt "%m\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#endif /* __LOG_H__ */

--- a/flog/include/log.h
+++ b/flog/include/log.h
@@ -3,15 +3,15 @@
 
 #include <stdio.h>
 
-#define pr_out(fmt, ...)	fprintf(stdout, fmt, ##__VA_ARGS__)
+#define pr_out(fmt, ...) fprintf(stdout, fmt, ##__VA_ARGS__)
 
 #if 1
-# define pr_debug(fmt, ...)	fprintf(stderr, fmt, ##__VA_ARGS__)
+#define pr_debug(fmt, ...) fprintf(stderr, fmt, ##__VA_ARGS__)
 #else
-# define pr_debug(fmt, ...)
+#define pr_debug(fmt, ...)
 #endif
 
-#define pr_err(fmt, ...)	fprintf(stderr, "Error (%s:%d): "fmt, __FILE__, __LINE__, ##__VA_ARGS__)
-#define pr_perror(fmt, ...)	fprintf(stderr, "Error (%s:%d): "fmt "%m\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#define pr_err(fmt, ...)    fprintf(stderr, "Error (%s:%d): " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
+#define pr_perror(fmt, ...) fprintf(stderr, "Error (%s:%d): " fmt "%m\n", __FILE__, __LINE__, ##__VA_ARGS__)
 
 #endif /* __LOG_H__ */

--- a/flog/include/types.h
+++ b/flog/include/types.h
@@ -1,0 +1,16 @@
+#ifndef __FLOG_TYPES_H__
+#define __FLOG_TYPES_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef uint64_t	u64;
+typedef int64_t		s64;
+typedef uint32_t	u32;
+typedef int32_t		s32;
+typedef uint16_t	u16;
+typedef int16_t		s16;
+typedef uint8_t		u8;
+typedef int8_t		s8;
+
+#endif /* __FLOG_TYPES_H__ */

--- a/flog/include/types.h
+++ b/flog/include/types.h
@@ -4,13 +4,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-typedef uint64_t	u64;
-typedef int64_t		s64;
-typedef uint32_t	u32;
-typedef int32_t		s32;
-typedef uint16_t	u16;
-typedef int16_t		s16;
-typedef uint8_t		u8;
-typedef int8_t		s8;
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint8_t u8;
+typedef int8_t s8;
 
 #endif /* __FLOG_TYPES_H__ */

--- a/flog/include/uapi/flog.h
+++ b/flog/include/uapi/flog.h
@@ -1,0 +1,149 @@
+#ifndef __UAPI_FLOG_H__
+#define __UAPI_FLOG_H__
+
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+
+/*
+ * We work with up to 32 arguments in macros here.
+ * If more provided -- behaviour is undefined.
+ */
+
+/*
+ * By Laurent Deniau at https://groups.google.com/forum/#!topic/comp.std.c/d-6Mj5Lko_s
+ */
+#define FLOG_PP_NARG_(...)			FLOG_PP_ARG_N(__VA_ARGS__)
+#define FLOG_PP_NARG(...)			FLOG_PP_NARG_(1, ##__VA_ARGS__, FLOG_PP_RSEQ_N())
+
+#define FLOG_PP_ARG_N( _0, _1, _2, _3, _4,	\
+		       _5, _6, _7, _8, _9,	\
+		      _10,_11,_12,_13,_14,	\
+		      _15,_16,_17,_18,_19,	\
+		      _20,_21,_22,_23,_24,	\
+		      _25,_26,_27,_28,_29,	\
+		      _30,_31,  N, ...)		N
+
+#define FLOG_PP_RSEQ_N()			\
+		       31, 30, 29, 28, 27,	\
+		       26, 25, 24, 23, 22,	\
+		       21, 20, 19, 18, 17,	\
+		       16, 15, 14, 13, 12,	\
+		       11, 10,  9,  8,  7,	\
+		        6,  5,  4,  3,  2,	\
+		        1,  0
+
+#define FLOG_GENMASK_0(N, x)		0
+#define FLOG_GENMASK_1(N,  op, x, ...)	 (op(N,  0, x))
+#define FLOG_GENMASK_2(N,  op, x, ...)	((op(N,  1, x)) | FLOG_GENMASK_1(N,  op,  __VA_ARGS__))
+#define FLOG_GENMASK_3(N,  op, x, ...)	((op(N,  2, x)) | FLOG_GENMASK_2(N,  op,  __VA_ARGS__))
+#define FLOG_GENMASK_4(N,  op, x, ...)	((op(N,  3, x)) | FLOG_GENMASK_3(N,  op,  __VA_ARGS__))
+#define FLOG_GENMASK_5(N,  op, x, ...)	((op(N,  4, x)) | FLOG_GENMASK_4(N,  op,  __VA_ARGS__))
+#define FLOG_GENMASK_6(N,  op, x, ...)	((op(N,  5, x)) | FLOG_GENMASK_5(N,  op,  __VA_ARGS__))
+#define FLOG_GENMASK_7(N,  op, x, ...)	((op(N,  6, x)) | FLOG_GENMASK_6(N,  op,  __VA_ARGS__))
+#define FLOG_GENMASK_8(N,  op, x, ...)	((op(N,  7, x)) | FLOG_GENMASK_7(N,  op,  __VA_ARGS__))
+#define FLOG_GENMASK_9(N,  op, x, ...)	((op(N,  8, x)) | FLOG_GENMASK_8(N,  op,  __VA_ARGS__))
+#define FLOG_GENMASK_10(N, op, x, ...)	((op(N,  9, x)) | FLOG_GENMASK_9(N,  op,  __VA_ARGS__))
+#define FLOG_GENMASK_11(N, op, x, ...)	((op(N, 10, x)) | FLOG_GENMASK_10(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_12(N, op, x, ...)	((op(N, 11, x)) | FLOG_GENMASK_11(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_13(N, op, x, ...)	((op(N, 12, x)) | FLOG_GENMASK_12(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_14(N, op, x, ...)	((op(N, 13, x)) | FLOG_GENMASK_13(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_15(N, op, x, ...)	((op(N, 14, x)) | FLOG_GENMASK_14(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_16(N, op, x, ...)	((op(N, 15, x)) | FLOG_GENMASK_15(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_17(N, op, x, ...)	((op(N, 16, x)) | FLOG_GENMASK_16(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_18(N, op, x, ...)	((op(N, 17, x)) | FLOG_GENMASK_17(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_19(N, op, x, ...)	((op(N, 18, x)) | FLOG_GENMASK_18(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_20(N, op, x, ...)	((op(N, 19, x)) | FLOG_GENMASK_19(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_21(N, op, x, ...)	((op(N, 20, x)) | FLOG_GENMASK_20(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_22(N, op, x, ...)	((op(N, 21, x)) | FLOG_GENMASK_21(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_23(N, op, x, ...)	((op(N, 22, x)) | FLOG_GENMASK_22(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_24(N, op, x, ...)	((op(N, 23, x)) | FLOG_GENMASK_23(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_25(N, op, x, ...)	((op(N, 24, x)) | FLOG_GENMASK_24(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_26(N, op, x, ...)	((op(N, 25, x)) | FLOG_GENMASK_25(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_27(N, op, x, ...)	((op(N, 26, x)) | FLOG_GENMASK_26(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_28(N, op, x, ...)	((op(N, 27, x)) | FLOG_GENMASK_27(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_29(N, op, x, ...)	((op(N, 28, x)) | FLOG_GENMASK_28(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_30(N, op, x, ...)	((op(N, 29, x)) | FLOG_GENMASK_29(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_31(N, op, x, ...)	((op(N, 30, x)) | FLOG_GENMASK_30(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_32(N, op, x, ...)	((op(N, 31, x)) | FLOG_GENMASK_31(N, op,  __VA_ARGS__))
+
+#define FLOG_CONCAT(arg1, arg2)		FLOG_CONCAT1(arg1, arg2)
+#define FLOG_CONCAT1(arg1, arg2)	FLOG_CONCAT2(arg1, arg2)
+#define FLOG_CONCAT2(arg1, arg2)	arg1##arg2
+
+#define FLOG_GENMASK_(N, op, ...)	FLOG_CONCAT(FLOG_GENMASK_, N)(N, op, ##__VA_ARGS__)
+#define FLOG_GENMASK(op, ...)		FLOG_GENMASK_(FLOG_PP_NARG(__VA_ARGS__), op, ##__VA_ARGS__)
+
+#define flog_genbit(ord, n, v, ...)					\
+	_Generic((v),							\
+									\
+		 /* Basic types */					\
+		 char:				0,			\
+		 signed char:			0,			\
+		 unsigned char:			0,			\
+		 signed short int:		0,			\
+		 unsigned short int:		0,			\
+		 signed int:			0,			\
+		 unsigned int:			0,			\
+		 signed long:			0,			\
+		 unsigned long:			0,			\
+		 signed long long:		0,			\
+		 unsigned long long:		0,			\
+									\
+		 /* Not used for a while */				\
+		 /* float:			12, */			\
+		 /* double:			13, */			\
+		 /* long double:		14, */			\
+									\
+		 /* Basic poniters */					\
+		 char *:			(1u << (ord - n - 1)),	\
+		 signed char *:			(1u << (ord - n - 1)),	\
+		 unsigned char *:		(1u << (ord - n - 1)),	\
+		 signed short int *:		0,			\
+		 unsigned short int *:		0,			\
+		 signed int *:			0,			\
+		 unsigned int *:		0,			\
+		 signed long *:			0,			\
+		 unsigned long *:		0,			\
+		 signed long long *:		0,			\
+		 unsigned long long *:		0,			\
+		 void *:			0,			\
+									\
+		 /* Const basic pointers */				\
+		 const char *:			(1u << (ord - n - 1)),	\
+		 const signed char *:		(1u << (ord - n - 1)),	\
+		 const unsigned char *:		(1u << (ord - n - 1)),	\
+		 const signed short int *:	0,			\
+		 const unsigned short int *:	0,			\
+		 const signed int *:		0,			\
+		 const unsigned int *:		0,			\
+		 const signed long *:		0,			\
+		 const unsigned long *:		0,			\
+		 const signed long long *:	0,			\
+		 const unsigned long long *:	0,			\
+		 const void *:			0,			\
+									\
+		 /* Systypes and pointers */				\
+		 default:			-1)
+
+typedef struct {
+	unsigned int	magic;
+	unsigned int	size;
+	unsigned int	nargs;
+	unsigned int	mask;
+	long		fmt;
+	long		args[0];
+} flog_msg_t;
+
+extern int flog_encode_msg(int fdout, unsigned int nargs, unsigned int mask, const char *format, ...);
+void flog_decode_msg(int fdout, const char *format, ...);
+extern int flog_decode_all(int fdin, int fdout);
+
+#define flog_encode(fdout, fmt, ...)							\
+	flog_encode_msg(fdout, FLOG_PP_NARG(__VA_ARGS__),				\
+			FLOG_GENMASK(flog_genbit, ##__VA_ARGS__), fmt, ##__VA_ARGS__)
+
+int flog_map_buf(int fdout);
+int flog_close(int fdout);
+
+#endif /* __UAPI_FLOG_H__ */

--- a/flog/include/uapi/flog.h
+++ b/flog/include/uapi/flog.h
@@ -13,68 +13,59 @@
 /*
  * By Laurent Deniau at https://groups.google.com/forum/#!topic/comp.std.c/d-6Mj5Lko_s
  */
-#define FLOG_PP_NARG_(...)			FLOG_PP_ARG_N(__VA_ARGS__)
-#define FLOG_PP_NARG(...)			FLOG_PP_NARG_(1, ##__VA_ARGS__, FLOG_PP_RSEQ_N())
+#define FLOG_PP_NARG_(...) FLOG_PP_ARG_N(__VA_ARGS__)
+#define FLOG_PP_NARG(...)  FLOG_PP_NARG_(1, ##__VA_ARGS__, FLOG_PP_RSEQ_N())
 
-#define FLOG_PP_ARG_N( _0, _1, _2, _3, _4,	\
-		       _5, _6, _7, _8, _9,	\
-		      _10,_11,_12,_13,_14,	\
-		      _15,_16,_17,_18,_19,	\
-		      _20,_21,_22,_23,_24,	\
-		      _25,_26,_27,_28,_29,	\
-		      _30,_31,  N, ...)		N
+#define FLOG_PP_ARG_N(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
+		      _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, N, ...)                                 \
+	N
 
-#define FLOG_PP_RSEQ_N()			\
-		       31, 30, 29, 28, 27,	\
-		       26, 25, 24, 23, 22,	\
-		       21, 20, 19, 18, 17,	\
-		       16, 15, 14, 13, 12,	\
-		       11, 10,  9,  8,  7,	\
-		        6,  5,  4,  3,  2,	\
-		        1,  0
+#define FLOG_PP_RSEQ_N()                                                                                             \
+	31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, \
+		2, 1, 0
 
-#define FLOG_GENMASK_0(N, x)		0
-#define FLOG_GENMASK_1(N,  op, x, ...)	 (op(N,  0, x))
-#define FLOG_GENMASK_2(N,  op, x, ...)	((op(N,  1, x)) | FLOG_GENMASK_1(N,  op,  __VA_ARGS__))
-#define FLOG_GENMASK_3(N,  op, x, ...)	((op(N,  2, x)) | FLOG_GENMASK_2(N,  op,  __VA_ARGS__))
-#define FLOG_GENMASK_4(N,  op, x, ...)	((op(N,  3, x)) | FLOG_GENMASK_3(N,  op,  __VA_ARGS__))
-#define FLOG_GENMASK_5(N,  op, x, ...)	((op(N,  4, x)) | FLOG_GENMASK_4(N,  op,  __VA_ARGS__))
-#define FLOG_GENMASK_6(N,  op, x, ...)	((op(N,  5, x)) | FLOG_GENMASK_5(N,  op,  __VA_ARGS__))
-#define FLOG_GENMASK_7(N,  op, x, ...)	((op(N,  6, x)) | FLOG_GENMASK_6(N,  op,  __VA_ARGS__))
-#define FLOG_GENMASK_8(N,  op, x, ...)	((op(N,  7, x)) | FLOG_GENMASK_7(N,  op,  __VA_ARGS__))
-#define FLOG_GENMASK_9(N,  op, x, ...)	((op(N,  8, x)) | FLOG_GENMASK_8(N,  op,  __VA_ARGS__))
-#define FLOG_GENMASK_10(N, op, x, ...)	((op(N,  9, x)) | FLOG_GENMASK_9(N,  op,  __VA_ARGS__))
-#define FLOG_GENMASK_11(N, op, x, ...)	((op(N, 10, x)) | FLOG_GENMASK_10(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_12(N, op, x, ...)	((op(N, 11, x)) | FLOG_GENMASK_11(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_13(N, op, x, ...)	((op(N, 12, x)) | FLOG_GENMASK_12(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_14(N, op, x, ...)	((op(N, 13, x)) | FLOG_GENMASK_13(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_15(N, op, x, ...)	((op(N, 14, x)) | FLOG_GENMASK_14(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_16(N, op, x, ...)	((op(N, 15, x)) | FLOG_GENMASK_15(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_17(N, op, x, ...)	((op(N, 16, x)) | FLOG_GENMASK_16(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_18(N, op, x, ...)	((op(N, 17, x)) | FLOG_GENMASK_17(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_19(N, op, x, ...)	((op(N, 18, x)) | FLOG_GENMASK_18(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_20(N, op, x, ...)	((op(N, 19, x)) | FLOG_GENMASK_19(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_21(N, op, x, ...)	((op(N, 20, x)) | FLOG_GENMASK_20(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_22(N, op, x, ...)	((op(N, 21, x)) | FLOG_GENMASK_21(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_23(N, op, x, ...)	((op(N, 22, x)) | FLOG_GENMASK_22(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_24(N, op, x, ...)	((op(N, 23, x)) | FLOG_GENMASK_23(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_25(N, op, x, ...)	((op(N, 24, x)) | FLOG_GENMASK_24(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_26(N, op, x, ...)	((op(N, 25, x)) | FLOG_GENMASK_25(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_27(N, op, x, ...)	((op(N, 26, x)) | FLOG_GENMASK_26(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_28(N, op, x, ...)	((op(N, 27, x)) | FLOG_GENMASK_27(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_29(N, op, x, ...)	((op(N, 28, x)) | FLOG_GENMASK_28(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_30(N, op, x, ...)	((op(N, 29, x)) | FLOG_GENMASK_29(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_31(N, op, x, ...)	((op(N, 30, x)) | FLOG_GENMASK_30(N, op,  __VA_ARGS__))
-#define FLOG_GENMASK_32(N, op, x, ...)	((op(N, 31, x)) | FLOG_GENMASK_31(N, op,  __VA_ARGS__))
+#define FLOG_GENMASK_0(N, x)	       0
+#define FLOG_GENMASK_1(N, op, x, ...)  (op(N, 0, x))
+#define FLOG_GENMASK_2(N, op, x, ...)  ((op(N, 1, x)) | FLOG_GENMASK_1(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_3(N, op, x, ...)  ((op(N, 2, x)) | FLOG_GENMASK_2(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_4(N, op, x, ...)  ((op(N, 3, x)) | FLOG_GENMASK_3(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_5(N, op, x, ...)  ((op(N, 4, x)) | FLOG_GENMASK_4(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_6(N, op, x, ...)  ((op(N, 5, x)) | FLOG_GENMASK_5(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_7(N, op, x, ...)  ((op(N, 6, x)) | FLOG_GENMASK_6(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_8(N, op, x, ...)  ((op(N, 7, x)) | FLOG_GENMASK_7(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_9(N, op, x, ...)  ((op(N, 8, x)) | FLOG_GENMASK_8(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_10(N, op, x, ...) ((op(N, 9, x)) | FLOG_GENMASK_9(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_11(N, op, x, ...) ((op(N, 10, x)) | FLOG_GENMASK_10(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_12(N, op, x, ...) ((op(N, 11, x)) | FLOG_GENMASK_11(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_13(N, op, x, ...) ((op(N, 12, x)) | FLOG_GENMASK_12(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_14(N, op, x, ...) ((op(N, 13, x)) | FLOG_GENMASK_13(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_15(N, op, x, ...) ((op(N, 14, x)) | FLOG_GENMASK_14(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_16(N, op, x, ...) ((op(N, 15, x)) | FLOG_GENMASK_15(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_17(N, op, x, ...) ((op(N, 16, x)) | FLOG_GENMASK_16(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_18(N, op, x, ...) ((op(N, 17, x)) | FLOG_GENMASK_17(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_19(N, op, x, ...) ((op(N, 18, x)) | FLOG_GENMASK_18(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_20(N, op, x, ...) ((op(N, 19, x)) | FLOG_GENMASK_19(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_21(N, op, x, ...) ((op(N, 20, x)) | FLOG_GENMASK_20(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_22(N, op, x, ...) ((op(N, 21, x)) | FLOG_GENMASK_21(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_23(N, op, x, ...) ((op(N, 22, x)) | FLOG_GENMASK_22(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_24(N, op, x, ...) ((op(N, 23, x)) | FLOG_GENMASK_23(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_25(N, op, x, ...) ((op(N, 24, x)) | FLOG_GENMASK_24(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_26(N, op, x, ...) ((op(N, 25, x)) | FLOG_GENMASK_25(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_27(N, op, x, ...) ((op(N, 26, x)) | FLOG_GENMASK_26(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_28(N, op, x, ...) ((op(N, 27, x)) | FLOG_GENMASK_27(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_29(N, op, x, ...) ((op(N, 28, x)) | FLOG_GENMASK_28(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_30(N, op, x, ...) ((op(N, 29, x)) | FLOG_GENMASK_29(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_31(N, op, x, ...) ((op(N, 30, x)) | FLOG_GENMASK_30(N, op, __VA_ARGS__))
+#define FLOG_GENMASK_32(N, op, x, ...) ((op(N, 31, x)) | FLOG_GENMASK_31(N, op, __VA_ARGS__))
 
-#define FLOG_CONCAT(arg1, arg2)		FLOG_CONCAT1(arg1, arg2)
-#define FLOG_CONCAT1(arg1, arg2)	FLOG_CONCAT2(arg1, arg2)
-#define FLOG_CONCAT2(arg1, arg2)	arg1##arg2
+#define FLOG_CONCAT(arg1, arg2)	 FLOG_CONCAT1(arg1, arg2)
+#define FLOG_CONCAT1(arg1, arg2) FLOG_CONCAT2(arg1, arg2)
+#define FLOG_CONCAT2(arg1, arg2) arg1##arg2
 
-#define FLOG_GENMASK_(N, op, ...)	FLOG_CONCAT(FLOG_GENMASK_, N)(N, op, ##__VA_ARGS__)
-#define FLOG_GENMASK(op, ...)		FLOG_GENMASK_(FLOG_PP_NARG(__VA_ARGS__), op, ##__VA_ARGS__)
+#define FLOG_GENMASK_(N, op, ...) FLOG_CONCAT(FLOG_GENMASK_, N)(N, op, ##__VA_ARGS__)
+#define FLOG_GENMASK(op, ...)	  FLOG_GENMASK_(FLOG_PP_NARG(__VA_ARGS__), op, ##__VA_ARGS__)
 
-#define flog_genbit(ord, n, v, ...)					\
+#define flog_genbit(ord, n, v, ...) \
 	_Generic((v),							\
 									\
 		 /* Basic types */					\
@@ -127,21 +118,20 @@
 		 default:			-1)
 
 typedef struct {
-	unsigned int	magic;
-	unsigned int	size;
-	unsigned int	nargs;
-	unsigned int	mask;
-	long		fmt;
-	long		args[0];
+	unsigned int magic;
+	unsigned int size;
+	unsigned int nargs;
+	unsigned int mask;
+	long fmt;
+	long args[0];
 } flog_msg_t;
 
 extern int flog_encode_msg(int fdout, unsigned int nargs, unsigned int mask, const char *format, ...);
 void flog_decode_msg(int fdout, const char *format, ...);
 extern int flog_decode_all(int fdin, int fdout);
 
-#define flog_encode(fdout, fmt, ...)							\
-	flog_encode_msg(fdout, FLOG_PP_NARG(__VA_ARGS__),				\
-			FLOG_GENMASK(flog_genbit, ##__VA_ARGS__), fmt, ##__VA_ARGS__)
+#define flog_encode(fdout, fmt, ...) \
+	flog_encode_msg(fdout, FLOG_PP_NARG(__VA_ARGS__), FLOG_GENMASK(flog_genbit, ##__VA_ARGS__), fmt, ##__VA_ARGS__)
 
 int flog_map_buf(int fdout);
 int flog_close(int fdout);

--- a/flog/include/util.h
+++ b/flog/include/util.h
@@ -1,0 +1,37 @@
+#ifndef __UTIL_H__
+#define __UTIL_H__
+
+#include <string.h>
+#include <errno.h>
+
+#include "log.h"
+#include "types.h"
+
+#define __xalloc(op, size, ...)						\
+	({								\
+		void *___p = op(__VA_ARGS__);				\
+		___p;							\
+	})
+
+#define xstrdup(str)		__xalloc(strdup, strlen(str) + 1, str)
+#define xmalloc(size)		__xalloc(malloc, size, size)
+#define xzalloc(size)		__xalloc(calloc, size, 1, size)
+#define xrealloc(p, size)	__xalloc(realloc, size, p, size)
+
+#define xfree(p)		do { if (p) free(p); } while (0)
+
+#define xrealloc_safe(pptr, size)					\
+	({								\
+		int __ret = -ENOMEM;					\
+		void *new = xrealloc(*pptr, size);			\
+		if (new) {						\
+			*pptr = new;					\
+			__ret = 0;					\
+		}							\
+		__ret;							\
+	 })
+
+#define memzero_p(p)		memset(p, 0, sizeof(*p))
+#define memzero(p, size)	memset(p, 0, size)
+
+#endif /* __UTIL_H__ */

--- a/flog/include/util.h
+++ b/flog/include/util.h
@@ -7,31 +7,35 @@
 #include "log.h"
 #include "types.h"
 
-#define __xalloc(op, size, ...)						\
-	({								\
-		void *___p = op(__VA_ARGS__);				\
-		___p;							\
+#define __xalloc(op, size, ...)               \
+	({                                    \
+		void *___p = op(__VA_ARGS__); \
+		___p;                         \
 	})
 
-#define xstrdup(str)		__xalloc(strdup, strlen(str) + 1, str)
-#define xmalloc(size)		__xalloc(malloc, size, size)
-#define xzalloc(size)		__xalloc(calloc, size, 1, size)
-#define xrealloc(p, size)	__xalloc(realloc, size, p, size)
+#define xstrdup(str)	  __xalloc(strdup, strlen(str) + 1, str)
+#define xmalloc(size)	  __xalloc(malloc, size, size)
+#define xzalloc(size)	  __xalloc(calloc, size, 1, size)
+#define xrealloc(p, size) __xalloc(realloc, size, p, size)
 
-#define xfree(p)		do { if (p) free(p); } while (0)
+#define xfree(p)                 \
+	do {                     \
+		if (p)           \
+			free(p); \
+	} while (0)
 
-#define xrealloc_safe(pptr, size)					\
-	({								\
-		int __ret = -ENOMEM;					\
-		void *new = xrealloc(*pptr, size);			\
-		if (new) {						\
-			*pptr = new;					\
-			__ret = 0;					\
-		}							\
-		__ret;							\
-	 })
+#define xrealloc_safe(pptr, size)                  \
+	({                                         \
+		int __ret = -ENOMEM;               \
+		void *new = xrealloc(*pptr, size); \
+		if (new) {                         \
+			*pptr = new;               \
+			__ret = 0;                 \
+		}                                  \
+		__ret;                             \
+	})
 
-#define memzero_p(p)		memset(p, 0, sizeof(*p))
-#define memzero(p, size)	memset(p, 0, size)
+#define memzero_p(p)	 memset(p, 0, sizeof(*p))
+#define memzero(p, size) memset(p, 0, size)
 
 #endif /* __UTIL_H__ */

--- a/flog/src/Makefile
+++ b/flog/src/Makefile
@@ -1,0 +1,5 @@
+ccflags-y += -DCONFIG_X86_64 -iquote ./include $(OPTS)
+ldflags-y		+= -r
+
+#obj-y += main.o
+obj-y += flog.o

--- a/flog/src/flog.c
+++ b/flog/src/flog.c
@@ -186,6 +186,7 @@ int flog_encode_msg(int fdout, unsigned int nargs, unsigned int mask, const char
 			p = memccpy(str_start, (void *)m->args[i], 0, mbuf_size - (str_start - mbuf));
 			if (p == NULL) {
 				fprintf(stderr, "No memory for string argument\n");
+				va_end(argptr);
 				return -1;
 			}
 			m->args[i] = str_start - mbuf;

--- a/flog/src/flog.c
+++ b/flog/src/flog.c
@@ -1,0 +1,215 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/param.h>
+#include <sys/mman.h>
+
+//#include <ffi.h>
+
+#include "uapi/flog.h"
+#include "util.h"
+
+#define MAGIC 0xABCDABCD
+
+#define BUF_SIZE (1<<20)
+static char _mbuf[BUF_SIZE];
+static char *mbuf = _mbuf;
+static char *fbuf;
+static uint64_t fsize;
+static uint64_t mbuf_size = sizeof(_mbuf);
+
+/*int flog_decode_all(int fdin, int fdout)
+{
+	flog_msg_t *m = (void *)mbuf;
+	ffi_type *args[34] = {
+		[0]		= &ffi_type_sint,
+		[1]		= &ffi_type_pointer,
+		[2 ... 33]	= &ffi_type_slong
+	};
+	void *values[34];
+	ffi_cif cif;
+	ffi_arg rc;
+	size_t i, ret;
+	char *fmt;
+
+	values[0] = (void *)&fdout;
+
+	while (1) {
+		ret = read(fdin, mbuf, sizeof(m));
+		if (ret == 0)
+			break;
+		if (ret < 0) {
+			fprintf(stderr, "Unable to read a message: %m");
+			return -1;
+		}
+		if (m->magic != MAGIC) {
+			fprintf(stderr, "The log file was not properly closed\n");
+			break;
+		}
+		ret = m->size - sizeof(m);
+		if (m->size > mbuf_size) {
+			fprintf(stderr, "The buffer is too small");
+			return -1;
+		}
+		if (read(fdin, mbuf + sizeof(m), ret) != ret) {
+			fprintf(stderr, "Unable to read a message: %m");
+			return -1;
+		}
+
+		fmt = mbuf + m->fmt;
+		values[1] = &fmt;
+
+		for (i = 0; i < m->nargs; i++) {
+			values[i + 2] = (void *)&m->args[i];
+			if (m->mask & (1u << i)) {
+				m->args[i] = (long)(mbuf + m->args[i]);
+			}
+		}
+
+		if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, m->nargs + 2,
+				 &ffi_type_sint, args) == FFI_OK)
+			ffi_call(&cif, FFI_FN(dprintf), &rc, values);
+	}
+	return 0;
+}*/
+
+static int flog_enqueue(flog_msg_t *m)
+{
+	if (write(1, m, m->size) != m->size) {
+		fprintf(stderr, "Unable to write a message\n");
+		return -1;
+	}
+	return 0;
+}
+
+/*extern char *rodata_start;
+extern char *rodata_end;
+*/
+/* Pre-allocate a buffer in a file and map it into memory. */
+int flog_map_buf(int fdout)
+{
+	uint64_t off = 0;
+	void *addr;
+
+	/*
+	 * Two buffers are mmaped into memory. A new one is mapped when a first
+	 * one is completly filled.
+	 */
+	if (fbuf && (mbuf - fbuf < BUF_SIZE))
+		return 0;
+
+	if (fbuf) {
+		if (munmap(fbuf, BUF_SIZE * 2)) {
+			fprintf(stderr, "Unable to unmap a buffer: %m");
+			return -1;
+		}
+		off = mbuf - fbuf - BUF_SIZE;
+		fbuf = NULL;
+	}
+
+	if (fsize == 0)
+		fsize += BUF_SIZE;
+	fsize += BUF_SIZE;
+
+	if (ftruncate(fdout, fsize)) {
+		fprintf(stderr, "Unable to truncate a file: %m");
+		return -1;
+	}
+
+	if (!fbuf)
+		addr = mmap(NULL, BUF_SIZE * 2, PROT_WRITE | PROT_READ,
+			    MAP_FILE | MAP_SHARED, fdout, fsize - 2 * BUF_SIZE);
+	else
+		addr = mremap(fbuf + BUF_SIZE, BUF_SIZE,
+				BUF_SIZE * 2, MREMAP_FIXED, fbuf);
+	if (addr == MAP_FAILED) {
+		fprintf(stderr, "Unable to map a buffer: %m");
+		return -1;
+	}
+
+	fbuf = addr;
+	mbuf = fbuf + off;
+	mbuf_size = 2 * BUF_SIZE;
+
+	return 0;
+}
+
+int flog_close(int fdout)
+{
+	if (mbuf == _mbuf)
+		return 0;
+
+	munmap(fbuf, BUF_SIZE * 2);
+
+	if (ftruncate(fdout, fsize - 2 * BUF_SIZE + mbuf - fbuf)) {
+		fprintf(stderr, "Unable to truncate a file: %m");
+		return -1;
+	}
+	return 0;
+}
+
+int flog_encode_msg(int fdout, unsigned int nargs, unsigned int mask, const char *format, ...)
+{
+	flog_msg_t *m;
+	va_list argptr;
+	char *str_start, *p;
+	size_t i;
+
+	if (mbuf != _mbuf && flog_map_buf(fdout))
+		return -1;
+
+	m = (void *) mbuf;
+
+	m->nargs = nargs;
+	m->mask = mask;
+
+	str_start = (void *)m->args + sizeof(m->args[0]) * nargs;
+	p = memccpy(str_start, format, 0, mbuf_size - (str_start - mbuf));
+	if (p == NULL) {
+		fprintf(stderr, "No memory for string argument\n");
+		return -1;
+	}
+	m->fmt = str_start - mbuf;
+	str_start = p;
+
+	va_start(argptr, format);
+	for (i = 0; i < nargs; i++) {
+		m->args[i] = (long)va_arg(argptr, long);
+		/*
+		 * If we got a string, we should either
+		 * reference it when in rodata, or make
+		 * a copy (FIXME implement rodata refs).
+		 */
+		if (mask & (1u << i)) {
+			p = memccpy(str_start, (void *)m->args[i], 0, mbuf_size - (str_start - mbuf));
+			if (p == NULL) {
+				fprintf(stderr, "No memory for string argument\n");
+				return -1;
+			}
+			m->args[i] = str_start - mbuf;
+			str_start = p;
+		}
+	}
+	va_end(argptr);
+	m->size = str_start - mbuf;
+
+	/*
+	 * A magic is required to know where we stop writing into a log file,
+	 * if it was not properly closed.  The file is mapped into memory, so a
+	 * space in the file is allocated in advance and at the end it can have
+	 * some unused tail.
+	 */
+	m->magic = MAGIC;
+
+	m->size = roundup(m->size, 8);
+	if (mbuf == _mbuf) {
+		if (flog_enqueue(m))
+			return -1;
+	} else {
+		mbuf += m->size;
+		mbuf_size -= m->size;
+	}
+	return 0;
+}

--- a/flog/src/flog.c
+++ b/flog/src/flog.c
@@ -13,7 +13,7 @@
 
 #define MAGIC 0xABCDABCD
 
-#define BUF_SIZE (1<<20)
+#define BUF_SIZE (1 << 20)
 static char _mbuf[BUF_SIZE];
 static char *mbuf = _mbuf;
 static char *fbuf;
@@ -119,11 +119,10 @@ int flog_map_buf(int fdout)
 	}
 
 	if (!fbuf)
-		addr = mmap(NULL, BUF_SIZE * 2, PROT_WRITE | PROT_READ,
-			    MAP_FILE | MAP_SHARED, fdout, fsize - 2 * BUF_SIZE);
+		addr = mmap(NULL, BUF_SIZE * 2, PROT_WRITE | PROT_READ, MAP_FILE | MAP_SHARED, fdout,
+			    fsize - 2 * BUF_SIZE);
 	else
-		addr = mremap(fbuf + BUF_SIZE, BUF_SIZE,
-				BUF_SIZE * 2, MREMAP_FIXED, fbuf);
+		addr = mremap(fbuf + BUF_SIZE, BUF_SIZE, BUF_SIZE * 2, MREMAP_FIXED, fbuf);
 	if (addr == MAP_FAILED) {
 		fprintf(stderr, "Unable to map a buffer: %m");
 		return -1;
@@ -160,7 +159,7 @@ int flog_encode_msg(int fdout, unsigned int nargs, unsigned int mask, const char
 	if (mbuf != _mbuf && flog_map_buf(fdout))
 		return -1;
 
-	m = (void *) mbuf;
+	m = (void *)mbuf;
 
 	m->nargs = nargs;
 	m->mask = mask;

--- a/flog/src/flog.c
+++ b/flog/src/flog.c
@@ -94,7 +94,7 @@ int flog_map_buf(int fdout)
 	void *addr;
 
 	/*
-	 * Two buffers are mmaped into memory. A new one is mapped when a first
+	 * Two buffers are mmapped into memory. A new one is mapped when a first
 	 * one is completly filled.
 	 */
 	if (fbuf && (mbuf - fbuf < BUF_SIZE))

--- a/flog/src/flog.c
+++ b/flog/src/flog.c
@@ -95,7 +95,7 @@ int flog_map_buf(int fdout)
 
 	/*
 	 * Two buffers are mmapped into memory. A new one is mapped when a first
-	 * one is completly filled.
+	 * one is completely filled.
 	 */
 	if (fbuf && (mbuf - fbuf < BUF_SIZE))
 		return 0;

--- a/flog/src/main.c
+++ b/flog/src/main.c
@@ -1,0 +1,170 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <unistd.h>
+
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "flog.h"
+
+extern char _rodata_start, _rodata_end;
+char *rodata_start = &_rodata_start;
+char *rodata_end = &_rodata_end;
+
+enum {
+	MODE_BINARY,
+	MODE_FPRINTF,
+	MODE_SPRINTF,
+	MODE_DPRINTF,
+};
+
+int main(int argc, char *argv[])
+{
+	static const char str1[] = "String1 String1";
+	static const char str2[] = "string2 string2 string2";
+	int fdout = STDOUT_FILENO;
+	bool use_decoder = false;
+	int mode = MODE_BINARY;
+	size_t niter = 100;
+	int opt, idx;
+	size_t i;
+
+	static const char short_opts[] = "m:o:di:h";
+	static struct option long_opts[] = {
+		{ "mode",		required_argument,	0, 'm'	},
+		{ "output",		required_argument,	0, 'o'	},
+		{ "decode",		no_argument,		0, 'd'	},
+		{ "iter",		required_argument,	0, 'i'	},
+		{ "help",		no_argument,		0, 'h'	},
+		{ },
+	};
+
+	while (1) {
+		idx = -1;
+		opt = getopt_long(argc, argv, short_opts, long_opts, &idx);
+		if (opt == -1)
+			break;
+
+		switch (opt) {
+		case 'm':
+			if (strcmp(optarg, "binary") == 0) {
+				mode = MODE_BINARY;
+			} else if (strcmp(optarg, "fprintf") == 0) {
+				mode = MODE_FPRINTF;
+			} else if (strcmp(optarg, "sprintf") == 0) {
+				mode = MODE_SPRINTF;
+			} else if (strcmp(optarg, "dprintf") == 0) {
+				mode = MODE_DPRINTF;
+			} else
+				goto usage;
+			break;
+		case 'o':
+			if (strcmp(optarg, "stdout") == 0) {
+				fdout = fileno(stdout);
+			} else if (strcmp(optarg, "stderr") == 0) {
+				fdout = fileno(stderr);
+			} else {
+				fdout = open(optarg, O_RDWR | O_CREAT | O_TRUNC, 0644);
+				if (fdout < 0) {
+					fprintf(stderr, "Can't open %s: %s\n",
+						optarg, strerror(errno));
+					exit(1);
+				}
+			}
+			break;
+		case 'i':
+			niter = atoi(optarg);
+			break;
+		case 'd':
+			use_decoder = true;
+			break;
+		case 'h':
+		default:
+			goto usage;
+		}
+	}
+
+	switch (mode) {
+	case MODE_BINARY:
+		if (use_decoder)
+			return flog_decode_all(STDIN_FILENO, fdout);
+
+		if (fdout != STDOUT_FILENO && flog_map_buf(fdout))
+			return 1;
+		for (i = 0; i < niter; i++)
+			if (flog_encode(fdout, "Some message %s %s %c %li %d %lu\n",
+				    str1, str2, 'c', (long)-4, (short)2,
+				    (unsigned long)2))
+				return 1;
+		if (flog_close(fdout))
+			return 1;
+	break;
+	case MODE_DPRINTF:
+	{
+		for (i = 0; i < niter; i++) {
+			dprintf(fdout, "Some message %s %s %c %li %d %lu\n",
+				str1, str2, 'c', (long)-4, (short)2,
+				(unsigned long)2);
+		}
+		break;
+	}
+	case MODE_FPRINTF:
+	{
+		FILE *f = fdopen(fdout, "w");
+
+		for (i = 0; i < niter; i++) {
+			fprintf(f, "Some message %s %s %c %li %d %lu\n",
+				str1, str2, 'c', (long)-4, (short)2,
+				(unsigned long)2);
+			fflush(f);
+		}
+		fclose(f);
+		break;
+	}
+	case MODE_SPRINTF:
+	{
+		static char buf[4096];
+
+		for (i = 0; i < niter; i++) {
+			sprintf(buf, "Some message %s %s %c %li %d %lu\n",
+				str1, str2, 'c', (long)-4, (short)2,
+				(unsigned long)2);
+		}
+		break;
+	}
+	default:
+		return 1;
+	}
+
+	return 0;
+usage:
+	fprintf(stderr,
+		"flog [--mode binary|dprintf] [--output stdout|stderr|filename] [--decode] [--iter number]\n"
+		"\n"
+
+		"Examples:\n"
+		"\n"
+
+		" - run 100000 iterations of instant message processing (immediate dprintf calls)\n"
+		"\n"
+		"       flog -m dprintf -i 100000\n"
+		"\n"
+
+		" - run 100000 iterations in binary mode without processing (queue messages only)\n"
+		"\n"
+		"       flog -i 100000\n"
+		"\n"
+
+		" - run 100000 iterations in binary mode with decoding after\n"
+		"\n"
+		"       flog -i 100000 -d\n"
+		"\n"
+
+		" - run 100000 iterations in binary mode with decoding after, writting results into 'out' file\n"
+		"\n"
+		"       flog -i 100000 -d -o out\n"
+		"\n");
+	return 1;
+}

--- a/flog/src/main.c
+++ b/flog/src/main.c
@@ -33,12 +33,9 @@ int main(int argc, char *argv[])
 
 	static const char short_opts[] = "m:o:di:h";
 	static struct option long_opts[] = {
-		{ "mode",		required_argument,	0, 'm'	},
-		{ "output",		required_argument,	0, 'o'	},
-		{ "decode",		no_argument,		0, 'd'	},
-		{ "iter",		required_argument,	0, 'i'	},
-		{ "help",		no_argument,		0, 'h'	},
-		{ },
+		{ "mode", required_argument, 0, 'm' }, { "output", required_argument, 0, 'o' },
+		{ "decode", no_argument, 0, 'd' },     { "iter", required_argument, 0, 'i' },
+		{ "help", no_argument, 0, 'h' },       {},
 	};
 
 	while (1) {
@@ -68,8 +65,7 @@ int main(int argc, char *argv[])
 			} else {
 				fdout = open(optarg, O_RDWR | O_CREAT | O_TRUNC, 0644);
 				if (fdout < 0) {
-					fprintf(stderr, "Can't open %s: %s\n",
-						optarg, strerror(errno));
+					fprintf(stderr, "Can't open %s: %s\n", optarg, strerror(errno));
 					exit(1);
 				}
 			}
@@ -94,42 +90,35 @@ int main(int argc, char *argv[])
 		if (fdout != STDOUT_FILENO && flog_map_buf(fdout))
 			return 1;
 		for (i = 0; i < niter; i++)
-			if (flog_encode(fdout, "Some message %s %s %c %li %d %lu\n",
-				    str1, str2, 'c', (long)-4, (short)2,
-				    (unsigned long)2))
+			if (flog_encode(fdout, "Some message %s %s %c %li %d %lu\n", str1, str2, 'c', (long)-4,
+					(short)2, (unsigned long)2))
 				return 1;
 		if (flog_close(fdout))
 			return 1;
-	break;
-	case MODE_DPRINTF:
-	{
+		break;
+	case MODE_DPRINTF: {
 		for (i = 0; i < niter; i++) {
-			dprintf(fdout, "Some message %s %s %c %li %d %lu\n",
-				str1, str2, 'c', (long)-4, (short)2,
+			dprintf(fdout, "Some message %s %s %c %li %d %lu\n", str1, str2, 'c', (long)-4, (short)2,
 				(unsigned long)2);
 		}
 		break;
 	}
-	case MODE_FPRINTF:
-	{
+	case MODE_FPRINTF: {
 		FILE *f = fdopen(fdout, "w");
 
 		for (i = 0; i < niter; i++) {
-			fprintf(f, "Some message %s %s %c %li %d %lu\n",
-				str1, str2, 'c', (long)-4, (short)2,
+			fprintf(f, "Some message %s %s %c %li %d %lu\n", str1, str2, 'c', (long)-4, (short)2,
 				(unsigned long)2);
 			fflush(f);
 		}
 		fclose(f);
 		break;
 	}
-	case MODE_SPRINTF:
-	{
+	case MODE_SPRINTF: {
 		static char buf[4096];
 
 		for (i = 0; i < niter; i++) {
-			sprintf(buf, "Some message %s %s %c %li %d %lu\n",
-				str1, str2, 'c', (long)-4, (short)2,
+			sprintf(buf, "Some message %s %s %c %li %d %lu\n", str1, str2, 'c', (long)-4, (short)2,
 				(unsigned long)2);
 		}
 		break;

--- a/flog/src/main.c
+++ b/flog/src/main.c
@@ -129,31 +129,30 @@ int main(int argc, char *argv[])
 
 	return 0;
 usage:
-	fprintf(stderr,
-		"flog [--mode binary|dprintf] [--output stdout|stderr|filename] [--decode] [--iter number]\n"
-		"\n"
+	fprintf(stderr, "flog [--mode binary|dprintf] [--output stdout|stderr|filename] [--decode] [--iter number]\n"
+			"\n"
 
-		"Examples:\n"
-		"\n"
+			"Examples:\n"
+			"\n"
 
-		" - run 100000 iterations of instant message processing (immediate dprintf calls)\n"
-		"\n"
-		"       flog -m dprintf -i 100000\n"
-		"\n"
+			" - run 100000 iterations of instant message processing (immediate dprintf calls)\n"
+			"\n"
+			"       flog -m dprintf -i 100000\n"
+			"\n"
 
-		" - run 100000 iterations in binary mode without processing (queue messages only)\n"
-		"\n"
-		"       flog -i 100000\n"
-		"\n"
+			" - run 100000 iterations in binary mode without processing (queue messages only)\n"
+			"\n"
+			"       flog -i 100000\n"
+			"\n"
 
-		" - run 100000 iterations in binary mode with decoding after\n"
-		"\n"
-		"       flog -i 100000 -d\n"
-		"\n"
+			" - run 100000 iterations in binary mode with decoding after\n"
+			"\n"
+			"       flog -i 100000 -d\n"
+			"\n"
 
-		" - run 100000 iterations in binary mode with decoding after, writting results into 'out' file\n"
-		"\n"
-		"       flog -i 100000 -d -o out\n"
-		"\n");
+			" - run 100000 iterations in binary mode with decoding after, writing results into 'out' file\n"
+			"\n"
+			"       flog -i 100000 -d -o out\n"
+			"\n");
 	return 1;
 }

--- a/flog/tests/test00
+++ b/flog/tests/test00
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e -x
+
+echo Map a log file into memory
+time ./flog run -i 1000000 -o /tmp/flog.raw.map
+echo Write into a log file
+time ./flog run -i 1000000 > /tmp/flog.raw
+echo Use fprintf
+time ./flog run -m fprintf -i 1000000 -o /tmp/flog.fprintf.txt
+echo Use dprintf
+time ./flog run -m dprintf -i 1000000 -o /tmp/flog.dprintf.txt
+echo Use sprintf
+time ./flog run -m sprintf -i 1000000
+
+time ./flog run -d < /tmp/flog.raw > /tmp/flog.raw.txt
+cmp /tmp/flog.raw.txt /tmp/flog.fprintf.txt
+
+time ./flog run -d < /tmp/flog.raw.map > /tmp/flog.raw.map.txt
+cmp /tmp/flog.raw.map.txt /tmp/flog.fprintf.txt
+
+cmp /tmp/flog.dprintf.txt /tmp/flog.fprintf.txt

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -2,7 +2,7 @@ PLUGIN_NAME		:= amdgpu_plugin
 PLUGIN_SOBJ		:= amdgpu_plugin.so
 
 
-PLUGIN_INCLUDE  	:= -iquote../../../criu/include
+PLUGIN_INCLUDE  	:= -iquote../../include
 PLUGIN_INCLUDE  	+= -iquote../../criu/include
 PLUGIN_INCLUDE  	+= -iquote../../criu/arch/$(ARCH)/include/
 PLUGIN_INCLUDE  	+= -iquote../../

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -15,7 +15,7 @@ DEPS_NOK 		:= ;
 include $(__nmk_dir)msg.mk
 
 CC      		:= gcc
-PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
+PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC -DCR_PLUGIN_DEFAULT="$(PLUGINDIR)"
 PLUGIN_LDFLAGS		:= -lpthread -lrt -ldrm -ldrm_amdgpu
 
 ifeq ($(CONFIG_AMDGPU),y)
@@ -50,16 +50,16 @@ clean: amdgpu_plugin_clean amdgpu_plugin_test_clean
 mrproper: clean
 
 install:
-	$(Q) mkdir -p $(PLUGINDIR)
 ifeq ($(CONFIG_AMDGPU),y)
+	$(Q) mkdir -p $(DESTDIR)$(PLUGINDIR)
 	$(E) "  INSTALL " $(PLUGIN_NAME)
-	$(Q) install -m 644 $(PLUGIN_SOBJ) $(PLUGINDIR)
+	$(Q) install -m 644 $(PLUGIN_SOBJ) $(DESTDIR)$(PLUGINDIR)
 endif
 .PHONY: install
 
 uninstall:
 ifeq ($(CONFIG_AMDGPU),y)
 	$(E) " UNINSTALL" $(PLUGIN_NAME)
-	$(Q) $(RM) $(PLUGINDIR)/$(PLUGIN_SOBJ)
+	$(Q) $(RM) $(DESTDIR)$(PLUGINDIR)/$(PLUGIN_SOBJ)
 endif
 .PHONY: uninstall

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -268,6 +268,7 @@ make -C test/others/rpc/ run
 ./test/zdtm.py run -t zdtm/transition/maps007 --pre 2 --noauto-dedup
 ./test/zdtm.py run -t zdtm/transition/maps007 --pre 2 --page-server
 ./test/zdtm.py run -t zdtm/transition/maps007 --pre 2 --page-server --dedup
+./test/zdtm.py run -t zdtm/transition/maps007 --pre 2 --pre-dump-mode read
 
 ./test/zdtm.py run -t zdtm/transition/pid_reuse --pre 2 # start time based pid reuse detection
 ./test/zdtm.py run -t zdtm/transition/pidfd_store_sk --rpc --pre 2 # pidfd based pid reuse detection

--- a/scripts/crit-setup.py
+++ b/scripts/crit-setup.py
@@ -1,10 +1,24 @@
+import os
 from distutils.core import setup
 
+criu_version = "0.0.1"
+env = os.environ
+
+if 'CRIU_VERSION_MAJOR' in env and 'CRIU_VERSION_MINOR' in env:
+    criu_version = '{}.{}'.format(
+        env['CRIU_VERSION_MAJOR'],
+        env['CRIU_VERSION_MINOR']
+    )
+
+    if 'CRIU_VERSION_SUBLEVEL' in env and env['CRIU_VERSION_SUBLEVEL']:
+        criu_version += '.' + env['CRIU_VERSION_SUBLEVEL']
+
 setup(name="crit",
-      version="0.0.1",
+      version=criu_version,
       description="CRiu Image Tool",
       author="CRIU team",
       author_email="criu@openvz.org",
+      license="GPLv2",
       url="https://github.com/checkpoint-restore/criu",
       package_dir={'pycriu': 'lib/py'},
       packages=["pycriu", "pycriu.images"],

--- a/test/check_actions.py
+++ b/test/check_actions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-import sys
 import os
+import sys
 
 actions = set(['pre-dump', 'pre-restore', 'post-dump', 'setup-namespaces', \
   'post-setup-namespaces', 'post-restore', 'post-resume', \

--- a/test/crit-recode.py
+++ b/test/crit-recode.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
-import pycriu
-import sys
 import os
 import subprocess
+import sys
+
+import pycriu
 
 find = subprocess.Popen(
     ['find', 'test/dump/', '-size', '+0', '-name', '*.img'],

--- a/test/jenkins/criu-dedup.sh
+++ b/test/jenkins/criu-dedup.sh
@@ -4,7 +4,7 @@
 set -e
 source `dirname $0`/criu-lib.sh
 prep
-./test/zdtm.py run --all --keep-going --report report --parallel 4 -f h --pre 2 --dedup -x maps04 -x maps007 -x maps09 -x maps10 || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 -f h --pre 2 --dedup -x maps04 -x maps007 || fail
 
 # Additionally run these tests as they touch a lot of
 # memory and it makes sense to additionally check it

--- a/test/jenkins/criu-lazy-migration.sh
+++ b/test/jenkins/criu-lazy-migration.sh
@@ -15,7 +15,7 @@ LAZY_MIGRATE_EXCLUDE="-x fifo_loop -x file_locks -x ptrace_sig -x overmount_file
 	       --lazy-migrate $LAZY_EXCLUDE $LAZY_MIGRATE_EXCLUDE || fail
 
 # During pre-dump + lazy-pages we leave VM_NOHUGEPAGE set
-LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02 -x maps09 -x maps10"
+LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02"
 
 # lazy restore from images with pre-dumps
 ./test/zdtm.py run --all --keep-going --report report --parallel 4 -f uns \

--- a/test/jenkins/criu-lazy-pages.sh
+++ b/test/jenkins/criu-lazy-pages.sh
@@ -12,7 +12,7 @@ source `dirname $0`/criu-lazy-common.sh
 	       --lazy-pages $LAZY_EXCLUDE || fail
 
 # During pre-dump + lazy-pages we leave VM_NOHUGEPAGE set
-LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02 -x maps09 -x maps10"
+LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02"
 
 # lazy restore from images with pre-dumps
 ./test/zdtm.py run --all --keep-going --report report --parallel 4 \

--- a/test/jenkins/criu-pre-dump.sh
+++ b/test/jenkins/criu-pre-dump.sh
@@ -5,6 +5,5 @@ set -e
 source `dirname $0`/criu-lib.sh
 prep
 mount_tmpfs_to_dump
-# FIXME: https://github.com/checkpoint-restore/criu/issues/1868
-./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 -x 'maps04' -x 'maps09' -x 'maps10' || fail
-./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --page-server -x 'maps04' -x 'maps09' -x 'maps10' || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 -x 'maps04' || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --page-server -x 'maps04' || fail

--- a/test/jenkins/criu-remote-lazy-pages.sh
+++ b/test/jenkins/criu-remote-lazy-pages.sh
@@ -12,7 +12,7 @@ source `dirname $0`/criu-lazy-common.sh
 	       --remote-lazy-pages $LAZY_EXCLUDE -x maps04 || fail
 
 # During pre-dump + lazy-pages we leave VM_NOHUGEPAGE set
-LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02  -x maps09 -x maps10"
+LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02"
 
 # lazy restore from "remote" dump with pre-dumps
 ./test/zdtm.py run --all --keep-going --report report --parallel 4 \

--- a/test/jenkins/criu-snap.sh
+++ b/test/jenkins/criu-snap.sh
@@ -5,5 +5,5 @@ set -e
 source `dirname $0`/criu-lib.sh
 prep
 mount_tmpfs_to_dump
-./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --snaps -x 'maps04' -x 'maps09' -x 'maps10' || fail
-./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --snaps --page-server -x 'maps04' -x 'maps09' -x 'maps10' || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --snaps -x 'maps04' || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --snaps --page-server -x 'maps04' || fail

--- a/test/zdtm/__init__.py
+++ b/test/zdtm/__init__.py
@@ -1,0 +1,32 @@
+from .cg_freezer import get_freezer
+from .criu_config import criu_config
+from .exceptions import TestFailException, TestFailExpectedException
+from .groups_test import GroupsTest
+from .inherit_fd_test import InheritFdTest
+from .utils import (
+    decode_flav,
+    encode_flav,
+    flavors,
+    get_test_desc,
+    print_sep,
+    test_flag,
+    try_run_hook
+)
+from .zdtm import ZdtmTest
+
+test_classes = {'zdtm': ZdtmTest, 'inhfd': InheritFdTest, 'groups': GroupsTest}
+
+__all__ = [
+    'criu_config',
+    'get_freezer',
+    'get_test_desc',
+    'test_flag',
+    'encode_flav',
+    'decode_flav',
+    'flavors',
+    'try_run_hook',
+    'print_sep',
+    'test_classes',
+    'TestFailException',
+    'TestFailExpectedException',
+]

--- a/test/zdtm/cg_freezer.py
+++ b/test/zdtm/cg_freezer.py
@@ -1,0 +1,99 @@
+from __future__ import unicode_literals
+
+import os
+from builtins import open
+
+
+class NoopFreezer:
+    def __init__(self):
+        self.kernel = False
+
+    def attach(self):
+        pass
+
+    def freeze(self):
+        pass
+
+    def thaw(self):
+        pass
+
+    def getdopts(self):
+        return []
+
+    def getropts(self):
+        return []
+
+
+class CgroupFreezer:
+    def __init__(self, path, state):
+        self.__path = '/sys/fs/cgroup/freezer/' + path
+        self.__state = state
+        self.kernel = True
+
+    def attach(self):
+        if not os.access(self.__path, os.F_OK):
+            os.makedirs(self.__path)
+        with open(self.__path + '/tasks', 'w') as f:
+            f.write('0')
+
+    def __set_state(self, state):
+        with open(self.__path + '/freezer.state', 'w') as f:
+            f.write(state)
+
+    def freeze(self):
+        if self.__state.startswith('f'):
+            self.__set_state('FROZEN')
+
+    def thaw(self):
+        if self.__state.startswith('f'):
+            self.__set_state('THAWED')
+
+    def getdopts(self):
+        return ['--freeze-cgroup', self.__path, '--manage-cgroups']
+
+    def getropts(self):
+        return ['--manage-cgroups']
+
+
+class CgroupFreezer2:
+    def __init__(self, path, state):
+        self.__path = '/sys/fs/cgroup/' + path
+        self.__state = state
+        self.kernel = True
+
+    def attach(self):
+        if not os.access(self.__path, os.F_OK):
+            os.makedirs(self.__path)
+        with open(self.__path + '/cgroup.procs', 'w') as f:
+            f.write('0')
+
+    def __set_state(self, state):
+        with open(self.__path + '/cgroup.freeze', 'w') as f:
+            f.write(state)
+
+    def freeze(self):
+        if self.__state.startswith('f'):
+            self.__set_state('1')
+
+    def thaw(self):
+        if self.__state.startswith('f'):
+            self.__set_state('0')
+
+    def getdopts(self):
+        return ['--freeze-cgroup', self.__path, '--manage-cgroups']
+
+    def getropts(self):
+        return ['--manage-cgroups']
+
+
+def get_freezer(desc):
+    if not desc:
+        return NoopFreezer()
+
+    fd = desc.split(':')
+
+    if os.access("/sys/fs/cgroup/user.slice/cgroup.procs", os .F_OK):
+        fr = CgroupFreezer2(path=fd[0], state=fd[1])
+    else:
+        fr = CgroupFreezer(path=fd[0], state=fd[1])
+    return fr

--- a/test/zdtm/criu_config.py
+++ b/test/zdtm/criu_config.py
@@ -1,6 +1,8 @@
+from __future__ import unicode_literals
+
 import os
-import tempfile
 import subprocess
+import tempfile
 
 
 class criu_config:

--- a/test/zdtm/exceptions.py
+++ b/test/zdtm/exceptions.py
@@ -1,0 +1,19 @@
+"""
+Exceptions thrown when something inside a ZDTM test goes wrong,
+e.g. test doesn't start, criu returns with non zero code or
+test checks fail.
+"""
+from builtins import str
+
+
+class TestFailException(Exception):
+    def __init__(self, step):
+        self.step = step
+
+    def __str__(self):
+        return str(self.step)
+
+
+class TestFailExpectedException(Exception):
+    def __init__(self, cr_action):
+        self.cr_action = cr_action

--- a/test/zdtm/groups_test.py
+++ b/test/zdtm/groups_test.py
@@ -1,0 +1,61 @@
+from __future__ import unicode_literals
+
+import os
+import subprocess
+from builtins import open
+
+from .exceptions import TestFailException
+from .utils import get_test_desc, tail
+from .zdtm import ZdtmTest
+
+
+class GroupsTest(ZdtmTest):
+    def __init__(self, name, desc, flavor, freezer):
+        ZdtmTest.__init__(self, 'zdtm/lib/groups', desc, flavor, freezer)
+        if flavor.ns:
+            self.__real_name = name
+            with open(name) as fd:
+                self.__subs = list(map(lambda x: x.strip(), fd.readlines()))
+            print("Subs:\n%s" % '\n'.join(self.__subs))
+        else:
+            self.__real_name = ''
+            self.__subs = []
+
+        self._bins += self.__subs
+        self._deps += get_test_desc('zdtm/lib/groups')['deps']
+        self._env = {'ZDTM_TESTS': self.__real_name}
+
+    def __get_start_cmd(self, name):
+        tdir = os.path.dirname(name)
+        tname = os.path.basename(name)
+
+        s_args = ['make', '--no-print-directory', '-C', tdir]
+        subprocess.check_call(s_args + [tname + '.cleanout'])
+        s = subprocess.Popen(s_args + ['--dry-run', tname + '.pid'],
+                             stdout=subprocess.PIPE)
+        out, _ = s.communicate()
+        cmd = out.decode().splitlines()[-1].strip()
+        s.wait()
+
+        return 'cd /' + tdir + ' && ' + cmd
+
+    def start(self):
+        if (self.__subs):
+            with open(self.__real_name + '.start', 'w') as f:
+                for test in self.__subs:
+                    cmd = self.__get_start_cmd(test)
+                    f.write(cmd + '\n')
+
+            with open(self.__real_name + '.stop', 'w') as f:
+                for test in self.__subs:
+                    f.write('kill -TERM `cat /%s.pid`\n' % test)
+
+        ZdtmTest.start(self)
+
+    def stop(self):
+        ZdtmTest.stop(self)
+
+        for test in self.__subs:
+            res = tail(test + '.out')
+            if 'PASS' not in res.split():
+                raise TestFailException("sub %s result check" % test)

--- a/test/zdtm/host_flavor.py
+++ b/test/zdtm/host_flavor.py
@@ -1,0 +1,20 @@
+"""
+A host flavor test runs in the same set of namespaces as criu.
+"""
+
+
+class HostFlavor:
+    def __init__(self, opts):
+        self.name = "host"
+        self.ns = False
+        self.root = None
+
+    def init(self, l_bins, x_bins):
+        pass
+
+    def fini(self):
+        pass
+
+    @staticmethod
+    def clean():
+        pass

--- a/test/zdtm/inherit_fd_test.py
+++ b/test/zdtm/inherit_fd_test.py
@@ -1,0 +1,180 @@
+"""
+The --inherit-fd option cannot be tested using classic zdtm tests as it implies
+some data created before restore and passed through criu restore down to the
+restored process (descriptor in our case). The InheritFdTest class is used to
+implement such tests.
+"""
+from __future__ import unicode_literals
+
+import fcntl
+import os
+import random
+import signal
+import string
+import sys
+import time
+from builtins import open, range
+
+from .exceptions import TestFailException
+from .utils import load_module_from_file, wait_pid_die
+
+
+class InheritFdTest:
+    def __init__(self, name, desc, flavor, freezer):
+        self.__name = os.path.basename(name)
+        print("Load %s" % name)
+        self.__fdtyp = load_module_from_file(self.__name, name)
+        self.__peer_pid = 0
+        self.__files = None
+        self.__peer_file_names = []
+        self.__dump_opts = []
+        self.__messages = {}
+
+    def __get_message(self, i):
+        m = self.__messages.get(i, None)
+        if not m:
+            m = b"".join([
+                random.choice(string.ascii_letters).encode() for _ in range(10)
+            ]) + b"%06d" % i
+        self.__messages[i] = m
+        return m
+
+    def start(self):
+        self.__files = self.__fdtyp.create_fds()
+
+        # Check FDs returned for inter-connection
+        i = 0
+        for my_file, peer_file in self.__files:
+            msg = self.__get_message(i)
+            my_file.write(msg)
+            my_file.flush()
+            data = peer_file.read(len(msg))
+            if data != msg:
+                raise TestFailException("FDs screwup: %r %r" % (msg, data))
+            i += 1
+
+        start_pipe = os.pipe()
+        self.__peer_pid = os.fork()
+        if self.__peer_pid == 0:
+            os.setsid()
+
+            for _, peer_file in self.__files:
+                getattr(self.__fdtyp, "child_prep", lambda fd: None)(peer_file)
+
+            try:
+                os.unlink(self.__name + ".out")
+            except Exception as e:
+                print(e)
+            fd = os.open(self.__name + ".out",
+                         os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+            os.dup2(fd, 1)
+            os.dup2(fd, 2)
+            os.close(fd)
+            fd = os.open("/dev/null", os.O_RDONLY)
+            os.dup2(fd, 0)
+            for my_file, _ in self.__files:
+                my_file.close()
+            os.close(start_pipe[0])
+            os.close(start_pipe[1])
+            i = 0
+            for _, peer_file in self.__files:
+                msg = self.__get_message(i)
+                try:
+                    # File pairs naturally block on read() until the write()
+                    # happen (or the writer is closed). This is not the case for
+                    # regular files, so we loop.
+                    data = b''
+                    while not data:
+                        # In python 2.7, peer_file.read() doesn't call the read
+                        # system call if it's read file to the end once. The
+                        # next seek allows to workaround this problem.
+                        data = os.read(peer_file.fileno(), 16)
+                        time.sleep(0.1)
+                except Exception as e:
+                    print("Unable to read a peer file: %s" % e)
+                    sys.exit(1)
+
+                if data != msg:
+                    print("%r %r" % (data, msg))
+                i += 1
+            sys.exit(data == msg and 42 or 2)
+
+        os.close(start_pipe[1])
+        os.read(start_pipe[0], 12)
+        os.close(start_pipe[0])
+
+        for _, peer_file in self.__files:
+            self.__peer_file_names.append(self.__fdtyp.filename(peer_file))
+            self.__dump_opts += self.__fdtyp.dump_opts(peer_file)
+
+        self.__fds = set(os.listdir("/proc/%s/fd" % self.__peer_pid))
+
+    def stop(self):
+        fds = set(os.listdir("/proc/%s/fd" % self.__peer_pid))
+        if fds != self.__fds:
+            raise TestFailException("File descriptors mismatch: %s %s" %
+                                    (fds, self.__fds))
+        i = 0
+        for my_file, _ in self.__files:
+            msg = self.__get_message(i)
+            my_file.write(msg)
+            my_file.flush()
+            i += 1
+        _, status = os.waitpid(self.__peer_pid, 0)
+        with open(self.__name + ".out") as output:
+            print(output.read())
+        self.__peer_pid = 0
+        if not os.WIFEXITED(status) or os.WEXITSTATUS(status) != 42:
+            raise TestFailException("test failed with %d" % status)
+
+    def kill(self):
+        if self.__peer_pid:
+            os.kill(self.__peer_pid, signal.SIGKILL)
+
+    def getname(self):
+        return self.__name
+
+    def getpid(self):
+        return "%s" % self.__peer_pid
+
+    def gone(self, force=True):
+        os.waitpid(self.__peer_pid, 0)
+        wait_pid_die(self.__peer_pid, self.__name)
+        self.__files = None
+
+    def getdopts(self):
+        return self.__dump_opts
+
+    def getropts(self):
+        self.__files = self.__fdtyp.create_fds()
+        ropts = ["--restore-sibling"]
+        for i in range(len(self.__files)):
+            _, peer_file = self.__files[i]
+            fd = peer_file.fileno()
+            fdflags = fcntl.fcntl(fd, fcntl.F_GETFD) & ~fcntl.FD_CLOEXEC
+            fcntl.fcntl(fd, fcntl.F_SETFD, fdflags)
+            peer_file_name = self.__peer_file_names[i]
+            ropts.extend(["--inherit-fd", "fd[%d]:%s" % (fd, peer_file_name)])
+        self.__peer_file_names = []
+        self.__dump_opts = []
+        for _, peer_file in self.__files:
+            self.__peer_file_names.append(self.__fdtyp.filename(peer_file))
+            self.__dump_opts += self.__fdtyp.dump_opts(peer_file)
+        return ropts
+
+    def print_output(self):
+        pass
+
+    def static(self):
+        return True
+
+    def blocking(self):
+        return False
+
+    @staticmethod
+    def available():
+        pass
+
+    @staticmethod
+    def cleanup():
+        pass

--- a/test/zdtm/ns_flavor.py
+++ b/test/zdtm/ns_flavor.py
@@ -1,0 +1,163 @@
+"""
+A namespaces flavor test runs in its own set of namespaces.
+"""
+from __future__ import unicode_literals
+
+import atexit
+import errno
+import fcntl
+import os
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+from builtins import open, str
+
+from .exceptions import TestFailException
+
+# Root dir for ns and uns flavors. All tests
+# sit in the same dir
+tests_root = None
+
+
+def clean_tests_root():
+    global tests_root
+    if tests_root and tests_root[0] == os.getpid():
+        os.rmdir(os.path.join(tests_root[1], "root"))
+        os.rmdir(tests_root[1])
+
+
+def make_tests_root():
+    global tests_root
+    if not tests_root:
+        tests_root = (os.getpid(), tempfile.mkdtemp("", "criu-root-", "/tmp"))
+        atexit.register(clean_tests_root)
+        os.mkdir(os.path.join(tests_root[1], "root"))
+    os.chmod(tests_root[1], 0o777)
+    return os.path.join(tests_root[1], "root")
+
+
+class NsFlavor:
+    __root_dirs = [
+        "/bin", "/sbin", "/etc", "/lib", "/lib64", "/dev", "/dev/pts",
+        "/dev/net", "/tmp", "/usr", "/proc", "/run"
+    ]
+
+    def __init__(self, opts):
+        self.name = "ns"
+        self.ns = True
+        self.uns = False
+        self.root = make_tests_root()
+        self.root_mounted = False
+
+    def __copy_one(self, fname):
+        tfname = self.root + fname
+        if not os.access(tfname, os.F_OK):
+            # Copying should be atomic as tests can be
+            # run in parallel
+            try:
+                os.makedirs(self.root + os.path.dirname(fname))
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+            dst = tempfile.mktemp(".tso", "",
+                                  self.root + os.path.dirname(fname))
+            shutil.copy2(fname, dst)
+            os.rename(dst, tfname)
+
+    def __copy_libs(self, binary):
+        ldd = subprocess.Popen(["ldd", binary], stdout=subprocess.PIPE)
+        stdout, _ = ldd.communicate()
+
+        xl = re.compile(
+            r'^(linux-gate.so|linux-vdso(64)?.so|not a dynamic|.*\s*ldd\s)')
+
+        # This Mayakovsky-style code gets list of libraries a binary
+        # needs minus vdso and gate .so-s
+        libs = map(
+            lambda x: x[1] == '=>' and x[2] or x[0],
+            map(
+                lambda x: str(x).split(),
+                filter(
+                    lambda x: not xl.match(x),
+                    map(
+                        lambda x: str(x).strip(),
+                        filter(lambda x: str(x).startswith('\t'),
+                               stdout.decode(
+                                   'ascii').splitlines())))))
+
+        for lib in libs:
+            if not os.access(lib, os.F_OK):
+                raise TestFailException("Can't find lib %s required by %s" %
+                                        (lib, binary))
+            self.__copy_one(lib)
+
+    def __mknod(self, name, rdev=None):
+        name = "/dev/" + name
+        if not rdev:
+            if not os.access(name, os.F_OK):
+                print("Skipping %s at root" % name)
+                return
+            else:
+                rdev = os.stat(name).st_rdev
+
+        name = self.root + name
+        os.mknod(name, stat.S_IFCHR, rdev)
+        os.chmod(name, 0o666)
+
+    def __construct_root(self):
+        for dir in self.__root_dirs:
+            os.mkdir(self.root + dir)
+            os.chmod(self.root + dir, 0o777)
+
+        for ldir in ["/bin", "/sbin", "/lib", "/lib64"]:
+            os.symlink(".." + ldir, self.root + "/usr" + ldir)
+
+        self.__mknod("tty", os.makedev(5, 0))
+        self.__mknod("null", os.makedev(1, 3))
+        self.__mknod("net/tun")
+        self.__mknod("rtc")
+        self.__mknod("autofs", os.makedev(10, 235))
+
+    def __copy_deps(self, deps):
+        for d in deps.split('|'):
+            if os.access(d, os.F_OK):
+                self.__copy_one(d)
+                self.__copy_libs(d)
+                return
+        raise TestFailException("Deps check %s failed" % deps)
+
+    def init(self, l_bins, x_bins):
+        subprocess.check_call(
+            ["mount", "--make-slave", "--bind", ".", self.root])
+        self.root_mounted = True
+
+        if not os.access(self.root + "/.constructed", os.F_OK):
+            with open(os.path.abspath(__file__)) as o:
+                fcntl.flock(o, fcntl.LOCK_EX)
+                if not os.access(self.root + "/.constructed", os.F_OK):
+                    print("Construct root for %s" % l_bins[0])
+                    self.__construct_root()
+                    os.mknod(self.root + "/.constructed", stat.S_IFREG | 0o600)
+
+        for b in l_bins:
+            self.__copy_libs(b)
+        for b in x_bins:
+            self.__copy_deps(b)
+
+    def fini(self):
+        if self.root_mounted:
+            subprocess.check_call(["./umount2", self.root])
+            self.root_mounted = False
+
+    @staticmethod
+    def clean():
+        for d in NsFlavor.__root_dirs:
+            p = './' + d
+            print('Remove %s' % p)
+            if os.access(p, os.F_OK):
+                shutil.rmtree('./' + d)
+
+        if os.access('./.constructed', os.F_OK):
+            os.unlink('./.constructed')

--- a/test/zdtm/static/shm-hugetlb.checkskip
+++ b/test/zdtm/static/shm-hugetlb.checkskip
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# will fail with EOPNOTSUPP
+cat /proc/sys/vm/nr_hugepages &> /dev/null

--- a/test/zdtm/userns_flavor.py
+++ b/test/zdtm/userns_flavor.py
@@ -1,0 +1,25 @@
+"""
+A user namespace flavor test is the same as namespace flavor,
+but it also includes user namespace.
+"""
+from __future__ import unicode_literals
+
+import os
+
+from .ns_flavor import NsFlavor
+
+
+class UserNsFlavor(NsFlavor):
+    def __init__(self, opts):
+        NsFlavor.__init__(self, opts)
+        self.name = "userns"
+        self.uns = True
+
+    def init(self, l_bins, x_bins):
+        # To be able to create roots_yard in CRIU
+        os.chmod(".", os.stat(".").st_mode | 0o077)
+        NsFlavor.init(self, l_bins, x_bins)
+
+    @staticmethod
+    def clean():
+        pass

--- a/test/zdtm/utils.py
+++ b/test/zdtm/utils.py
@@ -1,0 +1,105 @@
+"""
+Helper functions reused across modules.
+"""
+from __future__ import unicode_literals
+
+import errno
+import os
+import subprocess
+import sys
+import time
+from builtins import int, open, range, str, zip
+
+from .exceptions import TestFailException
+from .host_flavor import HostFlavor
+from .ns_flavor import NsFlavor
+from .userns_flavor import UserNsFlavor
+
+# Flavors
+#  h -- host, test is run in the same set of namespaces as criu
+#  ns -- namespaces, test is run in itw own set of namespaces
+#  uns -- user namespace, the same as above plus user namespace
+
+flavors = {'h': HostFlavor, 'ns': NsFlavor, 'uns': UserNsFlavor}
+
+flavors_codes = dict(zip(range(len(flavors)), sorted(flavors.keys())))
+
+
+def try_run_hook(test, args):
+    hname = test.getname() + '.hook'
+    if os.access(hname, os.X_OK):
+        print("Running %s(%s)" % (hname, ', '.join(args)))
+        hook = subprocess.Popen([hname] + args)
+        if hook.wait() != 0:
+            raise TestFailException("hook " + " ".join(args))
+
+
+def wait_pid_die(pid, who, tmo=30):
+    stime = 0.1
+    while stime < tmo:
+        try:
+            os.kill(int(pid), 0)
+        except OSError as e:
+            if e.errno != errno.ESRCH:
+                print(e)
+            break
+
+        print("Wait for %s(%d) to die for %f" % (who, pid, stime))
+        time.sleep(stime)
+        stime *= 2
+    else:
+        subprocess.Popen(["ps", "-p", str(pid)]).wait()
+        subprocess.Popen(["ps", "axf", str(pid)]).wait()
+        raise TestFailException("%s die" % who)
+
+
+def test_flag(tdesc, flag):
+    return flag in tdesc.get('flags', '').split()
+
+
+def tail(path):
+    p = subprocess.Popen(['tail', '-n1', path], stdout=subprocess.PIPE)
+    out, _ = p.communicate()
+    return out.decode()
+
+
+def print_sep(title, sep="=", width=80):
+    print((" " + title + " ").center(width, sep))
+
+
+def encode_flav(f):
+    return sorted(flavors.keys()).index(f) + 128
+
+
+def decode_flav(i):
+    return flavors_codes.get(i - 128, "unknown")
+
+
+def rpidfile(path):
+    with open(path) as fd:
+        return fd.readline().strip()
+
+
+def load_module_from_file(name, path):
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 5:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    else:
+        import imp
+        mod = imp.load_source(name, path)
+    return mod
+
+
+# Descriptor for abstract test not in list
+default_test = {}
+
+
+def get_test_desc(tname):
+    d_path = tname + '.desc'
+    if os.access(d_path, os.F_OK) and os.path.getsize(d_path) > 0:
+        with open(d_path) as fd:
+            return eval(fd.read())
+
+    return default_test

--- a/test/zdtm/zdtm.py
+++ b/test/zdtm/zdtm.py
@@ -1,0 +1,263 @@
+from __future__ import unicode_literals
+
+import os
+import random
+import signal
+import struct
+import subprocess
+import sys
+import time
+import uuid
+from builtins import int, open, str
+
+from .exceptions import TestFailException
+from .utils import (
+    print_sep,
+    rpidfile,
+    tail,
+    test_flag,
+    try_run_hook,
+    wait_pid_die
+)
+
+
+class ZdtmTest:
+    """
+    An object representing a test in zdtm/ directory.
+    """
+
+    uuid = uuid.uuid4()
+
+    def __init__(self, name, desc, flavor, freezer):
+        self.__name = name
+        self.__desc = desc
+        self.__freezer = None
+        self.__make_action('cleanout')
+        self.__pid = 0
+        self.__flavor = flavor
+        self.__freezer = freezer
+        self._bins = [name]
+        self._env = {}
+        self._deps = desc.get('deps', [])
+        self.auto_reap = True
+        self.__timeout = int(self.__desc.get('timeout') or 30)
+
+    def __make_action(self, act, env=None, root=None):
+        sys.stdout.flush()  # Not to let make's messages appear before ours
+        tpath = self.__name + '.' + act
+        s_args = [
+            'make', '--no-print-directory', '-C',
+            os.path.dirname(tpath),
+            os.path.basename(tpath)
+        ]
+
+        if env:
+            env = dict(os.environ, **env)
+
+        s = subprocess.Popen(
+            s_args,
+            env=env,
+            cwd=root,
+            close_fds=True,
+            preexec_fn=self.__freezer and self.__freezer.attach or None)
+        if act == "pid":
+            try_run_hook(self, ["--post-start"])
+        if s.wait():
+            raise TestFailException(str(s_args))
+
+        if self.__freezer:
+            self.__freezer.freeze()
+
+    def __pidfile(self):
+        return self.__name + '.pid'
+
+    def __wait_task_die(self):
+        wait_pid_die(int(self.__pid), self.__name, self.__timeout)
+
+    def __add_wperms(self):
+        # Add write perms for .out and .pid files
+        for b in self._bins:
+            p = os.path.dirname(b)
+            os.chmod(p, os.stat(p).st_mode | 0o222)
+
+    def start(self):
+        self.__flavor.init(self._bins, self._deps)
+
+        print("Start test")
+
+        env = self._env
+        if not self.__freezer.kernel:
+            env['ZDTM_THREAD_BOMB'] = "5"
+
+        if test_flag(self.__desc, 'pre-dump-notify'):
+            env['ZDTM_NOTIFY_FDIN'] = "100"
+            env['ZDTM_NOTIFY_FDOUT'] = "101"
+
+        if not test_flag(self.__desc, 'suid'):
+            # Numbers should match those in criu
+            env['ZDTM_UID'] = "18943"
+            env['ZDTM_GID'] = "58467"
+            env['ZDTM_GROUPS'] = "27495 48244"
+            self.__add_wperms()
+        else:
+            print("Test is SUID")
+
+        if self.__flavor.ns:
+            env['ZDTM_NEWNS'] = "1"
+            env['ZDTM_ROOT'] = self.__flavor.root
+            env['PATH'] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+            if self.__flavor.uns:
+                env['ZDTM_USERNS'] = "1"
+                self.__add_wperms()
+            if os.getenv("GCOV"):
+                criu_dir = os.path.dirname(os.getcwd())
+                criu_dir_r = "%s%s" % (self.__flavor.root, criu_dir)
+
+                env['ZDTM_CRIU'] = os.path.dirname(os.getcwd())
+                subprocess.check_call(["mkdir", "-p", criu_dir_r])
+
+        self.__make_action('pid', env, self.__flavor.root)
+
+        try:
+            os.kill(int(self.getpid()), 0)
+        except Exception as e:
+            raise TestFailException("start: %s" % e)
+
+        if not self.static():
+            # Wait less than a second to give the test chance to
+            # move into some semi-random state
+            time.sleep(random.random())
+
+        if self.__flavor.ns:
+            # In the case of runc the path specified with the opts.root
+            # option is created in /run/runc/ which is inaccessible to
+            # unprivileged users. The permissions here are set to test
+            # this use case.
+            os.chmod(os.path.dirname(self.__flavor.root), 0o700)
+
+    def kill(self, sig=signal.SIGKILL):
+        self.__freezer.thaw()
+        if self.__pid:
+            print("Send the %d signal to  %s" % (sig, self.__pid))
+            os.kill(int(self.__pid), sig)
+            self.gone(sig == signal.SIGKILL)
+
+        self.__flavor.fini()
+
+    def pre_dump_notify(self):
+        env = self._env
+
+        if 'ZDTM_NOTIFY_FDIN' not in env:
+            return
+
+        if self.__pid == 0:
+            self.getpid()
+
+        notify_fdout_path = "/proc/%s/fd/%s" % (self.__pid,
+                                                env['ZDTM_NOTIFY_FDOUT'])
+        notify_fdin_path = "/proc/%s/fd/%s" % (self.__pid,
+                                               env['ZDTM_NOTIFY_FDIN'])
+
+        print("Send pre-dump notify to %s" % (self.__pid))
+        with open(notify_fdout_path, "rb") as fdout:
+            with open(notify_fdin_path, "wb") as fdin:
+                fdin.write(struct.pack("i", 0))
+                fdin.flush()
+                print("Wait pre-dump notify reply")
+                ret = struct.unpack('i', fdout.read(4))
+                print("Completed pre-dump notify with %d" % (ret))
+
+    def stop(self):
+        self.__freezer.thaw()
+        self.getpid()  # Read the pid from pidfile back
+        self.kill(signal.SIGTERM)
+
+        res = tail(self.__name + '.out')
+        if 'PASS' not in list(map(lambda s: s.strip(), res.split())):
+            if os.access(self.__name + '.out.inprogress', os.F_OK):
+                print_sep(self.__name + '.out.inprogress')
+                with open(self.__name + '.out.inprogress') as fd:
+                    print(fd.read())
+                print_sep(self.__name + '.out.inprogress')
+            raise TestFailException("result check")
+
+    def getpid(self):
+        if self.__pid == 0:
+            self.__pid = rpidfile(self.__pidfile())
+
+        return self.__pid
+
+    def getname(self):
+        return self.__name
+
+    def __getcropts(self):
+        opts = self.__desc.get('opts', '').split() + [
+            "--pidfile", os.path.realpath(self.__pidfile())
+        ]
+        if self.__flavor.ns:
+            opts += ["--root", self.__flavor.root]
+        if test_flag(self.__desc, 'crlib'):
+            opts += [
+                "--libdir",
+                os.path.dirname(os.path.realpath(self.__name)) + '/lib'
+            ]
+        return opts
+
+    def getdopts(self):
+        return self.__getcropts() + self.__freezer.getdopts(
+        ) + self.__desc.get('dopts', '').split()
+
+    def getropts(self):
+        return self.__getcropts() + self.__freezer.getropts(
+        ) + self.__desc.get('ropts', '').split()
+
+    def unlink_pidfile(self):
+        self.__pid = 0
+        os.unlink(self.__pidfile())
+
+    def gone(self, force=True):
+        if not self.auto_reap:
+            pid, status = os.waitpid(int(self.__pid), 0)
+            if pid != int(self.__pid):
+                raise TestFailException("kill pid mess")
+
+        self.__wait_task_die()
+        self.__pid = 0
+        if force:
+            os.unlink(self.__pidfile())
+
+    def print_output(self):
+        for postfix in ['.out', '.out.inprogress']:
+            if os.access(self.__name + postfix, os.R_OK):
+                print("Test output: " + "=" * 32)
+                with open(self.__name + postfix) as output:
+                    print(output.read())
+                print(" <<< " + "=" * 32)
+
+    def static(self):
+        return self.__name.split('/')[1] == 'static'
+
+    def ns(self):
+        return self.__flavor.ns
+
+    def blocking(self):
+        return test_flag(self.__desc, 'crfail')
+
+    @staticmethod
+    def available():
+        if not os.access("umount2", os.X_OK):
+            subprocess.check_call(
+                ["make", "umount2"], env=dict(os.environ, MAKEFLAGS=""))
+        if not os.access("zdtm_ct", os.X_OK):
+            subprocess.check_call(
+                ["make", "zdtm_ct"], env=dict(os.environ, MAKEFLAGS=""))
+        if not os.access("zdtm/lib/libzdtmtst.a", os.F_OK):
+            subprocess.check_call(["make", "-C", "zdtm/"])
+        subprocess.check_call(
+            ["flock", "zdtm_mount_cgroups.lock", "./zdtm_mount_cgroups", str(ZdtmTest.uuid)])
+
+    @staticmethod
+    def cleanup():
+        subprocess.check_call(
+            ["flock", "zdtm_mount_cgroups.lock", "./zdtm_umount_cgroups", str(ZdtmTest.uuid)])


### PR DESCRIPTION
The zdtm.py file has grown over time to more than 2500 lines. It contains a number of classes, functions and variables all combined into a single monolithic python module.

This patch moves test classes, helper functions, flavors and exceptions into separate files that are imported in zdtm.py. This makes the code easier to extend and maintain in the future.

This pull request is rebased on top of https://github.com/checkpoint-restore/criu/pull/1581.