### PR TITLE
ci: set continue-on-error for cross-compile

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -6,18 +6,26 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
+        experimental: [false]
         target: [
           armv7-stable-cross,
-          armv7-unstable-cross,
           aarch64-stable-cross,
-          aarch64-unstable-cross,
           ppc64-stable-cross,
-          ppc64-unstable-cross,
           mips64el-stable-cross,
-          mips64el-unstable-cross
         ]
+        include:
+          - experimental: true
+            target: armv7-unstable-cross
+          - experimental: true
+            target: aarch64-unstable-cross
+          - experimental: true
+            target: ppc64-unstable-cross
+          - experimental: true
+            target: mips64el-unstable-cross
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Running cross compile tests with Debian unstable sometimes fails due to missing or outdated packages.

In this patch we set [continue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error) to prevent the GitHub Action workflow run from failing when one or more cross-compile tests with Debian unstable fails.

In other words, we can still see test errors with Debian _unstable_, but the workflow would fail only when the Debian _stable_ tests fail.

![img1](https://user-images.githubusercontent.com/9142901/151520865-bdee55f1-1a79-439c-9a78-7e0173513e1e.png)
![img2](https://user-images.githubusercontent.com/9142901/151520871-15ea5314-465b-4384-8c13-9ea811555de3.png)
