### PR TITLE
Fix building with annobin

### DIFF
--- a/compel/plugins/Makefile
+++ b/compel/plugins/Makefile
@@ -1,4 +1,4 @@
-CFLAGS		:= $(filter-out -pg $(CFLAGS-GCOV) $(CFLAGS-ASAN),$(CFLAGS))
+CFLAGS		:= $(filter-out -pg $(CFLAGS-GCOV) $(CFLAGS-ASAN) -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1,$(CFLAGS))
 CFLAGS		+= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
 CFLAGS		+= -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=0
 

--- a/criu/pie/Makefile
+++ b/criu/pie/Makefile
@@ -4,7 +4,7 @@
 
 target		:= parasite restorer
 
-CFLAGS		:= $(filter-out -pg $(CFLAGS-GCOV) $(CFLAGS-ASAN),$(CFLAGS))
+CFLAGS		:= $(filter-out -pg $(CFLAGS-GCOV) $(CFLAGS-ASAN) -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1,$(CFLAGS))
 CFLAGS		+= $(CFLAGS_PIE)
 ccflags-y	+= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
 ccflags-y	+= -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=0

--- a/criu/pie/Makefile.library
+++ b/criu/pie/Makefile.library
@@ -21,7 +21,7 @@ ifeq ($(ARCH),arm)
         lib-y		+= ./$(ARCH_DIR)/pie-cacheflush.o
 endif
 
-CFLAGS		:= $(filter-out -pg $(CFLAGS-GCOV) $(CFLAGS-ASAN),$(CFLAGS))
+CFLAGS		:= $(filter-out -pg $(CFLAGS-GCOV) $(CFLAGS-ASAN) -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1,$(CFLAGS))
 CFLAGS		+= $(CFLAGS_PIE)
 
 ifeq ($(ARCH),mips)


### PR DESCRIPTION
Annobin (used at least in Fedora and RHEL) injects annotation into the compiled objects which break the parasite and restorer.

This removes the annobin flags as used in Fedora and RHEL and makes CRIU work on Fedora and RHEL with annobin enabled.

This change is unfortunately where distribution specific and I do not know if we want to carry it. If there are any other suggestions how to remove this compiler flag I am happy to use other approaches.

I can also carry this patch only downstream in the CRIU packages for Fedora and RHEL.

CC: @rst0git 