### PR TITLE
files: generate unique transport socket names

### DIFF
--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -254,6 +254,8 @@ int main(int argc, char *argv[], char *envp[])
 		return 1;
 	}
 
+	util_init();
+
 	if (log_init(opts.output))
 		return 1;
 

--- a/criu/files.c
+++ b/criu/files.c
@@ -957,7 +957,7 @@ static int receive_fd(struct fdinfo_list_entry *fle);
 static void transport_name_gen(struct sockaddr_un *addr, int *len, int pid)
 {
 	addr->sun_family = AF_UNIX;
-	snprintf(addr->sun_path, UNIX_PATH_MAX, "x/crtools-fd-%d", pid);
+	snprintf(addr->sun_path, UNIX_PATH_MAX, "x/crtools-fd-%d-%" PRIx64, pid, criu_run_id);
 	*len = SUN_LEN(addr);
 	*addr->sun_path = '\0';
 }

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -393,4 +393,10 @@ static inline void cleanup_freep(void *p)
 
 extern int run_command(char *buf, size_t buf_size, int (*child_fn)(void *), void *args);
 
+/*
+ * criu_run_id is a unique value of the current run. It can be used to
+ * generate resource ID-s to avoid conflicts with other CRIU processes.
+ */
+extern uint64_t criu_run_id;
+extern void util_init(void);
 #endif /* __CR_UTIL_H__ */

--- a/criu/util.c
+++ b/criu/util.c
@@ -27,6 +27,7 @@
 #include <netinet/tcp.h>
 #include <sched.h>
 #include <ftw.h>
+#include <time.h>
 
 #include "linux/mount.h"
 
@@ -1803,4 +1804,14 @@ int run_command(char *buf, size_t buf_size, int (*child_fn)(void *), void *args)
 	close(pipefd[0]);
 
 	return fret;
+}
+
+uint64_t criu_run_id;
+
+void util_init()
+{
+	struct timespec tp;
+
+	clock_gettime(CLOCK_MONOTONIC, &tp);
+	criu_run_id = ((uint64_t)getpid() << 32) + tp.tv_sec + tp.tv_nsec;
 }


### PR DESCRIPTION
Transport socket names have to be unique for each criu run.
    
Fixes #1735 #1720
