### PR TITLE
zdtm: fix missplacement of err=True

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1485,8 +1485,8 @@ class criu:
             self.__page_server_p = None
         if self.__dump_process:
             self.__dump_process.terminate()
-            print("criu dump exited with %s" % self.__dump_process.wait(), err=True)
-            grep_errors(os.path.join(self.__ddir(), "dump.log"))
+            print("criu dump exited with %s" % self.__dump_process.wait())
+            grep_errors(os.path.join(self.__ddir(), "dump.log"), err=True)
             self.__dump_process = None
         if self.__img_streamer_process:
             self.__img_streamer_process.terminate()


### PR DESCRIPTION
There is no 'err' argument for print(), it should be in grep_errors() in
line below.

Fixes: bed670f62 ("zdtm: print tails of all logs if a test has failed")
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
