### PR TITLE
compel: set mxcsr during error injection to zero

### DIFF
--- a/compel/arch/x86/src/lib/infect.c
+++ b/compel/arch/x86/src/lib/infect.c
@@ -272,6 +272,17 @@ static void validate_random_xstate(struct xsave_struct *xsave)
 
 	/* No reserved bits may be set */
 	memset(&hdr->reserved, 0, sizeof(hdr->reserved));
+
+	/*
+	 * While using PTRACE_SETREGSET the kernel checks that
+	 * "Reserved bits in MXCSR must be zero."
+	 * if (mxcsr[0] & ~mxcsr_feature_mask)
+	 *	return -EINVAL;
+	 *
+	 * As the mxcsr_feature_mask depends on the CPU the easiest solution for
+	 * this error injection test is to set mxcsr just to zero.
+	 */
+	xsave->i387.mxcsr = 0;
 }
 
 /*


### PR DESCRIPTION
During error injection tests there are random values loaded in some of
the registers. The kernel, however, has the following check:

    if (mxcsr[0] & ~mxcsr_feature_mask)
        return -EINVAL;

So depending on the random values loaded mxcsr might have values that
the kernel rejects with EINVAL. Setting mxcsr to zero during the tests
lets the error injection test pass.

Fixes: #1734