### PR TITLE
mount: fix e_str leak in ext_mount_add

### DIFF
--- a/criu/mount.c
+++ b/criu/mount.c
@@ -55,7 +55,7 @@ static LIST_HEAD(delayed_unbindable);
 
 int ext_mount_add(char *key, char *val)
 {
-	char *e_str;
+	cleanup_free char *e_str = NULL;
 
 	e_str = xmalloc(strlen(key) + strlen(val) + 8);
 	if (!e_str)


### PR DESCRIPTION
coverity CID 389202:
```
54int ext_mount_add(char *key, char *val)
 55{
 56        char *e_str;
 57
   1. alloc_fn: Storage is returned from allocation function malloc.
   2. var_assign: Assigning: ___p = storage returned from malloc(strlen(key) + strlen(val) + 8UL).
   3. Condition !___p, taking false branch.
   4. leaked_storage: Variable ___p going out of scope leaks the storage it points to.
   5. var_assign: Assigning: e_str = ({...; ___p;}).
 58        e_str = xmalloc(strlen(key) + strlen(val) + 8);
   6. Condition !e_str, taking false branch.
 59        if (!e_str)
 60                return -1;
...
   7. noescape: Resource e_str is not freed or pointed-to in sprintf.
 73        sprintf(e_str, "mnt[%s]:%s", key, val);
   8. noescape: Resource e_str is not freed or pointed-to in add_external. [show details]
   CID 389202 (#1 of 1): Resource leak (RESOURCE_LEAK)9. leaked_storage: Variable e_str going out of scope leaks the storage it points to.
 74        return add_external(e_str);
 75}
```
We need to free e_str after add_external used it.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
