### PR TITLE
config: fix ns leak in parse_join_ns

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -549,7 +549,7 @@ static size_t parse_size(char *optarg)
 static int parse_join_ns(const char *ptr)
 {
 	char *aux, *ns_file, *extra_opts = NULL;
-	char *ns;
+	cleanup_free char *ns = NULL;
 
 	ns = xstrdup(ptr);
 	if (ns == NULL)


### PR DESCRIPTION
coverity CID 389192:
```
550static int parse_join_ns(const char *ptr)
551{
...
553        char *ns;
554
   1. alloc_fn: Storage is returned from allocation function strdup.
   2. var_assign: Assigning: ___p = storage returned from strdup(ptr).
   3. Condition !___p, taking false branch.
   4. leaked_storage: Variable ___p going out of scope leaks the storage it points to.
   5. var_assign: Assigning: ns = ({...; ___p;}).
555        ns = xstrdup(ptr);
   6. Condition ns == NULL, taking false branch.
556        if (ns == NULL)
557                return -1;
558
   7. noescape: Resource ns is not freed or pointed-to in strchr.
559        aux = strchr(ns, ':');
   8. Condition aux == NULL, taking true branch.
560        if (aux == NULL)
   CID 389192 (#1 of 1): Resource leak (RESOURCE_LEAK)9. leaked_storage: Variable ns going out of scope leaks the storage it points to.
561                return -1;
```
We should free ns string after we finish it's use in parse_join_ns,
easiest way to do it is to use cleanup_free attribute.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
