### PR TITLE
mount-v2: make mount engine fallback messages loglevel debug

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -1110,7 +1110,7 @@ int check_options(void)
 		return 1;
 	} else if (!opts.mntns_compat_mode && opts.mode == CR_RESTORE) {
 		if (check_mount_v2()) {
-			pr_warn("Mount engine fallback to --mntns-compat-mode mode\n");
+			pr_debug("Mount engine fallback to --mntns-compat-mode mode\n");
 			opts.mntns_compat_mode = true;
 		}
 	}

--- a/criu/mount-v2.c
+++ b/criu/mount-v2.c
@@ -33,12 +33,12 @@ LIST_HEAD(sharing_groups);
 int check_mount_v2(void)
 {
 	if (!kdat.has_move_mount_set_group) {
-		pr_warn("Mounts-v2 requires MOVE_MOUNT_SET_GROUP support\n");
+		pr_debug("Mounts-v2 requires MOVE_MOUNT_SET_GROUP support\n");
 		return -1;
 	}
 
 	if (!kdat.has_openat2) {
-		pr_warn("Mounts-v2 requires openat2 support\n");
+		pr_debug("Mounts-v2 requires openat2 support\n");
 		return -1;
 	}
 


### PR DESCRIPTION
On pre v5.15 kernel we don't have MOVE_MOUNT_SET_GROUP support and thus
all our ci logs are filled with "fallback" messages. Let's decrease log
level to debug, so that we don't see it in ci logs.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
