### PR TITLE
scripts/ci: create test cgroup controllers once

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -139,6 +139,13 @@ time make unittest
 
 ulimit -c unlimited
 
+cgid=$$
+cleanup_cgroup() {
+	./test/zdtm_umount_cgroups $cgid
+}
+trap cleanup_cgroup EXIT
+./test/zdtm_mount_cgroups $cgid
+
 echo "|$(pwd)/test/abrt.sh %P %p %s %e" > /proc/sys/kernel/core_pattern
 
 if [ "${COMPAT_TEST}x" = "yx" ] ; then

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from builtins import input, int, open, range, str, zip
 
 import yaml
@@ -38,6 +39,7 @@ from zdtm.criu_config import criu_config
 STREAMED_IMG_FILE_NAME = "img.criu"
 
 prev_line = None
+uuid = uuid.uuid4()
 
 
 def alarm(*args):
@@ -617,12 +619,12 @@ class zdtm_test:
         if not os.access("zdtm/lib/libzdtmtst.a", os.F_OK):
             subprocess.check_call(["make", "-C", "zdtm/"])
         subprocess.check_call(
-            ["flock", "zdtm_mount_cgroups.lock", "./zdtm_mount_cgroups"])
+            ["flock", "zdtm_mount_cgroups.lock", "./zdtm_mount_cgroups", str(uuid)])
 
     @staticmethod
     def cleanup():
         subprocess.check_call(
-            ["flock", "zdtm_mount_cgroups.lock", "./zdtm_umount_cgroups"])
+            ["flock", "zdtm_mount_cgroups.lock", "./zdtm_umount_cgroups", str(uuid)])
 
 
 def load_module_from_file(name, path):

--- a/test/zdtm_mount_cgroups
+++ b/test/zdtm_mount_cgroups
@@ -4,13 +4,15 @@
 # Error (cgroup.c:768): cg: Set 3 is not subset of 2
 # so lets create all test controllers before executing tests.
 
+uuid=$1
+
 cat /proc/self/cgroup | grep -q zdtmtst.defaultroot && exit
 
 tdir=`mktemp -d zdtm.XXXXXX`
 for i in "zdtmtst" "zdtmtst.defaultroot"; do
 	mount -t cgroup -o none,name=$i zdtm $tdir &&
 	# a fake group prevents destroying of a controller
-	mkdir -p $tdir/holder &&
+	mkdir -p $tdir/holder.$uuid &&
 	umount -l $tdir || exit 1
 done
 rmdir $tdir

--- a/test/zdtm_umount_cgroups
+++ b/test/zdtm_umount_cgroups
@@ -4,12 +4,14 @@
 
 cat /proc/self/cgroup | grep -q zdtmtst.defaultroot || exit 0
 
+uuid=$1
+
 tdir=`mktemp -d zdtm.XXXXXX`
 for i in "zdtmtst" "zdtmtst.defaultroot"; do
 	mount -t cgroup -o none,name=$i zdtm $tdir || { rmdir $tdir; exit 1; }
 	# remove a fake group if exists
-	if [ -d "$tdir/holder" ]; then
-		rmdir $tdir/holder || { umount -l $tdir && rmdir $tdir; exit 1; }
+	if [ -d "$tdir/holder.$uuid" ]; then
+		rmdir $tdir/holder.$uuid || { umount -l $tdir && rmdir $tdir; exit 1; }
 	fi
 	umount -l $tdir || exit 1;
 done


### PR DESCRIPTION
zdtm.py mounts two named controllers for tests. In CI, we run zdtm.py a few
times, so we can mount (create) these controllers once from the ci script to
avoid any unwanted effects.

Fixes: #1774