### PR TITLE
criu-ns: add a helper to hold a pid namespace

### DIFF
--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -82,6 +82,27 @@ def run_criu(args):
     raise OSError(errno.ENOENT, "No such command")
 
 
+# pidns_holder creates a process that is reparented to the init.
+#
+# The init process can exit if it doesn't have any child processes and its
+# pidns is destroyed in this case. CRIU dump is running in the target pid
+# namespace and it kills dumped processes at the end. We need to create a
+# holder process to be sure that the pid namespace will not be destroy before
+# criu exits.
+def pidns_holder():
+    r, w = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        pid = os.fork()
+        if pid == 0:
+            os.close(w)
+            # The write end is owned by the parent process and it is closed by
+            # kernel when the parent process exits.
+            os.read(r, 1)
+        sys.exit(0)
+    os.waitpid(pid, 0)
+
+
 def wrap_restore():
     restore_args = sys.argv[1:]
     if '--restore-sibling' in restore_args:
@@ -199,6 +220,8 @@ def wrap_dump():
 
     set_pidns(pid, pid_idx)
     set_mntns(pid)
+
+    pidns_holder()
 
     criu_pid = os.fork()
     if criu_pid == 0:


### PR DESCRIPTION
The init process can exit if it doesn't have any child processes and its
pidns is destroyed in this case. CRIU dump is running in the target pid
namespace and it kills dumped processes at the end. We need to create a
holder process to be sure that the pid namespace will not be destroy
before criu exits.

Fixes: #1775

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
