### PR TITLE
apparmor: Fix -Wfortify-source for Clang

### DIFF
--- a/criu/apparmor.c
+++ b/criu/apparmor.c
@@ -668,7 +668,7 @@ int dump_aa_namespaces(void)
 
 bool check_aa_ns_dumping(void)
 {
-	char contents[48];
+	char contents[49];
 	int major, minor, ret;
 	FILE *f;
 


### PR DESCRIPTION
```
criu/apparmor.c:679:26: error: 'fscanf' may overflow; destination buffer in argument 3 has size 48, but the corresponding specifier may require size 49 [-Werror,-Wfortify-source]
        ret = fscanf(f, "%48s", contents);
```
The buffer size should be at least one larger than the fscanf maximum
field width.

Fixes: 8d992a680ef3 ("lsm: support checkpoint/restore of stacked apparmor profiles")