### PR TITLE
mount: fix -Wunused-but-set-variable for Clang 15

### DIFF
--- a/criu/mount.c
+++ b/criu/mount.c
@@ -1991,6 +1991,7 @@ static int mnt_tree_for_each_reverse(struct mount_info *m, int (*fn)(struct moun
 	int progress = 0;
 
 	MNT_TREE_WALK(m, prev, MNT_WALK_NONE, fn, (struct list_head *)NULL, progress);
+	(void)progress; // Suppress -Wused-but-unset-variable for clang>=15
 
 	return 0;
 }


### PR DESCRIPTION
Since https://reviews.llvm.org/D122271, Clang -Wset-but-unused-variable
gets smarter to warn about unused post-increments.
