### PR TITLE
Makefile: switch to gnu11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,8 @@ export GMON GMONLDOPT
 endif
 
 AFLAGS			+= -D__ASSEMBLY__
-CFLAGS			+= $(USERCFLAGS) $(WARNINGS) $(DEFINES) -iquote include/
-HOSTCFLAGS		+= $(WARNINGS) $(DEFINES) -iquote include/
+CFLAGS			+= $(USERCFLAGS) $(WARNINGS) $(DEFINES) -iquote include/ -std=gnu11
+HOSTCFLAGS		+= $(WARNINGS) $(DEFINES) -iquote include/ -std=gnu11
 export AFLAGS CFLAGS USERCLFAGS HOSTCFLAGS
 
 # Default target


### PR DESCRIPTION
Now that the kernel switched to gnu11, CRIU should follow as there are a couple of kernel files directly included in CRIU.