### PR TITLE
sk-unix: fix bind_on_deleted() return code

### DIFF
--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -1472,7 +1472,7 @@ static int bind_on_deleted(int sk, struct unix_sk_info *ui)
 	char path[PATH_MAX], path_parked[PATH_MAX], *pos;
 	struct sockaddr_un addr;
 	bool renamed = false;
-	int ret;
+	int ret, exit_code = -1;
 
 	if (ui->ue->name.len >= UNIX_PATH_MAX) {
 		pr_err("ghost: Too long name for socket id %#x ino %u name %s\n", ui->ue->id, ui->ue->ino, ui->name);
@@ -1494,10 +1494,9 @@ static int bind_on_deleted(int sk, struct unix_sk_info *ui)
 		}
 
 		if (errno != ENOENT) {
-			ret = -errno;
 			pr_perror("ghost: Can't access %s for socket id %#x ino %u name %s", path, ui->ue->id,
 				  ui->ue->ino, ui->name);
-			return ret;
+			return -1;
 		}
 	}
 
@@ -1508,9 +1507,8 @@ static int bind_on_deleted(int sk, struct unix_sk_info *ui)
 	pr_debug("ghost: socket id %#x ino %u name %s creating %s\n", ui->ue->id, ui->ue->ino, ui->name, pos);
 	ret = mkdirpat(AT_FDCWD, pos, 0755);
 	if (ret) {
-		errno = -ret;
 		pr_perror("ghost: Can't create %s", pos);
-		return ret;
+		return -1;
 	}
 
 	memset(&addr, 0, sizeof(addr));
@@ -1529,10 +1527,9 @@ static int bind_on_deleted(int sk, struct unix_sk_info *ui)
 			pr_debug("ghost: Unlinked stale socket id %#x ino %d name %s\n", ui->ue->id, ui->ue->ino,
 				 path_parked);
 		if (rename(ui->name, path_parked)) {
-			ret = -errno;
 			pr_perror("ghost: Can't rename id %#x ino %u addr %s -> %s", ui->ue->id, ui->ue->ino, ui->name,
 				  path_parked);
-			return ret;
+			return -1;
 		}
 		pr_debug("ghost: id %#x ino %d renamed %s -> %s\n", ui->ue->id, ui->ue->ino, ui->name, path_parked);
 		renamed = true;
@@ -1540,7 +1537,6 @@ static int bind_on_deleted(int sk, struct unix_sk_info *ui)
 
 	ret = bind(sk, (struct sockaddr *)&addr, sizeof(addr.sun_family) + ui->ue->name.len);
 	if (ret < 0) {
-		ret = -errno;
 		pr_perror("ghost: Can't bind on socket id %#x ino %d addr %s", ui->ue->id, ui->ue->ino, ui->name);
 		goto out_rename;
 	}
@@ -1552,9 +1548,10 @@ static int bind_on_deleted(int sk, struct unix_sk_info *ui)
 	ret = keep_deleted(ui);
 	if (ret < 0) {
 		pr_err("ghost: Can't save socket %#x ino %u addr %s into fdstore\n", ui->ue->id, ui->ue->ino, ui->name);
-		ret = -EIO;
+		goto out;
 	}
 
+	exit_code = 0;
 out:
 	/*
 	 * Once everything is ready, just remove the socket from the
@@ -1562,14 +1559,14 @@ out:
 	 */
 	ret = unlinkat(AT_FDCWD, ui->name, 0);
 	if (ret < 0) {
-		ret = -errno;
+		exit_code = -1;
 		pr_perror("ghost: Can't unlink socket %#x ino %u addr %s", ui->ue->id, ui->ue->ino, ui->name);
 	}
 
 out_rename:
 	if (renamed) {
 		if (rename(path_parked, ui->name)) {
-			ret = -errno;
+			exit_code = -1;
 			pr_perror("ghost: Can't rename id %#x ino %u addr %s -> %s", ui->ue->id, ui->ue->ino,
 				  path_parked, ui->name);
 		} else {
@@ -1598,7 +1595,7 @@ out_rename:
 		}
 	}
 
-	return 0;
+	return exit_code;
 }
 
 static int bind_unix_sk(int sk, struct unix_sk_info *ui)
@@ -1643,8 +1640,6 @@ static int bind_unix_sk(int sk, struct unix_sk_info *ui)
 	if (ui->flags & USK_GHOST_FDSTORE) {
 		pr_debug("ghost: bind id %#x ino %u addr %s\n", ui->ue->id, ui->ue->ino, ui->name);
 		ret = bind_on_deleted(sk, ui);
-		if (ret)
-			errno = -ret;
 	} else {
 		pr_debug("bind id %#x ino %u addr %s\n", ui->ue->id, ui->ue->ino, ui->name);
 		ret = bind(sk, (struct sockaddr *)&addr, sizeof(addr.sun_family) + ui->ue->name.len);


### PR DESCRIPTION
Commit d0308e5ecc1c ("sk-unix: make criu respect existing files while restoring ghost unix socket fd") broke return codes for bind_on_deleted(). Not only function will always return 0, but setting ret is pointless since it will be overriden by unlink() and rename()
~~Fix this by adding new err variable to store first-encountered error.~~
Simpilfy return codes and errno juggling. No one is relying on it. Also all encountered errors already print some info.
