### PR TITLE
criu: generate unique socket names

### DIFF
--- a/compel/include/uapi/infect-util.h
+++ b/compel/include/uapi/infect-util.h
@@ -3,6 +3,12 @@
 
 #include "common/compiler.h"
 
+/*
+ * compel_run_id is a unique value of the current run. It can be used to
+ * generate resource ID-s to avoid conflicts with other processes.
+ */
+extern uint64_t compel_run_id;
+
 struct parasite_ctl;
 extern int __must_check compel_util_send_fd(struct parasite_ctl *ctl, int fd);
 extern int compel_util_recv_fd(struct parasite_ctl *ctl, int *pfd);

--- a/compel/src/lib/infect-util.c
+++ b/compel/src/lib/infect-util.c
@@ -7,6 +7,8 @@
 #include "infect-rpc.h"
 #include "infect-util.h"
 
+uint64_t compel_run_id;
+
 int compel_util_send_fd(struct parasite_ctl *ctl, int fd)
 {
 	int sk;

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <sys/wait.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -364,7 +365,7 @@ static int gen_parasite_saddr(struct sockaddr_un *saddr, int key)
 	int sun_len;
 
 	saddr->sun_family = AF_UNIX;
-	snprintf(saddr->sun_path, UNIX_PATH_MAX, "X/crtools-pr-%d", key);
+	snprintf(saddr->sun_path, UNIX_PATH_MAX, "X/crtools-pr-%d-%" PRIx64, key, compel_run_id);
 
 	sun_len = SUN_LEN(saddr);
 	*saddr->sun_path = '\0';

--- a/criu/fdstore.c
+++ b/criu/fdstore.c
@@ -12,6 +12,7 @@
 #include "xmalloc.h"
 #include "rst-malloc.h"
 #include "log.h"
+#include "util.h"
 
 /* clang-format off */
 static struct fdstore_desc {
@@ -56,7 +57,8 @@ int fdstore_init(void)
 	}
 
 	addr.sun_family = AF_UNIX;
-	addrlen = snprintf(addr.sun_path, sizeof(addr.sun_path), "X/criu-fdstore-%" PRIx64, st.st_ino);
+	addrlen = snprintf(addr.sun_path, sizeof(addr.sun_path), "X/criu-fdstore-%" PRIx64 "-%" PRIx64, st.st_ino,
+			   criu_run_id);
 	addrlen += sizeof(addr.sun_family);
 
 	addr.sun_path[0] = 0;

--- a/criu/pidfd-store.c
+++ b/criu/pidfd-store.c
@@ -100,7 +100,8 @@ int init_pidfd_store_sk(pid_t pid, int sk)
 			goto err;
 		}
 
-		addrlen = snprintf(addr.sun_path, sizeof(addr.sun_path), "X/criu-pidfd-store-%d-%d", pid, sk);
+		addrlen = snprintf(addr.sun_path, sizeof(addr.sun_path), "X/criu-pidfd-store-%d-%d-%" PRIx64, pid, sk,
+				   criu_run_id);
 		addrlen += sizeof(addr.sun_family);
 
 		addr.sun_path[0] = 0;

--- a/criu/unittest/mock.c
+++ b/criu/unittest/mock.c
@@ -2,6 +2,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 int add_external(char *key)
@@ -141,3 +142,5 @@ int check_mount_v2(void)
 {
 	return 0;
 }
+
+uint64_t compel_run_id;

--- a/criu/util.c
+++ b/criu/util.c
@@ -52,6 +52,8 @@
 #include "cr-errno.h"
 #include "action-scripts.h"
 
+#include "compel/infect-util.h"
+
 #define VMA_OPT_LEN 128
 
 static int xatol_base(const char *string, long *number, int base)
@@ -1816,6 +1818,7 @@ void util_init()
 
 	clock_gettime(CLOCK_MONOTONIC, &tp);
 	criu_run_id = ((uint64_t)getpid() << 32) + tp.tv_sec + tp.tv_nsec;
+	compel_run_id = criu_run_id;
 }
 
 /*


### PR DESCRIPTION
CRIU has a few places where it creates unix sockets and their names have to be
unique for each criu run.

Fixes: #1798
