### PR TITLE
criu: fail migration if data was sent to an in-flight socket

### DIFF
--- a/test/zdtm/lib/zdtmtst.h
+++ b/test/zdtm/lib/zdtmtst.h
@@ -126,11 +126,25 @@ extern int write_pidfile(int pid);
 /* message helpers */
 extern int test_log_init(const char *outfile, const char *suffix);
 extern int zdtm_seccomp;
-#define pr_err(format, arg...) test_msg("ERR: %s:%d: " format, __FILE__, __LINE__, ##arg)
-#define pr_perror(format, arg...) \
-	test_msg("ERR: %s:%d: " format " (errno = %d (%s))\n", __FILE__, __LINE__, ##arg, errno, strerror(errno))
-#define fail(format, arg...) \
-	test_msg("FAIL: %s:%d: " format " (errno = %d (%s))\n", __FILE__, __LINE__, ##arg, errno, strerror(errno))
+#define pr_err(format, arg...)                                              \
+	({                                                                  \
+		test_msg("ERR: %s:%d: " format, __FILE__, __LINE__, ##arg); \
+		1;                                                          \
+	})
+
+#define pr_perror(format, arg...)                                                                        \
+	({                                                                                               \
+		test_msg("ERR: %s:%d: " format " (errno = %d (%s))\n", __FILE__, __LINE__, ##arg, errno, \
+			 strerror(errno));                                                               \
+		1;                                                                                       \
+	})
+
+#define fail(format, arg...)                                                                              \
+	({                                                                                                \
+		test_msg("FAIL: %s:%d: " format " (errno = %d (%s))\n", __FILE__, __LINE__, ##arg, errno, \
+			 strerror(errno));                                                                \
+		1;                                                                                        \
+	})
 #define skip(format, arg...) test_msg("SKIP: %s:%d: " format "\n", __FILE__, __LINE__, ##arg)
 #define pass()		     test_msg("PASS\n")
 

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -348,6 +348,10 @@ TST_FILE	=				\
 		socket_close_data01		\
 		fifo_upon_unix_socket00		\
 		fifo_upon_unix_socket01		\
+		sk-unix-listen01		\
+		sk-unix-listen02		\
+		sk-unix-listen03		\
+		sk-unix-listen04		\
 
 TST_DIR		=				\
 		cwd00				\
@@ -664,6 +668,10 @@ bpf_hash:		LDLIBS += -lbpf
 bpf_array:		LDLIBS += -lbpf
 
 fifo_upon_unix_socket01:	CFLAGS += -DFIFO_UPON_UNIX01
+
+sk-unix-listen02: CFLAGS += -DSK_UNIX_LISTEN02
+sk-unix-listen03: CFLAGS += -DSK_UNIX_LISTEN03
+sk-unix-listen04: CFLAGS += -DSK_UNIX_LISTEN02 -DSK_UNIX_LISTEN03
 
 $(LIB):	force
 	$(Q) $(MAKE) -C $(LIBDIR)

--- a/test/zdtm/static/sk-unix-listen01.c
+++ b/test/zdtm/static/sk-unix-listen01.c
@@ -1,0 +1,117 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <sys/un.h>
+#include <sys/stat.h>
+#include <sys/mount.h>
+#include <limits.h>
+#include <fcntl.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Test in-flight unix sockets with data in them\n";
+const char *test_author = "Andrei Vagin <avagin@gmail.com>";
+
+#define SK_DATA "packet"
+
+char *filename;
+TEST_OPTION(filename, string, "socket file name", 1);
+
+#define TEST_MODE 0640
+
+#ifdef ZDTM_UNIX_SEQPACKET
+#define SOCK_TYPE SOCK_SEQPACKET
+#else
+#define SOCK_TYPE SOCK_STREAM
+#endif
+
+int main(int argc, char *argv[])
+{
+	struct sockaddr_un addr;
+	unsigned int addrlen;
+	int ssk, sk;
+
+	char path[PATH_MAX];
+	char *cwd;
+	int ret;
+
+	test_init(argc, argv);
+
+	cwd = get_current_dir_name();
+	if (!cwd)
+		return pr_perror("get_current_dir_name");
+
+	snprintf(path, sizeof(path), "%s/%s", cwd, filename);
+	unlink(path);
+
+	addr.sun_family = AF_UNIX;
+	addrlen = strlen(filename);
+	if (addrlen > sizeof(addr.sun_path))
+		return pr_err("address is too long");
+	memcpy(addr.sun_path, filename, addrlen);
+	addrlen += sizeof(addr.sun_family);
+
+	ssk = socket(AF_UNIX, SOCK_TYPE, 0);
+	if (ssk == -1)
+		return pr_perror("socket");
+
+	sk = socket(AF_UNIX, SOCK_TYPE, 0);
+	if (sk < 0)
+		return pr_perror("socket");
+
+	ret = bind(ssk, (struct sockaddr *)&addr, addrlen);
+	if (ret)
+		return pr_perror("bind");
+
+	ret = listen(ssk, 16);
+	if (ret)
+		return pr_perror("listen");
+
+	if (connect(sk, (struct sockaddr *)&addr, addrlen))
+		return pr_perror("connect");
+
+#ifdef SK_UNIX_LISTEN02
+	{
+		char buf[64];
+		memset(buf, 0, sizeof(buf));
+		write(sk, SK_DATA, sizeof(SK_DATA));
+	}
+#endif
+
+#ifdef SK_UNIX_LISTEN03
+	close(sk);
+	sk = -1;
+#endif
+
+	test_daemon();
+	test_waitsig();
+
+	if (sk != -1)
+		close(sk);
+
+	ret = accept(ssk, NULL, NULL);
+	if (ret < 0)
+		return fail("accept");
+
+#ifdef SK_UNIX_LISTEN02
+	{
+		char buf[64];
+		if (read(ret, &buf, sizeof(buf)) != sizeof(SK_DATA))
+			return pr_perror("read");
+
+		if (strcmp(buf, SK_DATA))
+			return fail("data corrupted");
+	}
+#endif
+
+	close(ssk);
+	unlink(path);
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/sk-unix-listen02.c
+++ b/test/zdtm/static/sk-unix-listen02.c
@@ -1,0 +1,1 @@
+sk-unix-listen01.c

--- a/test/zdtm/static/sk-unix-listen02.desc
+++ b/test/zdtm/static/sk-unix-listen02.desc
@@ -1,0 +1,1 @@
+{'flags': 'crfail'}

--- a/test/zdtm/static/sk-unix-listen03.c
+++ b/test/zdtm/static/sk-unix-listen03.c
@@ -1,0 +1,1 @@
+sk-unix-listen01.c

--- a/test/zdtm/static/sk-unix-listen03.desc
+++ b/test/zdtm/static/sk-unix-listen03.desc
@@ -1,0 +1,1 @@
+{'flags': 'crfail'}

--- a/test/zdtm/static/sk-unix-listen04.c
+++ b/test/zdtm/static/sk-unix-listen04.c
@@ -1,0 +1,1 @@
+sk-unix-listen01.c

--- a/test/zdtm/static/sk-unix-listen04.desc
+++ b/test/zdtm/static/sk-unix-listen04.desc
@@ -1,0 +1,1 @@
+{'flags': 'crfail'}


### PR DESCRIPTION
Before this change, CRIU would just lose that data upon migration. So
it's better to fail migration in this case.

To reproduce the bug one can:
1. Create an AF_UNIX socket and call listen on it.
2. Create a second AF_UNIX socket and call connect to the first one.
3. Send the data to the second socket.
4. Migrate.
5. Call accept on the first socket and then read. There would be no data
   available.

It should be even possible to close the second socket before migration.
This would cause accept to hang because CRIU totally misses a closed
in-flight socket.