### PR TITLE
Shellcheck followup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,18 @@ jobs:
       image: registry.fedoraproject.org/fedora:latest
     steps:
     - name: Install tools
-      run: sudo dnf -y install git make python3-flake8 ShellCheck clang-tools-extra which findutils codespell git-clang-format
+      run: sudo dnf -y install git make python3-flake8 xz clang-tools-extra which codespell git-clang-format
+
+    # TODO: remove this and use ShellCheck from repo once F37 with ShellCheck 0.8.0 is out.
+    - name: install shellcheck
+      env:
+        VERSION: v0.8.0
+        BASEURL: https://github.com/koalaman/shellcheck/releases/download
+        SHA256: f4bce23c11c3919c1b20bcb0f206f6b44c44e26f2bc95f8aa708716095fa0651
+      run: |
+        curl -sSfL --retry 5 $BASEURL/$VERSION/shellcheck-$VERSION.linux.x86_64.tar.xz |
+          tar xfJ - -C /usr/local/bin --strip 1 shellcheck-$VERSION/shellcheck
+        sha256sum --strict --check - <<<"$SHA256 /usr/local/bin/shellcheck"
 
     - uses: actions/checkout@v2
 

--- a/Makefile
+++ b/Makefile
@@ -433,10 +433,10 @@ lint:
 	shellcheck --version
 	shellcheck scripts/*.sh
 	shellcheck scripts/ci/*.sh scripts/ci/apt-install
-	shellcheck test/others/crit/*.sh
-	shellcheck test/others/libcriu/*.sh
-	shellcheck test/others/crit/*.sh test/others/criu-coredump/*.sh
-	shellcheck test/others/config-file/*.sh
+	shellcheck -x test/others/crit/*.sh
+	shellcheck -x test/others/libcriu/*.sh
+	shellcheck -x test/others/crit/*.sh test/others/criu-coredump/*.sh
+	shellcheck -x test/others/config-file/*.sh
 	codespell
 	# Do not append \n to pr_perror or fail
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*\\n"'

--- a/scripts/ci/apt-install
+++ b/scripts/ci/apt-install
@@ -15,8 +15,7 @@ while true; do
 	if [ "${install_retry_counter}" -gt "${max_apt_retries}" ]; then
 		exit 1
 	fi
-	# shellcheck disable=SC2068
-	apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-install-recommends $@ && break
+	apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-install-recommends "$@" && break
 
 	# In case it is a network error let's wait a bit.
 	echo "Retrying attempt ${install_retry_counter}"

--- a/scripts/ci/asan.sh
+++ b/scripts/ci/asan.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=2044
-
 set -x
 
 cat /proc/self/mountinfo
@@ -13,7 +11,8 @@ chmod 0777 test/zdtm/static
 ./test/zdtm.py run -a --keep-going -k always --parallel 4 -x zdtm/static/rtc "$@"
 ret=$?
 
-for i in $(find / -name 'asan.log*'); do
+shopt -s globstar nullglob
+for i in /**/asan.log*; do
 	echo "$i"
 	echo ========================================
 	cat "$i"

--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# shellcheck disable=SC1091,SC2015
+# shellcheck disable=SC2015
 
 set -x -e -o pipefail
 
@@ -19,6 +19,7 @@ add-apt-repository \
 
 ./apt-install docker-ce
 
+# shellcheck source=/dev/null
 . /etc/lsb-release
 
 # overlayfs with current Ubuntu kernel breaks CRIU

--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC2015
-
 set -x -e -o pipefail
 
 ./apt-install \

--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -31,7 +31,6 @@ rm -rf "${tmp_dir}"
 export STORAGE_DRIVER=vfs
 podman --storage-driver vfs info
 
-# shellcheck disable=SC2016
 podman run --name cr -d docker.io/library/alpine /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
 
 sleep 1

--- a/scripts/protobuf-gen.sh
+++ b/scripts/protobuf-gen.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-# shellcheck disable=SC2013,SC1004
-
 TR="y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
 
-for x in $(sed -n '/PB_AUTOGEN_START/,/PB_AUTOGEN_STOP/ {
+sed -n '/PB_AUTOGEN_START/,/PB_AUTOGEN_STOP/ {
 		/PB_AUTOGEN_ST/d;
+		/^[ \t]*$/d;
 		s/,.*$//;
 		s/\tPB_//;
 		p;
-	   }' criu/include/protobuf-desc.h); do
+	   }' criu/include/protobuf-desc.h | \
+while IFS= read -r x; do
 	x_la=$(echo "$x" | sed $TR)
 	x_uf=$(echo "$x" | sed -nr 's/^./&#\\\
 /;

--- a/test/others/config-file/run.sh
+++ b/test/others/config-file/run.sh
@@ -11,7 +11,7 @@
 
 set -xbm
 
-#shellcheck disable=SC1091
+# shellcheck source=test/others/env.sh
 source ../env.sh
 
 if [ ! -d /etc/criu ]; then

--- a/test/others/crit/test.sh
+++ b/test/others/crit/test.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# shellcheck disable=SC1091,SC2002
+# shellcheck disable=SC2002
 
 set -x
 
+# shellcheck source=test/others/env.sh
 source ../env.sh
 
 images_list=""

--- a/test/others/crit/test.sh
+++ b/test/others/crit/test.sh
@@ -6,7 +6,7 @@ set -x
 # shellcheck source=test/others/env.sh
 source ../env.sh
 
-images_list=""
+images_list=()
 
 function gen_imgs {
 	PID=$(../loop)
@@ -17,15 +17,15 @@ function gen_imgs {
 		exit 1
 	fi
 
-	images_list=$(ls -1 ./*.img)
-	if [ -z "$images_list" ]; then
+	images_list=(./*.img)
+	if [ "${#images_list[@]}" -eq 0 ]; then
 		echo "Failed to generate images"
 		exit 1
 	fi
 }
 
 function run_test1 {
-	for x in $images_list
+	for x in "${images_list[@]}"
 	do
 		echo "=== $x"
 		if [[ $x == *pages* ]]; then
@@ -46,9 +46,7 @@ function run_test1 {
 
 
 function run_test2 {
-	mapfile -t array <<< "$images_list"
-
-	PROTO_IN=${array[0]}
+	PROTO_IN="${images_list[0]}"
 	JSON_IN=$(mktemp -p ./ tmp.XXXXXXXXXX.json)
 	OUT=$(mktemp -p ./ tmp.XXXXXXXXXX.log)
 

--- a/test/others/criu-coredump/test.sh
+++ b/test/others/criu-coredump/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -x
-# shellcheck disable=SC1091
+# shellcheck source=test/others/env.sh
 source ../env.sh || exit 1
 
 function gen_imgs {

--- a/test/others/libcriu/run.sh
+++ b/test/others/libcriu/run.sh
@@ -9,7 +9,7 @@ TEST_LOG="${TEST_DIR}/test.log"
 DUMP_LOG="${TEST_DIR}/dump.log"
 RESTORE_LOG="${TEST_DIR}/restore.log"
 
-# shellcheck disable=1091
+# shellcheck source=test/others/env.sh
 source "${MAIN_DIR}/../env.sh" || exit 1
 
 echo "== Clean"


### PR DESCRIPTION
1. Update shellcheck used in CI to the latest version (v0.7.2 -> v0.8.0).
2. Fix shellcheck warnings that were previously disabled (except for one).