### PR TITLE
[WIP] Support libbpf >= 0.7

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -19,6 +19,9 @@ ifeq ($(call pkg-config-check,libbpf),y)
         LIBS_FEATURES	+= -lbpf
         FEATURE_DEFINES	+= -DCONFIG_HAS_LIBBPF
         export CONFIG_HAS_LIBBPF := y
+        ifeq ($(call try-cc,$(FEATURE_TEST_BPF_MAP_CREATE),-lbpf),true)
+                FEATURE_DEFINES += -DCONFIG_HAS_BPF_MAP_CREATE
+        endif
 endif
 
 ifeq ($(call pkg-config-check,libdrm),y)

--- a/scripts/feature-tests.mak
+++ b/scripts/feature-tests.mak
@@ -196,3 +196,15 @@ int main(void)
 	return 0;
 }
 endef
+
+define FEATURE_TEST_BPF_MAP_CREATE
+
+#include <bpf/bpf.h>
+
+int main(void)
+{
+	/* bpf_map_create is available since libbpf 0.7 */
+	return bpf_map_create(BPF_MAP_TYPE_UNSPEC, \"foo\", 0, 0, 0, NULL);
+}
+
+endef


### PR DESCRIPTION
Currently, the compilation on Arch Linux (which now uses libbpf 0.7)
fails with:

	criu/bpfmap.c: In function ‘bpfmap_open’:
	criu/bpfmap.c:289:9: error: ‘bpf_create_map_xattr’ is deprecated: libbpf v0.7+: use bpf_map_create() instead [-Werror=deprecated-declarations]

Add a feature test for and use bpf_map_create if available.

**TODO: fix `test/zdtm/static/bpf_hash.c`**