### PR TITLE
[RFC] Add SIGTSTP support

### DIFF
--- a/Documentation/compel.txt
+++ b/Documentation/compel.txt
@@ -97,7 +97,10 @@ Following steps are performed to infect the victim process:
     - execute system call: *int compel_syscall(ctl, int syscall_nr, long *ret, int arg ...);*
     - infect victim: *int compel_infect(ctl, nr_thread, size_of_args_area);*
     - cure the victim: *int compel_cure(ctl);* //ctl pointer is freed by this call
-    - Resume victim: *int compel_resume_task(pid, orig_state, state);*
+    - Resume victim: *int compel_resume_task(pid, orig_state, state)* or
+    *int compel_resume_task_sig(pid, orig_state, state, stop_signo).*
+    //compel_resume_task_sig() could be used in case when victim is in stopped state.
+    stop_signo could be read by calling compel_parse_stop_signo().
 
 *ctl* must be configured with blob information by calling *PREFIX_setup_c_header()*, with ctl as its argument.
 *PREFIX* is the argument given to *-p* when calling hgen, else it is deduced from file name.

--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -18,6 +18,7 @@ extern int __must_check compel_interrupt_task(int pid);
 struct seize_task_status {
 	unsigned long long sigpnd;
 	unsigned long long shdpnd;
+	unsigned long long sigblk;
 	char state;
 	int vpid;
 	int ppid;
@@ -30,7 +31,9 @@ extern int __must_check compel_wait_task(int pid, int ppid,
 					 struct seize_task_status *st, void *data);
 
 extern int __must_check compel_stop_task(int pid);
+extern int __must_check compel_parse_stop_signo(int pid);
 extern int compel_resume_task(pid_t pid, int orig_state, int state);
+extern int compel_resume_task_sig(pid_t pid, int orig_state, int state, int stop_signo);
 
 struct parasite_ctl;
 struct parasite_thread_ctl;

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -781,6 +781,11 @@ static int dump_task_core_all(struct parasite_ctl *ctl, struct pstree_item *item
 	core->thread_core->creds->lsm_profile = dmpi(item)->thread_lsms[0]->profile;
 	core->thread_core->creds->lsm_sockcreate = dmpi(item)->thread_lsms[0]->sockcreate;
 
+	if (core->tc->task_state == TASK_STOPPED) {
+		core->tc->has_stop_signo = true;
+		core->tc->stop_signo = item->pid->stop_signo;
+	}
+
 	ret = parasite_dump_thread_leader_seized(ctl, pid, core);
 	if (ret)
 		goto err;

--- a/criu/include/pid.h
+++ b/criu/include/pid.h
@@ -31,6 +31,10 @@ struct pid {
 	pid_t real;
 
 	int state; /* TASK_XXX constants */
+	/* If an item is in stopped state it has a signal number
+	 * that caused task to stop.
+	 */
+	int stop_signo;
 
 	/*
 	 * The @virt pid is one which used in the image itself and keeps

--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -222,6 +222,7 @@ struct pstree_item *__alloc_pstree_item(bool rst)
 	item->pid->ns[0].virt = -1;
 	item->pid->real = -1;
 	item->pid->state = TASK_UNDEF;
+	item->pid->stop_signo = -1;
 	item->born_sid = -1;
 	item->pid->item = item;
 	futex_init(&item->task_st);

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -615,6 +615,9 @@ static int collect_children(struct pstree_item *item)
 		else
 			processes_to_wait--;
 
+		if (ret == TASK_STOPPED)
+			c->pid->stop_signo = compel_parse_stop_signo(pid);
+
 		c->pid->real = pid;
 		c->parent = item;
 		c->pid->state = ret;
@@ -646,7 +649,7 @@ static void unseize_task_and_threads(const struct pstree_item *item, int st)
 	 * the item->state is the state task was in when we seized one.
 	 */
 
-	compel_resume_task(item->pid->real, item->pid->state, st);
+	compel_resume_task_sig(item->pid->real, item->pid->state, st, item->pid->stop_signo);
 
 	if (st == TASK_DEAD)
 		return;
@@ -949,6 +952,9 @@ int collect_pstree(void)
 		ret = TASK_DEAD;
 	else
 		processes_to_wait--;
+
+	if (ret == TASK_STOPPED)
+		root_item->pid->stop_signo = compel_parse_stop_signo(pid);
 
 	pr_info("Seized task %d, state %d\n", pid, ret);
 	root_item->pid->state = ret;

--- a/images/core.proto
+++ b/images/core.proto
@@ -60,6 +60,8 @@ message task_core_entry {
 	// Reserved for container relative start time
 	//optional uint64		start_time	= 19;
 	optional uint64			blk_sigset_extended = 20[(criu).hex = true];
+
+	optional uint32			stop_signo = 21;
 }
 
 message task_kobj_ids_entry {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -184,6 +184,8 @@ TST_NOFILE	:=				\
 		stopped01			\
 		stopped02			\
 		stopped12			\
+		stopped03			\
+		stopped04			\
 		rtc				\
 		clean_mntns			\
 		mntns_rw_ro_rw			\

--- a/test/zdtm/static/stopped03.c
+++ b/test/zdtm/static/stopped03.c
@@ -1,0 +1,161 @@
+#include <signal.h>
+#include <sys/wait.h>
+#include <sys/mman.h>
+
+#include "zdtmtst.h"
+#include "lock.h"
+
+const char *test_doc = "Check, that stopped by SIGTSTP tasks are restored correctly";
+const char *test_author = "Yuriy Vasiliev <yuriy.vasiliev@openvz.org>";
+
+#define STOP_SIGNO SIGTSTP
+const char *stop_sigstr = "SIGTSTP";
+enum {
+	FUTEX_INITIALIZED = 0,
+	TEST_CRIU,
+	TEST_CHECK,
+	TEST_DONE,
+	TEST_EXIT,
+	TEST_EMERGENCY_ABORT,
+};
+
+struct shared {
+	futex_t fstate;
+	int status;
+	int code;
+} * sh;
+
+static int new_pgrp(void)
+{
+	siginfo_t infop;
+	int ret = 1;
+	pid_t pid;
+
+	/*
+	 * Set the PGID to avoid creating an orphaned process group,
+	 * which is not to be affected by terminal-generated stop signals.
+	 */
+	setpgid(0, 0);
+
+	pid = test_fork();
+	if (pid < 0)
+		goto err_cr;
+
+	if (pid == 0) {
+		/* wait for TEST_EXIT or TEST_EMERGENCY_ABORT*/
+		futex_wait_while_lt(&sh->fstate, TEST_EXIT);
+		exit(0);
+	}
+
+	if (kill(pid, STOP_SIGNO)) {
+		pr_perror("Unable to send %s", stop_sigstr);
+		goto err_cr;
+	}
+
+	if (waitid(P_PID, pid, &infop, WNOWAIT | WSTOPPED) < 0) {
+		pr_perror("Unable to waitid %d", pid);
+		goto err_cont;
+	}
+
+	sh->code = infop.si_code;
+	sh->status = infop.si_status;
+
+	/* Return the control back to MAIN worker to do C/R */
+	futex_set_and_wake(&sh->fstate, TEST_CRIU);
+	futex_wait_while_lt(&sh->fstate, TEST_CHECK);
+
+	infop.si_code = 0;
+	infop.si_status = 0;
+
+	if (waitid(P_PID, pid, &infop, WNOWAIT | WSTOPPED) < 0) {
+		pr_perror("Unable to waitid %d", pid);
+		goto err_cont;
+	}
+
+	sh->code = infop.si_code;
+	sh->status = infop.si_status;
+
+	futex_set_and_wake(&sh->fstate, TEST_DONE);
+	futex_wait_while_lt(&sh->fstate, TEST_EXIT);
+
+	ret = 0;
+err_cont:
+	kill(pid, SIGCONT);
+err_cr:
+	if (ret)
+		futex_set_and_wake(&sh->fstate, TEST_EMERGENCY_ABORT);
+	if (pid > 0)
+		wait(NULL);
+
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	int fail = 0;
+	pid_t pid;
+
+	test_init(argc, argv);
+
+	sh = mmap(NULL, sizeof(struct shared), PROT_WRITE | PROT_READ, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+	if (sh == MAP_FAILED) {
+		pr_perror("Failed to alloc shared region");
+		return 1;
+	}
+
+	futex_set(&sh->fstate, FUTEX_INITIALIZED);
+
+	pid = test_fork();
+	if (pid < 0) {
+		fail = 1;
+		goto out;
+	}
+
+	if (pid == 0)
+		exit(new_pgrp());
+
+	/* Wait until pgrp is ready to C/R */
+	futex_wait_while_lt(&sh->fstate, TEST_CRIU);
+	if (futex_get(&sh->fstate) == TEST_EMERGENCY_ABORT) {
+		pr_err("Fail in child worker before C/R\n");
+		fail = 1;
+		goto out;
+	}
+
+	if (sh->code != CLD_STOPPED || sh->status != STOP_SIGNO) {
+		pr_err("Process is not in correct state before C/R."
+		       " Expected stop signo: %d. Get stop signo: %d\n",
+		       STOP_SIGNO, sh->status);
+		fail = 1;
+		goto out;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	futex_set_and_wake(&sh->fstate, TEST_CHECK);
+	futex_wait_while_lt(&sh->fstate, TEST_DONE);
+	if (futex_get(&sh->fstate) == TEST_EMERGENCY_ABORT) {
+		pr_err("Fail in child worker after C/R\n");
+		goto out;
+	}
+
+	if (sh->code != CLD_STOPPED || sh->status != STOP_SIGNO) {
+		fail = 1;
+		pr_err("Process is not in correct state after C/R."
+		       " Expected stop signo: %d. Get stop signo: %d\n",
+		       STOP_SIGNO, sh->status);
+	}
+
+	if (!fail)
+		pass();
+
+	futex_set_and_wake(&sh->fstate, TEST_EXIT);
+out:
+	if (pid > 0)
+		wait(NULL);
+
+	munmap(sh, sizeof(struct shared));
+
+	return fail;
+}

--- a/test/zdtm/static/stopped04.c
+++ b/test/zdtm/static/stopped04.c
@@ -1,0 +1,135 @@
+#include <signal.h>
+#include <sys/wait.h>
+#include <sys/mman.h>
+
+#include "zdtmtst.h"
+#include "lock.h"
+
+const char *test_doc = "Check, that stopped by SIGTSTP tasks are restored correctly";
+const char *test_author = "Yuriy Vasiliev <yuriy.vasiliev@openvz.org>";
+
+const char *stop_sigstr = "SIGTSTP";
+enum {
+	FUTEX_INITIALIZED = 0,
+	TEST_CRIU,
+	TEST_DONE,
+	TEST_EXIT,
+	TEST_EMERGENCY_ABORT,
+};
+
+struct shared {
+	futex_t fstate;
+	int status;
+	int code;
+} * sh;
+
+static int new_pgrp(void)
+{
+	sigset_t sigset;
+	siginfo_t infop;
+	int ret = 1;
+	pid_t pid;
+
+	/*
+	 * Set the PGID to avoid creating an orphaned process group,
+	 * which is not to be affected by terminal-generated stop signals.
+	 */
+	setpgid(0, 0);
+
+	sigemptyset(&sigset);
+	sigaddset(&sigset, SIGTSTP);
+	sigprocmask(SIG_BLOCK, &sigset, NULL);
+
+	pid = test_fork();
+	if (pid < 0)
+		goto err_cr;
+
+	if (pid == 0) {
+		/* wait for TEST_EXIT or TEST_EMERGENCY_ABORT*/
+		futex_wait_while_lt(&sh->fstate, TEST_EXIT);
+		exit(0);
+	}
+
+	if (kill(pid, SIGSTOP)) {
+		pr_perror("Unable to send %s", stop_sigstr);
+		goto err_cr;
+	}
+
+	if (waitid(P_PID, pid, &infop, WNOWAIT | WSTOPPED) < 0) {
+		pr_perror("Unable to waitid %d", pid);
+		goto err_cont;
+	}
+
+	if (kill(pid, SIGTSTP)) {
+		pr_perror("Unable to send %s", stop_sigstr);
+		goto err_cr;
+	}
+
+	/* Return the control back to MAIN worker to do C/R */
+	futex_set_and_wake(&sh->fstate, TEST_CRIU);
+	futex_wait_while_lt(&sh->fstate, TEST_EXIT);
+
+	ret = 0;
+err_cont:
+	kill(pid, SIGCONT);
+err_cr:
+	if (ret)
+		futex_set_and_wake(&sh->fstate, TEST_EMERGENCY_ABORT);
+	if (pid > 0)
+		wait(NULL);
+
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	int fail = 0;
+	pid_t pid;
+
+	test_init(argc, argv);
+
+	sh = mmap(NULL, sizeof(struct shared), PROT_WRITE | PROT_READ, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+	if (sh == MAP_FAILED) {
+		pr_perror("Failed to alloc shared region");
+		return 1;
+	}
+
+	futex_set(&sh->fstate, FUTEX_INITIALIZED);
+
+	pid = test_fork();
+	if (pid < 0) {
+		fail = 1;
+		goto out;
+	}
+
+	if (pid == 0)
+		exit(new_pgrp());
+
+	/* Wait until pgrp is ready to C/R */
+	futex_wait_while_lt(&sh->fstate, TEST_CRIU);
+	if (futex_get(&sh->fstate) == TEST_EMERGENCY_ABORT) {
+		pr_err("Fail in child worker before C/R\n");
+		fail = 1;
+		goto out;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	if (futex_get(&sh->fstate) == TEST_EMERGENCY_ABORT) {
+		pr_err("Fail in child worker after C/R\n");
+		goto out;
+	}
+
+	if (!fail)
+		pass();
+
+	futex_set_and_wake(&sh->fstate, TEST_EXIT);
+out:
+	if (pid > 0)
+		wait(NULL);
+
+	munmap(sh, sizeof(struct shared));
+
+	return fail;
+}


### PR DESCRIPTION
Criu is currently missing SIGTSTP signal support: infect reports unsupported signal.

Add SIGTSTP signal dump and restore. Add a corresponding field in the image, save it only if a task is in the stopped state.

Restore task state by sending desired stop signal if it is present in the image. Fallback to SIGSTOP if it's absent.