### PR TITLE
breakpoint: implement hw breakpoint for arm64 platform

### DIFF
--- a/compel/arch/aarch64/src/lib/include/uapi/asm/breakpoints.h
+++ b/compel/arch/aarch64/src/lib/include/uapi/asm/breakpoints.h
@@ -5,6 +5,37 @@
 #include <sys/types.h>
 #include <stdbool.h>
 
+struct hwbp_cap {
+	char arch;
+	char bp_count;
+};
+
+/* copied from `linux/arch/arm64/include/asm/hw_breakpoint.h` */
+/* Lengths */
+#define ARM_BREAKPOINT_LEN_1 0x1
+#define ARM_BREAKPOINT_LEN_2 0x3
+#define ARM_BREAKPOINT_LEN_3 0x7
+#define ARM_BREAKPOINT_LEN_4 0xf
+#define ARM_BREAKPOINT_LEN_5 0x1f
+#define ARM_BREAKPOINT_LEN_6 0x3f
+#define ARM_BREAKPOINT_LEN_7 0x7f
+#define ARM_BREAKPOINT_LEN_8 0xff
+
+/* Privilege Levels */
+#define AARCH64_BREAKPOINT_EL1 1
+#define AARCH64_BREAKPOINT_EL0 2
+
+/* Breakpoint */
+#define ARM_BREAKPOINT_EXECUTE 0
+
+/* Watchpoints */
+#define ARM_BREAKPOINT_LOAD	1
+#define ARM_BREAKPOINT_STORE	2
+#define AARCH64_ESR_ACCESS_MASK (1 << 6)
+
+#define DISABLE_HBP 0
+#define ENABLE_HBP  1
+
 int ptrace_set_breakpoint(pid_t pid, void *addr);
 int ptrace_flush_breakpoints(pid_t pid, bool restore);
 

--- a/compel/arch/aarch64/src/lib/include/uapi/asm/breakpoints.h
+++ b/compel/arch/aarch64/src/lib/include/uapi/asm/breakpoints.h
@@ -2,14 +2,10 @@
 #define __COMPEL_BREAKPOINTS_H__
 #define ARCH_SI_TRAP TRAP_BRKPT
 
-static inline int ptrace_set_breakpoint(pid_t pid, void *addr)
-{
-	return 0;
-}
+#include <sys/types.h>
+#include <stdbool.h>
 
-static inline int ptrace_flush_breakpoints(pid_t pid)
-{
-	return 0;
-}
+int ptrace_set_breakpoint(pid_t pid, void *addr);
+int ptrace_flush_breakpoints(pid_t pid, bool restore);
 
 #endif

--- a/compel/arch/aarch64/src/lib/include/uapi/asm/sigframe.h
+++ b/compel/arch/aarch64/src/lib/include/uapi/asm/sigframe.h
@@ -43,6 +43,13 @@ struct rt_sigframe {
 			: "x8", "memory")
 /* clang-format on */
 
+#ifdef ARCH_SIGRETURN_ADDR
+#undef ARCH_SIGRETURN_ADDR
+#endif
+
+/* one arm64 instruction is 4 bytes, offset 0x8 standards for the `svc #0` instruction address */
+#define ARCH_SIGRETURN_ADDR(addr) ((void *)(uintptr_t)addr + 0x8)
+
 /* cr_sigcontext is copied from arch/arm64/include/uapi/asm/sigcontext.h */
 struct cr_sigcontext {
 	__u64 fault_address;

--- a/compel/arch/aarch64/src/lib/infect.c
+++ b/compel/arch/aarch64/src/lib/infect.c
@@ -2,7 +2,9 @@
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <sys/uio.h>
+#include <asm/ptrace.h>
 #include <linux/elf.h>
+
 #include <compel/plugins/std/syscall-codes.h>
 #include "common/page.h"
 #include "uapi/compel/asm/infect-types.h"
@@ -10,6 +12,7 @@
 #include "errno.h"
 #include "infect.h"
 #include "infect-priv.h"
+#include "asm/breakpoints.h"
 
 unsigned __page_size = 0;
 unsigned __page_shift = 0;
@@ -177,12 +180,120 @@ unsigned long compel_task_size(void)
 	return task_size;
 }
 
+static struct hwbp_cap *ptrace_get_hwbp_cap(pid_t pid)
+{
+	static struct hwbp_cap info;
+	static int available = -1;
+
+	if (available == -1) {
+		unsigned int val;
+		struct iovec iovec = {
+			.iov_base = &val,
+			.iov_len = sizeof(val),
+		};
+
+		if (ptrace(PTRACE_GETREGSET, pid, NT_ARM_HW_BREAK, &iovec) < 0)
+			available = 0;
+		else {
+			info.arch = (char)((val >> 8) & 0xff);
+			info.bp_count = (char)(val & 0xff);
+
+			available = (info.arch != 0);
+		}
+	}
+
+	return available == 1 ? &info : NULL;
+}
+
 int ptrace_set_breakpoint(pid_t pid, void *addr)
 {
-	return 0;
+	struct hwbp_cap *info = ptrace_get_hwbp_cap(pid);
+	struct user_hwdebug_state regs = {};
+	unsigned int ctrl = 0;
+	struct iovec iovec;
+
+	if (info == NULL || info->bp_count == 0)
+		return 0;
+
+	/*
+	 * The struct is copied from `arch/arm64/include/asm/hw_breakpoint.h` in
+	 * linux kernel:
+	 *  struct arch_hw_breakpoint_ctrl {
+	 *  	__u32 __reserved        : 19,
+	 *  	len             : 8,
+	 *  	type            : 2,
+	 *  	privilege       : 2,
+	 *  	enabled         : 1;
+	 *  };
+	 *
+	 * The part of `struct arch_hw_breakpoint_ctrl` bits meaning is defined
+	 * in <<ARM Architecture Reference Manual for A-profile architecture>>,
+	 * D13.3.2 DBGBCR<n>_EL1, Debug Breakpoint Control Registers.
+	 */
+	ctrl = ARM_BREAKPOINT_LEN_4;
+	ctrl = (ctrl << 2) | ARM_BREAKPOINT_EXECUTE;
+	ctrl = (ctrl << 2) | AARCH64_BREAKPOINT_EL0;
+	ctrl = (ctrl << 1) | ENABLE_HBP;
+	regs.dbg_regs[0].addr = (__u64)addr;
+	regs.dbg_regs[0].ctrl = ctrl;
+	iovec.iov_base = &regs;
+	iovec.iov_len = (offsetof(struct user_hwdebug_state, dbg_regs) + sizeof(regs.dbg_regs[0]));
+
+	if (ptrace(PTRACE_SETREGSET, pid, NT_ARM_HW_BREAK, &iovec))
+		return -1;
+
+	if (ptrace(PTRACE_CONT, pid, NULL, NULL) != 0) {
+		pr_perror("Unable to restart the  stopped tracee process %d", pid);
+		return -1;
+	}
+
+	return 1;
 }
 
 int ptrace_flush_breakpoints(pid_t pid, bool restore)
 {
+	struct hwbp_cap *info = ptrace_get_hwbp_cap(pid);
+	struct user_hwdebug_state regs = {};
+	unsigned int ctrl = 0;
+	struct iovec iovec;
+
+	if (info == NULL || info->bp_count == 0)
+		return 0;
+
+	ctrl = ARM_BREAKPOINT_LEN_4;
+	ctrl = (ctrl << 2) | ARM_BREAKPOINT_EXECUTE;
+	ctrl = (ctrl << 2) | AARCH64_BREAKPOINT_EL0;
+	ctrl = (ctrl << 1) | DISABLE_HBP;
+	regs.dbg_regs[0].addr = 0ul;
+	regs.dbg_regs[0].ctrl = ctrl;
+
+	iovec.iov_base = &regs;
+	iovec.iov_len = (offsetof(struct user_hwdebug_state, dbg_regs) + sizeof(regs.dbg_regs[0]));
+
+	if (ptrace(PTRACE_SETREGSET, pid, NT_ARM_HW_BREAK, &iovec))
+		return -1;
+
+	/*
+	 * It's okay to return directly during checkpointing procedure, the
+	 * program will stop at the `svc` instruction fetching point.
+	 */
+	if (!restore)
+		return 0;
+
+	/*
+	 * The restorer stops at the breakpoint, but segment fault will trigger
+	 * if the function returns here. The reason is that the breakpoint event
+	 * happens before the instruction(`svc`) is fetched, the segment fault
+	 * will trigger once the restorer continues to execute after the
+	 * parasite blob area is mumapped.
+	 * To prevent the above problem, use single step debug tip here. It will
+	 * make restorer to execute `svc` instruction, then stop to the status
+	 * which is the same as using `ptrace(SYSCALL)`.
+	 */
+	if (ptrace(PTRACE_SINGLESTEP, pid, NULL, NULL)) {
+		pr_perror("Unable to restart the %d process", pid);
+		return -1;
+	}
+
 	return 0;
 }

--- a/compel/arch/aarch64/src/lib/infect.c
+++ b/compel/arch/aarch64/src/lib/infect.c
@@ -176,3 +176,13 @@ unsigned long compel_task_size(void)
 			break;
 	return task_size;
 }
+
+int ptrace_set_breakpoint(pid_t pid, void *addr)
+{
+	return 0;
+}
+
+int ptrace_flush_breakpoints(pid_t pid, bool restore)
+{
+	return 0;
+}

--- a/compel/arch/arm/src/lib/include/uapi/asm/breakpoints.h
+++ b/compel/arch/arm/src/lib/include/uapi/asm/breakpoints.h
@@ -2,12 +2,14 @@
 #define __COMPEL_BREAKPOINTS_H__
 #define ARCH_SI_TRAP TRAP_BRKPT
 
+#include <stdbool.h>
+
 static inline int ptrace_set_breakpoint(pid_t pid, void *addr)
 {
 	return 0;
 }
 
-static inline int ptrace_flush_breakpoints(pid_t pid)
+static inline int ptrace_flush_breakpoints(pid_t pid, bool restore)
 {
 	return 0;
 }

--- a/compel/arch/mips/src/lib/include/uapi/asm/breakpoints.h
+++ b/compel/arch/mips/src/lib/include/uapi/asm/breakpoints.h
@@ -1,6 +1,9 @@
 #ifndef __COMPEL_BREAKPOINTS_H__
 #define __COMPEL_BREAKPOINTS_H__
 #define ARCH_SI_TRAP TRAP_BRKPT
+
+#include <stdbool.h>
+
 extern int ptrace_set_breakpoint(pid_t pid, void *addr);
-extern int ptrace_flush_breakpoints(pid_t pid);
+extern int ptrace_flush_breakpoints(pid_t pid, bool restore);
 #endif

--- a/compel/arch/mips/src/lib/infect.c
+++ b/compel/arch/mips/src/lib/infect.c
@@ -232,7 +232,7 @@ int ptrace_set_breakpoint(pid_t pid, void *addr)
 	return 0;
 }
 
-int ptrace_flush_breakpoints(pid_t pid)
+int ptrace_flush_breakpoints(pid_t pid, bool restore)
 {
 	return 0;
 }

--- a/compel/arch/ppc64/src/lib/include/uapi/asm/breakpoints.h
+++ b/compel/arch/ppc64/src/lib/include/uapi/asm/breakpoints.h
@@ -2,12 +2,14 @@
 #define __COMPEL_BREAKPOINTS_H__
 #define ARCH_SI_TRAP TRAP_BRKPT
 
+#include <stdbool.h>
+
 static inline int ptrace_set_breakpoint(pid_t pid, void *addr)
 {
 	return 0;
 }
 
-static inline int ptrace_flush_breakpoints(pid_t pid)
+static inline int ptrace_flush_breakpoints(pid_t pid, bool restore)
 {
 	return 0;
 }

--- a/compel/arch/s390/src/lib/include/uapi/asm/breakpoints.h
+++ b/compel/arch/s390/src/lib/include/uapi/asm/breakpoints.h
@@ -2,12 +2,14 @@
 #define __COMPEL_BREAKPOINTS_H__
 #define ARCH_SI_TRAP TRAP_BRKPT
 
+#include <stdbool.h>
+
 static inline int ptrace_set_breakpoint(pid_t pid, void *addr)
 {
 	return 0;
 }
 
-static inline int ptrace_flush_breakpoints(pid_t pid)
+static inline int ptrace_flush_breakpoints(pid_t pid, bool restore)
 {
 	return 0;
 }

--- a/compel/arch/x86/src/lib/include/uapi/asm/breakpoints.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/breakpoints.h
@@ -1,6 +1,9 @@
 #ifndef __COMPEL_BREAKPOINTS_H__
 #define __COMPEL_BREAKPOINTS_H__
 #define ARCH_SI_TRAP SI_KERNEL
+
+#include <stdbool.h>
+
 extern int ptrace_set_breakpoint(pid_t pid, void *addr);
-extern int ptrace_flush_breakpoints(pid_t pid);
+extern int ptrace_flush_breakpoints(pid_t pid, bool restore);
 #endif

--- a/compel/arch/x86/src/lib/infect.c
+++ b/compel/arch/x86/src/lib/infect.c
@@ -608,7 +608,7 @@ int ptrace_set_breakpoint(pid_t pid, void *addr)
 	return 1;
 }
 
-int ptrace_flush_breakpoints(pid_t pid)
+int ptrace_flush_breakpoints(pid_t pid, bool restore)
 {
 	/* Disable the breakpoint */
 	if (ptrace(PTRACE_POKEUSER, pid, offsetof(struct user, u_debugreg[DR_CONTROL]), 0)) {

--- a/compel/include/uapi/sigframe-common.h
+++ b/compel/include/uapi/sigframe-common.h
@@ -33,6 +33,10 @@ struct rt_sigframe;
 #define SI_PAD_SIZE ((SI_MAX_SIZE - __ARCH_SI_PREAMBLE_SIZE) / sizeof(int))
 #endif
 
+#ifndef ARCH_SIGRETURN_ADDR
+#define ARCH_SIGRETURN_ADDR(addr) ((void *)(uintptr_t)addr)
+#endif
+
 typedef struct rt_siginfo {
 	int si_signo;
 	int si_errno;

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -665,7 +665,7 @@ static int parasite_init_daemon(struct parasite_ctl *ctl)
 		goto err;
 	}
 
-	ctl->sigreturn_addr = (void *)(uintptr_t)args->sigreturn_addr;
+	ctl->sigreturn_addr = ARCH_SIGRETURN_ADDR(args->sigreturn_addr);
 	ctl->daemonized = true;
 	pr_info("Parasite %d has been switched to daemon mode\n", pid);
 	return 0;

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -1357,7 +1357,7 @@ static int parasite_fini_seized(struct parasite_ctl *ctl)
 	if (compel_stop_on_syscall(1, __NR(rt_sigreturn, 0), __NR(rt_sigreturn, 1), flag))
 		return -1;
 
-	if (ptrace_flush_breakpoints(pid))
+	if (ptrace_flush_breakpoints(pid, false))
 		return -1;
 
 	/*

--- a/criu/arch/x86/include/asm/restorer.h
+++ b/criu/arch/x86/include/asm/restorer.h
@@ -199,7 +199,7 @@ int restore_gpregs(struct rt_sigframe *f, UserX86RegsEntry *r);
 int restore_nonsigframe_gpregs(UserX86RegsEntry *r);
 
 int ptrace_set_breakpoint(pid_t pid, void *addr);
-int ptrace_flush_breakpoints(pid_t pid);
+int ptrace_flush_breakpoints(pid_t pid, bool restore);
 
 extern int arch_map_vdso(unsigned long map_at, bool compatible);
 

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2075,7 +2075,7 @@ static int clear_breakpoints(void)
 		if (!task_alive(item))
 			continue;
 		for (i = 0; i < item->nr_threads; i++)
-			ret |= ptrace_flush_breakpoints(item->threads[i].real);
+			ret |= ptrace_flush_breakpoints(item->threads[i].real, true);
 	}
 
 	return ret;

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2063,10 +2063,15 @@ static int catch_tasks(bool root_seized, enum trace_flags *flag)
 	return 0;
 }
 
+int __attribute__((weak)) arch_wait_tasks_trap(int nr)
+{
+	return 0;
+}
+
 static int clear_breakpoints(void)
 {
 	struct pstree_item *item;
-	int ret = 0, i;
+	int ret = 0, i, nr = 0;
 
 	if (fault_injected(FI_NO_BREAKPOINTS))
 		return 0;
@@ -2076,9 +2081,10 @@ static int clear_breakpoints(void)
 			continue;
 		for (i = 0; i < item->nr_threads; i++)
 			ret |= ptrace_flush_breakpoints(item->threads[i].real, true);
+		nr += item->nr_threads;
 	}
 
-	return ret;
+	return arch_wait_tasks_trap(nr);
 }
 
 static void finalize_restore(void)

--- a/criu/include/fault-injection.h
+++ b/criu/include/fault-injection.h
@@ -24,13 +24,19 @@ enum faults {
 
 static inline bool __fault_injected(enum faults f, enum faults fi_strategy)
 {
+#ifdef CONFIG_X86_64
 	/*
+	 * Only arm64 and x86_64 platform supports breakpoints. The performance
+	 * degradation happens in x86_64 platform before. Allow arm64 uses
+	 * breakpoints here to accerate the restoration procedure.
+	 *
 	 * Temporary workaround for Xen guests. Breakpoints degrade
 	 * performance linearly, so until we find out the reason,
 	 * let's disable them.
 	 */
 	if (f == FI_NO_BREAKPOINTS)
 		return true;
+#endif
 
 	return fi_strategy == f;
 }

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1418,7 +1418,7 @@ long __export_restore_task(struct task_restore_args *args)
 	n_helpers = args->helpers_n;
 	zombies = args->zombies;
 	n_zombies = args->zombies_n;
-	*args->breakpoint = rst_sigreturn;
+	*args->breakpoint = ARCH_SIGRETURN_ADDR(rst_sigreturn);
 #ifdef ARCH_HAS_LONG_PAGES
 	__page_size = args->page_size;
 #endif


### PR DESCRIPTION
The same as commit [0b1b815](https://github.com/checkpoint-restore/criu/commit/0b1b815), I implement the hardware breakpoint for arm64 platform :-)

I notice the following commit, therefore the feature can't be enabled:
```c
        /*
         * Temporary workaround for Xen guests. Breakpoints degrade
         * performance linearly, so until we find out the reason,
         * let's disable them.
         */
        if (f == FI_NO_BREAKPOINTS)
                return true;
```
I don't know the reason here, and I don't have Xen environment. Besides the arm64 breakpoint, only x86 has this feature, therefore I only disable x86 by macro `CONFIG_X86_64`.

Note: the problem I met before is here #1811 

**NOTICE**:
DOING -- bug: Can't restore `SIGTRAP` signal (testcase `zdtm/static/sigtrap01` failed)