### PR TITLE
cr-dump: do not report success to logs if post-dump script failed

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -2049,7 +2049,7 @@ static int cr_dump_finish(int ret)
 	close_service_fd(CR_PROC_FD_OFF);
 	close_image_dir();
 
-	if (ret) {
+	if (ret || post_dump_ret) {
 		pr_err("Dumping FAILED.\n");
 	} else {
 		write_stats(DUMP_STATS);


### PR DESCRIPTION
It can be confusing to see error from post-dump action script and non
zero return from criu though at the same time see "Dumping finished
successfully" in log. I believe it is logical to consider post-dump
action script as a part of "dump" process so fail in it means that the
whole dump failed.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
