### PR TITLE
test: install criu in /usr

### DIFF
--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -7,7 +7,7 @@ export SKIP_CI_TEST=1
 
 cd ../../
 
-make install
+make install PREFIX=/usr
 
 criu --version
 


### PR DESCRIPTION
GitHub Actions comes with pre-installed criu in /usr. configure scripts looking for CRIU will pickup the pre-installed version in /usr if we do not install CI criu also in /usr.

@rst0git: PTAL (without this the Podman test in https://github.com/checkpoint-restore/criu/pull/1862 fails once we increase the version to 3.17 because crun will pickup the wrong CRIU version)