### PR TITLE
ci: workaround zdtm/static/bridge race with sit module load

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -111,6 +111,9 @@ print_env() {
 	set -x
 }
 
+# FIXME: workaround for the issue https://github.com/checkpoint-restore/criu/issues/1866
+modprobe -v sit || :
+
 print_env
 
 ci_prep

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -91,6 +91,8 @@ print_env() {
 	cat /proc/self/mountinfo || :
 	print_header "Kernel command line"
 	cat /proc/cmdline || :
+	print_header "Kernel modules"
+	lsmod || :
 	print_header "Distribution information"
 	[ -e /etc/lsb-release ] && cat /etc/lsb-release
 	[ -e /etc/redhat-release ] && cat /etc/redhat-release


### PR DESCRIPTION
Let's workaround race between `bridge` and `sit` tests by loading `sit` module before running zdtm suite

See also https://github.com/checkpoint-restore/criu/issues/1866