### PR TITLE
mem: Skip pre-dumping on hugetlb mappings

### DIFF
--- a/test/jenkins/criu-dedup.sh
+++ b/test/jenkins/criu-dedup.sh
@@ -4,7 +4,7 @@
 set -e
 source `dirname $0`/criu-lib.sh
 prep
-./test/zdtm.py run --all --keep-going --report report --parallel 4 -f h --pre 2 --dedup -x maps04 -x maps007 -x maps09 -x maps10 || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 -f h --pre 2 --dedup -x maps04 -x maps007 || fail
 
 # Additionally run these tests as they touch a lot of
 # memory and it makes sense to additionally check it

--- a/test/jenkins/criu-lazy-migration.sh
+++ b/test/jenkins/criu-lazy-migration.sh
@@ -15,7 +15,7 @@ LAZY_MIGRATE_EXCLUDE="-x fifo_loop -x file_locks -x ptrace_sig -x overmount_file
 	       --lazy-migrate $LAZY_EXCLUDE $LAZY_MIGRATE_EXCLUDE || fail
 
 # During pre-dump + lazy-pages we leave VM_NOHUGEPAGE set
-LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02 -x maps09 -x maps10"
+LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02"
 
 # lazy restore from images with pre-dumps
 ./test/zdtm.py run --all --keep-going --report report --parallel 4 -f uns \

--- a/test/jenkins/criu-lazy-pages.sh
+++ b/test/jenkins/criu-lazy-pages.sh
@@ -12,7 +12,7 @@ source `dirname $0`/criu-lazy-common.sh
 	       --lazy-pages $LAZY_EXCLUDE || fail
 
 # During pre-dump + lazy-pages we leave VM_NOHUGEPAGE set
-LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02 -x maps09 -x maps10"
+LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02"
 
 # lazy restore from images with pre-dumps
 ./test/zdtm.py run --all --keep-going --report report --parallel 4 \

--- a/test/jenkins/criu-pre-dump.sh
+++ b/test/jenkins/criu-pre-dump.sh
@@ -5,6 +5,5 @@ set -e
 source `dirname $0`/criu-lib.sh
 prep
 mount_tmpfs_to_dump
-# FIXME: https://github.com/checkpoint-restore/criu/issues/1868
-./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 -x 'maps04' -x 'maps09' -x 'maps10' || fail
-./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --page-server -x 'maps04' -x 'maps09' -x 'maps10' || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 -x 'maps04' || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --page-server -x 'maps04' || fail

--- a/test/jenkins/criu-remote-lazy-pages.sh
+++ b/test/jenkins/criu-remote-lazy-pages.sh
@@ -12,7 +12,7 @@ source `dirname $0`/criu-lazy-common.sh
 	       --remote-lazy-pages $LAZY_EXCLUDE -x maps04 || fail
 
 # During pre-dump + lazy-pages we leave VM_NOHUGEPAGE set
-LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02  -x maps09 -x maps10"
+LAZY_EXCLUDE="$LAZY_EXCLUDE -x maps02"
 
 # lazy restore from "remote" dump with pre-dumps
 ./test/zdtm.py run --all --keep-going --report report --parallel 4 \

--- a/test/jenkins/criu-snap.sh
+++ b/test/jenkins/criu-snap.sh
@@ -5,5 +5,5 @@ set -e
 source `dirname $0`/criu-lib.sh
 prep
 mount_tmpfs_to_dump
-./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --snaps -x 'maps04' -x 'maps09' -x 'maps10' || fail
-./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --snaps --page-server -x 'maps04' -x 'maps09' -x 'maps10' || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --snaps -x 'maps04' || fail
+./test/zdtm.py run --all --keep-going --report report --parallel 4 --pre 3 --snaps --page-server -x 'maps04' || fail


### PR DESCRIPTION
As private hugetlb mappings are not pre-mapped, the content of them is restored
in the the restorer which cannot use page_read->read_pages. As a result, we
cannot recursively read the content of pre-dumped image in the parent directory
and use preadv to read the content from the last dumped image only. Therefore,
it may freeze while restoring when the content of mapping is in pre-dumped image
in parent directory.

We need to skip pre-dumping on hugetlb mappings to resolve the issue.

Fixes: #1868 