### PR TITLE
amdgpu: Set PLUGINDIR to /usr/lib/criu

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -7,7 +7,7 @@ MANDIR		?= $(PREFIX)/share/man
 INCLUDEDIR	?= $(PREFIX)/include
 LIBEXECDIR	?= $(PREFIX)/libexec
 RUNDIR		?= /run
-PLUGINDIR	?= /var/lib/criu
+PLUGINDIR	?= $(PREFIX)/lib/criu
 
 #
 # For recent Debian/Ubuntu with multiarch support.

--- a/criu/include/plugin.h
+++ b/criu/include/plugin.h
@@ -5,7 +5,9 @@
 #include "common/compiler.h"
 #include "common/list.h"
 
-#define CR_PLUGIN_DEFAULT "/var/lib/criu/"
+#ifndef CR_PLUGIN_DEFAULT
+#define CR_PLUGIN_DEFAULT "/usr/lib/criu/"
+#endif
 
 void cr_plugin_fini(int stage, int err);
 int cr_plugin_init(int stage);

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -15,7 +15,7 @@ DEPS_NOK 		:= ;
 include $(__nmk_dir)msg.mk
 
 CC      		:= gcc
-PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
+PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC -DCR_PLUGIN_DEFAULT="$(PLUGINDIR)"
 PLUGIN_LDFLAGS		:= -lpthread -lrt -ldrm -ldrm_amdgpu
 
 ifeq ($(CONFIG_AMDGPU),y)
@@ -50,16 +50,16 @@ clean: amdgpu_plugin_clean amdgpu_plugin_test_clean
 mrproper: clean
 
 install:
-	$(Q) mkdir -p $(PLUGINDIR)
 ifeq ($(CONFIG_AMDGPU),y)
+	$(Q) mkdir -p $(DESTDIR)$(PLUGINDIR)
 	$(E) "  INSTALL " $(PLUGIN_NAME)
-	$(Q) install -m 644 $(PLUGIN_SOBJ) $(PLUGINDIR)
+	$(Q) install -m 644 $(PLUGIN_SOBJ) $(DESTDIR)$(PLUGINDIR)
 endif
 .PHONY: install
 
 uninstall:
 ifeq ($(CONFIG_AMDGPU),y)
 	$(E) " UNINSTALL" $(PLUGIN_NAME)
-	$(Q) $(RM) $(PLUGINDIR)/$(PLUGIN_SOBJ)
+	$(Q) $(RM) $(DESTDIR)$(PLUGINDIR)/$(PLUGIN_SOBJ)
 endif
 .PHONY: uninstall


### PR DESCRIPTION
This patch fixes the following error which appears when building criu packages for Ubuntu/Debian.

	mkdir: cannot create directory '/var/lib/criu': Permission denied
