### PR TITLE
crit: Use same version as criu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,7 @@ lint:
 	flake8 --config=scripts/flake8.cfg test/others/rpc/config_file.py
 	flake8 --config=scripts/flake8.cfg lib/py/images/pb2dict.py
 	flake8 --config=scripts/flake8.cfg scripts/criu-ns
+	flake8 --config=scripts/flake8.cfg scripts/crit-setup.py
 	flake8 --config=scripts/flake8.cfg coredump/
 	shellcheck --version
 	shellcheck scripts/*.sh

--- a/scripts/crit-setup.py
+++ b/scripts/crit-setup.py
@@ -1,10 +1,24 @@
+import os
 from distutils.core import setup
 
+criu_version = "0.0.1"
+env = os.environ
+
+if 'CRIU_VERSION_MAJOR' in env and 'CRIU_VERSION_MINOR' in env:
+    criu_version = '{}.{}'.format(
+        env['CRIU_VERSION_MAJOR'],
+        env['CRIU_VERSION_MINOR']
+    )
+
+    if 'CRIU_VERSION_SUBLEVEL' in env and env['CRIU_VERSION_SUBLEVEL']:
+        criu_version += '.' + env['CRIU_VERSION_SUBLEVEL']
+
 setup(name="crit",
-      version="0.0.1",
+      version=criu_version,
       description="CRiu Image Tool",
       author="CRIU team",
       author_email="criu@openvz.org",
+      license="GPLv2",
       url="https://github.com/checkpoint-restore/criu",
       package_dir={'pycriu': 'lib/py'},
       packages=["pycriu", "pycriu.images"],


### PR DESCRIPTION
Name collision with an abandoned project named 'crit' in pypi causes pip to show crit (CRiu Image Tool) as outdated.  This patch updates crit to use the same version and license as criu.

```console
$ pip show crit
Name: crit
Version: 3.17
Summary: CRiu Image Tool
Home-page: https://github.com/checkpoint-restore/criu
Author: CRIU team
Author-email: criu@openvz.org
License: GPLv2
Location: /usr/local/lib/python3.10/site-packages
Requires: 
Required-by:
```