### PR TITLE
hugetlb: don't dump anonymous private hugetlb mapping using memfd approach

### DIFF
--- a/criu/hugetlb.c
+++ b/criu/hugetlb.c
@@ -35,6 +35,19 @@ int is_hugetlb_dev(dev_t dev, int *hugetlb_size_flag)
 	return 0;
 }
 
+int can_dump_with_memfd_hugetlb(dev_t dev, int *hugetlb_size_flag, const char *file_path, struct vma_area *vma)
+{
+	/*
+	 * Dump the hugetlb backed mapping using memfd_hugetlb when it is not
+	 * anonymous private mapping.
+	 */
+	if (kdat.has_memfd_hugetlb && is_hugetlb_dev(dev, hugetlb_size_flag) &&
+	    !((vma->e->flags & MAP_PRIVATE) && !strncmp(file_path, ANON_HUGEPAGE_PREFIX, ANON_HUGEPAGE_PREFIX_LEN)))
+		return 1;
+
+	return 0;
+}
+
 unsigned long get_size_from_hugetlb_flag(int flag)
 {
 	int i;

--- a/criu/include/hugetlb.h
+++ b/criu/include/hugetlb.h
@@ -4,6 +4,11 @@
 #include <sys/types.h>
 #include <stddef.h>
 
+#include "vma.h"
+
+#define ANON_HUGEPAGE_PREFIX	 "/anon_hugepage"
+#define ANON_HUGEPAGE_PREFIX_LEN (sizeof(ANON_HUGEPAGE_PREFIX) - 1)
+
 enum hugepage_size {
 	HUGETLB_16KB,
 	HUGETLB_64KB,
@@ -46,6 +51,7 @@ struct htlb_info {
 extern struct htlb_info hugetlb_info[HUGETLB_MAX];
 
 int is_hugetlb_dev(dev_t dev, int *hugetlb_size_flag);
+int can_dump_with_memfd_hugetlb(dev_t dev, int *hugetlb_size_flag, const char *file_path, struct vma_area *vma);
 unsigned long get_size_from_hugetlb_flag(int flag);
 
 #ifndef MFD_HUGETLB

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -620,17 +620,16 @@ static int handle_vma(pid_t pid, struct vma_area *vma_area, const char *file_pat
 			pr_info("path: %s\n", file_path);
 			vma_area->e->status |= VMA_AREA_SYSVIPC;
 		} else {
-			/* Dump shmem dev, hugetlb dev (private and share) mappings the same way as memfd
-			 * when possible.
+			/* We dump memfd backed mapping, both normal and hugepage anonymous share
+			 * mapping using memfd approach when possible.
 			 */
 			if (is_memfd(st_buf->st_dev) || is_anon_shmem_map(st_buf->st_dev) ||
-			    (kdat.has_memfd_hugetlb && is_hugetlb_dev(st_buf->st_dev, &hugetlb_flag))) {
+			    can_dump_with_memfd_hugetlb(st_buf->st_dev, &hugetlb_flag, file_path, vma_area)) {
 				vma_area->e->status |= VMA_AREA_MEMFD;
 				vma_area->e->flags |= hugetlb_flag;
 				if (fault_injected(FI_HUGE_ANON_SHMEM_ID))
 					vma_area->e->shmid += FI_HUGE_ANON_SHMEM_ID_BASE;
 			} else if (is_hugetlb_dev(st_buf->st_dev, &hugetlb_flag)) {
-				/* hugetlb mapping but memfd does not support HUGETLB */
 				vma_area->e->flags |= hugetlb_flag;
 				vma_area->e->flags |= MAP_ANONYMOUS;
 


### PR DESCRIPTION
Currently, the content of anonymous private hugetlb mapping is dumped in 2
different images: memfd approach and normal private mapping dumping. In memfd
approach, we dump the content of the backing pseudo file (/anon_hugepage). This
is incorrect and redundant since the mapping is private, the content of backing
file may differ from the content of the mapping. With this commit, we remove the
redundant memfd approach dump and only do the normal private mapping dump on
anonymous hugetlb mapping.

Run zdtm.py run -f h --keep-img always -t zdtm/static/maps09, du -h in the
dumped image directory

Before this commit
	13M     test/dump/zdtm/static/maps09/55/1
After this commit
	8.5M    test/dump/zdtm/static/maps09/55/1

The reduction in size is approximately 4MB which is the size of anonymous
private hugetlb mapping in the test.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
