### PR TITLE
amdgpu/Makefile: Fix include path

### DIFF
--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -2,7 +2,7 @@ PLUGIN_NAME		:= amdgpu_plugin
 PLUGIN_SOBJ		:= amdgpu_plugin.so
 
 
-PLUGIN_INCLUDE  	:= -iquote../../../criu/include
+PLUGIN_INCLUDE  	:= -iquote../../include
 PLUGIN_INCLUDE  	+= -iquote../../criu/include
 PLUGIN_INCLUDE  	+= -iquote../../criu/arch/$(ARCH)/include/
 PLUGIN_INCLUDE  	+= -iquote../../


### PR DESCRIPTION
When building packages for CRIU the source directory might have a name different than `criu`.

Fixes: #1877

Reported-by: @siris