### PR TITLE
seize: check process status before seizing it.

### DIFF
--- a/criu/include/proc_parse.h
+++ b/criu/include/proc_parse.h
@@ -90,6 +90,7 @@ extern unsigned int parse_pid_loginuid(pid_t pid, int *err, bool ignore_noent);
 extern int parse_pid_oom_score_adj(pid_t pid, int *err);
 extern int prepare_loginuid(unsigned int value);
 extern int parse_pid_status(pid_t pid, struct seize_task_status *, void *data);
+extern int pid_is_stopped(pid_t pid);
 extern int parse_file_locks(void);
 extern int get_fd_mntid(int fd, int *mnt_id);
 


### PR DESCRIPTION
Ptrace() hangs forever when seizing stopped & frozen process.
So when using cgroup freezer to freeze process, we should check
whether process is stopped or not before seizing it.

references:
 Discuss in kernel community: https://lore.kernel.org/lkml/20151117193419.GA9993@redhat.com/t/

Signed-off-by: Liu Hua <weldonliu@tencent.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
