### PR TITLE
Fix the check for mnt namespace in criu-ns

### DIFF
--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -153,9 +153,9 @@ def _set_namespace(fd):
         raise OSError(_errno, errno.errorcode[_errno])
 
 
-def is_my_namespace(fd):
+def is_my_namespace(fd, ns):
     """Returns True if fd refers to current namespace"""
-    return os.stat('/proc/self/ns/pid').st_ino != os.fstat(fd).st_ino
+    return os.stat('/proc/self/ns/%s' % ns).st_ino == os.fstat(fd).st_ino
 
 
 def set_pidns(tpid, pid_idx):
@@ -165,7 +165,7 @@ def set_pidns(tpid, pid_idx):
     pid namespace.
     """
     ns_fd = os.open('/proc/%s/ns/pid' % tpid, os.O_RDONLY)
-    if is_my_namespace(ns_fd):
+    if not is_my_namespace(ns_fd, "pid"):
         for line in open('/proc/%s/status' % tpid):
             if not line.startswith('NSpid:'):
                 continue
@@ -190,7 +190,7 @@ def set_mntns(tpid):
     will be the same in target mntns.
     """
     ns_fd = os.open('/proc/%s/ns/mnt' % tpid, os.O_RDONLY)
-    if is_my_namespace(ns_fd):
+    if not is_my_namespace(ns_fd, "mnt"):
         root_st = os.stat('/')
         cwd_st = os.stat('.')
         cwd_path = os.path.realpath('.')


### PR DESCRIPTION
criu-ns script incorrectly compares the pidns fd with mntns fd.
Also reversed the condition in is_my_namespace function to align it
with the function name.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>
