### PR TITLE
util/mount-v2: fix resolve_mountpoint() to always return freeable pointer

### DIFF
--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -403,6 +403,7 @@ TST_DIR		=				\
 		mnt_ext_master			\
 		mnt_ext_dev			\
 		mnt_ext_root			\
+		mnt_root_ext			\
 		mnt_ext_collision		\
 		mntns_pivot_root		\
 		mntns_pivot_root_ro		\

--- a/test/zdtm/static/mnt_root_ext.c
+++ b/test/zdtm/static/mnt_root_ext.c
@@ -1,0 +1,79 @@
+#include <sched.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <linux/limits.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check external mount from host's rootfs";
+const char *test_author = "Pavel Tikhomirov <ptikhomirov@virtuozzo.com>";
+
+char *dirname = "mnt_root_ext.test";
+TEST_OPTION(dirname, string, "directory name", 1);
+
+int main(int argc, char **argv)
+{
+	char *root, testdir[PATH_MAX], nstestdir[PATH_MAX];
+	char *zdtm_newns = getenv("ZDTM_NEWNS");
+	char tmp[] = "/.zdtm_root_ext.tmp";
+
+	root = getenv("ZDTM_ROOT");
+	if (root == NULL) {
+		pr_perror("root");
+		return 1;
+	}
+
+	if (!zdtm_newns) {
+		pr_perror("ZDTM_NEWNS is not set");
+		return 1;
+	} else if (strcmp(zdtm_newns, "1")) {
+		goto test;
+	}
+
+	/* Prepare directories in test root */
+	sprintf(testdir, "%s/%s", root, dirname);
+	mkdir(testdir, 0755);
+
+	/* Prepare directories in criu root */
+	mkdir(tmp, 0755);
+
+	/* Make criu's mntns root mount shared */
+	if (mount(NULL, "/", NULL, MS_SHARED, NULL)) {
+		pr_perror("make shared");
+		return 1;
+	}
+
+	/*
+	 * Create temporary mntns, next mounts will not show up in criu mntns
+	 */
+	if (unshare(CLONE_NEWNS)) {
+		pr_perror("unshare");
+		return 1;
+	}
+
+	/*
+	 * Populate to the tests root host's rootfs subdir
+	 */
+	if (mount(tmp, testdir, NULL, MS_BIND, NULL)) {
+		pr_perror("bind");
+		return 1;
+	}
+test:
+	test_init(argc, argv);
+
+	/*
+	 * Make "external" mount to be slave
+	 */
+	sprintf(nstestdir, "/%s", dirname);
+	if (mount(NULL, nstestdir, NULL, MS_SLAVE, NULL)) {
+		pr_perror("make slave");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	pass();
+
+	return 0;
+}

--- a/test/zdtm/static/mnt_root_ext.desc
+++ b/test/zdtm/static/mnt_root_ext.desc
@@ -1,0 +1,5 @@
+{   'dopts': '--external mnt[/mnt_root_ext.test]:MNT',
+    'feature': 'mnt_id move_mount_set_group',
+    'flavor': 'ns uns',
+    'flags': 'suid',
+    'ropts': '--external mnt[MNT]:.zdtm_root_ext.tmp --no-mntns-compat-mode'}

--- a/test/zdtm/static/mnt_root_ext.hook
+++ b/test/zdtm/static/mnt_root_ext.hook
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+[ "$1" == "--clean" ] || exit 0
+
+rmdir /.zdtm_root_ext.tmp


### PR DESCRIPTION
Else we have a Segmentation fault in __move_mount_set_group() on
xfree(source_mp) if resolve_mountpoint() returned statically allocated
path.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
