### PR TITLE
config: fail on --track-mem option if dirty tracking is not available

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -1115,6 +1115,11 @@ int check_options(void)
 		}
 	}
 
+	if (opts.track_mem && !kdat.has_dirty_track) {
+		pr_err("Tracking memory is not available. Consider omitting --track-mem option.\n");
+		return 1;
+	}
+
 	if (check_namespace_opts()) {
 		pr_err("Error: namespace flags conflict\n");
 		return 1;

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -420,10 +420,6 @@ static int kerndat_get_dirty_track(void)
 	} else {
 	no_dt:
 		pr_info("Dirty tracking support is OFF\n");
-		if (opts.track_mem) {
-			pr_err("Tracking memory is not available\n");
-			return -1;
-		}
 	}
 
 	return 0;


### PR DESCRIPTION
Else we trigger BUG in task_reset_dirty_track():
  Error (criu/mem.c:45): BUG at criu/mem.c:45

The check in kerndat_get_dirty_track() does not work right.

https://github.com/checkpoint-restore/criu/issues/1917

Reported-by: @mrc1119
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
