### PR TITLE
Criu ns tty fix

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -14,6 +14,8 @@
 #include <sys/mount.h>
 #include <elf.h>
 
+#include "tty.h"
+
 #ifndef SEEK_DATA
 #define SEEK_DATA 3
 #define SEEK_HOLE 4
@@ -1688,6 +1690,7 @@ int dump_one_reg_file(int lfd, u32 id, const struct fd_parms *p)
 	int ret;
 	FileEntry fe = FILE_ENTRY__INIT;
 	RegFileEntry rfe = REG_FILE_ENTRY__INIT;
+	bool skip_for_shell_job = false;
 
 	if (!p->link) {
 		if (fill_fdlink(lfd, p, &_link))
@@ -1707,11 +1710,15 @@ int dump_one_reg_file(int lfd, u32 id, const struct fd_parms *p)
 
 	mi = lookup_mnt_id(p->mnt_id);
 	if (mi == NULL) {
-		pr_err("Can't lookup mount=%d for fd=%d path=%s\n", p->mnt_id, p->fd, link->name + 1);
-		return -1;
+		if (opts.shell_job && is_tty(p->stat.st_rdev, p->stat.st_dev)) {
+			skip_for_shell_job = true;
+		} else {
+			pr_err("Can't lookup mount=%d for fd=%d path=%s\n", p->mnt_id, p->fd, link->name + 1);
+			return -1;
+		}
 	}
 
-	if (mnt_is_overmounted(mi)) {
+	if (!skip_for_shell_job && mnt_is_overmounted(mi)) {
 		pr_err("Open files on overmounted mounts are not supported yet\n");
 		return -1;
 	}
@@ -1731,7 +1738,7 @@ int dump_one_reg_file(int lfd, u32 id, const struct fd_parms *p)
 		return -1;
 	}
 
-	if (check_path_remap(link, p, lfd, id, mi->nsid))
+	if (!skip_for_shell_job && check_path_remap(link, p, lfd, id, mi->nsid))
 		return -1;
 	rfe.name = &link->name[1];
 ext:

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -4,6 +4,8 @@ import ctypes.util
 import errno
 import sys
 import os
+import fcntl
+import termios
 
 # <sched.h> constants for unshare
 CLONE_NEWNS = 0x00020000
@@ -124,6 +126,16 @@ def wrap_restore():
     criu_pid = os.fork()
     if criu_pid == 0:
         os.setsid()
+        # Set stdin tty to be a controlling tty of our new session, this is
+        # required by --shell-job option, as for it CRIU would try to set a
+        # process group of restored root task to be a foreground group on the
+        # terminal.
+        if '--shell-job' in restore_args or '-j' in restore_args:
+            if os.isatty(sys.stdin.fileno()):
+                fcntl.ioctl(sys.stdin.fileno(), termios.TIOCSCTTY, 1)
+            else:
+                raise OSError(errno.EINVAL, 'The stdin is not a tty for a --shell-job')
+
         _mount_new_proc()
         run_criu(restore_args)
 


### PR DESCRIPTION
These are (probable) fixes for two errors when using criu-ns:

1. When restoring first time via criu-ns (from criu-ns dump):

```
Error (criu/tty.c:689): tty: Failed to set group 40816 on 0: Inappropriate ioctl for device
```

2. When dumping second time via criu-ns:

```
(00.005678) Error (criu/files-reg.c:1710): Can't lookup mount=29 for fd=0 path=/dev/pts/20
```

Fixes: #1893

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
