### PR TITLE
Allow CRIU to be used as non-root (Take 2)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,6 +69,27 @@ task:
     make -C scripts/ci vagrant-fedora-rawhide
 
 task:
+  name: Vagrant Fedora based test (non-root)
+  environment:
+    HOME: "/root"
+    CIRRUS_WORKING_DIR: "/tmp/criu"
+
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-kvm
+    platform: linux
+    cpu: 4
+    memory: 16G
+    nested_virtualization: true
+
+  setup_script: |
+    scripts/ci/apt-install make gcc pkg-config git perl-modules iproute2 kmod wget cpu-checker
+    sudo kvm-ok
+    ln -sf /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto
+  build_script: |
+    make -C scripts/ci vagrant-fedora-non-root
+
+task:
   name: CentOS Stream 8 based test
   environment:
     HOME: "/root"

--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -155,6 +155,12 @@ not compatible with *--external* *dev*.
             notification message contains a file descriptor for
             the master pty
 
+*--unprivileged*::
+    This option tells *criu* to accept the limitations when running
+    as non-root. Running as non-root requires *criu* at least to have
+    *CAP_SYS_ADMIN* or *CAP_CHECKPOINT_RESTORE*. For details about running
+    *criu* as non-root please consult the *NON-ROOT* section.
+
 *-V*, *--version*::
     Print program version and exit.
 
@@ -876,6 +882,32 @@ via "req.opts.config_file = '/path/to/file'". The values from this
 configuration file will overwrite all other configuration file settings
 or RPC options. *This can lead to undesired behavior of criu and
 should only be used carefully.*
+
+NON-ROOT
+--------
+*criu* can be used as non-root with either the *CAP_SYS_ADMIN* capability
+or with the *CAP_CHECKPOINT_RESTORE* capability introduces in Linux kernel 5.9.
+*CAP_CHECKPOINT_RESTORE* is the minimum that is required.
+
+*criu* also needs either *CAP_SYS_PTRACE* or a value of 0 in
+*/proc/sys/kernel/yama/ptrace_scope* (see *ptrace*(2)) to be able to interrupt
+the process for dumping.
+
+Running *criu* as non-root has many limitations and depending on the process
+to checkpoint and restore it may not be possible.
+
+In addition to *CAP_CHECKPOINT_RESTORE* it is possible to give *criu* additional
+capabilities to enable additional features in non-root mode.
+
+Currently *criu* can benefit from the following additional capabilities:
+
+    - *CAP_NET_ADMIN*
+    - *CAP_SYS_CHROOT*
+    - *CAP_SETUID*
+    - *CAP_SYS_RESOURCE*
+
+Independent of the capabilities it is always necessary to use "*--unprivileged*" to
+accept *criu*'s limitation in non-root mode.
 
 EXAMPLES
 --------

--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -734,6 +734,9 @@ int dump_task_cgroup(struct pstree_item *item, u32 *cg_id, struct parasite_dump_
 	unsigned int n_ctls = 0;
 	struct cg_set *cs;
 
+	if (opts.unprivileged)
+		return 0;
+
 	if (item)
 		pid = item->pid->real;
 	else
@@ -988,6 +991,9 @@ int dump_cgroups(void)
 {
 	CgroupEntry cg = CGROUP_ENTRY__INIT;
 	int ret = -1;
+
+	if (opts.unprivileged)
+		return 0;
 
 	BUG_ON(!criu_cgset || !root_cgset);
 

--- a/criu/config.c
+++ b/criu/config.c
@@ -705,6 +705,9 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 
 #undef BOOL_OPT
 
+	if (argv && argv[0])
+		SET_CHAR_OPTS(argv_0, argv[0]);
+
 	ret = pre_parse(argc, argv, usage_error, &no_default_config, &cfg_file);
 
 	if (ret)

--- a/criu/config.c
+++ b/criu/config.c
@@ -700,6 +700,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		{ "lsm-mount-context", required_argument, 0, 1099 },
 		{ "network-lock", required_argument, 0, 1100 },
 		BOOL_OPT("mntns-compat-mode", &opts.mntns_compat_mode),
+		BOOL_OPT("unprivileged", &opts.unprivileged),
 		{},
 	};
 

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3748,6 +3748,10 @@ static int sigreturn_restore(pid_t pid, struct task_restore_args *task_args, uns
 
 	prep_libc_rseq_info(&task_args->libc_rseq);
 
+	task_args->uid = opts.uid;
+	for (i = 0; i < CR_CAP_SIZE; i++)
+		task_args->cap_eff[i] = opts.cap_eff[i];
+
 	/*
 	 * Fill up per-thread data.
 	 */

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1809,6 +1809,9 @@ static int restore_task_with_children(void *_arg)
 				goto err;
 		}
 
+		if (set_opts_cap_eff())
+			goto err;
+
 		/* Wait prepare_userns */
 		if (restore_finish_ns_stage(CR_STATE_ROOT_TASK, CR_STATE_PREPARE_NAMESPACES) < 0)
 			goto err;

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 #include <arpa/inet.h>
 #include <sched.h>
+#include <sys/prctl.h>
 
 #include "version.h"
 #include "crtools.h"
@@ -408,6 +409,12 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 	if (req->config_file) {
 		pr_debug("Would overwrite RPC settings with values from %s\n", req->config_file);
 	}
+
+	if (req->has_unprivileged)
+		opts.unprivileged = req->unprivileged;
+
+	if (check_caps())
+		return 1;
 
 	if (kerndat_init())
 		return 1;

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -185,6 +185,9 @@ int main(int argc, char *argv[], char *envp[])
 		return cr_service_work(atoi(argv[optind + 1]));
 	}
 
+	if (check_caps())
+		return 1;
+
 	if (opts.imgs_dir == NULL)
 		SET_CHAR_OPTS(imgs_dir, ".");
 
@@ -414,6 +417,8 @@ usage:
 	       "  --network-lock METHOD\n"
 	       "                      network locking/unlocking method; argument\n"
 	       "                      can be 'nftables' or 'iptables' (default).\n"
+	       "  --unprivileged        accept limitations when running as non-root\n"
+	       "                        consult documentation for further details\n"
 	       "\n"
 	       "* External resources support:\n"
 	       "  --external RES        dump objects from this list as external resources:\n"

--- a/criu/image.c
+++ b/criu/image.c
@@ -226,7 +226,8 @@ int prepare_inventory(InventoryEntry *he)
 	if (get_task_ids(&crt.i))
 		return -1;
 
-	he->has_root_cg_set = true;
+	if (!opts.unprivileged)
+		he->has_root_cg_set = true;
 	if (dump_task_cgroup(NULL, &he->root_cg_set, NULL))
 		return -1;
 

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -1,10 +1,11 @@
 #ifndef __CR_OPTIONS_H__
 #define __CR_OPTIONS_H__
 
-#include <sys/types.h>
 #include <stdbool.h>
 #include "common/config.h"
 #include "common/list.h"
+#include "int.h"
+#include "image.h"
 
 /* Configuration and CLI parsing order defines */
 #define PARSING_GLOBAL_CONF  1
@@ -210,6 +211,20 @@ struct cr_options {
 	enum criu_mode mode;
 
 	int mntns_compat_mode;
+
+	/* Remember the program name passed to main() so we can use it in
+	 * error messages elsewhere.
+	 */
+	char *argv_0;
+	/*
+	 * This contains the eUID of the current CRIU user. It
+	 * will only be set to a non-zero value if CRIU has
+	 * the necessary capabilities to run as non root.
+	 * CAP_CHECKPOINT_RESTORE or CAP_SYS_ADMIN
+	 */
+	uid_t uid;
+	/* This contains the value from /proc/pid/status: CapEff */
+	u32 cap_eff[CR_CAP_SIZE];
 };
 
 extern struct cr_options opts;

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -2,6 +2,7 @@
 #define __CR_OPTIONS_H__
 
 #include <stdbool.h>
+#include <sys/capability.h>
 #include "common/config.h"
 #include "common/list.h"
 #include "int.h"
@@ -223,8 +224,14 @@ struct cr_options {
 	 * CAP_CHECKPOINT_RESTORE or CAP_SYS_ADMIN
 	 */
 	uid_t uid;
-	/* This contains the value from /proc/pid/status: CapEff */
-	u32 cap_eff[CR_CAP_SIZE];
+	/* This contains the value from capget()->effective */
+	u32 cap_eff[_LINUX_CAPABILITY_U32S_3];
+	/*
+	 * If CRIU should be running as non-root with the help of
+	 * CAP_CHECKPOINT_RESTORE or CAP_SYS_ADMIN the user should
+	 * explicitly request it as it comes with many limitations.
+	 */
+	int unprivileged;
 };
 
 extern struct cr_options opts;

--- a/criu/include/crtools.h
+++ b/criu/include/crtools.h
@@ -26,6 +26,7 @@ extern int cr_pre_dump_tasks(pid_t pid);
 extern int cr_restore_tasks(void);
 extern int convert_to_elf(char *elf_path, int fd_core);
 extern int cr_check(void);
+extern int check_caps(void);
 extern int cr_dedup(void);
 extern int cr_lazy_pages(bool daemon);
 

--- a/criu/include/restorer.h
+++ b/criu/include/restorer.h
@@ -235,6 +235,9 @@ struct task_restore_args {
 	 * unregister it before memory restoration procedure
 	 */
 	struct rst_rseq_param libc_rseq;
+
+	uid_t uid;
+	u32 cap_eff[CR_CAP_SIZE];
 } __aligned(64);
 
 /*

--- a/criu/include/util-caps.h
+++ b/criu/include/util-caps.h
@@ -1,0 +1,58 @@
+#ifndef __CR_UTIL_CAPS_H__
+#define __CR_UTIL_CAPS_H__
+
+#include <sys/capability.h>
+
+#ifndef CAP_CHECKPOINT_RESTORE
+#define CAP_CHECKPOINT_RESTORE 40
+#endif
+
+static inline bool has_capability(int cap, u32 *cap_eff)
+{
+	int mask = CAP_TO_MASK(cap);
+	int index = CAP_TO_INDEX(cap);
+	u32 effective;
+
+	effective = cap_eff[index];
+
+	if (!(mask & effective)) {
+		pr_debug("Effective capability %d missing\n", cap);
+		return false;
+	}
+
+	return true;
+}
+
+static inline bool has_cap_checkpoint_restore(u32 *cap_eff)
+{
+	/*
+	 * Everything guarded by CAP_CHECKPOINT_RESTORE is also
+	 * guarded by CAP_SYS_ADMIN. Check for both capabilities.
+	 */
+	if (has_capability(CAP_CHECKPOINT_RESTORE, cap_eff) || has_capability(CAP_SYS_ADMIN, cap_eff))
+		return true;
+
+	return false;
+}
+
+static inline bool has_cap_net_admin(u32 *cap_eff)
+{
+	return has_capability(CAP_NET_ADMIN, cap_eff);
+}
+
+static inline bool has_cap_sys_chroot(u32 *cap_eff)
+{
+	return has_capability(CAP_SYS_CHROOT, cap_eff);
+}
+
+static inline bool has_cap_setuid(u32 *cap_eff)
+{
+	return has_capability(CAP_SETUID, cap_eff);
+}
+
+static inline bool has_cap_sys_resource(u32 *cap_eff)
+{
+	return has_capability(CAP_SYS_RESOURCE, cap_eff);
+}
+
+#endif /* __CR_UTIL_CAPS_H__ */

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -386,6 +386,8 @@ extern int mount_detached_fs(const char *fsname);
 
 extern char *get_legacy_iptables_bin(bool ipv6);
 
+extern int set_opts_cap_eff(void);
+
 extern ssize_t read_all(int fd, void *buf, size_t size);
 extern ssize_t write_all(int fd, const void *buf, size_t size);
 

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -28,6 +28,7 @@
 #include "cgroup.h"
 #include "fdstore.h"
 #include "kerndat.h"
+#include "util-caps.h"
 
 #include "protobuf.h"
 #include "util.h"
@@ -1623,10 +1624,12 @@ int collect_namespaces(bool for_dump)
 
 int prepare_userns_creds(void)
 {
-	/* UID and GID must be set after restoring /proc/PID/{uid,gid}_maps */
-	if (setuid(0) || setgid(0) || setgroups(0, NULL)) {
-		pr_perror("Unable to initialize id-s");
-		return -1;
+	if (!opts.unprivileged || has_cap_setuid(opts.cap_eff)) {
+		/* UID and GID must be set after restoring /proc/PID/{uid,gid}_maps */
+		if (setuid(0) || setgid(0) || setgroups(0, NULL)) {
+			pr_perror("Unable to initialize id-s");
+			return -1;
+		}
 	}
 
 	/*

--- a/criu/timens.c
+++ b/criu/timens.c
@@ -5,6 +5,7 @@
 #include "proc_parse.h"
 #include "namespaces.h"
 #include "timens.h"
+#include "cr_options.h"
 
 #include "protobuf.h"
 #include "images/timens.pb-c.h"
@@ -56,6 +57,9 @@ int prepare_timens(int id)
 	TimensEntry *te;
 	struct timespec ts;
 	struct timespec prev_moff = {}, prev_boff = {};
+
+	if (opts.unprivileged)
+		return 0;
 
 	img = open_image(CR_FD_TIMENS, O_RSTR, id);
 	if (!img)

--- a/images/rpc.proto
+++ b/images/rpc.proto
@@ -139,6 +139,7 @@ message criu_opts {
 	optional criu_network_lock_method	network_lock		= 64 [default = IPTABLES];
 	optional bool			mntns_compat_mode	= 65;
 	optional bool			skip_file_rwx_check	= 66;
+	optional bool			unprivileged		= 67;
 /*	optional bool			check_mounts		= 128;	*/
 }
 

--- a/lib/c/criu.c
+++ b/lib/c/criu.c
@@ -566,6 +566,17 @@ void criu_set_skip_file_rwx_check(bool skip_file_rwx_check)
 	criu_local_set_skip_file_rwx_check(global_opts, skip_file_rwx_check);
 }
 
+void criu_local_set_unprivileged(criu_opts *opts, bool unprivileged)
+{
+	opts->rpc->has_unprivileged = true;
+	opts->rpc->unprivileged = unprivileged;
+}
+
+void criu_set_unprivileged(bool unprivileged)
+{
+	criu_local_set_unprivileged(global_opts, unprivileged);
+}
+
 void criu_local_set_orphan_pts_master(criu_opts *opts, bool orphan_pts_master)
 {
 	opts->rpc->has_orphan_pts_master = true;

--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -79,6 +79,7 @@ void criu_set_weak_sysctls(bool val);
 void criu_set_evasive_devices(bool evasive_devices);
 void criu_set_shell_job(bool shell_job);
 void criu_set_skip_file_rwx_check(bool skip_file_rwx_check);
+void criu_set_unprivileged(bool unprivileged);
 void criu_set_orphan_pts_master(bool orphan_pts_master);
 void criu_set_file_locks(bool file_locks);
 void criu_set_track_mem(bool track_mem);

--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -97,7 +97,10 @@ vagrant-fedora-no-vdso: setup-vagrant
 vagrant-fedora-rawhide: setup-vagrant
 	./vagrant.sh fedora-rawhide
 
-.PHONY: setup-vagrant vagrant-fedora-no-vdso vagrant-fedora-rawhide
+vagrant-fedora-non-root: setup-vagrant
+	./vagrant.sh fedora-non-root
+
+.PHONY: setup-vagrant vagrant-fedora-no-vdso vagrant-fedora-rawhide vagrant-fedora-non-root
 
 %:
 	$(MAKE) -C ../build $@$(target-suffix)

--- a/test/zdtm/lib/test.c
+++ b/test/zdtm/lib/test.c
@@ -239,34 +239,37 @@ void test_init(int argc, char **argv)
 		exit(1);
 	}
 
-	val = getenv("ZDTM_GROUPS");
-	if (val) {
-		char *tok = NULL;
-		unsigned int size = 0, groups[NGROUPS_MAX];
+	val = getenv("ZDTM_ROOTLESS");
+	if (!val) {
+		val = getenv("ZDTM_GROUPS");
+		if (val) {
+			char *tok = NULL;
+			unsigned int size = 0, groups[NGROUPS_MAX];
 
-		tok = strtok(val, " ");
-		while (tok) {
-			size++;
-			groups[size - 1] = atoi(tok);
-			tok = strtok(NULL, " ");
+			tok = strtok(val, " ");
+			while (tok) {
+				size++;
+				groups[size - 1] = atoi(tok);
+				tok = strtok(NULL, " ");
+			}
+
+			if (setgroups(size, groups)) {
+				fprintf(stderr, "Can't set groups: %m");
+				exit(1);
+			}
 		}
 
-		if (setgroups(size, groups)) {
-			fprintf(stderr, "Can't set groups: %m");
+		val = getenv("ZDTM_GID");
+		if (val && (setgid(atoi(val)) == -1)) {
+			fprintf(stderr, "Can't set gid: %m");
 			exit(1);
 		}
-	}
 
-	val = getenv("ZDTM_GID");
-	if (val && (setgid(atoi(val)) == -1)) {
-		fprintf(stderr, "Can't set gid: %m");
-		exit(1);
-	}
-
-	val = getenv("ZDTM_UID");
-	if (val && (setuid(atoi(val)) == -1)) {
-		fprintf(stderr, "Can't set gid: %m");
-		exit(1);
+		val = getenv("ZDTM_UID");
+		if (val && (setuid(atoi(val)) == -1)) {
+			fprintf(stderr, "Can't set gid: %m");
+			exit(1);
+		}
 	}
 
 	if (prctl(PR_SET_DUMPABLE, 1)) {

--- a/test/zdtm_ct.c
+++ b/test/zdtm_ct.c
@@ -93,44 +93,50 @@ static int create_timens(void)
 
 int main(int argc, char **argv)
 {
+	uid_t uid;
 	pid_t pid;
 	int status;
+
+	uid = getuid();
 
 	/*
 	 * pidns is used to avoid conflicts
 	 * mntns is used to mount /proc
 	 * net is used to avoid conflicts of parasite sockets
 	 */
-	if (unshare(CLONE_NEWNS | CLONE_NEWPID | CLONE_NEWNET | CLONE_NEWIPC))
-		return 1;
+	if (!uid)
+		if (unshare(CLONE_NEWNS | CLONE_NEWPID | CLONE_NEWNET | CLONE_NEWIPC))
+			return 1;
 	pid = fork();
 	if (pid == 0) {
-		if (create_timens())
-			exit(1);
-		if (mount(NULL, "/", NULL, MS_REC | MS_SLAVE, NULL)) {
-			fprintf(stderr, "mount(/, S_REC | MS_SLAVE)): %m");
-			return 1;
+		if (!uid) {
+			if (create_timens())
+				exit(1);
+			if (mount(NULL, "/", NULL, MS_REC | MS_SLAVE, NULL)) {
+				fprintf(stderr, "mount(/, S_REC | MS_SLAVE)): %m");
+				return 1;
+			}
+			umount2("/proc", MNT_DETACH);
+			umount2("/dev/pts", MNT_DETACH);
+			if (mount("zdtm_proc", "/proc", "proc", 0, NULL)) {
+				fprintf(stderr, "mount(/proc): %m");
+				return 1;
+			}
+			if (mount("zdtm_devpts", "/dev/pts", "devpts", 0, "newinstance,ptmxmode=0666")) {
+				fprintf(stderr, "mount(pts): %m");
+				return 1;
+			}
+			if (mount("zdtm_binfmt", "/proc/sys/fs/binfmt_misc", "binfmt_misc", 0, NULL)) {
+				fprintf(stderr, "mount(binfmt_misc): %m");
+				return 1;
+			}
+			if (mount("/dev/pts/ptmx", "/dev/ptmx", NULL, MS_BIND, NULL)) {
+				fprintf(stderr, "mount(ptmx): %m");
+				return 1;
+			}
+			if (system("ip link set up dev lo"))
+				return 1;
 		}
-		umount2("/proc", MNT_DETACH);
-		umount2("/dev/pts", MNT_DETACH);
-		if (mount("zdtm_proc", "/proc", "proc", 0, NULL)) {
-			fprintf(stderr, "mount(/proc): %m");
-			return 1;
-		}
-		if (mount("zdtm_devpts", "/dev/pts", "devpts", 0, "newinstance,ptmxmode=0666")) {
-			fprintf(stderr, "mount(pts): %m");
-			return 1;
-		}
-		if (mount("zdtm_binfmt", "/proc/sys/fs/binfmt_misc", "binfmt_misc", 0, NULL)) {
-			fprintf(stderr, "mount(binfmt_misc): %m");
-			return 1;
-		}
-		if (mount("/dev/pts/ptmx", "/dev/ptmx", NULL, MS_BIND, NULL)) {
-			fprintf(stderr, "mount(ptmx): %m");
-			return 1;
-		}
-		if (system("ip link set up dev lo"))
-			return 1;
 		execv(argv[1], argv + 1);
 		fprintf(stderr, "execve: %m");
 		return 1;


### PR DESCRIPTION
We at the OpenJ9 and Open Liberty projects have been experimenting with CRIU to improve JVM and Java web application start-up times, primarily in container deployments.[^1] To that end we've been testing #1155 for a while now and having success and we want to help get it across the finish line.

---

With @adrianreber's agreement I've rebased the patches in #1155 and added 4 additional patches as follows:

Patches to add the `--unprivileged` option to `libcriu` and the RPC interface, and a fix to do the required `check_caps()` on the service worker path, equivalent to what's done on the tool path:

- 3807cc9cd non-root: Call check_caps() in service worker mode as well
- 8df76f09b non-root: Allow unprivileged flag to be set via libcriu

Patches to move some new code (that I believe requires root) recently landed in criu-dev to the root-only init path introduced by in #1155:

- b32f887ad non-root: Do kerndat_has_move_mount_set_group() in root-only init
- f42e25fe7 non-root: Do kerndat_has_nftables_concat() in root-only init

---

As suggested by @adrianreber I'm currently working on where to store `criu.kdat`, if/how to use `XDG_RUNTIME_PATH` for that purpose, and what to do when it's not set (e.g. when running via `sudo`).

I'm also looking over #1155 to see if there are any other unresolved questions.

In the meantime I wanted to open this PR now in case anyone has any fresh thoughts on the subject, comments on how to proceed, and so on.

[^1]: This use-case is a bit different from using CRIU to facilitate process migration and has some unique challenges, including the fact that we're using CRIU "under the covers" in a scenario that to end-users shouldn't appear too different from simply starting a process from scratch. Allowing non-root users to restore processes, particularly inside unprivileged containers, makes this use-case much more accessible to end-users because it reduces the privileges required to "start" a process in this way, relative to starting the process from scratch. 