### PR TITLE
mips: generalize the special handling of sig_mask_extended by mips

### DIFF
--- a/compel/arch/mips/plugins/include/asm/syscall-types.h
+++ b/compel/arch/mips/plugins/include/asm/syscall-types.h
@@ -33,4 +33,5 @@ typedef struct {
 	k_rtsigset_t rt_sa_mask;
 } rt_sigaction_t;
 
+#define ARCH_HAS_SIG_MASK_EXTENDED
 #endif /* COMPEL_ARCH_SYSCALL_TYPES_H__ */

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -186,11 +186,9 @@ int parasite_dump_thread_seized(struct parasite_thread_ctl *tctl, struct parasit
 	pc->cap_last_cap = kdat.last_cap;
 
 	tc->has_blk_sigset = true;
-#ifdef CONFIG_MIPS
-	memcpy(&tc->blk_sigset, (unsigned long *)compel_thread_sigmask(tctl), sizeof(tc->blk_sigset));
-	memcpy(&tc->blk_sigset_extended, (unsigned long *)compel_thread_sigmask(tctl) + 1, sizeof(tc->blk_sigset));
-#else
-	memcpy(&tc->blk_sigset, compel_thread_sigmask(tctl), sizeof(k_rtsigset_t));
+	memcpy(&tc->blk_sigset, compel_thread_sigmask(tctl), sizeof(tc->blk_sigset));
+#ifdef ARCH_HAS_SIG_MASK_EXTENDED
+	memcpy(&tc->blk_sigset_extended, (unsigned long *)compel_thread_sigmask(tctl) + 1, sizeof(tc->blk_sigset_extended));
 #endif
 	ret = compel_get_thread_regs(tctl, save_task_regs, core);
 	if (ret) {
@@ -262,14 +260,10 @@ int parasite_dump_sigacts_seized(struct parasite_ctl *ctl, struct pstree_item *i
 		ASSIGN_TYPED(sa->sigaction, encode_pointer(args->sas[i].rt_sa_handler));
 		ASSIGN_TYPED(sa->flags, args->sas[i].rt_sa_flags);
 		ASSIGN_TYPED(sa->restorer, encode_pointer(args->sas[i].rt_sa_restorer));
-#ifdef CONFIG_MIPS
-		sa->has_mask_extended = 1;
-		BUILD_BUG_ON(sizeof(sa->mask) * 2 != sizeof(args->sas[0].rt_sa_mask.sig));
-		memcpy(&sa->mask, &(args->sas[i].rt_sa_mask.sig[0]), sizeof(sa->mask));
-		memcpy(&sa->mask_extended, &(args->sas[i].rt_sa_mask.sig[1]), sizeof(sa->mask));
-#else
-		BUILD_BUG_ON(sizeof(sa->mask) != sizeof(args->sas[0].rt_sa_mask.sig));
 		memcpy(&sa->mask, args->sas[i].rt_sa_mask.sig, sizeof(sa->mask));
+#ifdef ARCH_HAS_SIG_MASK_EXTENDED
+		sa->has_mask_extended = 1;
+		memcpy(&sa->mask_extended, &(args->sas[i].rt_sa_mask.sig[1]), sizeof(sa->mask_extended));
 #endif
 		sa->has_compat_sigaction = true;
 		sa->compat_sigaction = !compel_mode_native(ctl);
@@ -642,13 +636,10 @@ struct parasite_ctl *parasite_infect_seized(pid_t pid, struct pstree_item *item,
 	}
 
 	parasite_args_size = PARASITE_ARG_SIZE_MIN; /* reset for next task */
-#ifdef CONFIG_MIPS
-	memcpy(&item->core[0]->tc->blk_sigset, (unsigned long *)compel_task_sigmask(ctl),
-	       sizeof(item->core[0]->tc->blk_sigset));
+	memcpy(&item->core[0]->tc->blk_sigset, compel_task_sigmask(ctl), sizeof(item->core[0]->tc->blk_sigset));
+#ifdef ARCH_HAS_SIG_MASK_EXTENDED
 	memcpy(&item->core[0]->tc->blk_sigset_extended, (unsigned long *)compel_task_sigmask(ctl) + 1,
-	       sizeof(item->core[0]->tc->blk_sigset));
-#else
-	memcpy(&item->core[0]->tc->blk_sigset, compel_task_sigmask(ctl), sizeof(k_rtsigset_t));
+	       sizeof(item->core[0]->tc->blk_sigset_extended));
 #endif
 	dmpi(item)->parasite_ctl = ctl;
 


### PR DESCRIPTION
I notice that mips have special handling of the `sig_mask_extended`. This approach is not scalable.  When I try to port criu to a new architecture, this part will be a hindrance and the code doesn't look concise enough. So I 
use `ARCH_HAS_SIG_MASK_EXTENDED` generalize this special handling.

Signed-off-by: znley <shanjiantao@loongson.cn>