### PR TITLE
cr-restore: rseq: dynamically handle *libc with rseq

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3102,14 +3102,14 @@ static void prep_libc_rseq_info(struct rst_rseq_param *rseq)
 #else
 static void prep_libc_rseq_info(struct rst_rseq_param *rseq)
 {
-	/*
-	 * TODO: handle built-in rseq on other libc'ies like musl
-	 * We can do that using get_rseq_conf kernel feature.
-	 *
-	 * For now we just assume that other libc libraries are
-	 * not registering rseq by default.
-	 */
-	rseq->rseq_abi_pointer = 0;
+	if (!kdat.has_rseq || !kdat.has_ptrace_get_rseq_conf) {
+		rseq->rseq_abi_pointer = 0;
+		return;
+	}
+
+	rseq->rseq_abi_pointer = kdat.libc_rseq_conf.rseq_abi_pointer;
+	rseq->rseq_abi_size = kdat.libc_rseq_conf.rseq_abi_size;
+	rseq->signature = kdat.libc_rseq_conf.signature;
 }
 #endif
 

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -7,6 +7,7 @@
 #include "asm/kerndat.h"
 #include "util-vdso.h"
 #include "hugetlb.h"
+#include <compel/ptrace.h>
 
 struct stat;
 
@@ -82,6 +83,7 @@ struct kerndat_s {
 	bool has_openat2;
 	bool has_rseq;
 	bool has_ptrace_get_rseq_conf;
+	struct __ptrace_rseq_configuration libc_rseq_conf;
 };
 
 extern struct kerndat_s kdat;


### PR DESCRIPTION
Before this patch we assumed that CRIU is compiled against
the same GLibc as it runs with. But as we see from real
world examples like #1935 it's not always true.

The idea of this patch is to detect rseq configuration
for the main CRIU process and use it to unregister
rseq for all further child processes. It's correct,
because we restore pstree using clone*() syscalls,
don't use exec*() (!) syscalls, so rseq gets inherited
in the kernel and rseq configuration remains the same
for all children processes.

This will prevent issues like this:
https://github.com/checkpoint-restore/criu/issues/1935

Suggested-by: Florian Weimer <fweimer@redhat.com>
Signed-off-by: Alexander Mikhalitsyn <alexander.mikhalitsyn@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
