### PR TITLE
zdtm: Remove permission part check for skipping vsyscall vma

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1651,6 +1651,15 @@ def get_visible_state(test):
     return files, maps, mounts
 
 
+def has_vsyscall(maps):
+    vsyscall = u"ffffffffff600000-ffffffffff601000"
+    for i in maps:
+        if vsyscall in i:
+            return i
+
+    return None
+
+
 def check_visible_state(test, state, opts):
     new = get_visible_state(test)
 
@@ -1666,9 +1675,9 @@ def check_visible_state(test, state, opts):
         new_maps = new[1][pid]
         if os.getenv("COMPAT_TEST"):
             # the vsyscall vma isn't unmapped from x32 processes
-            vsyscall = u"ffffffffff600000-ffffffffff601000 r-xp"
-            if vsyscall in new_maps and vsyscall not in old_maps:
-                new_maps.remove(vsyscall)
+            entry = has_vsyscall(new_maps)
+            if entry and has_vsyscall(old_maps) is None:
+                new_maps.remove(entry)
         if old_maps != new_maps:
             print("%s: Old maps lost: %s" % (pid, old_maps - new_maps))
             print("%s: New maps appeared: %s" % (pid, new_maps - old_maps))


### PR DESCRIPTION
Normally, vsyscall vma has VM_READ, VM_EXEC permission. However, when
CONFIG_LEGACY_VSYSCALL_XONLY=y, that vma only has VM_EXEC. This commit removes
the permission part when checking to skip vsyscall vma in x32 tests.

Signed-off-by: Bui Quang Minh <minhquangbui99@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
