### PR TITLE
zdtm: fix race when propagations in root mount of criu mntns affected tests

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -267,7 +267,7 @@ class ns_flavor:
 
     def init(self, l_bins, x_bins):
         subprocess.check_call(
-            ["mount", "--make-slave", "--bind", ".", self.root])
+            ["mount", "--make-private", "--bind", ".", self.root])
         self.root_mounted = True
 
         if not os.access(self.root + "/.constructed", os.F_OK):

--- a/test/zdtm/static/mnt_root_ext.c
+++ b/test/zdtm/static/mnt_root_ext.c
@@ -52,6 +52,14 @@ int main(int argc, char **argv)
 	}
 
 	/*
+	 * Make mounts in temporary mntns slave, to prevent propagation to criu mntns
+	 */
+	if (mount(NULL, "/", NULL, MS_SLAVE | MS_REC, NULL)) {
+		pr_perror("make rslave");
+		return 1;
+	}
+
+	/*
 	 * Populate to the tests root host's rootfs subdir
 	 */
 	if (mount(tmp, testdir, NULL, MS_BIND, NULL)) {


### PR DESCRIPTION
1) "zdtm: make root mount private in criu mntns" - this protects from possible test fails in case host creates mounts in criu directory.
2) "zdtm/mnt_root_ext: don't allow propagation from test mntns to criu mntns" - this fixes race when mnt_root_ext creates mount which propagates into criu mntns creating children-overmount of the root mount source. Fixes: #1941