### PR TITLE
MAINTAINERS: Add Radostin (myself) to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,3 +4,4 @@ Mike Rapoport <rppt@kernel.org>
 Dmitry Safonov <0x7f454c46@gmail.com>
 Adrian Reber <areber@redhat.com>
 Pavel Tikhomirov <ptikhomirov@virtuozzo.com>
+Radostin Stoyanov <rstoyanov@fedoraproject.org>


### PR DESCRIPTION
I've been contributing to CRIU for sometime and I'm hoping that my familiarity with the project would be sufficient to self-nominate as a maintainer. I would like to help with code reviews, submitting patches, implementing new features, and maintaining the project in general.