### PR TITLE
cr-check: fix check for apparmor stacking

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -104,7 +104,7 @@ out:
 
 static int check_apparmor_stacking(void)
 {
-	if (!check_aa_ns_dumping())
+	if (!kdat.apparmor_ns_dumping_enabled)
 		return -1;
 
 	return 0;

--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1478,13 +1478,15 @@ int cr_check(void)
 		ret |= check_newifindex();
 		ret |= check_pidfd_store();
 		ret |= check_ns_pid();
-		ret |= check_apparmor_stacking();
 		ret |= check_network_lock_nftables();
 		ret |= check_sockopt_buf_lock();
 		ret |= check_memfd_hugetlb();
 		ret |= check_move_mount_set_group();
 		ret |= check_openat2();
 		ret |= check_ptrace_get_rseq_conf();
+
+		if (kdat.lsm == LSMTYPE__APPARMOR)
+			ret |= check_apparmor_stacking();
 	}
 
 	/*


### PR DESCRIPTION
The feature check for AppArmor stacking was introduced in commit 8723e3f998d1ec5f125e6600436a96f7ff9c1631. However, on systems that don't support AppArmour, this check always fails. As a result, `criu check --all` shows the following message:

> Looks good but some kernel features are missing which, depending on your process tree, may cause dump or restore failure.