### PR TITLE
ci: fix docker test

### DIFF
--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -21,10 +21,7 @@ add-apt-repository \
 
 . /etc/lsb-release
 
-# overlayfs with current Ubuntu kernel breaks CRIU
-# https://bugs.launchpad.net/ubuntu/+source/linux-azure/+bug/1967924
-# Use devicemapper storage drive as a work-around
-echo '{ "experimental": true, "storage-driver": "devicemapper" }' > /etc/docker/daemon.json
+echo '{ "experimental": true }' > /etc/docker/daemon.json
 
 CRIU_LOG='/criu.log'
 mkdir -p /etc/criu

--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -21,23 +21,13 @@ add-apt-repository \
 
 . /etc/lsb-release
 
+# docker checkpoint and restore is an experimental feature
 echo '{ "experimental": true }' > /etc/docker/daemon.json
+service docker restart
 
 CRIU_LOG='/criu.log'
 mkdir -p /etc/criu
 echo "log-file=$CRIU_LOG" > /etc/criu/runc.conf
-
-service docker stop
-systemctl stop containerd.service
-
-# Always use the latest containerd release.
-# Restore with containerd versions after v1.2.14 and before v1.5.0-beta.0 are broken.
-# https://github.com/checkpoint-restore/criu/issues/1223
-CONTAINERD_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/containerd/containerd/releases/latest | grep '"browser_download_url":.*/containerd-.*-linux-amd64.tar.gz.$' | cut -d\" -f4)
-wget -nv "$CONTAINERD_DOWNLOAD_URL" -O - | tar -xz -C /usr/
-
-systemctl restart containerd.service
-service docker restart
 
 export SKIP_CI_TEST=1
 

--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -25,11 +25,7 @@ make install
 popd
 rm -rf "${tmp_dir}"
 
-# overlayfs with current Ubuntu kernel breaks CRIU
-# https://bugs.launchpad.net/ubuntu/+source/linux-azure/+bug/1967924
-# Use VFS storage drive as a work-around
-export STORAGE_DRIVER=vfs
-podman --storage-driver vfs info
+podman info
 
 # shellcheck disable=SC2016
 podman run --name cr -d docker.io/library/alpine /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'


### PR DESCRIPTION
In commits https://github.com/checkpoint-restore/criu/commit/046cad8 and https://github.com/checkpoint-restore/criu/commit/81a68ad the version of containerd installed by default in the GitHub CI virtual environment was replaced with the latest release from GitHub as a workaround to a bug in containerd.

This bug has been fixed sometime ago and the current default version of containerd (1.6.6) does not require this workaround. However, with the latest release, the containerd binaries uploaded on GitHub have been built for Ubuntu 22.04 (https://github.com/containerd/containerd/commit/6b2dc9a37). Our tests are still running on Ubuntu 20.04 and this results in the following error:
    
    /usr/bin/containerd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/bin/containerd)
    /usr/bin/containerd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/bin/containerd)
 