### PR TITLE
[GSoC 2022] Improve copy file algorithm in dump_ghost_file

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -430,6 +430,7 @@ void init_opts(void)
 	opts.pre_dump_mode = PRE_DUMP_SPLICE;
 	opts.file_validation_method = FILE_VALIDATION_DEFAULT;
 	opts.network_lock_method = NETWORK_LOCK_DEFAULT;
+	opts.ghost_fiemap = FIEMAP_DEFAULT;
 }
 
 bool deprecated_ok(char *what)
@@ -701,6 +702,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		{ "network-lock", required_argument, 0, 1100 },
 		BOOL_OPT("mntns-compat-mode", &opts.mntns_compat_mode),
 		BOOL_OPT("unprivileged", &opts.unprivileged),
+		BOOL_OPT("ghost-fiemap", &opts.ghost_fiemap),
 		{},
 	};
 

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -95,6 +95,9 @@ enum FILE_VALIDATION_OPTIONS {
 /* This constant dictates which file validation method should be tried by default. */
 #define FILE_VALIDATION_DEFAULT FILE_VALIDATION_BUILD_ID
 
+/* This constant dictates that criu use fiemap to copy ghost file by default.*/
+#define FIEMAP_DEFAULT 1
+
 struct irmap;
 
 struct irmap_path_opt {
@@ -167,6 +170,7 @@ struct cr_options {
 	int enable_external_masters;
 	bool aufs; /* auto-detected, not via cli */
 	bool overlayfs;
+	int ghost_fiemap;
 #ifdef CONFIG_BINFMT_MISC_VIRTUALIZED
 	bool has_binfmt_misc; /* auto-detected */
 #endif

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -308,6 +308,8 @@ TST_FILE	=				\
 		ghost_holes02			\
 		ghost_holes_large00     \
 		ghost_holes_large01     \
+		ghost_multi_hole00      \
+		ghost_multi_hole01      \
 		unlink_largefile		\
 		mtime_mmap			\
 		fifo				\

--- a/test/zdtm/static/ghost_multi_hole00.c
+++ b/test/zdtm/static/ghost_multi_hole00.c
@@ -1,0 +1,122 @@
+#include <errno.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+#include <linux/limits.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Test ghost with a lot of holes(every 8K length contains only 4K data)";
+const char *test_author = "Liang-Chun Chen <featherclc@gmail.com>";
+
+char *filename;
+TEST_OPTION(filename, string, "file name", 1);
+
+/* Buffer that is suitable for hole size */
+#define BUFSIZE 4096
+static unsigned char buf4k[BUFSIZE];
+
+#ifndef SEEK_DATA
+#define SEEK_DATA 3
+#define SEEK_HOLE 4
+#endif
+
+#define FILE_SIZE (1 << 23) /* 8Mb */
+
+#define FILE_INTERVAL (1 << 13) /* 8Kb */
+
+int main(int argc, char **argv)
+{
+	int fd, off;
+	struct stat st;
+	uint32_t crc;
+
+	test_init(argc, argv);
+
+	fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0644);
+	if (fd < 0) {
+		pr_perror("can't open %s", filename);
+		exit(1);
+	}
+
+	if (unlink(filename) < 0) {
+		pr_perror("can't unlink %s", filename);
+		goto failed;
+	}
+
+	for (off = 0; off < FILE_SIZE; off += FILE_INTERVAL) {
+		crc = ~0;
+		datagen(buf4k, BUFSIZE, &crc);
+		if (pwrite(fd, &buf4k, BUFSIZE, off) != BUFSIZE) {
+			perror("pwrite");
+			goto failed;
+		}
+
+		/*
+		* In some file system, such as xfs,
+		* only pwrite might not able to create highly sparse file,
+		* so we need to forcibly allocate hole inside the file.
+		*/
+		if (fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, off + BUFSIZE, BUFSIZE)) {
+			perror("fallocate");
+			goto failed;
+		}
+	}
+
+	if (ftruncate(fd, FILE_SIZE)) {
+		pr_perror("Can't fixup file size");
+		goto failed;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	if (fstat(fd, &st) < 0) {
+		fail("can't stat after");
+		goto failed;
+	}
+
+	if (st.st_size != FILE_SIZE) {
+		fail("file size changed to %ld", (long)st.st_size);
+		goto failed;
+	}
+
+	test_msg("Size %u OK\n", FILE_SIZE);
+
+	/* Data*/
+	for (off = 0; off < FILE_SIZE; off += FILE_INTERVAL) {
+		if (pread(fd, buf4k, BUFSIZE, off) != BUFSIZE) {
+			fail("pread failed @ %u", off / FILE_INTERVAL);
+			goto failed;
+		}
+
+		crc = ~0;
+		if (datachk(buf4k, BUFSIZE, &crc)) {
+			fail("datachk failed @ %u", off / FILE_INTERVAL);
+			goto failed;
+		}
+
+		test_msg("Data @%du OK\n", off / FILE_INTERVAL);
+	}
+
+	/* Hole */
+	for (off = 0; off < FILE_SIZE; off += FILE_INTERVAL) {
+		if (lseek(fd, off, SEEK_HOLE) != off + BUFSIZE) {
+			fail("failed to find hole @ %u", off / FILE_SIZE);
+			goto failed;
+		}
+		test_msg("Hole @%du OK\n", off / FILE_INTERVAL);
+	}
+
+	close(fd);
+	pass();
+	return 0;
+
+failed:
+	close(fd);
+	return 1;
+}

--- a/test/zdtm/static/ghost_multi_hole00.desc
+++ b/test/zdtm/static/ghost_multi_hole00.desc
@@ -1,0 +1,1 @@
+{'dopts': '--ghost-limit 8M --no-ghost-fiemap'}

--- a/test/zdtm/static/ghost_multi_hole01.c
+++ b/test/zdtm/static/ghost_multi_hole01.c
@@ -1,0 +1,1 @@
+ghost_multi_hole00.c

--- a/test/zdtm/static/ghost_multi_hole01.desc
+++ b/test/zdtm/static/ghost_multi_hole01.desc
@@ -1,0 +1,1 @@
+{'dopts': '--ghost-limit 8M --ghost-fiemap'}


### PR DESCRIPTION
In order to reduce the frequency of using system call, I created a new algorithm
of copying chunk via fiemap.(copy_file_to_chunks_fiemap)

Also, I modified the sendfile-related inequality (e.g. from <= to =) to
avoid corresponding error.

Signed-off-by: Liang-Chun Chen <featherclc@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
