### PR TITLE
cgroup-v2: Checkpoint/restore global properties and threaded controllers

### DIFF
--- a/criu/cgroup-props.c
+++ b/criu/cgroup-props.c
@@ -35,10 +35,27 @@ static const char *____criu_global_props____[] = {
 	"tasks",
 };
 
+/* cgroup2 global properties */
+// clang-format off
+static const char *____criu_global_props_v2____[] = {
+	"cgroup.subtree_control",
+	"cgroup.max.descendants",
+	"cgroup.max.depth",
+	"cgroup.freeze",
+	"cgroup.type",
+};
+// clang-format on
+
 cgp_t cgp_global = {
 	.name = "____criu_global_props____",
 	.nr_props = ARRAY_SIZE(____criu_global_props____),
 	.props = ____criu_global_props____,
+};
+
+cgp_t cgp_global_v2 = {
+	.name = "____criu_global_props_v2____",
+	.nr_props = ARRAY_SIZE(____criu_global_props_v2____),
+	.props = ____criu_global_props_v2____,
 };
 
 typedef struct {

--- a/criu/image.c
+++ b/criu/image.c
@@ -228,7 +228,7 @@ int prepare_inventory(InventoryEntry *he)
 
 	if (!opts.unprivileged)
 		he->has_root_cg_set = true;
-	if (dump_task_cgroup(NULL, &he->root_cg_set, NULL))
+	if (dump_thread_cgroup(NULL, &he->root_cg_set, NULL, -1))
 		return -1;
 
 	he->root_ids = crt.i.ids;

--- a/criu/include/cgroup-props.h
+++ b/criu/include/cgroup-props.h
@@ -10,6 +10,7 @@ typedef struct {
 } cgp_t;
 
 extern cgp_t cgp_global;
+extern cgp_t cgp_global_v2;
 extern const cgp_t *cgp_get_props(const char *name);
 extern bool cgp_should_skip_controller(const char *name);
 extern bool cgp_add_dump_controller(const char *name);

--- a/criu/include/cgroup.h
+++ b/criu/include/cgroup.h
@@ -7,7 +7,7 @@
 struct pstree_item;
 struct parasite_dump_cgroup_args;
 extern u32 root_cg_set;
-int dump_task_cgroup(struct pstree_item *, u32 *, struct parasite_dump_cgroup_args *args);
+int dump_thread_cgroup(const struct pstree_item *, u32 *, struct parasite_dump_cgroup_args *args, int id);
 int dump_cgroups(void);
 int prepare_task_cgroup(struct pstree_item *);
 int prepare_cgroup(void);
@@ -60,6 +60,9 @@ struct cg_controller {
 
 	/* for cgroup list in cgroup.c */
 	struct list_head l;
+
+	/* controller is a threaded cgroup or not */
+	int is_threaded;
 };
 struct cg_controller *new_controller(const char *name);
 
@@ -87,7 +90,8 @@ struct cg_ctl {
  */
 struct list_head;
 struct parasite_dump_cgroup_args;
-extern int parse_task_cgroup(int pid, struct parasite_dump_cgroup_args *args, struct list_head *l, unsigned int *n);
+extern int parse_thread_cgroup(int pid, int tid, struct parasite_dump_cgroup_args *args, struct list_head *l,
+			       unsigned int *n);
 extern void put_ctls(struct list_head *);
 
 int collect_controllers(struct list_head *cgroups, unsigned int *n_cgroups);

--- a/criu/include/cgroup.h
+++ b/criu/include/cgroup.h
@@ -96,4 +96,6 @@ extern void put_ctls(struct list_head *);
 
 int collect_controllers(struct list_head *cgroups, unsigned int *n_cgroups);
 
+int stop_cgroupd(void);
+
 #endif /* __CR_CGROUP_H__ */

--- a/criu/include/namespaces.h
+++ b/criu/include/namespaces.h
@@ -1,6 +1,8 @@
 #ifndef __CR_NS_H__
 #define __CR_NS_H__
 
+#include <sys/socket.h>
+
 #include "common/compiler.h"
 #include "files.h"
 #include "common/list.h"
@@ -223,5 +225,20 @@ extern int add_ns_shared_cb(int (*actor)(void *data), void *data);
 
 extern struct ns_id *get_socket_ns(int lfd);
 extern struct ns_id *lookup_ns_by_kid(unsigned int kid, struct ns_desc *nd);
+
+struct unsc_msg {
+	struct msghdr h;
+	/*
+	 * 0th is the call address
+	 * 1st is the flags
+	 * 2nd is the optional (NULL in response) arguments
+	 */
+	struct iovec iov[3];
+	char c[CMSG_SPACE(sizeof(struct ucred)) + CMSG_SPACE(sizeof(int))];
+};
+
+extern void unsc_msg_init(struct unsc_msg *m, uns_call_t *c, int *x, void *arg, size_t asize, int fd, pid_t *pid);
+extern void unsc_msg_pid_fd(struct unsc_msg *um, pid_t *pid, int *fd);
+extern int start_unix_cred_daemon(pid_t *pid, int (*daemon_func)(int sk));
 
 #endif /* __CR_NS_H__ */

--- a/criu/include/parasite.h
+++ b/criu/include/parasite.h
@@ -241,7 +241,12 @@ struct parasite_dump_cgroup_args {
 	 *
 	 * The string is null terminated.
 	 */
-	char contents[1 << 12];
+	char contents[(1 << 12) - 32];
+	/*
+	 * Contains the path to thread cgroup procfs.
+	 * "self/task/<tid>/cgroup"
+	 */
+	char thread_cgrp[32];
 };
 
 #endif /* !__ASSEMBLY__ */

--- a/criu/include/restorer.h
+++ b/criu/include/restorer.h
@@ -121,6 +121,8 @@ struct thread_restore_args {
 	bool seccomp_force_tsync;
 
 	char comm[TASK_COMM_LEN];
+	int cg_set;
+	int cgroupd_sk;
 } __aligned(64);
 
 typedef long (*thread_restore_fcall_t)(struct thread_restore_args *args);

--- a/criu/include/servicefd.h
+++ b/criu/include/servicefd.h
@@ -24,6 +24,7 @@ enum sfd_type {
 				 */
 	ROOT_FD_OFF,	/* Root of the namespace we dump/restore */
 	CGROUP_YARD,
+	CGROUPD_SK,	  /* Socket for cgroupd to fix up thread's cgroup controller */
 	USERNSD_SK,	  /* Socket for usernsd */
 	NS_FD_OFF,	  /* Node's net namespace fd */
 	TRANSPORT_FD_OFF, /* to transfer file descriptors */

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -513,6 +513,7 @@ int parasite_dump_cgroup(struct parasite_ctl *ctl, struct parasite_dump_cgroup_a
 	struct parasite_dump_cgroup_args *ca;
 
 	ca = compel_parasite_args(ctl, struct parasite_dump_cgroup_args);
+	memcpy(ca->thread_cgrp, cgroup->thread_cgrp, sizeof(ca->thread_cgrp));
 	ret = compel_rpc_call_sync(PARASITE_CMD_DUMP_CGROUP, ctl);
 	if (ret) {
 		pr_err("Parasite failed to dump /proc/self/cgroup\n");

--- a/criu/pie/parasite.c
+++ b/criu/pie/parasite.c
@@ -745,7 +745,7 @@ static int parasite_dump_cgroup(struct parasite_dump_cgroup_args *args)
 		return -1;
 	}
 
-	cgroup = sys_openat(proc, "self/cgroup", O_RDONLY, 0);
+	cgroup = sys_openat(proc, args->thread_cgrp, O_RDONLY, 0);
 	sys_close(proc);
 	if (cgroup < 0) {
 		pr_err("can't get /proc/self/cgroup fd\n");

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -2549,7 +2549,8 @@ err:
 	return -1;
 }
 
-int parse_task_cgroup(int pid, struct parasite_dump_cgroup_args *args, struct list_head *retl, unsigned int *n)
+int parse_thread_cgroup(int pid, int tid, struct parasite_dump_cgroup_args *args, struct list_head *retl,
+			unsigned int *n)
 {
 	FILE *f;
 	int ret;
@@ -2557,7 +2558,7 @@ int parse_task_cgroup(int pid, struct parasite_dump_cgroup_args *args, struct li
 	unsigned int n_internal = 0;
 	struct cg_ctl *intern, *ext;
 
-	f = fopen_proc(pid, "cgroup");
+	f = fopen_proc(pid, "task/%d/cgroup", tid);
 	if (!f)
 		return -1;
 

--- a/images/cgroup.proto
+++ b/images/cgroup.proto
@@ -24,6 +24,7 @@ message cgroup_dir_entry {
 message cg_controller_entry {
 	repeated string			cnames		= 1;
 	repeated cgroup_dir_entry	dirs		= 2;
+	required bool			is_threaded	= 3;
 }
 
 message cg_member_entry {

--- a/images/core.proto
+++ b/images/core.proto
@@ -105,6 +105,7 @@ message thread_core_entry {
 	optional string			comm		= 13;
 	optional uint64			blk_sigset_extended	= 14;
 	optional rseq_entry		rseq_entry	= 15;
+	required uint32			cg_set		= 16;
 }
 
 message task_rlimits_entry {

--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -1,4 +1,10 @@
-local:
+# Umount cpuset in cgroupv1 to make it move to cgroupv2
+cpuset-cgroupv2:
+	if [ -d /sys/fs/cgroup/cpuset ]; then \
+		umount /sys/fs/cgroup/cpuset; \
+	fi
+
+local: cpuset-cgroupv2
 	./run-ci-tests.sh
 .PHONY: local
 

--- a/test/zdtm/lib/Makefile
+++ b/test/zdtm/lib/Makefile
@@ -4,7 +4,7 @@ CFLAGS	+= $(USERCFLAGS)
 
 LIB	:= libzdtmtst.a
 
-LIBSRC	:= datagen.c msg.c parseargs.c test.c streamutil.c lock.c ns.c tcp.c unix.c fs.c sysctl.c mem.c
+LIBSRC	:= datagen.c msg.c parseargs.c test.c streamutil.c lock.c ns.c tcp.c unix.c fs.c sysctl.c mem.c file.c
 
 PKG_CONFIG ?= pkg-config
 pkg-config-check = $(shell sh -c '$(PKG_CONFIG) $(1) && echo y')

--- a/test/zdtm/lib/file.c
+++ b/test/zdtm/lib/file.c
@@ -1,0 +1,46 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include "zdtmtst.h"
+
+int write_value(const char *path, const char *value)
+{
+	int fd, l;
+
+	fd = open(path, O_WRONLY);
+	if (fd < 0) {
+		pr_perror("open %s", path);
+		return -1;
+	}
+
+	l = write(fd, value, strlen(value));
+	if (l < 0) {
+		pr_perror("failed to write %s to %s", value, path);
+		close(fd);
+		return -1;
+	}
+
+	close(fd);
+	return 0;
+}
+
+int read_value(const char *path, char *value, int size)
+{
+	int fd, ret;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		pr_perror("open %s", path);
+		return -1;
+	}
+
+	ret = read(fd, (void *)value, size);
+	if (ret < 0) {
+		pr_perror("read %s", path);
+		close(fd);
+		return -1;
+	}
+
+	value[ret] = '\0';
+	close(fd);
+	return 0;
+}

--- a/test/zdtm/lib/zdtmtst.h
+++ b/test/zdtm/lib/zdtmtst.h
@@ -216,4 +216,7 @@ static inline void cleanup_closep(void *p)
 		TEMP_FAILURE_RETRY(close(*pp));
 }
 
+extern int write_value(const char *path, const char *value);
+extern int read_value(const char *path, char *value, int size);
+
 #endif /* _VIMITESU_H_ */

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -386,6 +386,7 @@ TST_DIR		=				\
 		cgroup02			\
 		cgroup03			\
 		cgroup04			\
+		cgroupv2_00			\
 		cgroup_ifpriomap		\
 		cgroup_ignore			\
 		cgroup_stray			\

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -387,6 +387,7 @@ TST_DIR		=				\
 		cgroup03			\
 		cgroup04			\
 		cgroupv2_00			\
+		cgroupv2_01			\
 		cgroup_ifpriomap		\
 		cgroup_ignore			\
 		cgroup_stray			\
@@ -678,6 +679,8 @@ fifo_upon_unix_socket01:	CFLAGS += -DFIFO_UPON_UNIX01
 sk-unix-listen02: CFLAGS += -DSK_UNIX_LISTEN02
 sk-unix-listen03: CFLAGS += -DSK_UNIX_LISTEN03
 sk-unix-listen04: CFLAGS += -DSK_UNIX_LISTEN02 -DSK_UNIX_LISTEN03
+
+cgroupv2_01:		LDLIBS += -pthread
 
 $(LIB):	force
 	$(Q) $(MAKE) -C $(LIBDIR)

--- a/test/zdtm/static/cgroup04.c
+++ b/test/zdtm/static/cgroup04.c
@@ -19,26 +19,6 @@ char *dirname;
 TEST_OPTION(dirname, string, "cgroup directory name", 1);
 static const char *cgname = "zdtmtst";
 
-int write_value(const char *path, const char *value)
-{
-	int fd, l;
-
-	fd = open(path, O_WRONLY);
-	if (fd < 0) {
-		pr_perror("open %s", path);
-		return -1;
-	}
-
-	l = write(fd, value, strlen(value));
-	close(fd);
-	if (l < 0) {
-		pr_perror("failed to write %s to %s", value, path);
-		return -1;
-	}
-
-	return 0;
-}
-
 int mount_and_add(const char *controller, const char *path, const char *prop, const char *value)
 {
 	char aux[1024], paux[1024], subdir[1024];

--- a/test/zdtm/static/cgroupv2_00.c
+++ b/test/zdtm/static/cgroupv2_00.c
@@ -1,0 +1,86 @@
+#include <sys/mount.h>
+#include <sys/stat.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check that some cgroup-v2 properties in kernel controllers are preserved";
+const char *test_author = "Bui Quang Minh <minhquangbui99@gmail.com>";
+
+char *dirname;
+TEST_OPTION(dirname, string, "cgroup-v2 directory name", 1);
+const char *cgname = "subcg00";
+
+int main(int argc, char **argv)
+{
+	char path[1024], aux[1024];
+	int ret = -1;
+
+	test_init(argc, argv);
+
+	if (mkdir(dirname, 0700) < 0 && errno != EEXIST) {
+		pr_perror("Can't make dir");
+		return -1;
+	}
+
+	if (mount("cgroup2", dirname, "cgroup2", 0, NULL)) {
+		pr_perror("Can't mount cgroup-v2");
+		return -1;
+	}
+
+	sprintf(path, "%s/%s", dirname, cgname);
+	if (mkdir(path, 0700) < 0 && errno != EEXIST) {
+		pr_perror("Can't make dir");
+		goto out;
+	}
+
+	/* Make cpuset controllers available in children directory */
+	sprintf(path, "%s/%s", dirname, "cgroup.subtree_control");
+	sprintf(aux, "%s", "+cpuset");
+	if (write_value(path, aux))
+		goto out;
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "cgroup.subtree_control");
+	sprintf(aux, "%s", "+cpuset");
+	if (write_value(path, aux))
+		goto out;
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "cgroup.type");
+	sprintf(aux, "%s", "threaded");
+	if (write_value(path, aux))
+		goto out;
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "cgroup.procs");
+	sprintf(aux, "%d", getpid());
+	if (write_value(path, aux))
+		goto out;
+
+	test_daemon();
+	test_waitsig();
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "cgroup.subtree_control");
+	if (read_value(path, aux, sizeof(aux)))
+		goto out;
+
+	if (strcmp(aux, "cpuset\n")) {
+		fail("cgroup.subtree_control mismatches");
+		goto out;
+	}
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "cgroup.type");
+	if (read_value(path, aux, sizeof(aux)))
+		goto out;
+
+	if (strcmp(aux, "threaded\n")) {
+		fail("cgroup.type mismatches");
+		goto out;
+	}
+
+	pass();
+
+	ret = 0;
+
+out:
+	sprintf(path, "%s", dirname);
+	umount(path);
+	return ret;
+}

--- a/test/zdtm/static/cgroupv2_00.checkskip
+++ b/test/zdtm/static/cgroupv2_00.checkskip
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+	grep -q "cpuset" /sys/fs/cgroup/cgroup.controllers && exit 0
+fi
+
+if [ -d /sys/fs/cgroup/unified ]; then
+	grep -q "cpuset" /sys/fs/cgroup/unified/cgroup.controllers && exit 0
+fi
+
+exit 1

--- a/test/zdtm/static/cgroupv2_00.desc
+++ b/test/zdtm/static/cgroupv2_00.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h ns', 'flags': 'suid', 'opts': '--manage-cgroups=full'}

--- a/test/zdtm/static/cgroupv2_00.hook
+++ b/test/zdtm/static/cgroupv2_00.hook
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+[ "$1" == "--clean" -o "$1" == "--pre-restore" ] || exit 0
+
+set -e
+cgname="subcg00"
+tname=$(mktemp -d cgclean.XXXXXX)
+mount -t cgroup2 cgroup2 $tname
+
+echo "Cleaning $tname"
+echo "-cpuset" > "$tname/$cgname/cgroup.subtree_control"
+
+set +e
+rmdir "$tname/$cgname"
+umount "$tname"
+rmdir "$tname"

--- a/test/zdtm/static/cgroupv2_01.c
+++ b/test/zdtm/static/cgroupv2_01.c
@@ -1,0 +1,180 @@
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <pthread.h>
+#include <syscall.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check that cgroup-v2 threaded controllers";
+const char *test_author = "Bui Quang Minh <minhquangbui99@gmail.com>";
+
+char *dirname;
+TEST_OPTION(dirname, string, "cgroup-v2 directory name", 1);
+const char *cgname = "subcg01";
+
+task_waiter_t t;
+
+#define gettid(code) syscall(__NR_gettid)
+
+void cleanup(void)
+{
+	char path[1024];
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "thread2");
+	rmdir(path);
+	sprintf(path, "%s/%s/%s", dirname, cgname, "thread1");
+	rmdir(path);
+	sprintf(path, "%s/%s", dirname, cgname);
+	rmdir(path);
+	sprintf(path, "%s", dirname);
+	umount(path);
+}
+
+int is_in_cgroup(char *cgname)
+{
+	FILE *cgf;
+	char buffer[1024];
+
+	sprintf(buffer, "/proc/self/task/%ld/cgroup", gettid());
+	cgf = fopen(buffer, "r");
+	if (cgf == NULL) {
+		pr_err("Fail to open thread's cgroup procfs\n");
+		return 0;
+	}
+
+	while (fgets(buffer, sizeof(buffer), cgf)) {
+		if (strstr(buffer, cgname)) {
+			fclose(cgf);
+			return 1;
+		}
+	}
+
+	fclose(cgf);
+	return 0;
+}
+
+void *thread_func(void *arg)
+{
+	char path[1024], aux[1024];
+
+	sprintf(path, "%s/%s/%s/%s", dirname, cgname, "thread2", "cgroup.threads");
+	sprintf(aux, "%ld", gettid());
+	if (write_value(path, aux)) {
+		cleanup();
+		exit(1);
+	}
+
+	read_value(path, aux, sizeof(aux));
+
+	task_waiter_complete(&t, 1);
+
+	/* Wait for restore */
+	task_waiter_wait4(&t, 2);
+
+	sprintf(path, "/%s/%s", cgname, "thread2");
+	if (!is_in_cgroup(path)) {
+		fail("Thread2's cgroup is not restored");
+		cleanup();
+		exit(1);
+	}
+
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	char path[1024], aux[1024];
+	pthread_t thread2;
+	int ret = 1;
+
+	test_init(argc, argv);
+	task_waiter_init(&t);
+
+	if (mkdir(dirname, 0700) < 0 && errno != EEXIST) {
+		pr_perror("Can't make dir");
+		return -1;
+	}
+
+	if (mount("cgroup2", dirname, "cgroup2", 0, NULL)) {
+		pr_perror("Can't mount cgroup-v2");
+		return -1;
+	}
+
+	sprintf(path, "%s/%s", dirname, cgname);
+	if (mkdir(path, 0700) < 0 && errno != EEXIST) {
+		pr_perror("Can't make dir");
+		goto out;
+	}
+
+	/* Make cpuset controllers available in children directory */
+	sprintf(path, "%s/%s", dirname, "cgroup.subtree_control");
+	sprintf(aux, "%s", "+cpuset");
+	if (write_value(path, aux))
+		goto out;
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "cgroup.subtree_control");
+	sprintf(aux, "%s", "+cpuset");
+	if (write_value(path, aux))
+		goto out;
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "cgroup.procs");
+	sprintf(aux, "%d", getpid());
+	if (write_value(path, aux))
+		goto out;
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "thread1");
+	if (mkdir(path, 0700) < 0 && errno != EEXIST) {
+		pr_perror("Can't make dir");
+		goto out;
+	}
+
+	sprintf(path, "%s/%s/%s/%s", dirname, cgname, "thread1", "cgroup.type");
+	sprintf(aux, "%s", "threaded");
+	if (write_value(path, aux))
+		goto out;
+
+	sprintf(path, "%s/%s/%s", dirname, cgname, "thread2");
+	if (mkdir(path, 0700) < 0 && errno != EEXIST) {
+		pr_perror("Can't make dir");
+		goto out;
+	}
+
+	sprintf(path, "%s/%s/%s/%s", dirname, cgname, "thread2", "cgroup.type");
+	sprintf(aux, "%s", "threaded");
+	if (write_value(path, aux))
+		goto out;
+
+	ret = pthread_create(&thread2, NULL, thread_func, NULL);
+	if (ret < 0) {
+		pr_err("pthread_create %s\n", strerror(ret));
+		ret = 1;
+		goto out;
+	}
+
+	sprintf(path, "%s/%s/%s/%s", dirname, cgname, "thread1", "cgroup.threads");
+	sprintf(aux, "%ld", gettid());
+	if (write_value(path, aux))
+		goto out;
+
+	task_waiter_wait4(&t, 1);
+
+	test_daemon();
+	test_waitsig();
+
+	task_waiter_complete(&t, 2);
+
+	sprintf(path, "/%s/%s", cgname, "thread1");
+	if (!is_in_cgroup(path)) {
+		fail("Main thread's cgroup is not restored");
+		cleanup();
+		exit(1);
+	}
+	pthread_join(thread2, NULL);
+	pass();
+
+	ret = 0;
+
+out:
+	cleanup();
+	return ret;
+}

--- a/test/zdtm/static/cgroupv2_01.checkskip
+++ b/test/zdtm/static/cgroupv2_01.checkskip
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+	grep -q "cpuset" /sys/fs/cgroup/cgroup.controllers && exit 0
+fi
+
+if [ -d /sys/fs/cgroup/unified ]; then
+	grep -q "cpuset" /sys/fs/cgroup/unified/cgroup.controllers && exit 0
+fi
+
+exit 1

--- a/test/zdtm/static/cgroupv2_01.desc
+++ b/test/zdtm/static/cgroupv2_01.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h ns', 'flags': 'suid', 'opts': '--manage-cgroups=full'}

--- a/test/zdtm/static/cgroupv2_01.hook
+++ b/test/zdtm/static/cgroupv2_01.hook
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+[ "$1" == "--clean" -o "$1" == "--pre-restore" ] || exit 0
+
+set -e
+cgname="subcg01"
+tname=$(mktemp -d cgclean.XXXXXX)
+mount -t cgroup2 cgroup2 $tname
+
+echo "Cleaning $tname"
+
+set +e
+rmdir "$tname/$cgname/thread1"
+
+# When the test finishes, the cleanup() function removes this directory
+# successfully because the thread in this controller exit and no other
+# threads belong to this controller
+if [ "$1" == "--pre-restore" ]; then
+	rmdir "$tname/$cgname/thread2"
+fi
+
+rmdir "$tname/$cgname"
+umount "$tname"
+rmdir "$tname"


### PR DESCRIPTION
#### 1. Checkpoint/restore some global properties in cgroup-v2 controller
These global properties of cgroup-v2 controller are checkpointed/restored
	cgroup.subtree_control
	cgroup.max.descendants
	cgroup.max.depth
	cgroup.freeze
	cgroup.type
#### 2. Checkpoint/restore threaded controllers
Threaded controllers allow threads in process to belong to different controllers which break the current assumption in CRIU. This PR reworks the logic to dump cgroup controllers for each thread, add a cgroupd service the fixup the cgroup controllers of threads when they are restored.


Currently, the zdtm tests run only on CI local test (Compat test, CentOS 9) not on CI tests run inside container because the container runtime seems does not support hybrid (both v1 and v2) cgroup controller