### PR TITLE
util: fix return value of is_iptables_nft()

### DIFF
--- a/criu/util.c
+++ b/criu/util.c
@@ -1577,11 +1577,11 @@ static int is_iptables_nft(char *bin)
 	}
 
 	buf[ret] = '\0';
-	ret = 0;
+	ret = 1;
 
 	if (strstr(buf, "nf_tables")) {
 		pr_info("iptables has nft backend: %s\n", buf);
-		ret = 1;
+		ret = 0;
 	}
 
 err:


### PR DESCRIPTION
is_iptables_nft() is used in the function get_legacy_iptables_bin() to detect if iptables uses nft backend.

The return value of this function should be 0, on success.

