### PR TITLE
Fix CentOS 7 CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,6 +111,8 @@ task:
     memory: 8G
 
   setup_script: |
+    # EPEL is needed for python2-future, python2-junit_xml, python-flake8 and libbsd-devel.
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     ln -sf /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto
     yum install -y findutils gcc git gnutls-devel iproute iptables libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel make procps-ng protobuf-c-devel protobuf-devel protobuf-python python python-flake8 python-ipaddress python2-future python2-junit_xml python-yaml python-six sudo tar which e2fsprogs python2-pip rubygem-asciidoctor libselinux-devel
     # Even with selinux in permissive mode the selinux tests will be executed


### PR DESCRIPTION
python2-future, python2-junit_xml, python-flake8 and libbsd-devel are now provided from the EPEL package repository. 