### PR TITLE
cgroup: add a comment to restore_cgroup_prop about path argument requirements

### DIFF
--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -1297,6 +1297,10 @@ static int restore_perms(int fd, const char *path, CgroupPerms *perms)
 	return 0;
 }
 
+/*
+ * Note: The path string can be modified in this function,
+ * the length of path string should be at least PATH_MAX.
+ */
 static int restore_cgroup_prop(const CgroupPropEntry *cg_prop_entry_p, char *path, int off, bool split_lines,
 			       bool skip_fails)
 {


### PR DESCRIPTION
In Virtuozzo we've faced out-of-bound access when calling this function on short path string, which corrupted other memory and lead to segmentation fault. So it may be useful to have this comment in code to avoid such a missuse of this function in future.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
