### PR TITLE
ipc_sysctl: Prioritize restoring IPC variables using non usernsd approach

### DIFF
--- a/criu/include/sysctl.h
+++ b/criu/include/sysctl.h
@@ -34,8 +34,9 @@ enum {
 /*
  * Some entries might be missing mark them as optional.
  */
-#define CTL_FLAGS_OPTIONAL	1
-#define CTL_FLAGS_HAS		2
-#define CTL_FLAGS_READ_EIO_SKIP 4
+#define CTL_FLAGS_OPTIONAL	  1
+#define CTL_FLAGS_HAS		  2
+#define CTL_FLAGS_READ_EIO_SKIP	  4
+#define CTL_FLAGS_IPC_EACCES_SKIP 5
 
 #endif /* __CR_SYSCTL_H__ */

--- a/criu/ipc_ns.c
+++ b/criu/ipc_ns.c
@@ -292,6 +292,8 @@ static void pr_info_ipc_shm(const IpcShmEntry *shm)
 
 static int ipc_sysctl_req(IpcVarEntry *e, int op)
 {
+	int i;
+
 	struct sysctl_req req[] = {
 		{ "kernel/sem", e->sem_ctls, CTL_U32A(e->n_sem_ctls) },
 		{ "kernel/msgmax", &e->msg_ctlmax, CTL_U32 },
@@ -331,6 +333,9 @@ static int ipc_sysctl_req(IpcVarEntry *e, int op)
 		req[nr++] = req[15];
 	if (e->has_shm_next_id)
 		req[nr++] = req[16];
+
+	for (i = 0; i < nr; i++)
+		req[i].flags = CTL_FLAGS_IPC_EACCES_SKIP;
 
 	return sysctl_op(req, nr, op, CLONE_NEWIPC);
 }
@@ -570,7 +575,7 @@ static int prepare_ipc_sem_desc(struct cr_img *img, const IpcSemEntry *sem)
 {
 	int ret, id;
 	struct sysctl_req req[] = {
-		{ "kernel/sem_next_id", &sem->desc->id, CTL_U32 },
+		{ "kernel/sem_next_id", &sem->desc->id, CTL_U32, CTL_FLAGS_IPC_EACCES_SKIP },
 	};
 	struct semid_ds semid;
 
@@ -703,7 +708,7 @@ static int prepare_ipc_msg_queue(struct cr_img *img, const IpcMsgEntry *msq)
 {
 	int ret, id;
 	struct sysctl_req req[] = {
-		{ "kernel/msg_next_id", &msq->desc->id, CTL_U32 },
+		{ "kernel/msg_next_id", &msq->desc->id, CTL_U32, CTL_FLAGS_IPC_EACCES_SKIP },
 	};
 	struct msqid_ds msqid;
 
@@ -841,7 +846,7 @@ static int prepare_ipc_shm_seg(struct cr_img *img, const IpcShmEntry *shm)
 {
 	int ret, id, hugetlb_flag = 0;
 	struct sysctl_req req[] = {
-		{ "kernel/shm_next_id", &shm->desc->id, CTL_U32 },
+		{ "kernel/shm_next_id", &shm->desc->id, CTL_U32, CTL_FLAGS_IPC_EACCES_SKIP },
 	};
 	struct shmid_ds shmid;
 


### PR DESCRIPTION
Since commit https://github.com/torvalds/linux/commit/5563cabdde, user with enough capability can open IPC sysctl files and write to them. Therefore, we don't need to use usernsd process in the outside user namespace to help with that anymore. Furthermore, some later commits:
https://github.com/torvalds/linux/commit/1f5c135ee5, https://github.com/torvalds/linux/commit/0889f44e28 bind the IPC namespace to the opened file descriptor of IPC sysctl at the open() time, the changed value does not depend on the IPC namespace of write() time anymore. This breaks the current usernsd approach.

So, we prioritize opening/writing IPC sysctl files in the context of restored process directly without usernsd help. This approach succeeds in the newer kernel since the restored process has enough capabilities at this restore stage. With older kernel, the open() fails and we fallback to the usernsd approach.

Fixes: #1982 

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
