### PR TITLE
cgroup: Remove redundant code that handles zombie tasks

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -811,16 +811,7 @@ static int dump_task_core_all(struct parasite_ctl *ctl, struct pstree_item *item
 			goto err;
 	}
 
-	/*
-	 * We don't support multithreads zombie tasks so there is
-	 * no thread_core in zombie tasks, store the cg_set in
-	 * task_core in these cases.
-	 */
 	cg_set = &core->thread_core->cg_set;
-	if (item->pid->state == TASK_THREAD) {
-		core->tc->has_cg_set = true;
-		cg_set = &core->tc->cg_set;
-	}
 	ret = dump_thread_cgroup(item, cg_set, info, -1);
 	if (ret)
 		goto err;

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1350,9 +1350,12 @@ static inline int fork_with_pid(struct pstree_item *item)
 
 		item->pid->state = ca.core->tc->task_state;
 
-		/* Zombie task's cg_set is stored in task_core */
+		/*
+		 * Zombie tasks' cgroup is not dumped/restored.
+		 * cg_set == 0 is skipped in prepare_task_cgroup()
+		 */
 		if (item->pid->state == TASK_DEAD)
-			rsti(item)->cg_set = ca.core->tc->cg_set;
+			rsti(item)->cg_set = 0;
 		else
 			rsti(item)->cg_set = ca.core->thread_core->cg_set;
 

--- a/images/core.proto
+++ b/images/core.proto
@@ -40,6 +40,7 @@ message task_core_entry {
 	optional task_timers_entry	timers		= 7;
 	optional task_rlimits_entry	rlimits		= 8;
 
+	/* This is deprecated, should be per-thread */
 	optional uint32			cg_set		= 9;
 
 	optional signal_queue_entry	signals_s	= 10;


### PR DESCRIPTION
Zombie tasks are dumped in dump_zombies() so it is redundant to handle them in dump_one_task().

Deprecate cg_set in task_core_entry as this field must be per thread now.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
