### PR TITLE
ci: move cgroup unmounting to run-ci-tests.sh

### DIFF
--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -1,10 +1,4 @@
-# Umount cpuset in cgroupv1 to make it move to cgroupv2
-cpuset-cgroupv2:
-	if [ -d /sys/fs/cgroup/cpuset ]; then \
-		umount /sys/fs/cgroup/cpuset; \
-	fi
-
-local: cpuset-cgroupv2
+local:
 	./run-ci-tests.sh
 .PHONY: local
 

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -144,6 +144,11 @@ time make unittest
 
 [ -n "$SKIP_CI_TEST" ] && exit 0
 
+# Umount cpuset in cgroupv1 to make it move to cgroupv2
+if [ -d /sys/fs/cgroup/cpuset ]; then
+	umount /sys/fs/cgroup/cpuset
+fi
+
 ulimit -c unlimited
 
 cgid=$$


### PR DESCRIPTION
A previous commit added a cgroup cpuset unmounting to scripts/ci/Makefile. We are sometimes running in a container without the necessary privileges to unmount certain cgroups.

This commit moves the cgroup unmounting to a place in run-ci-tests.sh which already requires privileged access and does not break unprivileged build-only CI runs.

CC: @minhbq-99 