### PR TITLE
kerndat: Mark memfd_create(MFD_HUGETLB) unavailable when ENOSYS is returned

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -500,7 +500,7 @@ static bool kerndat_has_memfd_hugetlb(void)
 	if (ret >= 0) {
 		kdat.has_memfd_hugetlb = true;
 		close(ret);
-	} else if (ret == -1 && (errno == EINVAL || errno == ENOENT)) {
+	} else if (ret == -1 && (errno == EINVAL || errno == ENOENT || errno == ENOSYS)) {
 		kdat.has_memfd_hugetlb = false;
 	} else {
 		pr_perror("Unexpected error from memfd_create(\"\", MFD_HUGETLB)");


### PR DESCRIPTION
Some users on Raspberry Pi report that the kerndat checking for memfd_create(MFD_HUGETLB) support returns ENOSYS even when memfd_create syscall is available. We currently treat this error as unexpected and return error. This commit marks the memfd_create(MFD_HUGETLB) as unavailable when ENOSYS is returned.

Fixes: #1986 

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
