### PR TITLE
amdgpu: define __nmk_dir if missing

### DIFF
--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -12,6 +12,7 @@ LIBDRM_INC 		:= -I/usr/include/libdrm
 DEPS_OK 		:= amdgpu_plugin.so amdgpu_plugin_test
 DEPS_NOK 		:= ;
 
+__nmk_dir ?= ../../scripts/nmk/scripts/
 include $(__nmk_dir)msg.mk
 
 CC      		:= gcc


### PR DESCRIPTION
This pull request adds a missing definition for `__nmk_dir` in the Makefile for the amdgpu plugin. This definition is required, for example, when building the `test_topology_remap` target:

	make -C plugins/amdgpu/ test_topology_remap