### PR TITLE
non-root: Fix socket restore issues

### DIFF
--- a/criu/fdstore.c
+++ b/criu/fdstore.c
@@ -15,6 +15,7 @@
 #include "util.h"
 #include "cr_options.h"
 #include "util-caps.h"
+#include "sockets.h"
 
 /* clang-format off */
 static struct fdstore_desc {
@@ -29,8 +30,6 @@ int fdstore_init(void)
 	uint32_t buf[2] = { INT_MAX / 2, INT_MAX / 2 };
 	struct sockaddr_un addr;
 	unsigned int addrlen;
-	int rcv_opt_name;
-	int snd_opt_name;
 	struct stat st;
 	int sk, ret;
 
@@ -53,17 +52,7 @@ int fdstore_init(void)
 		return -1;
 	}
 
-	if (!opts.unprivileged || has_cap_net_admin(opts.cap_eff)) {
-		rcv_opt_name = SO_RCVBUFFORCE;
-		snd_opt_name = SO_SNDBUFFORCE;
-	} else {
-		rcv_opt_name = SO_RCVBUF;
-		snd_opt_name = SO_SNDBUF;
-	}
-
-	if (setsockopt(sk, SOL_SOCKET, snd_opt_name, &buf[0], sizeof(buf[0])) < 0 ||
-	    setsockopt(sk, SOL_SOCKET, rcv_opt_name, &buf[1], sizeof(buf[1])) < 0) {
-		pr_perror("Unable to set SO_SNDBUFFORCE/SO_RCVBUFFORCE");
+	if (sk_setbufs(sk, buf)) {
 		close(sk);
 		return -1;
 	}

--- a/criu/include/sockets.h
+++ b/criu/include/sockets.h
@@ -27,6 +27,7 @@ struct socket_desc {
 extern int dump_socket(struct fd_parms *p, int lfd, FdinfoEntry *);
 extern int dump_socket_opts(int sk, SkOptsEntry *soe);
 extern int restore_socket_opts(int sk, SkOptsEntry *soe);
+extern int sk_setbufs(int sk, uint32_t *bufs);
 extern void release_skopts(SkOptsEntry *);
 extern int restore_prepare_socket(int sk);
 extern void preload_socket_modules(void);

--- a/criu/pidfd-store.c
+++ b/criu/pidfd-store.c
@@ -13,6 +13,7 @@
 #include "log.h"
 #include "util.h"
 #include "pidfd-store.h"
+#include "sockets.h"
 
 struct pidfd_entry {
 	pid_t pid;
@@ -94,9 +95,7 @@ int init_pidfd_store_sk(pid_t pid, int sk)
 	 * This is similar to how fdstore_init() works.
 	 */
 	if (addrlen == sizeof(sa_family_t)) {
-		if (setsockopt(pidfd_store_sk, SOL_SOCKET, SO_SNDBUFFORCE, &buf[0], sizeof(buf[0])) < 0 ||
-		    setsockopt(pidfd_store_sk, SOL_SOCKET, SO_RCVBUFFORCE, &buf[1], sizeof(buf[1])) < 0) {
-			pr_perror("Unable to set SO_SNDBUFFORCE/SO_RCVBUFFORCE");
+		if (sk_setbufs(pidfd_store_sk, buf)) {
 			goto err;
 		}
 

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -29,6 +29,7 @@
 #include "pstree.h"
 #include "util.h"
 #include "fdstore.h"
+#include "cr_options.h"
 
 #undef LOG_PREFIX
 #define LOG_PREFIX "sockets: "
@@ -465,16 +466,31 @@ int do_restore_opt(int sk, int level, int name, void *val, int len)
 	return 0;
 }
 
-static int sk_setbufs(void *arg, int fd, pid_t pid)
+int sk_setbufs(int sk, uint32_t *bufs)
 {
-	u32 *buf = (u32 *)arg;
+	uint32_t sndbuf = bufs[0], rcvbuf = bufs[1];
 
-	if (restore_opt(fd, SOL_SOCKET, SO_SNDBUFFORCE, &buf[0]))
-		return -1;
-	if (restore_opt(fd, SOL_SOCKET, SO_RCVBUFFORCE, &buf[1]))
-		return -1;
+	if (setsockopt(sk, SOL_SOCKET, SO_SNDBUFFORCE, &sndbuf, sizeof(sndbuf)) ||
+	    setsockopt(sk, SOL_SOCKET, SO_RCVBUFFORCE, &rcvbuf, sizeof(rcvbuf))) {
+		if (opts.unprivileged) {
+			pr_info("Unable to set SO_SNDBUFFORCE/SO_RCVBUFFORCE, falling back to SO_SNDBUF/SO_RCVBUF\n");
+			if (setsockopt(sk, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)) ||
+			    setsockopt(sk, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf))) {
+				pr_perror("Unable to set socket SO_SNDBUF/SO_RCVBUF");
+				return -1;
+			}
+		} else {
+			pr_perror("Unable to set socket SO_SNDBUFFORCE/SO_RCVBUFFORCE");
+			return -1;
+		}
+	}
 
 	return 0;
+}
+
+static int sk_setbufs_ns(void *arg, int fd, pid_t pid)
+{
+	return sk_setbufs(fd, (uint32_t *)arg);
 }
 
 /*
@@ -489,7 +505,7 @@ int restore_prepare_socket(int sk)
 	/* In kernel a bufsize has type int and a value is doubled. */
 	u32 maxbuf[2] = { INT_MAX / 2, INT_MAX / 2 };
 
-	if (userns_call(sk_setbufs, 0, maxbuf, sizeof(maxbuf), sk))
+	if (userns_call(sk_setbufs_ns, 0, maxbuf, sizeof(maxbuf), sk))
 		return -1;
 
 	/* Prevent blocking on restore */
@@ -517,7 +533,7 @@ int restore_socket_opts(int sk, SkOptsEntry *soe)
 	pr_info("%d restore sndbuf %d rcv buf %d\n", sk, soe->so_sndbuf, soe->so_rcvbuf);
 
 	/* setsockopt() multiplies the input values by 2 */
-	ret |= userns_call(sk_setbufs, 0, bufs, sizeof(bufs), sk);
+	ret |= userns_call(sk_setbufs_ns, 0, bufs, sizeof(bufs), sk);
 
 	if (soe->has_so_buf_lock) {
 		pr_debug("\trestore buf_lock %d for socket\n", soe->so_buf_lock);

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -647,8 +647,13 @@ int dump_socket_opts(int sk, SkOptsEntry *soe)
 	ret |= dump_opt(sk, SOL_SOCKET, SO_PRIORITY, &soe->so_priority);
 	soe->has_so_rcvlowat = true;
 	ret |= dump_opt(sk, SOL_SOCKET, SO_RCVLOWAT, &soe->so_rcvlowat);
-	soe->has_so_mark = true;
+	/*
+	 * Restoring SO_MARK requires root or CAP_NET_ADMIN. Avoid saving it
+	 * in unprivileged mode if still has its default value.
+	 */
 	ret |= dump_opt(sk, SOL_SOCKET, SO_MARK, &soe->so_mark);
+	if (soe->so_mark != 0)
+		soe->has_so_mark = true;
 
 	ret |= dump_opt(sk, SOL_SOCKET, SO_SNDTIMEO, &tv);
 	soe->so_snd_tmo_sec = tv.tv_sec;


### PR DESCRIPTION
Two fixes here related to running in unprivileged mode.

The first avoilds restoring `SO_MARK` on the service socket since we know the semantics of this socket and we know it doesn't need it.

The second changes how we use the `SO_*BUF*` options. As noted by @imachug[^1], checking if we have `CAP_NET_ADMIN` unfortunately doesn't tell us if we can really use these options. The easiest approach as suggested by @avagin is to simply try the `SO_*BUFFORCE` versions first and, if in unprivileged mode, fall back to the `SO_*BUF` ones on failure.

These two patches together allows users to avoid needing `CAP_NET_ADMIN` when doing unprivileged self-dump and restore, since the service socket is included in the dump and needs to be restored.

[^1]: https://github.com/checkpoint-restore/criu/pull/1930#discussion_r1007439001