### PR TITLE
Fix warnings from -Wstrict-prototypes in clang 16.0.0

### DIFF
--- a/criu/net.c
+++ b/criu/net.c
@@ -3366,7 +3366,7 @@ int collect_net_namespaces(bool for_dump)
 
 struct ns_desc net_ns_desc = NS_DESC_ENTRY(CLONE_NEWNET, "net");
 
-struct ns_id *net_get_root_ns()
+struct ns_id *net_get_root_ns(void)
 {
 	static struct ns_id *root_netns = NULL;
 

--- a/criu/util.c
+++ b/criu/util.c
@@ -1876,7 +1876,7 @@ int run_command(char *buf, size_t buf_size, int (*child_fn)(void *), void *args)
 
 uint64_t criu_run_id;
 
-void util_init()
+void util_init(void)
 {
 	struct timespec tp;
 


### PR DESCRIPTION
While building on a machine that has a HOL clang compiler, I ran into warnings regarding the changed lines.  It appears this warning is on by default because of anticipated changes to the C standard.

Signed-off-by: Drew Wock <ajwock@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
