### PR TITLE
Fix CI tests on Alpine Linux

### DIFF
--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -45,7 +45,4 @@ RUN adduser -u 1000 -D test
 
 RUN pip3 install junit_xml
 
-# For zdtm we need an unversioned python binary
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
 RUN make -C test/zdtm


### PR DESCRIPTION
The python3 package in Alpine has recently been updated to install symbolic link for /usr/bin/python.

https://git.alpinelinux.org/aports/commit/main/python3?id=d91da210b1614eb75517d59b7f348fee01699f35

This causes the following error in CI:

    Step 10/11 : RUN ln -s /usr/bin/python3 /usr/bin/python
     ---> Running in a5a94be9dc93
    ln: failed to create symbolic link '/usr/bin/python': File exists
    The command '/bin/sh -c ln -s /usr/bin/python3 /usr/bin/python' returned a non-zero code: 1