### PR TITLE
ci: fix make indent

### DIFF
--- a/test/zdtm/static/stopped03.c
+++ b/test/zdtm/static/stopped03.c
@@ -23,7 +23,7 @@ struct shared {
 	futex_t fstate;
 	int status;
 	int code;
-} * sh;
+} *sh;
 
 static int new_pgrp(void)
 {

--- a/test/zdtm/static/stopped04.c
+++ b/test/zdtm/static/stopped04.c
@@ -21,7 +21,7 @@ struct shared {
 	futex_t fstate;
 	int status;
 	int code;
-} * sh;
+} *sh;
 
 static int new_pgrp(void)
 {

--- a/test/zdtm/transition/maps007.c
+++ b/test/zdtm/transition/maps007.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
 	struct {
 		futex_t delta;
 		futex_t stop;
-	} * shm;
+	} *shm;
 	uint32_t v;
 	unsigned long long count = 0;
 	int i;


### PR DESCRIPTION
This patch fixes applies the changes required by clang-format v15.0.5 for `make indent`.