### PR TITLE
 sk-inet: support of SOL_IP, IP_PKTINFO option

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1375,6 +1375,14 @@ static int check_openat2(void)
 	return 0;
 }
 
+static int check_ipv6_freebind(void)
+{
+	if (!kdat.has_ipv6_freebind)
+		return -1;
+
+	return 0;
+}
+
 static int (*chk_feature)(void);
 
 /*
@@ -1494,6 +1502,7 @@ int cr_check(void)
 		ret |= check_move_mount_set_group();
 		ret |= check_openat2();
 		ret |= check_ptrace_get_rseq_conf();
+		ret |= check_ipv6_freebind();
 
 		if (kdat.lsm == LSMTYPE__APPARMOR)
 			ret |= check_apparmor_stacking();
@@ -1614,6 +1623,7 @@ static struct feature_list feature_list[] = {
 	{ "move_mount_set_group", check_move_mount_set_group },
 	{ "openat2", check_openat2 },
 	{ "get_rseq_conf", check_ptrace_get_rseq_conf },
+	{ "ipv6_freebind", check_ipv6_freebind },
 	{ NULL, NULL },
 };
 

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -84,6 +84,7 @@ struct kerndat_s {
 	bool has_rseq;
 	bool has_ptrace_get_rseq_conf;
 	struct __ptrace_rseq_configuration libc_rseq_conf;
+	bool has_ipv6_freebind;
 };
 
 extern struct kerndat_s kdat;

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -14,6 +14,8 @@
 #include <linux/icmp.h>
 #include <linux/icmpv6.h>
 #include <poll.h>
+#include <linux/in.h>
+#include <linux/in6.h>
 
 #include "../soccr/soccr.h"
 
@@ -388,6 +390,10 @@ static int dump_ip_raw_opts(int sk, int family, int proto, IpOptsRawEntry *r)
 	return ret;
 }
 
+#ifndef IPV6_FREEBIND
+#define IPV6_FREEBIND 78
+#endif
+
 static int dump_ip_opts(int sk, int family, int type, int proto, IpOptsEntry *ioe)
 {
 	int ret = 0;
@@ -398,11 +404,18 @@ static int dump_ip_opts(int sk, int family, int type, int proto, IpOptsEntry *io
 		 * and fetch additional options.
 		 */
 		ret |= dump_ip_raw_opts(sk, family, proto, ioe->raw);
-	} else {
-		/* Due to kernel code we can use SOL_IP instead of SOL_IPV6 */
-		ret |= dump_opt(sk, SOL_IP, IP_FREEBIND, &ioe->freebind);
-		ioe->has_freebind = ioe->freebind;
 	}
+
+	if (family == AF_INET6) {
+		if (kdat.has_ipv6_freebind)
+			ret |= dump_opt(sk, SOL_IPV6, IPV6_FREEBIND, &ioe->freebind);
+		else if (type != SOCK_RAW)
+			/* Due to kernel code we can use SOL_IP instead of SOL_IPV6 */
+			ret |= dump_opt(sk, SOL_IP, IP_FREEBIND, &ioe->freebind);
+	} else {
+		ret |= dump_opt(sk, SOL_IP, IP_FREEBIND, &ioe->freebind);
+	}
+	ioe->has_freebind = ioe->freebind;
 
 	return ret;
 }
@@ -787,8 +800,13 @@ int restore_ip_opts(int sk, int family, int proto, IpOptsEntry *ioe)
 {
 	int ret = 0;
 
-	if (ioe->has_freebind)
-		ret |= restore_opt(sk, SOL_IP, IP_FREEBIND, &ioe->freebind);
+	if (family == AF_INET6) {
+		if (ioe->has_freebind)
+			ret |= restore_opt(sk, SOL_IPV6, IPV6_FREEBIND, &ioe->freebind);
+	} else {
+		if (ioe->has_freebind)
+			ret |= restore_opt(sk, SOL_IP, IP_FREEBIND, &ioe->freebind);
+	}
 
 	if (ioe->raw)
 		ret |= restore_ip_raw_opts(sk, family, proto, ioe->raw);

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -412,10 +412,13 @@ static int dump_ip_opts(int sk, int family, int type, int proto, IpOptsEntry *io
 		else if (type != SOCK_RAW)
 			/* Due to kernel code we can use SOL_IP instead of SOL_IPV6 */
 			ret |= dump_opt(sk, SOL_IP, IP_FREEBIND, &ioe->freebind);
+		ret |= dump_opt(sk, SOL_IPV6, IPV6_RECVPKTINFO, &ioe->pktinfo);
 	} else {
 		ret |= dump_opt(sk, SOL_IP, IP_FREEBIND, &ioe->freebind);
+		ret |= dump_opt(sk, SOL_IP, IP_PKTINFO, &ioe->pktinfo);
 	}
 	ioe->has_freebind = ioe->freebind;
+	ioe->has_pktinfo = !!ioe->pktinfo;
 
 	return ret;
 }
@@ -803,9 +806,13 @@ int restore_ip_opts(int sk, int family, int proto, IpOptsEntry *ioe)
 	if (family == AF_INET6) {
 		if (ioe->has_freebind)
 			ret |= restore_opt(sk, SOL_IPV6, IPV6_FREEBIND, &ioe->freebind);
+		if (ioe->has_pktinfo)
+			ret |= restore_opt(sk, SOL_IPV6, IPV6_RECVPKTINFO, &ioe->pktinfo);
 	} else {
 		if (ioe->has_freebind)
 			ret |= restore_opt(sk, SOL_IP, IP_FREEBIND, &ioe->freebind);
+		if (ioe->has_pktinfo)
+			ret |= restore_opt(sk, SOL_IP, IP_PKTINFO, &ioe->pktinfo);
 	}
 
 	if (ioe->raw)

--- a/images/sk-inet.proto
+++ b/images/sk-inet.proto
@@ -17,6 +17,8 @@ message ip_opts_entry {
 	optional bool			freebind	= 1;
 	// Fields 2 and 3 are reserved for vz7 use
 	optional ip_opts_raw_entry	raw		= 4;
+
+	optional bool			pktinfo		= 5;
 }
 
 message inet_sk_entry {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -123,6 +123,8 @@ TST_NOFILE	:=				\
 		sock_opts00			\
 		sock_opts01			\
 		sock_opts02			\
+		sock_ip_opts00			\
+		sock_ip_opts01			\
 		sk-unix-unconn			\
 		sk-unix-unconn-seqpacket	\
 		ipc_namespace			\
@@ -598,6 +600,7 @@ socket-tcp6-closed:	CFLAGS += -D ZDTM_IPV6
 socket-tcp6-closed:	CFLAGS += -D ZDTM_IPV4V6
 socket-tcp-closed-last-ack:	CFLAGS += -D ZDTM_TCP_LAST_ACK
 socket-tcp-skip-in-flight:	CFLAGS += -D ZDTM_IPV4V6
+sock_ip_opts01:		CFLAGS += -DZDTM_VAL_ZERO
 tun_ns:			CFLAGS += -DTUN_NS
 mnt_ext_manual:		CFLAGS += -D ZDTM_EXTMAP_MANUAL
 mntns_pivot_root_ro:	CFLAGS += -DMNTNS_PIVOT_ROOT_RO

--- a/test/zdtm/static/sock_ip_opts00.c
+++ b/test/zdtm/static/sock_ip_opts00.c
@@ -1,0 +1,110 @@
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+
+#include <linux/in.h>
+#include <linux/in6.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check that different ip socket options are restored";
+const char *test_author = "Pavel Tikhomirov <ptikhomirov@virtuozzo.com>";
+
+#ifdef ZDTM_VAL_ZERO
+#define IP_OPT_VAL 0
+#else
+#define IP_OPT_VAL 1
+#endif
+
+struct sk_opt {
+	int level;
+	int opt;
+};
+
+struct sk_opt sk_opts_v4[] = {
+	{ SOL_IP, IP_FREEBIND },
+	{ SOL_IP, IP_PKTINFO },
+};
+
+#ifndef IPV6_FREEBIND
+#define IPV6_FREEBIND 78
+#endif
+
+struct sk_opt sk_opts_v6[] = {
+	{ SOL_IPV6, IPV6_FREEBIND },
+	{ SOL_IPV6, IPV6_RECVPKTINFO },
+};
+
+struct sk_conf {
+	int domain;
+	int type;
+	int protocol;
+	int sk;
+} sk_confs[] = {
+	{ AF_INET, SOCK_DGRAM, IPPROTO_UDP },
+	{ AF_INET, SOCK_RAW, IPPROTO_UDP },
+	{ AF_INET6, SOCK_DGRAM, IPPROTO_UDP },
+	{ AF_INET6, SOCK_RAW, IPPROTO_UDP },
+};
+
+int main(int argc, char **argv)
+{
+	struct sk_opt *opts;
+	int exit_code = 1;
+	int i, j, val;
+	socklen_t len;
+	int n_opts;
+
+	test_init(argc, argv);
+
+	for (i = 0; i < ARRAY_SIZE(sk_confs); i++) {
+		sk_confs[i].sk = socket(sk_confs[i].domain, sk_confs[i].type, sk_confs[i].protocol);
+		if (sk_confs[i].sk == -1) {
+			pr_perror("socket(%d,%d,%d) failed", sk_confs[i].domain, sk_confs[i].type,
+				  sk_confs[i].protocol);
+			goto close;
+		}
+	}
+
+	for (i = 0; i < ARRAY_SIZE(sk_confs); i++) {
+		opts = sk_confs[i].domain == AF_INET ? sk_opts_v4 : sk_opts_v6;
+		n_opts = sk_confs[i].domain == AF_INET ? ARRAY_SIZE(sk_opts_v4) : ARRAY_SIZE(sk_opts_v6);
+
+		for (j = 0; j < n_opts; j++) {
+			val = IP_OPT_VAL;
+			if (setsockopt(sk_confs[i].sk, opts[j].level, opts[j].opt, &val, sizeof(int)) == -1) {
+				pr_perror("setsockopt(%d, %d) failed", opts[j].level, opts[j].opt);
+				goto close;
+			}
+		}
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	for (i = 0; i < ARRAY_SIZE(sk_confs); i++) {
+		opts = sk_confs[i].domain == AF_INET ? sk_opts_v4 : sk_opts_v6;
+		n_opts = sk_confs[i].domain == AF_INET ? ARRAY_SIZE(sk_opts_v4) : ARRAY_SIZE(sk_opts_v6);
+
+		for (j = 0; j < n_opts; j++) {
+			len = sizeof(int);
+			if (getsockopt(sk_confs[i].sk, opts[j].level, opts[j].opt, &val, &len) == -1) {
+				pr_perror("getsockopt(%d, %d) failed", opts[j].level, opts[j].opt);
+				goto close;
+			}
+
+			if (val != IP_OPT_VAL) {
+				fail("Unexpected value socket(%d,%d,%d) opts(%d,%d)", sk_confs[i].domain,
+				     sk_confs[i].type, sk_confs[i].protocol, opts[j].level, opts[j].opt);
+				goto close;
+			}
+		}
+	}
+
+	pass();
+	exit_code = 0;
+close:
+	for (i = 0; i < ARRAY_SIZE(sk_confs); i++)
+		close(sk_confs[i].sk);
+	return exit_code;
+}

--- a/test/zdtm/static/sock_ip_opts00.desc
+++ b/test/zdtm/static/sock_ip_opts00.desc
@@ -1,0 +1,1 @@
+{'flags': 'suid', 'feature': 'ipv6_freebind'}

--- a/test/zdtm/static/sock_ip_opts01.c
+++ b/test/zdtm/static/sock_ip_opts01.c
@@ -1,0 +1,1 @@
+sock_ip_opts00.c

--- a/test/zdtm/static/sock_ip_opts01.desc
+++ b/test/zdtm/static/sock_ip_opts01.desc
@@ -1,0 +1,1 @@
+sock_ip_opts00.desc


### PR DESCRIPTION
We see systemd-resolved relying on this option, and after migration this
option is lost and systemd-resolved stops serving dns requests.

The IP_PKTINFO socket option makes kernel add cmsg with destination
address to packets, see more how systemd-resolved uses it:

https://github.com/systemd/systemd/blob/00a60eaf5fcb3a0e415349aa649f2699550d26b0/src/resolve/resolved-manager.c#L826

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
