### PR TITLE
test: Export ARCH variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ endif
 ifneq ($(filter-out x86 arm aarch64 ppc64 s390 mips,$(ARCH)),)
         $(error "The architecture $(ARCH) isn't supported")
 endif
+export ARCH
 
 # The PowerPC 64 bits architecture could be big or little endian.
 # They are handled in the same way.


### PR DESCRIPTION
Export `ARCH` variable so that it can be accessed by sub-make. For
example, it is needed to turn on platform specific tests in
`./test/zdtm/static/Makefile`.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
