### PR TITLE
test/javaTests: update org.testng:testng (Maven)

### DIFF
--- a/scripts/build/Dockerfile.hotspot-alpine
+++ b/scripts/build/Dockerfile.hotspot-alpine
@@ -1,4 +1,4 @@
-FROM docker.io/library/eclipse-temurin:8-alpine
+FROM docker.io/library/eclipse-temurin:11-alpine
 ARG CC=gcc
 
 RUN apk update && apk add \

--- a/scripts/build/Dockerfile.hotspot-ubuntu
+++ b/scripts/build/Dockerfile.hotspot-ubuntu
@@ -1,4 +1,4 @@
-FROM docker.io/library/eclipse-temurin:8-focal
+FROM docker.io/library/eclipse-temurin:11-focal
 ARG CC=gcc
 
 COPY scripts/ci/apt-install /bin/apt-install

--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -1,4 +1,4 @@
-FROM docker.io/library/ibm-semeru-runtimes:open-8-jdk-focal
+FROM docker.io/library/ibm-semeru-runtimes:open-11-jdk-focal
 ARG CC=gcc
 
 COPY scripts/ci/apt-install /bin/apt-install

--- a/test/javaTests/pom.xml
+++ b/test/javaTests/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
-			<version>6.3.1</version>
+			<version>7.7.0</version>
 		</dependency>
 	</dependencies>
 	<properties>


### PR DESCRIPTION
TestNG is vulnerable to Path Traversal

Fixes https://github.com/checkpoint-restore/criu/security/dependabot/1.

