### PR TITLE
link-remap: Add --keep-link-remaps option

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -703,6 +703,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		BOOL_OPT("mntns-compat-mode", &opts.mntns_compat_mode),
 		BOOL_OPT("unprivileged", &opts.unprivileged),
 		BOOL_OPT("ghost-fiemap", &opts.ghost_fiemap),
+		BOOL_OPT("keep-link-remaps", &opts.keep_link_remaps),
 		{},
 	};
 

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -895,6 +895,9 @@ int try_clean_remaps(bool only_ghosts)
 	struct remap_info *ri;
 	int ret = 0;
 
+	if (opts.keep_link_remaps)
+		return ret;
+
 	list_for_each_entry(ri, &remaps, list) {
 		if (ri->rpe->remap_type == REMAP_TYPE__GHOST)
 			ret |= clean_one_remap(ri);

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -236,6 +236,12 @@ struct cr_options {
 	 * explicitly request it as it comes with many limitations.
 	 */
 	int unprivileged;
+
+	/*
+	 * On restore, do not remove link-remaps.  This allows a checkpoint taken with --link-remap
+	 * to be reused.
+	 */
+	int keep_link_remaps;
 };
 
 extern struct cr_options opts;


### PR DESCRIPTION
When specified, this option disables the automatic deletion of link-remaps on restore.  This allows checkpoints dumped with --link-remap to be restored multiple times (provided that other conditions for reuse are met).

Signed-off-by: Drew Wock <ajwock@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
