### PR TITLE
cgroup: fix make indent error in kmem limit check

### DIFF
--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -1477,8 +1477,7 @@ static int restore_cgroup_prop(const CgroupPropEntry *cg_prop_entry_p, char *pat
 		/* memory.kmem.limit_in_bytes has been deprecated. Look at
 		 * 58056f77502f3 ("memcg, kmem: further deprecate
 		 * kmem.limit_in_bytes") for more details. */
-		if (ret == -1 && errno == EOPNOTSUPP &&
-		    !strcmp(cg_prop_entry_p->name, "memory.kmem.limit_in_bytes"))
+		if (ret == -1 && errno == EOPNOTSUPP && !strcmp(cg_prop_entry_p->name, "memory.kmem.limit_in_bytes"))
 			ret = len;
 		if (ret != len) {
 			pr_perror("Failed writing %s to %s", cg_prop_entry_p->value, path);


### PR DESCRIPTION
Fixes: a98722320 ("cgroups: ignore EOPNOTSUPP on setting memory.kmem.limit_in_byte")

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
