### PR TITLE
zdtm: fix 'zdtm.py list' command

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -626,14 +626,14 @@ class zdtm_test:
                 ["make", "zdtm_ct"], env=dict(os.environ, MAKEFLAGS=""))
         if not os.access("zdtm/lib/libzdtmtst.a", os.F_OK):
             subprocess.check_call(["make", "-C", "zdtm/"])
-        if opts['rootless']:
+        if 'rootless' in opts and opts['rootless']:
             return
         subprocess.check_call(
             ["flock", "zdtm_mount_cgroups.lock", "./zdtm_mount_cgroups", str(uuid)])
 
     @staticmethod
     def cleanup():
-        if opts['rootless']:
+        if 'rootless' in opts and opts['rootless']:
             return
         subprocess.check_call(
             ["flock", "zdtm_mount_cgroups.lock", "./zdtm_umount_cgroups", str(uuid)])


### PR DESCRIPTION
After commit https://github.com/checkpoint-restore/criu/commit/0add1b6cdbedaaac93d48ea323beceb7328b69b2, the command `./zdtm.py list` fails with the following error.

    if opts['rootless']:
       ~~~~^^^^^^^^^^^^
    KeyError: 'rootless'
