### PR TITLE
Dont indent goto labels

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -516,6 +516,7 @@ IncludeCategories:
     Priority: 1
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: false
+IndentGotoLabels: false
 IndentPPDirectives: None # Unknown to clang-format-5.0
 IndentWidth: 8
 IndentWrappedFunctionNames: false

--- a/scripts/fetch-clang-format.sh
+++ b/scripts/fetch-clang-format.sh
@@ -14,4 +14,5 @@ curl -s "${URL}" | sed -e "
 	s,ForEachMacros:,ForEachMacros:\n  - 'for_each_pstree_item',g;
 	s,\(AlignTrailingComments:.*\)$,\1\nAlignConsecutiveMacros: true,g;
 	s,AlignTrailingComments: false,AlignTrailingComments: true,g;
+	s,\(IndentCaseLabels: false\),\1\nIndentGotoLabels: false,g;
 "  > .clang-format


### PR DESCRIPTION
This is done to follow 'Linux kernel coding style', same change was added to .clang-format in linux kernel source recently https://github.com/torvalds/linux/commit/d7f6604341c74.