### PR TITLE
asm: fix for_each_bit macro

### DIFF
--- a/include/common/arch/ppc64/asm/bitops.h
+++ b/include/common/arch/ppc64/asm/bitops.h
@@ -46,6 +46,7 @@
 #define BITS_TO_LONGS(nr)  DIV_ROUND_UP(nr, BITS_PER_LONG)
 
 #define DECLARE_BITMAP(name, bits) unsigned long name[BITS_TO_LONGS(bits)]
+#define BITMAP_SIZE(name)	   (sizeof(name) * CHAR_BIT)
 
 #define __stringify_in_c(...) #__VA_ARGS__
 #define stringify_in_c(...)   __stringify_in_c(__VA_ARGS__) " "
@@ -202,8 +203,8 @@ found_middle:
 	return result + __ffs(tmp);
 }
 
-#define for_each_bit(i, bitmask)                                                  \
-	for (i = find_next_bit(bitmask, sizeof(bitmask), 0); i < sizeof(bitmask); \
-	     i = find_next_bit(bitmask, sizeof(bitmask), i + 1))
+#define for_each_bit(i, bitmask)                                                            \
+	for (i = find_next_bit(bitmask, BITMAP_SIZE(bitmask), 0); i < BITMAP_SIZE(bitmask); \
+	     i = find_next_bit(bitmask, BITMAP_SIZE(bitmask), i + 1))
 
 #endif /* __CR_BITOPS_H__ */

--- a/include/common/arch/s390/asm/bitops.h
+++ b/include/common/arch/s390/asm/bitops.h
@@ -10,6 +10,7 @@
 #define __BITOPS_WORDS(bits) (((bits) + BITS_PER_LONG - 1) / BITS_PER_LONG)
 
 #define DECLARE_BITMAP(name, bits) unsigned long name[BITS_TO_LONGS(bits)]
+#define BITMAP_SIZE(name)	   (sizeof(name) * CHAR_BIT)
 
 static inline unsigned long *__bitops_word(unsigned long nr, volatile unsigned long *ptr)
 {
@@ -143,8 +144,8 @@ static inline unsigned long find_next_bit(const unsigned long *addr, unsigned lo
 	return _find_next_bit(addr, size, offset, 0UL);
 }
 
-#define for_each_bit(i, bitmask)                                                  \
-	for (i = find_next_bit(bitmask, sizeof(bitmask), 0); i < sizeof(bitmask); \
-	     i = find_next_bit(bitmask, sizeof(bitmask), i + 1))
+#define for_each_bit(i, bitmask)                                                            \
+	for (i = find_next_bit(bitmask, BITMAP_SIZE(bitmask), 0); i < BITMAP_SIZE(bitmask); \
+	     i = find_next_bit(bitmask, BITMAP_SIZE(bitmask), i + 1))
 
 #endif /* _S390_BITOPS_H */

--- a/include/common/arch/x86/asm/bitops.h
+++ b/include/common/arch/x86/asm/bitops.h
@@ -10,6 +10,7 @@
 #define BITS_TO_LONGS(nr)  DIV_ROUND_UP(nr, BITS_PER_LONG)
 
 #define DECLARE_BITMAP(name, bits) unsigned long name[BITS_TO_LONGS(bits)]
+#define BITMAP_SIZE(name)	   (sizeof(name) * CHAR_BIT)
 
 #if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 1)
 /* Technically wrong, but this avoids compilation errors on some gcc
@@ -119,8 +120,8 @@ found_middle:
 	return result + __ffs(tmp);
 }
 
-#define for_each_bit(i, bitmask)                                                  \
-	for (i = find_next_bit(bitmask, sizeof(bitmask), 0); i < sizeof(bitmask); \
-	     i = find_next_bit(bitmask, sizeof(bitmask), i + 1))
+#define for_each_bit(i, bitmask)                                                            \
+	for (i = find_next_bit(bitmask, BITMAP_SIZE(bitmask), 0); i < BITMAP_SIZE(bitmask); \
+	     i = find_next_bit(bitmask, BITMAP_SIZE(bitmask), i + 1))
 
 #endif /* __CR_BITOPS_H__ */

--- a/include/common/asm-generic/bitops.h
+++ b/include/common/asm-generic/bitops.h
@@ -14,6 +14,7 @@
 #define BITS_TO_LONGS(nr)  DIV_ROUND_UP(nr, BITS_PER_LONG)
 
 #define DECLARE_BITMAP(name, bits) unsigned long name[BITS_TO_LONGS(bits)]
+#define BITMAP_SIZE(name)	   (sizeof(name) * CHAR_BIT)
 
 #if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 1)
 /* Technically wrong, but this avoids compilation errors on some gcc
@@ -103,8 +104,8 @@ found_middle:
 	return result + __ffs(tmp);
 }
 
-#define for_each_bit(i, bitmask)                                                  \
-	for (i = find_next_bit(bitmask, sizeof(bitmask), 0); i < sizeof(bitmask); \
-	     i = find_next_bit(bitmask, sizeof(bitmask), i + 1))
+#define for_each_bit(i, bitmask)                                                            \
+	for (i = find_next_bit(bitmask, BITMAP_SIZE(bitmask), 0); i < BITMAP_SIZE(bitmask); \
+	     i = find_next_bit(bitmask, BITMAP_SIZE(bitmask), i + 1))
 
 #endif /* __CR_GENERIC_BITOPS_H__ */


### PR DESCRIPTION
find_next_bit operates on a bit instead of byte positions/sizes.

Signed-off-by: Michal Clapinski <mclapinski@google.com>