### PR TITLE
clang-format: rework make indent to check specific commits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,16 +23,12 @@ jobs:
     - name: Run make indent
       run: >
         if [ -z "${{github.base_ref}}" ]; then
-          make indent
+          if ! make indent OPTS=--diff; then
+            exit 1
+          fi
         else
           git fetch origin ${{github.base_ref}} &&
-          git clang-format --style file --extensions c,h --quiet origin/${{github.base_ref}}
-        fi &&
-        STATUS=$(git status --porcelain) &&
-        if [ ! -z "$STATUS" ]; then
-          echo "FAIL: some files are not correctly formatted.";
-          echo "$STATUS"
-          git diff
-          echo "FAIL: please run 'make indent'";
-          exit 1;
+          if ! make indent OPTS=--diff BASE=origin/${{github.base_ref}}; then
+            exit 1
+          fi
         fi

--- a/Makefile
+++ b/Makefile
@@ -461,8 +461,10 @@ fetch-clang-format: .FORCE
 	$(E) ".clang-format"
 	$(Q) scripts/fetch-clang-format.sh
 
+BASE ?= "HEAD~1"
+OPTS ?= "--quiet"
 indent:
-	find . -name '*.[ch]' -type f -print0 | xargs --null --max-args 128 --max-procs 4 clang-format -i
+	git clang-format --style file --extensions c,h $(OPTS) $(BASE)
 .PHONY: indent
 
 include Makefile.install


### PR DESCRIPTION
Previousely "make indent" checked all files in criu source directory for codding style flaws. We have several problems with it:

- clang-format default format sometimes changes in new versions of the package and we need to reformat all our code base each time it happens
- on different systems we may have different versions of clang-format and on latest criu-dev "make indent" may be still unhappy on your system
- when we want to update clang-format rules ourselves we need to update all our code base each time
- sometimes clang-format rules are not fitting all our cases, (e.g.: an option IndentGotoLabels works nice for simple C code, but is a no go for assembler and C macros) and putting "clang-format off" everywhere is a mess
- sometimes we intentionally want to break clang-format rules (e.g.: we want to put function arguments on a new line separating them "logically" not "mechanically" following 120-char rule like clang-format does).

This adds a BASE option for "make indent" where all commits in range BASE..HEAD would be checked with git-clang-format for codding style flaws. For instance when developing on top of criu-dev, one can use "make BASE=origin/criu-dev indent" to check all their commits for compliance with the clang-format rules. Default base is HEAD~1 to make last commit checked when "make indent" is called. The closest thing to the old behaviour would then be "make indent BASE=init", note that only commited files would be checked.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
