### PR TITLE
autofs: fix a frankenstein auto-created by clang-format

### DIFF
--- a/criu/autofs.c
+++ b/criu/autofs.c
@@ -431,8 +431,7 @@ static int access_autofs_mount(struct mount_info *pm)
 		pr_err("failed to fork\n");
 		goto close_autofs_mnt;
 	case 0:
-		/* We don't care about results.
-			 * All we need is to "touch" */
+		/* We don't care about results, all we need is to "touch" */
 		/* coverity[check_return] */
 		openat(autofs_mnt, mnt_path, O_RDONLY | O_NONBLOCK | O_DIRECTORY);
 		_exit(0);


### PR DESCRIPTION
Fixes: 93dd984ca ("Run 'make indent' on all C files")

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
