### PR TITLE
Clang format fix for each bit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -71,6 +71,7 @@ FixNamespaceComments: false # Unknown to clang-format-4.0
 #   | sort | uniq
 ForEachMacros:
   - 'for_each_pstree_item'
+  - 'for_each_bit'
   - 'apei_estatus_for_each_section'
   - 'ata_for_each_dev'
   - 'ata_for_each_link'

--- a/criu/tty.c
+++ b/criu/tty.c
@@ -398,8 +398,7 @@ static int tty_verify_active_pairs(void)
 {
 	unsigned long i, unpaired_slaves = 0;
 
-	for_each_bit(i, tty_active_pairs)
-	{
+	for_each_bit(i, tty_active_pairs) {
 		if ((i % 2) == 0) {
 			if (test_bit(i + 1, tty_active_pairs)) {
 				i++;

--- a/scripts/fetch-clang-format.sh
+++ b/scripts/fetch-clang-format.sh
@@ -10,6 +10,7 @@ curl -s "${URL}" | sed -e "
 	s,ControlStatements,ControlStatementsExceptForEachMacros,g;
 	s,ColumnLimit: 80,ColumnLimit: 120,g;
 	s,Intended for clang-format >= 4,Intended for clang-format >= 11,g;
+	s,ForEachMacros:,ForEachMacros:\n  - 'for_each_bit',g;
 	s,ForEachMacros:,ForEachMacros:\n  - 'for_each_pstree_item',g;
 	s,\(AlignTrailingComments:.*\)$,\1\nAlignConsecutiveMacros: true,g;
 	s,AlignTrailingComments: false,AlignTrailingComments: true,g;


### PR DESCRIPTION
clang-format: add for_each_bit macros to ForEachMacros 
+
tty: fix codding-style around for_each_bit call
Wraping "{" to next line after for-each macros is wrong.
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
