### PR TITLE
ci: fix build on centos7 with libbsd-devel

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -37,13 +37,17 @@
 #include "crtools.h"
 #include "cr_options.h"
 #include "servicefd.h"
-#include "string.h"
 #include "ptrace-compat.h"
 #include "util.h"
 #include "namespaces.h"
 #include "image.h"
 #include "proc_parse.h"
 #include "parasite.h"
+/* string.h is included after parasite.h because the libbsd headers define
+ * __has_include as the constant 1.
+ * https://github.com/checkpoint-restore/criu/issues/2036
+ */
+#include "string.h"
 #include "parasite-syscall.h"
 #include "compel/ptrace.h"
 #include "files.h"


### PR DESCRIPTION
The libbsd-devel package is an optional dependency that enables support for setproctitle(). However, building CRIU on CentOS 7 with this package fails with the following error (https://github.com/checkpoint-restore/criu/issues/2036):

```
criu/include/linux/rseq.h:7:22: fatal error: sys/rseq.h: No such file or directory
 #include <sys/rseq.h>
```