### PR TITLE
restorer: add logging on prctl PR_SET_MM_MAP failure

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1813,6 +1813,24 @@ long __export_restore_task(struct task_restore_args *args)
 		.exe_fd = args->fd_exe_link,
 	};
 	ret = sys_prctl(PR_SET_MM, PR_SET_MM_MAP, (long)&prctl_map, sizeof(prctl_map), 0);
+	if (ret) {
+		pr_debug("prctl PR_SET_MM_MAP failed with %d\n", (int)ret);
+		pr_debug("  .start_code = %" PRIx64 "\n", prctl_map.start_code);
+		pr_debug("  .end_code = %" PRIx64 "\n", prctl_map.end_code);
+		pr_debug("  .start_data = %" PRIx64 "\n", prctl_map.start_data);
+		pr_debug("  .end_data = %" PRIx64 "\n", prctl_map.end_data);
+		pr_debug("  .start_stack = %" PRIx64 "\n", prctl_map.start_stack);
+		pr_debug("  .start_brk = %" PRIx64 "\n", prctl_map.start_brk);
+		pr_debug("  .brk = %" PRIx64 "\n", prctl_map.brk);
+		pr_debug("  .arg_start = %" PRIx64 "\n", prctl_map.arg_start);
+		pr_debug("  .arg_end = %" PRIx64 "\n", prctl_map.arg_end);
+		pr_debug("  .env_start = %" PRIx64 "\n", prctl_map.env_start);
+		pr_debug("  .env_end = %" PRIx64 "\n", prctl_map.env_end);
+		pr_debug("  .auxv_size = %" PRIu32 "\n", prctl_map.auxv_size);
+		for (i = 0; i < prctl_map.auxv_size / sizeof(auxv_t); i++)
+			pr_debug("  .auxv[%d] = %" PRIx64 "\n", i, ((auxv_t *)prctl_map.auxv)[i]);
+		pr_debug("  .exe_fd = %" PRIu32 "\n", prctl_map.exe_fd);
+	}
 	if (ret == -EINVAL) {
 		ret = sys_prctl_safe(PR_SET_MM, PR_SET_MM_START_CODE, (long)args->mm.mm_start_code, 0);
 		ret |= sys_prctl_safe(PR_SET_MM, PR_SET_MM_END_CODE, (long)args->mm.mm_end_code, 0);


### PR DESCRIPTION
This kernel feature contained some bugs initially. Those logs are useful in identifing what the underlaying issue is and which kernel patch to backport.

Example logs after faking a failure:
```
(00.013390) pie: 4: prctl PR_SET_MM_MAP failed with 1
(00.013391) pie: 4:   .start_code = 0x402000
(00.013392) pie: 4:   .end_code = 0x404af1
(00.013394) pie: 4:   .start_data = 0x407df0
(00.013395) pie: 4:   .end_data = 0x4083e4
(00.013396) pie: 4:   .start_stack = 0x7ffff0fd4e40
(00.013397) pie: 4:   .start_brk = 0xfe9000
(00.013398) pie: 4:   .brk = 0x100a000
(00.013400) pie: 4:   .arg_start = 0x7ffff0fd54d2
(00.013401) pie: 4:   .arg_end = 0x7ffff0fd5518
(00.013402) pie: 4:   .env_start = 0x7ffff0fd5518
(00.013403) pie: 4:   .env_end = 0x7ffff0fd5ff0
(00.013404) pie: 4:   .auxv_size = 336
(00.013405) pie: 4:   .auxv[0] = 0x21
(00.013407) pie: 4:   .auxv[1] = 0x7ffff0fe5000
(00.013408) pie: 4:   .auxv[2] = 0x33
(00.013409) pie: 4:   .auxv[3] = 0x6f0
(00.013410) pie: 4:   .auxv[4] = 0x10
(00.013411) pie: 4:   .auxv[5] = 0x78bfbff
(00.013413) pie: 4:   .auxv[6] = 0x6
(00.013414) pie: 4:   .auxv[7] = 0x1000
(00.013415) pie: 4:   .auxv[8] = 0x11
(00.013416) pie: 4:   .auxv[9] = 0x64
(00.013417) pie: 4:   .auxv[10] = 0x3
(00.013418) pie: 4:   .auxv[11] = 0x400040
(00.013420) pie: 4:   .auxv[12] = 0x4
(00.013421) pie: 4:   .auxv[13] = 0x38
(00.013422) pie: 4:   .auxv[14] = 0x5
(00.013423) pie: 4:   .auxv[15] = 0xd
(00.013424) pie: 4:   .auxv[16] = 0x7
(00.013426) pie: 4:   .auxv[17] = 0x7f899873b000
(00.013427) pie: 4:   .auxv[18] = 0x8
(00.013428) pie: 4:   .auxv[19] = 0x0
(00.013429) pie: 4:   .auxv[20] = 0x9
(00.013430) pie: 4:   .auxv[21] = 0x402660
(00.013431) pie: 4:   .auxv[22] = 0xb
(00.013433) pie: 4:   .auxv[23] = 0x0
(00.013434) pie: 4:   .auxv[24] = 0xc
(00.013435) pie: 4:   .auxv[25] = 0x0
(00.013436) pie: 4:   .auxv[26] = 0xd
(00.013437) pie: 4:   .auxv[27] = 0x0
(00.013438) pie: 4:   .auxv[28] = 0xe
(00.013440) pie: 4:   .auxv[29] = 0x0
(00.013441) pie: 4:   .auxv[30] = 0x17
(00.013442) pie: 4:   .auxv[31] = 0x0
(00.013443) pie: 4:   .auxv[32] = 0x19
(00.013444) pie: 4:   .auxv[33] = 0x7ffff0fd50a9
(00.013445) pie: 4:   .auxv[34] = 0x1a
(00.013447) pie: 4:   .auxv[35] = 0x2
(00.013448) pie: 4:   .auxv[36] = 0x1f
(00.013449) pie: 4:   .auxv[37] = 0x7ffff0fd5ff0
(00.013450) pie: 4:   .auxv[38] = 0xf
(00.013451) pie: 4:   .auxv[39] = 0x7ffff0fd50b9
(00.013452) pie: 4:   .auxv[40] = 0x0
(00.013454) pie: 4:   .auxv[41] = 0x0
(00.013455) pie: 4:   .exe_fd = 4
```