### PR TITLE
restorer: add logging on prctl PR_SET_MM_MAP failure

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1813,6 +1813,24 @@ long __export_restore_task(struct task_restore_args *args)
 		.exe_fd = args->fd_exe_link,
 	};
 	ret = sys_prctl(PR_SET_MM, PR_SET_MM_MAP, (long)&prctl_map, sizeof(prctl_map), 0);
+	if (ret) {
+		pr_debug("prctl PR_SET_MM_MAP failed with %d\n", (int)ret);
+		pr_debug("  .start_code = %" PRIx64 "\n", prctl_map.start_code);
+		pr_debug("  .end_code = %" PRIx64 "\n", prctl_map.end_code);
+		pr_debug("  .start_data = %" PRIx64 "\n", prctl_map.start_data);
+		pr_debug("  .end_data = %" PRIx64 "\n", prctl_map.end_data);
+		pr_debug("  .start_stack = %" PRIx64 "\n", prctl_map.start_stack);
+		pr_debug("  .start_brk = %" PRIx64 "\n", prctl_map.start_brk);
+		pr_debug("  .brk = %" PRIx64 "\n", prctl_map.brk);
+		pr_debug("  .arg_start = %" PRIx64 "\n", prctl_map.arg_start);
+		pr_debug("  .arg_end = %" PRIx64 "\n", prctl_map.arg_end);
+		pr_debug("  .env_start = %" PRIx64 "\n", prctl_map.env_start);
+		pr_debug("  .env_end = %" PRIx64 "\n", prctl_map.env_end);
+		pr_debug("  .auxv_size = %" PRIu32 "\n", prctl_map.auxv_size);
+		for (i = 0; i < prctl_map.auxv_size / sizeof(uint64_t); i++)
+			pr_debug("  .auxv[%d] = %" PRIx64 "\n", i, prctl_map.auxv[i]);
+		pr_debug("  .exe_fd = %" PRIu32 "\n", prctl_map.exe_fd);
+	}
 	if (ret == -EINVAL) {
 		ret = sys_prctl_safe(PR_SET_MM, PR_SET_MM_START_CODE, (long)args->mm.mm_start_code, 0);
 		ret |= sys_prctl_safe(PR_SET_MM, PR_SET_MM_END_CODE, (long)args->mm.mm_end_code, 0);


### PR DESCRIPTION
This kernel feature contained some bugs initially. Those logs are useful in identifing what the underlaying issue is and which kernel patch to backport.

Example logs after faking a failure:
```
[...]
(00.001826) pie: 56: prctl PR_SET_MM_MAP failed with 1
(00.001827) pie: 56:   .start_code = 0x402000
(00.001828) pie: 56:   .end_code = 0x404af1
(00.001829) pie: 56:   .start_data = 0x407df0
(00.001830) pie: 56:   .end_data = 0x4083e4
(00.001832) pie: 56:   .start_stack = 0x7ffe56abb870
(00.001833) pie: 56:   .start_brk = 0x768000
(00.001834) pie: 56:   .brk = 0x789000
(00.001835) pie: 56:   .arg_start = 0x7ffe56abd4ee
(00.001836) pie: 56:   .arg_end = 0x7ffe56abd534
(00.001837) pie: 56:   .env_start = 0x7ffe56abd534
(00.001838) pie: 56:   .env_end = 0x7ffe56abdff0
(00.001840) pie: 56:   .auxv_size = 336
(00.001841) pie: 56:   .auxv[0] = 0x21
(00.001842) pie: 56:   .auxv[1] = 0x7ffe56b0e000
(00.001846) pie: 56:   .auxv[2] = 0x33
(00.001847) pie: 56:   .auxv[3] = 0x6f0
(00.001849) pie: 56:   .auxv[4] = 0x10
(00.001850) pie: 56:   .auxv[5] = 0x78bfbff
(00.001851) pie: 56:   .auxv[6] = 0x6
(00.001852) pie: 56:   .auxv[7] = 0x1000
(00.001853) pie: 56:   .auxv[8] = 0x11
(00.001854) pie: 56:   .auxv[9] = 0x64
(00.001855) pie: 56:   .auxv[10] = 0x3
(00.001856) pie: 56:   .auxv[11] = 0x400040
(00.001858) pie: 56:   .auxv[12] = 0x4
(00.001859) pie: 56:   .auxv[13] = 0x38
(00.001860) pie: 56:   .auxv[14] = 0x5
(00.001861) pie: 56:   .auxv[15] = 0xd
(00.001862) pie: 56:   .auxv[16] = 0x7
(00.001863) pie: 56:   .auxv[17] = 0x7fa045be4000
(00.001864) pie: 56:   .auxv[18] = 0x8
(00.001866) pie: 56:   .auxv[19] = 0x0
(00.001867) pie: 56:   .auxv[20] = 0x9
(00.001868) pie: 56:   .auxv[21] = 0x402660
(00.001869) pie: 56:   .auxv[22] = 0xb
(00.001870) pie: 56:   .auxv[23] = 0x0
(00.001871) pie: 56:   .auxv[24] = 0xc
(00.001872) pie: 56:   .auxv[25] = 0x0
(00.001873) pie: 56:   .auxv[26] = 0xd
(00.001874) pie: 56:   .auxv[27] = 0x0
(00.001876) pie: 56:   .auxv[28] = 0xe
(00.001877) pie: 56:   .auxv[29] = 0x0
(00.001878) pie: 56:   .auxv[30] = 0x17
(00.001879) pie: 56:   .auxv[31] = 0x0
(00.001880) pie: 56:   .auxv[32] = 0x19
(00.001881) pie: 56:   .auxv[33] = 0x7ffe56abbac9
(00.001882) pie: 56:   .auxv[34] = 0x1a
(00.001883) pie: 56:   .auxv[35] = 0x2
(00.001885) pie: 56:   .auxv[36] = 0x1f
(00.001886) pie: 56:   .auxv[37] = 0x7ffe56abdff0
(00.001887) pie: 56:   .auxv[38] = 0xf
(00.001888) pie: 56:   .auxv[39] = 0x7ffe56abbad9
(00.001889) pie: 56:   .auxv[40] = 0x0
(00.001890) pie: 56:   .auxv[41] = 0x0
(00.001891) pie: 56:   .exe_fd = 8
(00.001893) pie: 56: Error (criu/pie/restorer.c:1857): sys_prctl(PR_SET_MM, PR_SET_MM_MAP) failed with 1
(00.001896) pie: 56: Error (criu/pie/restorer.c:2097): Restorer fail 56
(00.001978) Error (criu/cr-restore.c:1506): 56 exited, status=1
(00.001988) Error (criu/cr-restore.c:2543): Restoring FAILED.
```