### PR TITLE
rseq: hack to check if __has_include always returns true

### DIFF
--- a/criu/include/linux/rseq.h
+++ b/criu/include/linux/rseq.h
@@ -3,9 +3,11 @@
 #define _UAPI_LINUX_RSEQ_H
 
 #ifdef __has_include
+#if !__has_include("defunct/defunct.h")
 #if __has_include("sys/rseq.h")
 #include <sys/rseq.h>
 #include "asm/thread_pointer.h"
+#endif
 #endif
 #endif
 

--- a/test/zdtm/static/rseq00.c
+++ b/test/zdtm/static/rseq00.c
@@ -20,8 +20,10 @@
 #include "zdtmtst.h"
 
 #ifdef __has_include
+#if !__has_include("defunct/defunct.h")
 #if __has_include("sys/rseq.h")
 #include <sys/rseq.h>
+#endif
 #endif
 #endif
 

--- a/test/zdtm/transition/rseq01.c
+++ b/test/zdtm/transition/rseq01.c
@@ -15,8 +15,10 @@
 #include "zdtmtst.h"
 
 #ifdef __has_include
+#if !__has_include("defunct/defunct.h")
 #if __has_include("sys/rseq.h")
 #include <sys/rseq.h>
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
If __has_include("defunct/defunct.h") on non-existant header returns
true it means __has_include dos not work properly and can't be used.

https://github.com/checkpoint-restore/criu/issues/2036

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
