### PR TITLE
Hide bsd headers

### DIFF
--- a/criu/Makefile.crtools
+++ b/criu/Makefile.crtools
@@ -74,6 +74,7 @@ obj-y			+= sk-unix.o
 obj-y			+= sockets.o
 obj-y			+= stats.o
 obj-y			+= string.o
+obj-y			+= setproctitle.o
 obj-y			+= sysctl.o
 obj-y			+= sysfs_parse.o
 obj-y			+= timerfd.o

--- a/criu/apparmor.c
+++ b/criu/apparmor.c
@@ -108,7 +108,7 @@ static int collect_profile(char *path, int offset, char *dir, AaNamespace *ns)
 		return -1;
 	aa_policy__init(cur);
 
-	strlcat(path + my_offset, "name", PATH_MAX - my_offset);
+	__strlcat(path + my_offset, "name", PATH_MAX - my_offset);
 	f = fopen(path, "r");
 	if (!f) {
 		xfree(cur);
@@ -124,7 +124,7 @@ static int collect_profile(char *path, int offset, char *dir, AaNamespace *ns)
 		return -1;
 	}
 
-	strlcpy(path + my_offset, "raw_data", PATH_MAX - my_offset);
+	__strlcpy(path + my_offset, "raw_data", PATH_MAX - my_offset);
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
 		pr_perror("failed to open aa policy %s", path);
@@ -520,13 +520,13 @@ static int write_aa_policy(AaNamespace *ns, char *path, int offset, char *rewrit
 
 			tmp = *end;
 			*end = 0;
-			strlcpy(namespace, rewrite_pos + 1, sizeof(namespace));
+			__strlcpy(namespace, rewrite_pos + 1, sizeof(namespace));
 			*end = tmp;
 
 			break;
 		}
 		default:
-			strlcpy(namespace, ns->name, sizeof(namespace));
+			__strlcpy(namespace, ns->name, sizeof(namespace));
 			for (i = 0; i < ns->n_policies; i++) {
 				if (strcmp(ns->policies[i]->name, rewrite_pos))
 					pr_warn("binary rewriting of apparmor policies not supported right now, not renaming %s to %s\n",

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -429,7 +429,7 @@ static int dump_filemap(struct vma_area *vma_area, int fd)
 	if (vma_area->aufs_rpath) {
 		struct fd_link aufs_link;
 
-		strlcpy(aufs_link.name, vma_area->aufs_rpath, sizeof(aufs_link.name));
+		__strlcpy(aufs_link.name, vma_area->aufs_rpath, sizeof(aufs_link.name));
 		aufs_link.len = strlen(aufs_link.name);
 		p.link = &aufs_link;
 	}
@@ -774,7 +774,7 @@ static int dump_task_core_all(struct parasite_ctl *ctl, struct pstree_item *item
 	if (ret < 0)
 		goto err;
 
-	strlcpy((char *)core->tc->comm, stat->comm, TASK_COMM_LEN);
+	__strlcpy((char *)core->tc->comm, stat->comm, TASK_COMM_LEN);
 	core->tc->flags = stat->flags;
 	core->tc->task_state = item->pid->state;
 	core->tc->exit_code = 0;
@@ -919,7 +919,7 @@ static int dump_one_zombie(const struct pstree_item *item, const struct proc_pid
 	if (!core)
 		return -1;
 
-	strlcpy((char *)core->tc->comm, pps->comm, TASK_COMM_LEN);
+	__strlcpy((char *)core->tc->comm, pps->comm, TASK_COMM_LEN);
 	core->tc->task_state = TASK_DEAD;
 	core->tc->exit_code = pps->exit_code;
 

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3395,7 +3395,7 @@ static struct thread_creds_args *rst_prep_creds_args(CredsEntry *ce, unsigned lo
 
 			args = rst_mem_remap_ptr(this_pos, RM_PRIVATE);
 			args->lsm_profile = lsm_profile;
-			strlcpy(args->lsm_profile, rendered, lsm_profile_len + 1);
+			__strlcpy(args->lsm_profile, rendered, lsm_profile_len + 1);
 			xfree(rendered);
 		}
 	} else {
@@ -3429,7 +3429,7 @@ static struct thread_creds_args *rst_prep_creds_args(CredsEntry *ce, unsigned lo
 
 			args = rst_mem_remap_ptr(this_pos, RM_PRIVATE);
 			args->lsm_sockcreate = lsm_sockcreate;
-			strlcpy(args->lsm_sockcreate, rendered, lsm_sockcreate_len + 1);
+			__strlcpy(args->lsm_sockcreate, rendered, lsm_sockcreate_len + 1);
 			xfree(rendered);
 		}
 	} else {

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -752,7 +752,7 @@ static int dump_using_req(int sk, CriuOpts *req)
 	if (setup_opts_from_req(sk, req))
 		goto exit;
 
-	setproctitle("dump --rpc -t %d -D %s", req->pid, images_dir);
+	__setproctitle("dump --rpc -t %d -D %s", req->pid, images_dir);
 
 	if (init_pidfd_store_hash())
 		goto pidfd_store_err;
@@ -795,7 +795,7 @@ static int restore_using_req(int sk, CriuOpts *req)
 	if (setup_opts_from_req(sk, req))
 		goto exit;
 
-	setproctitle("restore --rpc -D %s", images_dir);
+	__setproctitle("restore --rpc -D %s", images_dir);
 
 	if (cr_restore_tasks())
 		goto exit;
@@ -841,7 +841,7 @@ static int check(int sk, CriuOpts *req)
 	}
 
 	if (pid == 0) {
-		setproctitle("check --rpc");
+		__setproctitle("check --rpc");
 
 		opts.mode = CR_CHECK;
 		if (setup_opts_from_req(sk, req))
@@ -879,7 +879,7 @@ static int pre_dump_using_req(int sk, CriuOpts *req, bool single)
 		if (setup_opts_from_req(sk, req))
 			goto cout;
 
-		setproctitle("pre-dump --rpc -t %d -D %s", req->pid, images_dir);
+		__setproctitle("pre-dump --rpc -t %d -D %s", req->pid, images_dir);
 
 		if (init_pidfd_store_hash())
 			goto pidfd_store_err;
@@ -957,7 +957,7 @@ static int start_page_server_req(int sk, CriuOpts *req, bool daemon_mode)
 		if (setup_opts_from_req(sk, req))
 			goto out_ch;
 
-		setproctitle("page-server --rpc --address %s --port %hu", opts.addr, opts.port);
+		__setproctitle("page-server --rpc --address %s --port %hu", opts.addr, opts.port);
 
 		pr_debug("Starting page server\n");
 
@@ -1117,7 +1117,7 @@ static int handle_feature_check(int sk, CriuReq *msg)
 		if (kerndat_init())
 			exit(1);
 
-		setproctitle("feature-check --rpc");
+		__setproctitle("feature-check --rpc");
 
 		if ((msg->features->has_mem_track == 1) && (msg->features->mem_track == true))
 			feat.mem_track = kdat.has_dirty_track;
@@ -1204,8 +1204,8 @@ static int handle_cpuinfo(int sk, CriuReq *msg)
 		if (setup_opts_from_req(sk, msg->opts))
 			goto cout;
 
-		setproctitle("cpuinfo %s --rpc -D %s", msg->type == CRIU_REQ_TYPE__CPUINFO_DUMP ? "dump" : "check",
-			     images_dir);
+		__setproctitle("cpuinfo %s --rpc -D %s", msg->type == CRIU_REQ_TYPE__CPUINFO_DUMP ? "dump" : "check",
+			       images_dir);
 
 		if (msg->type == CRIU_REQ_TYPE__CPUINFO_DUMP)
 			ret = cpuinfo_dump();

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[], char *envp[])
 	}
 
 	cr_pb_init();
-	setproctitle_init(argc, argv, envp);
+	__setproctitle_init(argc, argv, envp);
 
 	if (argc < 2)
 		goto usage;

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -507,7 +507,7 @@ static int nomntns_create_ghost(struct ghost_file *gf, GhostFileEntry *gfe, stru
 	if (ghost_apply_metadata(path, gfe))
 		return -1;
 
-	strlcpy(gf->remap.rpath, path + 1, PATH_MAX);
+	__strlcpy(gf->remap.rpath, path + 1, PATH_MAX);
 	pr_debug("Remap rpath is %s\n", gf->remap.rpath);
 	return 0;
 }
@@ -638,7 +638,7 @@ static int open_remap_ghost(struct reg_file_info *rfi, RemapFilePathEntry *rpe)
 	gf->remap.rmnt_id = rfi->rfe->mnt_id;
 
 	if (S_ISDIR(gfe->mode))
-		strlcpy(gf->remap.rpath, rfi->path, PATH_MAX);
+		__strlcpy(gf->remap.rpath, rfi->path, PATH_MAX);
 	else
 		ghost_path(gf->remap.rpath, PATH_MAX, rfi, rpe);
 

--- a/criu/files.c
+++ b/criu/files.c
@@ -302,7 +302,7 @@ static int fixup_overlayfs(struct fd_parms *p, struct fd_link *link)
 		char buf[PATH_MAX];
 		int n;
 
-		strlcpy(buf, link->name, PATH_MAX);
+		__strlcpy(buf, link->name, PATH_MAX);
 		n = snprintf(link->name, PATH_MAX, "%s/%s", m->ns_mountpoint, buf + 2);
 		if (n >= PATH_MAX) {
 			pr_err("Not enough space to replace %s\n", buf);

--- a/criu/include/setproctitle.h
+++ b/criu/include/setproctitle.h
@@ -1,19 +1,7 @@
 #ifndef __CR_SETPROCTITLE_H__
 #define __CR_SETPROCTITLE_H__
 
-#ifdef CONFIG_HAS_LIBBSD
-#include <bsd/unistd.h>
-#else
-
-/*
- * setproctitle_init is in the libbsd since v0.6.0. This macro allows to
- * compile criu with libbsd<0.6.0.
- */
-#ifndef CONFIG_HAS_SETPROCTITLE_INIT
-#define setproctitle_init(argc, argv, envp)
-#endif
-
-#define setproctitle(fmt, ...)
-#endif
+extern void __setproctitle_init(int argc, char *argv[], char *envp[]);
+extern void __setproctitle(const char *fmt, ...);
 
 #endif /* __CR_SETPROCTITLE_H__ */

--- a/criu/include/string.h
+++ b/criu/include/string.h
@@ -3,18 +3,9 @@
 
 #include <sys/types.h>
 
-#ifdef CONFIG_HAS_LIBBSD
-#include <bsd/string.h>
-#endif
-
 #include "common/config.h"
 
-#ifndef CONFIG_HAS_STRLCPY
-extern size_t strlcpy(char *dest, const char *src, size_t size);
-#endif
-
-#ifndef CONFIG_HAS_STRLCAT
-extern size_t strlcat(char *dest, const char *src, size_t count);
-#endif
+extern size_t __strlcpy(char *dest, const char *src, size_t size);
+extern size_t __strlcat(char *dest, const char *src, size_t count);
 
 #endif /* __CR_STRING_H__ */

--- a/criu/log.c
+++ b/criu/log.c
@@ -133,7 +133,7 @@ static void log_note_err(char *msg)
 		 */
 		mutex_lock(&first_err->l);
 		if (first_err->s[0] == '\0')
-			strlcpy(first_err->s, msg, sizeof(first_err->s));
+			__strlcpy(first_err->s, msg, sizeof(first_err->s));
 		mutex_unlock(&first_err->l);
 	}
 }

--- a/criu/net.c
+++ b/criu/net.c
@@ -1398,7 +1398,7 @@ static int move_veth(const char *netdev, struct ns_id *ns, struct net_link *link
 	len_val = strlen(netdev);
 	if (len_val >= IFNAMSIZ)
 		return -1;
-	strlcpy(mvreq.ifnam, netdev, IFNAMSIZ);
+	__strlcpy(mvreq.ifnam, netdev, IFNAMSIZ);
 
 	ret = userns_call(move_veth_cb, 0, &mvreq, sizeof(mvreq), ns->net.ns_fd);
 	if (ret < 0)
@@ -1528,7 +1528,7 @@ static int changeflags(int s, char *name, short flags)
 {
 	struct ifreq ifr;
 
-	strlcpy(ifr.ifr_name, name, IFNAMSIZ);
+	__strlcpy(ifr.ifr_name, name, IFNAMSIZ);
 	ifr.ifr_flags = flags;
 
 	if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0) {
@@ -3483,7 +3483,7 @@ static int move_to_bridge(struct external *ext, void *arg)
 			ret = -1;
 			goto out;
 		}
-		strlcpy(ifr.ifr_name, br, IFNAMSIZ);
+		__strlcpy(ifr.ifr_name, br, IFNAMSIZ);
 		ret = ioctl(s, SIOCBRADDIF, &ifr);
 		if (ret < 0) {
 			pr_perror("Can't add interface %s to bridge %s", out, br);
@@ -3495,7 +3495,7 @@ static int move_to_bridge(struct external *ext, void *arg)
 		 * $ ip link set dev <device> up
 		 */
 		ifr.ifr_ifindex = 0;
-		strlcpy(ifr.ifr_name, out, IFNAMSIZ);
+		__strlcpy(ifr.ifr_name, out, IFNAMSIZ);
 		ret = ioctl(s, SIOCGIFFLAGS, &ifr);
 		if (ret < 0) {
 			pr_perror("Can't get flags of interface %s", out);

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -315,7 +315,7 @@ static int vma_get_mapfile_user(const char *fname, struct vma_area *vma, struct 
 
 	if (is_memfd(vfi_dev)) {
 		char tmp[PATH_MAX];
-		strlcpy(tmp, fname, PATH_MAX);
+		__strlcpy(tmp, fname, PATH_MAX);
 		strip_deleted(tmp, strlen(tmp));
 
 		/*
@@ -890,7 +890,7 @@ int parse_pid_stat(pid_t pid, struct proc_pid_stat *s)
 	*tok = '\0';
 	*p = '\0';
 
-	strlcpy(s->comm, tok + 1, sizeof(s->comm));
+	__strlcpy(s->comm, tok + 1, sizeof(s->comm));
 
 	n = sscanf(p + 1,
 		   " %c %d %d %d %d %d %u %lu %lu %lu %lu "

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -146,12 +146,12 @@ static int freezer_write_state(int fd, enum freezer_state new_state)
 	if (new_state == THAWED) {
 		if (cgroup_v2)
 			state[0] = '0';
-		else if (strlcpy(state, thawed, sizeof(state)) >= sizeof(state))
+		else if (__strlcpy(state, thawed, sizeof(state)) >= sizeof(state))
 			return -1;
 	} else if (new_state == FROZEN) {
 		if (cgroup_v2)
 			state[0] = '1';
-		else if (strlcpy(state, frozen, sizeof(state)) >= sizeof(state))
+		else if (__strlcpy(state, frozen, sizeof(state)) >= sizeof(state))
 			return -1;
 	} else {
 		return -1;

--- a/criu/setproctitle.c
+++ b/criu/setproctitle.c
@@ -1,0 +1,42 @@
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#ifdef CONFIG_HAS_LIBBSD
+#include <bsd/unistd.h>
+#else
+
+#include "setproctitle.h"
+
+/*
+ * setproctitle_init is in the libbsd since v0.6.0. This macro allows to
+ * compile criu with libbsd<0.6.0.
+ */
+#ifndef CONFIG_HAS_SETPROCTITLE_INIT
+#define setproctitle_init(argc, argv, envp)
+#endif
+
+#define setproctitle(fmt, ...)
+#endif
+
+void __setproctitle_init(int argc, char *argv[], char *envp[])
+{
+	setproctitle_init(argc, argv, envp);
+}
+
+#ifndef SPT_MAXTITLE
+#define SPT_MAXTITLE 255
+#endif
+
+void __setproctitle(const char *fmt, ...)
+{
+	char buf[SPT_MAXTITLE + 1];
+	va_list args;
+
+	va_start(args, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, args);
+	va_end(args);
+
+	setproctitle("%s", buf);
+}

--- a/criu/string.c
+++ b/criu/string.c
@@ -6,7 +6,6 @@
 
 #include "string.h"
 
-#ifndef CONFIG_HAS_STRLCPY
 /**
  * strlcpy - Copy a %NUL terminated string into a sized buffer
  * @dest: Where to copy the string to
@@ -18,7 +17,7 @@
  * of course, the buffer size is zero). It does not pad
  * out the result like strncpy() does.
  */
-size_t strlcpy(char *dest, const char *src, size_t size)
+size_t __strlcpy(char *dest, const char *src, size_t size)
 {
 	size_t ret = strlen(src);
 
@@ -29,16 +28,14 @@ size_t strlcpy(char *dest, const char *src, size_t size)
 	}
 	return ret;
 }
-#endif
 
-#ifndef CONFIG_HAS_STRLCAT
 /**
  * strlcat - Append a length-limited, %NUL-terminated string to another
  * @dest: The string to be appended to
  * @src: The string to append to it
  * @count: The size of the destination buffer.
  */
-size_t strlcat(char *dest, const char *src, size_t count)
+size_t __strlcat(char *dest, const char *src, size_t count)
 {
 	size_t dsize = strlen(dest);
 	size_t len = strlen(src);
@@ -57,4 +54,3 @@ size_t strlcat(char *dest, const char *src, size_t count)
 	dest[len] = 0;
 	return res;
 }
-#endif

--- a/criu/tun.c
+++ b/criu/tun.c
@@ -121,7 +121,7 @@ static int list_tun_link(NetDeviceEntry *nde, unsigned ns_id)
 	if (!tl)
 		return -1;
 
-	strlcpy(tl->name, nde->name, sizeof(tl->name));
+	__strlcpy(tl->name, nde->name, sizeof(tl->name));
 	/*
 	 * Keep tun-flags not only for persistency fixup (see
 	 * comment below), but also for TUNSETIFF -- we must
@@ -153,7 +153,7 @@ static struct tun_link *__dump_tun_link_fd(int fd, char *name, unsigned ns_id, u
 	tl = xmalloc(sizeof(*tl));
 	if (!tl)
 		goto err;
-	strlcpy(tl->name, name, sizeof(tl->name));
+	__strlcpy(tl->name, name, sizeof(tl->name));
 	tl->ns_id = ns_id;
 	INIT_LIST_HEAD(&tl->l);
 
@@ -241,7 +241,7 @@ static int open_tun_dev(char *name, unsigned int idx, unsigned flags)
 	}
 
 	memset(&ifr, 0, sizeof(ifr));
-	strlcpy(ifr.ifr_name, name, sizeof(ifr.ifr_name));
+	__strlcpy(ifr.ifr_name, name, sizeof(ifr.ifr_name));
 	ifr.ifr_flags = flags;
 
 	if (ioctl(fd, TUNSETIFF, &ifr)) {
@@ -393,7 +393,7 @@ static int tunfile_open(struct file_desc *d, int *new_fd)
 	}
 
 	memset(&ifr, 0, sizeof(ifr));
-	strlcpy(ifr.ifr_name, tl->name, sizeof(ifr.ifr_name));
+	__strlcpy(ifr.ifr_name, tl->name, sizeof(ifr.ifr_name));
 	ifr.ifr_flags = tl->rst.flags;
 
 	if (ioctl(fd, TUNSETIFF, &ifr) < 0) {


### PR DESCRIPTION
string: define wrapers __setproctitle and __setproctitle_init to hide bsd headers

We see that libbsd redefines __has_include to be always true, which
breaks such checks for rseq. The idea behind this patch is to put all
uses of libbsd functions to separate c files and only export wrapper
functions for them.

Using __setproctitle and __setproctitle_init everywhere in existing
code:

git grep --files-with-matches "setproctitle" | xargs sed -i 's/setproctitle/__setproctitle/g'
git grep --files-with-matches "setproctitle_init" | xargs sed -i 's/setproctitle_init/__setproctitle_init/g'

Fixes: #2036
Suggested-by: Andrei Vagin <avagin@google.com>
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

string: define wrapers __strlcpy and __strlcat to hide bsd headers

We see that libbsd redefines __has_include to be always true, which
breaks such checks for rseq. The idea behind this patch is to put all
uses of libbsd functions to separate c files and only export wrapper
functions for them.

Using __strlcat and __strlcpy everywhere in existing code:
git grep --files-with-matches "strlcat" | xargs sed -i 's/strlcat/__strlcat/g'
git grep --files-with-matches "strlcpy" | xargs sed -i 's/strlcpy/__strlcpy/g'

Fixes: #2036
Suggested-by: Andrei Vagin <avagin@google.com>
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
