### PR TITLE
ci: update base OS from 20.04 to 22.04

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [GCC=1, CLANG=1]

--- a/.github/workflows/archlinux-test.yml
+++ b/.github/workflows/archlinux-test.yml
@@ -9,7 +9,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+
     steps:
     - uses: actions/checkout@v2
     - name: Run Arch Linux Test

--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -9,11 +9,10 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [GCC, CLANG]
-
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -9,10 +9,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
+    runs-on: ubuntu-22.04
+
     steps:
     - uses: actions/checkout@v2
     - name: Run Docker Test (${{ matrix.os }})

--- a/.github/workflows/fedora-asan-test.yml
+++ b/.github/workflows/fedora-asan-test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/fedora-rawhide-test.yml
+++ b/.github/workflows/fedora-rawhide-test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/gcov-test.yml
+++ b/.github/workflows/gcov-test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/java-test.yml
+++ b/.github/workflows/java-test.yml
@@ -9,7 +9,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+
     steps:
     - uses: actions/checkout@v2
     - name: Run Java Test

--- a/.github/workflows/podman-test.yml
+++ b/.github/workflows/podman-test.yml
@@ -9,7 +9,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+
     steps:
     - uses: actions/checkout@v2
     - name: Run Podman Test

--- a/.github/workflows/stream-test.yml
+++ b/.github/workflows/stream-test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/x86-64-clang-test.yml
+++ b/.github/workflows/x86-64-clang-test.yml
@@ -9,7 +9,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+
     steps:
     - uses: actions/checkout@v2
     - name: Run X86_64 CLANG Test

--- a/.github/workflows/x86-64-gcc-test.yml
+++ b/.github/workflows/x86-64-gcc-test.yml
@@ -9,7 +9,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+
     steps:
     - uses: actions/checkout@v2
     - name: Run X86_64 GCC Test


### PR DESCRIPTION
This patch updates the base OS image used with GitHub actions from Ubuntu 20.04 to 22.04.