### PR TITLE
log: make pr_* work nicely with %m

### DIFF
--- a/criu/log.c
+++ b/criu/log.c
@@ -316,6 +316,7 @@ static void early_vprint(const char *format, unsigned int loglevel, va_list para
 {
 	unsigned int log_size = 0;
 	struct early_log_hdr *hdr;
+	int _errno = errno;
 
 	if ((early_log_buf_off + sizeof(hdr)) >= EARLY_LOG_BUF_LEN)
 		return;
@@ -337,6 +338,7 @@ static void early_vprint(const char *format, unsigned int loglevel, va_list para
 				    "(00.000000) ");
 	}
 
+	errno = _errno;
 	log_size += vsnprintf(early_log_buffer + early_log_buf_off + log_size,
 			      sizeof(early_log_buffer) - early_log_buf_off - log_size, format, params);
 
@@ -359,6 +361,7 @@ static void vprint_on_level(unsigned int loglevel, const char *format, va_list p
 		 * make sure all messages are written to the early_log_buffer.
 		 */
 		if (!init_done) {
+			errno = _errno;
 			early_vprint(format, loglevel, params);
 			return;
 		}
@@ -369,6 +372,7 @@ static void vprint_on_level(unsigned int loglevel, const char *format, va_list p
 			print_ts();
 	}
 
+	errno = _errno;
 	size = vsnprintf(buffer + buf_off, sizeof buffer - buf_off, format, params);
 	size += buf_off;
 


### PR DESCRIPTION
As vprint_on_level calls different functions in different cases it is possible that errno can become overwritten by some operation. Let's resset errno to the original value just before calling vsnprintf.

Note: in compel %m is not allowed so we don't need to fix errno there.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
