### PR TITLE
Prohibit to use procent m in pr  functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,7 @@ lint:
 	# Do not append \n to pr_perror or fail
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*\\n"'
 	# Do not use %m with pr_perror or fail
-	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*%m'
+	! git --no-pager grep -E '^\s*\<(pr_(err|perror|warn|debug|info|msg)|fail)\>.*%m'
 	# Do not use errno with pr_perror or fail
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>\(".*".*errno'
 	# End pr_(err|warn|msg|info|debug) with \n

--- a/compel/include/log.h
+++ b/compel/include/log.h
@@ -1,6 +1,9 @@
 #ifndef COMPEL_LOG_H__
 #define COMPEL_LOG_H__
 
+#include <errno.h>
+#include <string.h>
+
 #include "uapi/compel/log.h"
 
 #ifndef LOG_PREFIX
@@ -45,6 +48,6 @@ extern void compel_print_on_level(unsigned int loglevel, const char *format, ...
 
 #define pr_debug(fmt, ...) compel_print_on_level(COMPEL_LOG_DEBUG, LOG_PREFIX fmt, ##__VA_ARGS__)
 
-#define pr_perror(fmt, ...) pr_err(fmt ": %m\n", ##__VA_ARGS__)
+#define pr_perror(fmt, ...) pr_err(fmt ": %s\n", ##__VA_ARGS__, strerror(errno))
 
 #endif /* COMPEL_LOG_H__ */

--- a/criu/fsnotify.c
+++ b/criu/fsnotify.c
@@ -183,7 +183,7 @@ static char *alloc_openable(unsigned int s_dev, unsigned long i_ino, FhEntry *f_
 				return path;
 			}
 		} else
-			pr_debug("\t\t\tnot openable as %s (%m)\n", __path);
+			pr_debug("\t\t\tnot openable as %s (%s)\n", __path, strerror(errno));
 	}
 
 err:

--- a/criu/include/sk-inet.h
+++ b/criu/include/sk-inet.h
@@ -76,7 +76,7 @@ static inline void tcp_repair_off(int fd)
 
 	ret = setsockopt(fd, SOL_TCP, TCP_REPAIR, &aux, sizeof(aux));
 	if (ret < 0)
-		pr_err("Failed to turn off repair mode on socket: %m\n");
+		pr_err("Failed to turn off repair mode on socket\n");
 }
 
 extern void tcp_locked_conn_add(struct inet_sk_info *);

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1055,9 +1055,9 @@ static int kerndat_has_move_mount_set_group(void)
 	exit_code = 0;
 out:
 	if (umount2(tmpdir, MNT_DETACH))
-		pr_warn("Fail to umount2 %s: %m\n", tmpdir);
+		pr_warn("Fail to umount2 %s: %s\n", tmpdir, strerror(errno));
 	if (rmdir(tmpdir))
-		pr_warn("Fail to rmdir %s: %m\n", tmpdir);
+		pr_warn("Fail to rmdir %s: %s\n", tmpdir, strerror(errno));
 	return exit_code;
 }
 

--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -221,7 +221,7 @@ int kerndat_socket_unix_file(void)
 	}
 	fd = ioctl(sk, SIOCUNIXFILE);
 	if (fd < 0 && errno != ENOENT) {
-		pr_warn("Unable to open a socket file: %m\n");
+		pr_warn("Unable to open a socket file: %s\n", strerror(errno));
 		kdat.sk_unix_file = false;
 		close(sk);
 		return 0;
@@ -620,7 +620,8 @@ static int unix_resolve_name_old(int lfd, uint32_t id, struct unix_sk_desc *d, U
 	snprintf(rpath, sizeof(rpath), ".%s", name);
 	if (fstatat(mntns_root, rpath, &st, 0)) {
 		if (errno != ENOENT) {
-			pr_warn("Can't stat socket %#" PRIx32 "(%s), skipping: %m (err %d)\n", id, rpath, errno);
+			pr_warn("Can't stat socket %#" PRIx32 "(%s), skipping: %s (err %d)\n", id, rpath,
+				strerror(errno), errno);
 			goto skip;
 		}
 
@@ -669,7 +670,7 @@ static int unix_resolve_name(int lfd, uint32_t id, struct unix_sk_desc *d, UnixS
 
 	fd = ioctl(lfd, SIOCUNIXFILE);
 	if (fd < 0) {
-		pr_warn("Unable to get a socket file descriptor with SIOCUNIXFILE ioctl: %m\n");
+		pr_warn("Unable to get a socket file descriptor with SIOCUNIXFILE ioctl: %s\n", strerror(errno));
 		goto fallback;
 	}
 


### PR DESCRIPTION
As our pr_* functions are complex and can call different system calls
inside before actual printing (e.g. gettimeofday for timestamps) actual
errno at the time of printing may be changed.
    
Let's just use %s + strerror(errno) instead of %m with pr_* functions to
be explicit that errno to string transformation happens before calling
anything else.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
