### PR TITLE
dump: Show task comm early

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1455,7 +1455,7 @@ static int pre_dump_one_task(struct pstree_item *item, InventoryEntry *parent_ie
 	vm_area_list_init(&vmas);
 
 	pr_info("========================================\n");
-	pr_info("Pre-dumping task (pid: %d)\n", pid);
+	pr_info("Pre-dumping task (pid: %d comm: %s)\n", pid, __task_comm_info(pid));
 	pr_info("========================================\n");
 
 	/*
@@ -1545,7 +1545,7 @@ static int dump_one_task(struct pstree_item *item, InventoryEntry *parent_ie)
 	vm_area_list_init(&vmas);
 
 	pr_info("========================================\n");
-	pr_info("Dumping task (pid: %d)\n", pid);
+	pr_info("Dumping task (pid: %d comm: %s)\n", pid, __task_comm_info(pid));
 	pr_info("========================================\n");
 
 	if (item->pid->state == TASK_DEAD)
@@ -2113,7 +2113,7 @@ int cr_dump_tasks(pid_t pid)
 	int ret = -1;
 
 	pr_info("========================================\n");
-	pr_info("Dumping processes (pid: %d)\n", pid);
+	pr_info("Dumping processes (pid: %d comm: %s)\n", pid, __task_comm_info(pid));
 	pr_info("========================================\n");
 
 	/*

--- a/criu/include/seize.h
+++ b/criu/include/seize.h
@@ -6,4 +6,7 @@ extern void pstree_switch_state(struct pstree_item *root_item, int st);
 extern const char *get_real_freezer_state(void);
 extern bool alarm_timeouted(void);
 
+extern char *task_comm_info(pid_t pid, char *comm, size_t size);
+extern char *__task_comm_info(pid_t pid);
+
 #endif

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -24,6 +24,46 @@
 #include "xmalloc.h"
 #include "util.h"
 
+char *task_comm_info(pid_t pid, char *comm, size_t size)
+{
+	int ret = 0;
+
+	if (!pr_quelled(LOG_INFO)) {
+		int saved_errno = errno;
+		char path[32];
+		int fd;
+
+		snprintf(path, sizeof(path), "/proc/%d/comm", pid);
+		fd = open(path, O_RDONLY);
+		if (fd >= 0) {
+			ssize_t n = read(fd, comm, size);
+			if (n > 0)
+				comm[n - 1] = '\0';
+			else
+				ret = -1;
+			close(fd);
+		} else {
+			ret = -1;
+		}
+		errno = saved_errno;
+	}
+
+	if (ret || (pr_quelled(LOG_INFO) && comm[0]))
+		comm[0] = '\0';
+
+	return comm;
+}
+
+/*
+ * NOTE: Don't run simultaneously, it uses local static buffer!
+ */
+char *__task_comm_info(pid_t pid)
+{
+	static char comm[32];
+
+	return task_comm_info(pid, comm, sizeof(comm));
+}
+
 #define NR_ATTEMPTS 5
 
 static const char frozen[] = "FROZEN";
@@ -249,13 +289,13 @@ static int seize_cgroup_tree(char *root_path, enum freezer_state state)
 		if (ret == 0)
 			continue;
 		if (errno != ESRCH) {
-			pr_perror("Unexpected error");
+			pr_perror("Unexpected error for pid %d (comm %s)", pid, __task_comm_info(pid));
 			fclose(f);
 			return -1;
 		}
 
 		if (!compel_interrupt_task(pid)) {
-			pr_debug("SEIZE %d: success\n", pid);
+			pr_debug("SEIZE %d (comm %s): success\n", pid, __task_comm_info(pid));
 			processes_to_wait++;
 		} else if (state == FROZEN) {
 			char buf[] = "/proc/XXXXXXXXXX/exe";
@@ -272,7 +312,7 @@ static int seize_cgroup_tree(char *root_path, enum freezer_state state)
 			 * before it compete exit procedure. The caller simply
 			 * should wait a bit and try freezing again.
 			 */
-			pr_err("zombie found while seizing\n");
+			pr_err("zombie %d (comm %s) found while seizing\n", pid, __task_comm_info(pid));
 			fclose(f);
 			return -EAGAIN;
 		}


### PR DESCRIPTION
When error happens on file dumping stage the only information about the task we dumping is its PID. For debug purpose show task's @comm early.

It proves useful when trying to understand which of dumped applications is "guilty" in brokern dump when pid is not there anymore.

Signed-off-by: Cyrill Gorcunov <gorcunov@virtuozzo.com>
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

--

This is a port of https://src.openvz.org/projects/OVZ/repos/criu/commits/487a62763
CC @cyrillos 

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
