### PR TITLE
ci/lint: make push action have at least too commits depth

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Run make indent
       run: >
         if [ -z "${{github.base_ref}}" ]; then
+          git fetch --deepen=1 &&
           if ! make indent OPTS=--diff; then
             exit 1
           fi


### PR DESCRIPTION
We see that when lint is called for push action git has only one last commit which makes make indent with git-clang-format fail to operate.

Fix it by increasing fetch depth to one more commit.

Fixes: #2066
Fixes: d6db3333a ("clang-format: rework make indent to check specific commits")
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
