### PR TITLE
net/iptables: remove libnft dependency for legacy iptables binary search

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1193,7 +1193,7 @@ static int check_ipt_legacy(void)
 	char *ipt_legacy_bin;
 	char *ip6t_legacy_bin;
 
-	ipt_legacy_bin = get_legacy_iptables_bin(false);
+	ipt_legacy_bin = get_legacy_iptables_bin(false, false);
 	if (!ipt_legacy_bin) {
 		pr_warn("Couldn't find iptables version which is using iptables legacy API\n");
 		return -1;
@@ -1204,7 +1204,7 @@ static int check_ipt_legacy(void)
 	if (!kdat.ipv6)
 		return 0;
 
-	ip6t_legacy_bin = get_legacy_iptables_bin(true);
+	ip6t_legacy_bin = get_legacy_iptables_bin(true, false);
 	if (!ip6t_legacy_bin) {
 		pr_warn("Couldn't find ip6tables version which is using iptables legacy API\n");
 		return -1;

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -384,7 +384,7 @@ static inline void print_stack_trace(pid_t pid)
 
 extern int mount_detached_fs(const char *fsname);
 
-extern char *get_legacy_iptables_bin(bool ipv6);
+extern char *get_legacy_iptables_bin(bool ipv6, bool restore);
 
 extern int set_opts_cap_eff(void);
 

--- a/criu/net.c
+++ b/criu/net.c
@@ -2038,12 +2038,10 @@ static inline int dump_iptables(struct cr_imgset *fds)
 	 * Let's skip iptables dump if we have nftables support compiled in,
 	 * and iptables backend is nft to prevent duplicate dumps.
 	 */
-#if defined(CONFIG_HAS_NFTABLES_LIB_API_0) || defined(CONFIG_HAS_NFTABLES_LIB_API_1)
 	iptables_cmd = get_legacy_iptables_bin(false);
 
 	if (kdat.ipv6)
 		ip6tables_cmd = get_legacy_iptables_bin(true);
-#endif
 
 	if (!iptables_cmd) {
 		pr_info("skipping iptables dump - no legacy version present\n");


### PR DESCRIPTION
We don't use libnft in get_legacy_iptables_bin, so we can safely remove libnft dependency and always search for right legacy binary.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
