### PR TITLE
lint: exclude tags file from codespell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,7 @@ lint:
 	shellcheck -x test/others/libcriu/*.sh
 	shellcheck -x test/others/crit/*.sh test/others/criu-coredump/*.sh
 	shellcheck -x test/others/config-file/*.sh
-	codespell
+	codespell -S tags
 	# Do not append \n to pr_perror or fail
 	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*\\n"'
 	# Do not use %m with pr_perror or fail


### PR DESCRIPTION
If we build tags for our repo:
```
[criu]$ make tags
  GEN      tags
```
And then run codespell, we get an error:
```
[criu]$ codespell
./tags:3755: struc ==> struct
```
Let's exclude tags file from codespell search, this would add usability to `make lint`.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
