### PR TITLE
crit: fix info action

### DIFF
--- a/lib/py/images/images.py
+++ b/lib/py/images/images.py
@@ -98,7 +98,7 @@ class entry_handler:
             # Read payload
             pbuff = self.payload()
             buf = f.read(4)
-            if buf == b'':
+            if len(buf) == 0:
                 break
             size, = struct.unpack('i', buf)
             pbuff.ParseFromString(f.read(size))
@@ -172,7 +172,7 @@ class entry_handler:
 
         while True:
             buf = f.read(4)
-            if buf == '':
+            if len(buf) == 0:
                 break
             size, = struct.unpack('i', buf)
             f.seek(size, 1)
@@ -195,7 +195,7 @@ class pagemap_handler:
         pbuff = pb.pagemap_head()
         while True:
             buf = f.read(4)
-            if buf == b'':
+            if len(buf) == 0:
                 break
             size, = struct.unpack('i', buf)
             pbuff.ParseFromString(f.read(size))
@@ -422,7 +422,7 @@ class ipc_msg_queue_handler:
         messages = []
         for x in range(0, entry['qnum']):
             buf = f.read(4)
-            if buf == '':
+            if len(buf) == 0:
                 break
             size, = struct.unpack('i', buf)
             msg = pb.ipc_msg()
@@ -455,7 +455,7 @@ class ipc_msg_queue_handler:
         pl_len = 0
         for x in range(0, entry['qnum']):
             buf = f.read(4)
-            if buf == '':
+            if len(buf) == 0:
                 break
             size, = struct.unpack('i', buf)
             msg = pb.ipc_msg()

--- a/test/others/crit/test.sh
+++ b/test/others/crit/test.sh
@@ -53,6 +53,9 @@ function run_test2 {
 	# prepare
 	${CRIT} decode -i "${PROTO_IN}" -o "${JSON_IN}"
 
+	# show info about image
+	${CRIT} info "${PROTO_IN}"
+
 	# proto in - json out decode
 	cat "${PROTO_IN}" | ${CRIT} decode || exit 1
 	cat "${PROTO_IN}" | ${CRIT} decode -o "${OUT}" || exit 1


### PR DESCRIPTION
In Python 3 `b'' == ''` is `False`. This causes the `crit info` action to fail with the following error.
```
  File "/usr/lib/python3.11/site-packages/crit-3.17-py3.11.egg/pycriu/images/images.py", line 178, in count
    size, = struct.unpack('i', buf)
            ^^^^^^^^^^^^^^^^^^^^^^^
  struct.error: unpack requires a buffer of 4 bytes
```
Reported-by: Sankalp Acharya (@sankalp-12)