### PR TITLE
Add documentation for --ghost-fiemap

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -384,6 +384,13 @@ mount -t cgroup -o devices,freezer none devices,freezer
     'size' may be postfixed with a *K*, *M* or *G*, which stands for kilo-,
     mega, and gigabytes, accordingly.
 
+*--ghost-fiemap*::
+    Enable an optimization based on fiemap ioctl that can reduce the
+    number of system calls used when checkpointing highly sparse ghost
+    files. This option is enabled by default, and it can be disabled
+    with *--no-ghost-fiemap*. An automatic fallback to SEEK_HOLE/SEEK_DATA
+    is used when fiemap is not supported.
+
 *-j*, *--shell-job*::
     Allow one to dump shell jobs. This implies the restored task will
     inherit session and process group ID from the *criu* itself.

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -445,6 +445,7 @@ usage:
 	       "                        is inaccessible\n"
 	       "  --link-remap          allow one to link unlinked files back when possible\n"
 	       "  --ghost-limit size    limit max size of deleted file contents inside image\n"
+	       "  --ghost-fiemap        enable dumping of deleted files using fiemap\n"
 	       "  --action-script FILE  add an external action script\n"
 	       "  -j|--" OPT_SHELL_JOB "        allow one to dump and restore shell jobs\n"
 	       "  -l|--" OPT_FILE_LOCKS "       handle file locks, for safety, only used for container\n"


### PR DESCRIPTION
The `--ghost-fiemap` option was introduced with #1963. It enables an optimized algorithm based on fiemap ioctl that can reduce the number of syscalls used to checkpoint highly sparse ghost files.
