### PR TITLE
ci: disable c/r of cgroups with podman

### DIFF
--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -25,6 +25,12 @@ make install
 popd
 rm -rf "${tmp_dir}"
 
+# FIXME: Disable checkpoint/restore of cgroups
+# https://github.com/checkpoint-restore/criu/issues/2091
+mkdir -p /etc/criu
+echo "manage-cgroups ignore" > /etc/criu/runc.conf
+sed -i 's/#runtime\s*=\s*.*/runtime = "runc"/' /usr/share/containers/containers.conf
+
 podman info
 
 podman run --name cr -d docker.io/library/alpine /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'

--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -11,20 +11,6 @@ make install PREFIX=/usr
 
 criu --version
 
-# Install crun build dependencies
-scripts/ci/apt-install libyajl-dev libseccomp-dev libsystemd-dev
-
-# Install crun from source to test libcriu integration
-tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
-pushd "${tmp_dir}"
-git clone --depth=1 https://github.com/containers/crun
-cd crun
-./autogen.sh && ./configure --prefix=/usr
-make -j"$(nproc)"
-make install
-popd
-rm -rf "${tmp_dir}"
-
 # FIXME: Disable checkpoint/restore of cgroups
 # https://github.com/checkpoint-restore/criu/issues/2091
 mkdir -p /etc/criu


### PR DESCRIPTION
This PR disables the checkpoint/restore of cgroups for the tests using Podman as a temporary workaround for https://github.com/checkpoint-restore/criu/issues/2091