### PR TITLE
zdtm/transition/epoll: don't rely on errno in case of zero return

### DIFF
--- a/test/zdtm/transition/epoll.c
+++ b/test/zdtm/transition/epoll.c
@@ -158,9 +158,11 @@ int main(int argc, char **argv)
 			exit(1);
 		}
 		for (i = 0; i < rv; i++) {
-			while (read(events[i].data.fd, buf, buf_size) > 0)
+			int ret;
+
+			while ((ret = read(events[i].data.fd, buf, buf_size)) > 0)
 				;
-			if (errno != EAGAIN && errno != 0 && errno) {
+			if (ret < 0 && errno != EAGAIN) {
 				pr_perror("read error");
 				killall();
 				exit(1);


### PR DESCRIPTION
Checking errno in case read succeeded is undefined behaviour.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
