### PR TITLE
coredump: two small fixes

### DIFF
--- a/coredump/coredump.py
+++ b/coredump/coredump.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 import criu_coredump
 
@@ -34,7 +35,12 @@ def main():
 
     opts = vars(parser.parse_args())
 
-    coredump(opts)
+    try:
+        coredump(opts)
+    except SystemExit as error:
+        print('ERROR: %s' % error)
+        print('Exiting')
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/coredump/criu_coredump/coredump.py
+++ b/coredump/criu_coredump/coredump.py
@@ -692,7 +692,11 @@ class coredump_generator:
             files = self.reg_files
             fname = next(filter(lambda x: x["id"] == shmid, files))["name"]
 
-            f = open(fname, 'rb')
+            try:
+                f = open(fname, 'rb')
+            except FileNotFoundError:
+                sys.exit('Required file %s not found.' % fname)
+
             f.seek(off)
 
         start = vma["start"]

--- a/coredump/criu_coredump/coredump.py
+++ b/coredump/criu_coredump/coredump.py
@@ -315,7 +315,9 @@ class coredump_generator:
         prpsinfo.pr_ppid = pstree["ppid"]
         prpsinfo.pr_pgrp = pstree["pgid"]
         prpsinfo.pr_sid = pstree["sid"]
-        prpsinfo.pr_psargs = self._gen_cmdline(pid)
+        # prpsinfo.pr_psargs has a limit of 80 characters which means it will
+        # fail here if the cmdline is longer than 80
+        prpsinfo.pr_psargs = self._gen_cmdline(pid)[:80]
         if (sys.version_info > (3, 0)):
             prpsinfo.pr_fname = core["tc"]["comm"].encode()
         else:

--- a/test/others/criu-coredump/test.sh
+++ b/test/others/criu-coredump/test.sh
@@ -5,7 +5,7 @@ set -x
 source ../env.sh || exit 1
 
 function gen_imgs {
-	PID=$(../loop)
+	PID=$(../loop with a very very very very very very very very very very very very long cmdline)
 	if ! $CRIU dump -v4 -o dump.log -D ./ -t "$PID"; then
 		echo "Failed to checkpoint process $PID"
 		cat dump.log


### PR DESCRIPTION
This fixes errors with long command-lines:
```
  File "/home/criu/coredump/criu_coredump/coredump.py", line 320, in _gen_prpsinfo
    prpsinfo.pr_psargs = self._gen_cmdline(pid)
    ^^^^^^^^^^^^^^^^^^
ValueError: bytes too long (88, maximum length 80)
```
and gives a cleaner error (without a complete Python backtrace) if files are missing:

New message:
```
 ERROR: Required file /usr/lib64/libcrypto.so.3.0.1 not found.
 Exiting
```
Old message:
```
   File "/home/criu/coredump/criu_coredump/coredump.py", line 693, in _gen_mem_chunk
     f = open(fname, 'rb')
 FileNotFoundError: [Errno 2] No such file or directory: '/usr/lib64/libcrypto.so.3.0.1'
```
Test has also been adapted verify that long command-lines do not break the coredump script.