### PR TITLE
pstree: fix shell job pgid replacement

### DIFF
--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -397,7 +397,7 @@ static int prepare_pstree_for_shell_job(pid_t pid)
 		return 0;
 
 	old_gid = root_item->pgid;
-	if (old_gid != current_gid) {
+	if (old_gid != current_gid && old_gid != current_sid) {
 		pr_info("Migrating process tree (GID %d->%d)\n", old_gid, current_gid);
 
 		tmp = pstree_pid_by_virt(current_gid);


### PR DESCRIPTION
Imagine situation entering prepare_pstree_for_shell_job we have:

  root_item->sid == 10
  root_item->pgid == 10
  current_sid == 20
  current_gid == 21

Then sid replacement loop would replace 10 to 20 everywhere in sids and pgids for all tasks including root_item so we have:

  root_item->sid == 20
  root_item->pgid == 20
  current_sid == 20
  current_gid == 21

Then pgid replacement loop would be entered and replace 20 to 21 everywhere in pgid and we would have:

  root_item->sid == 20
  root_item->pgid == 21

So 10,10 switched to 20,21, it does not feel right to me, better if restore would just ignore 21 in such case.

Alternatively we can just prohibit sid/pgid replacement `if ((root_item->sid == oot_item->pgid) != (current_sid == current_gid))`, but I believe it would be harder to use --shell-job option with this strict check.