### PR TITLE
make: disable '-Wdangling-pointer' warning with gcc 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,15 @@ DEFINES			+= -D_GNU_SOURCE
 
 WARNINGS		:= -Wall -Wformat-security -Wdeclaration-after-statement -Wstrict-prototypes
 
+# -Wdangling-pointer results in false warning when we add a list element to
+# local list head variable. It is false positive because before leaving the
+# function we always check that local list head variable is empty, thus
+# insuring that pointer to it is not dangling anywhere, but gcc can't
+# understand it.
+# Note: There is similar problem with kernel list, where this warning is also
+# disabled: https://github.com/torvalds/linux/commit/49beadbd47c2
+WARNINGS		+= -Wno-dangling-pointer -Wno-unknown-warning-option
+
 CFLAGS-GCOV		:= --coverage -fno-exceptions -fno-inline -fprofile-update=atomic
 export CFLAGS-GCOV
 


### PR DESCRIPTION
The patch is similar to what has been done in linux kernel, as this warning effectively prevents us from adding list elements to local list head. See https://github.com/torvalds/linux/commit/49beadbd47c2

Note: it fixes CI.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
