### PR TITLE
ci/lint: disable 'make indent'

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,17 +19,3 @@ jobs:
 
     - name: Run make lint
       run: make lint
-
-    - name: Run make indent
-      run: >
-        if [ -z "${{github.base_ref}}" ]; then
-          git fetch --deepen=1 &&
-          if ! make indent OPTS=--diff; then
-            exit 1
-          fi
-        else
-          git fetch origin ${{github.base_ref}} &&
-          if ! make indent OPTS=--diff BASE=origin/${{github.base_ref}}; then
-            exit 1
-          fi
-        fi


### PR DESCRIPTION
Following the discussions in https://github.com/checkpoint-restore/criu/pull/2044, https://github.com/checkpoint-restore/criu/pull/2035 and [[3]](https://github.com/checkpoint-restore/criu/pull/2106) we have decided that we should not blindly follow clang-format autoformat rules. In particular, if clang-format autoformat changes decrease code readability then we skip clang-format errors. Thus, in this patch we drop the `make indent` check to avoid false positive errors.