### PR TITLE
x86/xsave: Set only used XFEATURE_* in xstate_bv

### DIFF
--- a/criu/arch/x86/crtools.c
+++ b/criu/arch/x86/crtools.c
@@ -433,7 +433,7 @@ int restore_fpu(struct rt_sigframe *sigframe, CoreEntry *core)
 #define assign_array(dst, src, e) memcpy(dst.e, (src)->e, sizeof(dst.e))
 #define assign_xsave(feature, xsave, member, area)                                                                \
 	do {                                                                                                      \
-		if (compel_fpu_has_feature(feature)) {                                                            \
+		if (compel_fpu_has_feature(feature) && (xsave->xstate_bv & (1UL << feature))) {                   \
 			uint32_t off = compel_fpu_feature_offset(feature);                                        \
 			void *to = &area[off];                                                                    \
 			void *from = xsave->member;                                                               \


### PR DESCRIPTION
Just rebasing on top of `criu-dev`.

All credit to Dmitry @0x7f454c46 for this incredible investigation and fix. (-:
```
Setting all supported by CPU features in xstate_bv may bring it into dirty-upper-state as documented in specs, resulting in lower performance. Let's not do this and set only those have been used by dumpee.

P.S.
Off course it has to be a one-liner!

Fixes: #1171
```

Fixes: #1171