### PR TITLE
Handle processes with uprobes

### DIFF
--- a/criu/include/image.h
+++ b/criu/include/image.h
@@ -60,6 +60,11 @@
  *  	memory map for socket
  *  - AIO ring
  *  	memory area serves AIO buffers
+ *  - Uprobes
+ *  	XOL (execution out of line) memory area installed to the
+ *  	process mm_struct by the kernel for internal uprobes needs.
+ *  	CRIU skips it on restore, but we save all metadata about it
+ *  	to the CRIU images just in case.
  *  - unsupported
  *  	stands for any unknown memory areas, usually means
  *  	we don't know how to work with it and should stop
@@ -84,6 +89,7 @@
 #define VMA_AREA_VVAR	 (1 << 12)
 #define VMA_AREA_AIORING (1 << 13)
 #define VMA_AREA_MEMFD	 (1 << 14)
+#define VMA_AREA_UPROBES (1 << 15)
 
 #define VMA_EXT_PLUGIN	  (1 << 27)
 #define VMA_CLOSE	  (1 << 28)

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1768,6 +1768,18 @@ long __export_restore_task(struct task_restore_args *args)
 		unsigned long m;
 
 		vma_entry = args->vmas + i;
+
+		/*
+		 * We don't want to call madvice(2) on the mappings that are not restored by CRIU,
+		 * but presented in the CRIU images (uprobes XOL mapping, for instance), otherwise
+		 * we'll get -ENOMEM error from madvise(2).
+		 *
+		 * Please, keep this consistent with the checks before restore_mapping() call above.
+		 */
+		if (!vma_entry_is(vma_entry, VMA_PREMMAPED) && !vma_entry_is(vma_entry, VMA_AREA_REGULAR) &&
+		    !vma_entry_is(vma_entry, VMA_AREA_AIORING))
+			continue;
+
 		if (!vma_entry->has_madv || !vma_entry->madv)
 			continue;
 

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -572,6 +572,8 @@ static int handle_vma(pid_t pid, struct vma_area *vma_area, const char *file_pat
 			goto err;
 	} else if (!strcmp(file_path, "[heap]")) {
 		vma_area->e->status |= VMA_AREA_REGULAR | VMA_AREA_HEAP;
+	} else if (!strcmp(file_path, "[uprobes]")) {
+		vma_area->e->status |= VMA_AREA_UPROBES;
 	} else {
 		vma_area->e->status = VMA_AREA_REGULAR;
 	}
@@ -708,6 +710,9 @@ static int vma_list_add(struct vma_area *vma_area, struct vm_area_list *vma_area
 		 */
 		pr_debug("Device file mapping %016" PRIx64 "-%016" PRIx64 " supported via device plugins\n",
 			 vma_area->e->start, vma_area->e->end);
+	} else if (vma_area->e->status & VMA_AREA_UPROBES) {
+		pr_warn("Uprobes XOL area mapping %016" PRIx64 "-%016" PRIx64 " will be skipped\n", vma_area->e->start,
+			vma_area->e->end);
 	} else if (vma_area->e->status & VMA_UNSUPP) {
 		pr_err("Unsupported mapping found %016" PRIx64 "-%016" PRIx64 "\n", vma_area->e->start,
 		       vma_area->e->end);

--- a/criu/util.c
+++ b/criu/util.c
@@ -197,6 +197,7 @@ static void vma_opt_str(const struct vma_area *v, char *opt)
 	opt2s(VMA_AREA_SOCKET, "sk");
 	opt2s(VMA_AREA_AIORING, "aio");
 	opt2s(VMA_AREA_MEMFD, "memfd");
+	opt2s(VMA_AREA_UPROBES, "uprobes");
 	opt2s(VMA_EXT_PLUGIN, "ext");
 	opt2s(VMA_CLOSE, "close");
 	opt2s(VMA_NO_PROT_WRITE, "nowrite");

--- a/criu/util.c
+++ b/criu/util.c
@@ -195,6 +195,12 @@ static void vma_opt_str(const struct vma_area *v, char *opt)
 	opt2s(VMA_ANON_PRIVATE, "ap");
 	opt2s(VMA_AREA_SYSVIPC, "sysv");
 	opt2s(VMA_AREA_SOCKET, "sk");
+	opt2s(VMA_AREA_AIORING, "aio");
+	opt2s(VMA_AREA_MEMFD, "memfd");
+	opt2s(VMA_EXT_PLUGIN, "ext");
+	opt2s(VMA_CLOSE, "close");
+	opt2s(VMA_NO_PROT_WRITE, "nowrite");
+	opt2s(VMA_PREMMAPED, "premap");
 
 #undef opt2s
 }

--- a/lib/py/images/pb2dict.py
+++ b/lib/py/images/pb2dict.py
@@ -103,6 +103,11 @@ mmap_status_map = [
     ('VMA_AREA_SOCKET', 1 << 11),
     ('VMA_AREA_VVAR', 1 << 12),
     ('VMA_AREA_AIORING', 1 << 13),
+    ('VMA_AREA_MEMFD', 1 << 14),
+    ('VMA_EXT_PLUGIN', 1 << 27),
+    ('VMA_CLOSE', 1 << 28),
+    ('VMA_NO_PROT_WRITE', 1 << 29),
+    ('VMA_PREMMAPED', 1 << 30),
     ('VMA_UNSUPP', 1 << 31),
 ]
 

--- a/lib/py/images/pb2dict.py
+++ b/lib/py/images/pb2dict.py
@@ -104,6 +104,7 @@ mmap_status_map = [
     ('VMA_AREA_VVAR', 1 << 12),
     ('VMA_AREA_AIORING', 1 << 13),
     ('VMA_AREA_MEMFD', 1 << 14),
+    ('VMA_AREA_UPROBES', 1 << 15),
     ('VMA_EXT_PLUGIN', 1 << 27),
     ('VMA_CLOSE', 1 << 28),
     ('VMA_NO_PROT_WRITE', 1 << 29),


### PR DESCRIPTION
Linux kernel uprobes (userspace probes) subsystem, uses special
type of VMAs, so-called XOL (execution out of line) mappings.
( see ("uprobes/core: Allocate XOL slots for uprobes use") https://github.com/torvalds/linux/commit/d4b3b6384f98f8692ad0209891ccdbc7e78bbefe )
This mappings are service mappings for internal uprobes mechanism needs,
it stores the original instruction to execute.

uprobes mechanism works by replacing the original instruction in the
tracee's address space by some kind of a breakpoint [see set_swbp() in
kernel/events/uprobes.c].

To achieve that, uprobes modifies existing code mappings (VMAs),
and replaces the page, that corresponds to a tracable virtual address
by a new temporary page [see uprobe_write_opcode()].

CRIU ignores such code modifications because executable code lies in
a file mappings, but CRIU does nothing with the file mappings contents.

It means that after C/R we are running the original processes code,
without uprobes traps. Therefore, we can safely drop XOL mapping too,
because it's only needed when uprobe tracing is enabled, and used
only during the short period of time when uprobe trap is handled in the kernel.

Fixes: #1961