### PR TITLE
ci: cancel preceding workflows run

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -2,6 +2,11 @@ name: Alpine Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: alpine-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/archlinux-test.yml
+++ b/.github/workflows/archlinux-test.yml
@@ -2,6 +2,11 @@ name: Arch Linux Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: archlinux-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "11 6 * * 3"
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: codeql-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -2,6 +2,11 @@ name: Compat Tests
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: compat-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -2,6 +2,11 @@ name: Cross Compile Tests
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: cross-compile-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -2,6 +2,11 @@ name: Docker Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: docker-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/fedora-asan-test.yml
+++ b/.github/workflows/fedora-asan-test.yml
@@ -2,6 +2,11 @@ name: Fedora ASAN Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: fedora-asan-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/fedora-rawhide-test.yml
+++ b/.github/workflows/fedora-rawhide-test.yml
@@ -2,6 +2,11 @@ name: Fedora Rawhide Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: fedora-rawhide-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gcov-test.yml
+++ b/.github/workflows/gcov-test.yml
@@ -2,6 +2,11 @@ name: Coverage Tests
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: gcov-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/java-test.yml
+++ b/.github/workflows/java-test.yml
@@ -2,6 +2,11 @@ name: Java Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: java-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,11 @@ name: Run code linter
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: lint-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/podman-test.yml
+++ b/.github/workflows/podman-test.yml
@@ -2,6 +2,11 @@ name: Podman Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: podman-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/stream-test.yml
+++ b/.github/workflows/stream-test.yml
@@ -2,6 +2,11 @@ name: CRIU Image Streamer Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: stream-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/x86-64-clang-test.yml
+++ b/.github/workflows/x86-64-clang-test.yml
@@ -2,6 +2,11 @@ name: X86_64 CLANG Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: clang-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/x86-64-gcc-test.yml
+++ b/.github/workflows/x86-64-gcc-test.yml
@@ -2,6 +2,11 @@ name: X86_64 GCC Test
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: gcc-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This pull request adds concurrency groups to the CI workflows to automatically cancel any in-progress workflows when a pull request has been updated. A [`concurrency`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) group allows to ensure that a single job or workflow will run at a time. For example, when a pull request is updated with a force-push, the GiHub CI workflows currently in-progress will be automatically cancelled, and the CI would run only with the updated commits.

