### PR TITLE
limit the field width of 'scanf'

### DIFF
--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -1407,7 +1407,7 @@ static int parse_mountinfo_ent(char *str, struct mount_info *new, char **fsname)
 		goto err;
 
 	new->mountpoint[0] = '.';
-	ret = sscanf(str, "%i %i %u:%u %ms %s %ms %n", &new->mnt_id, &new->parent_mnt_id, &kmaj, &kmin, &new->root,
+	ret = sscanf(str, "%i %i %u:%u %ms %4094s %ms %n", &new->mnt_id, &new->parent_mnt_id, &kmaj, &kmin, &new->root,
 		     new->mountpoint + 1, &opt, &n);
 	if (ret != 7)
 		goto err;
@@ -2208,10 +2208,10 @@ static int parse_file_lock_buf(char *buf, struct file_lock *fl, bool is_blocked)
 	char fl_flag[10], fl_type[15], fl_option[10];
 
 	if (is_blocked) {
-		num = sscanf(buf, "%lld: -> %s %s %s %d %x:%x:%ld %lld %s", &fl->fl_id, fl_flag, fl_type, fl_option,
+		num = sscanf(buf, "%lld: -> %9s %14s %9s %d %x:%x:%ld %lld %31s", &fl->fl_id, fl_flag, fl_type, fl_option,
 			     &fl->fl_owner, &fl->maj, &fl->min, &fl->i_no, &fl->start, fl->end);
 	} else {
-		num = sscanf(buf, "%lld:%s %s %s %d %x:%x:%ld %lld %s", &fl->fl_id, fl_flag, fl_type, fl_option,
+		num = sscanf(buf, "%lld:%9s %14s %9s %d %x:%x:%ld %lld %31s", &fl->fl_id, fl_flag, fl_type, fl_option,
 			     &fl->fl_owner, &fl->maj, &fl->min, &fl->i_no, &fl->start, fl->end);
 	}
 

--- a/test/zdtm/lib/fs.c
+++ b/test/zdtm/lib/fs.c
@@ -54,7 +54,7 @@ mnt_info_t *get_cwd_mnt_info(void)
 
 	while (fgets(str, sizeof(str), f)) {
 		char *hyphen = strchr(str, '-');
-		ret = sscanf(str, "%i %i %u:%u %s %s", &mnt_id, &parent_mnt_id, &kmaj, &kmin, root, mountpoint);
+		ret = sscanf(str, "%i %i %u:%u %4095s %4095s", &mnt_id, &parent_mnt_id, &kmaj, &kmin, root, mountpoint);
 		if (ret != 6 || !hyphen)
 			goto err;
 		ret = sscanf(hyphen + 1, " %ms", &fsname);

--- a/test/zdtm/static/apparmor.c
+++ b/test/zdtm/static/apparmor.c
@@ -59,7 +59,7 @@ int checkprofile(void)
 		return -1;
 	}
 
-	len = fscanf(f, "%[^ \n]s", profile);
+	len = fscanf(f, "%1023[^ \n]s", profile);
 	fclose(f);
 	if (len != 1) {
 		fail("wrong number of items scanned %d", len);

--- a/test/zdtm/static/apparmor_stacking.c
+++ b/test/zdtm/static/apparmor_stacking.c
@@ -56,7 +56,7 @@ static int checkprofile(pid_t pid, char *expected)
 		return -1;
 	}
 
-	len = fscanf(f, "%[^ \n]s", profile);
+	len = fscanf(f, "%1023[^ \n]s", profile);
 	fclose(f);
 	if (len != 1) {
 		fail("wrong number of items scanned %d", len);

--- a/test/zdtm/static/cgroup01.c
+++ b/test/zdtm/static/cgroup01.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 		if (!s)
 			continue;
 
-		sscanf(paux, "%*d %*d %*d:%*d %*s %s", aux);
+		sscanf(paux, "%*d %*d %*d:%*d %*s %1023s", aux);
 		test_msg("found cgroup at %s\n", aux);
 
 		for (i = 0; i < 2; i++) {

--- a/test/zdtm/static/cgroup02.c
+++ b/test/zdtm/static/cgroup02.c
@@ -75,7 +75,7 @@ bool test_exists(char *mountinfo_line, char *path)
 	char aux[1024], paux[1024];
 	struct stat st;
 
-	sscanf(mountinfo_line, "%*d %*d %*d:%*d %*s %s", aux);
+	sscanf(mountinfo_line, "%*d %*d %*d:%*d %*s %1023s", aux);
 	test_msg("found cgroup at %s\n", aux);
 
 	ssprintf(paux, "%s/%s", aux, path);

--- a/test/zdtm/static/change_mnt_context.c
+++ b/test/zdtm/static/change_mnt_context.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 		if (!pos)
 			continue;
 
-		result = sscanf(pos, " - %*s %*s %s", opts);
+		result = sscanf(pos, " - %*s %*s %1023s", opts);
 		if (result != 1) {
 			fail("Not able to sscanf line from mountinfo");
 			goto out;

--- a/test/zdtm/static/file_locks01.c
+++ b/test/zdtm/static/file_locks01.c
@@ -107,7 +107,7 @@ static int check_file_lock(int fd, char *expected_type, char *expected_option, u
 		memset(fl_type, 0, sizeof(fl_type));
 		memset(fl_option, 0, sizeof(fl_option));
 
-		num = sscanf(buf, "%*s %*d:%s %s %s %d %x:%x:%ld %*d %*s", fl_flag, fl_type, fl_option, &fl_owner, &maj,
+		num = sscanf(buf, "%*s %*d:%15s %15s %15s %d %x:%x:%ld %*d %*s", fl_flag, fl_type, fl_option, &fl_owner, &maj,
 			     &min, &i_no);
 		if (num < 7) {
 			pr_err("Invalid lock info\n");

--- a/test/zdtm/static/file_locks02.c
+++ b/test/zdtm/static/file_locks02.c
@@ -41,7 +41,7 @@ static int check_file_lock(pid_t pid, pid_t child, int fd, char *expected_type, 
 		memset(fl_type, 0, sizeof(fl_type));
 		memset(fl_option, 0, sizeof(fl_option));
 
-		num = sscanf(buf, "%*s %*d:%s %s %s %d", fl_flag, fl_type, fl_option, &fl_owner);
+		num = sscanf(buf, "%*s %*d:%15s %15s %15s %d", fl_flag, fl_type, fl_option, &fl_owner);
 		if (num < 4) {
 			pr_perror("Invalid lock info.");
 			break;

--- a/test/zdtm/static/file_locks03.c
+++ b/test/zdtm/static/file_locks03.c
@@ -41,7 +41,7 @@ static int check_file_lock(pid_t pid, pid_t child, int fd, char *expected_type, 
 		memset(fl_type, 0, sizeof(fl_type));
 		memset(fl_option, 0, sizeof(fl_option));
 
-		num = sscanf(buf, "%*s %*d:%s %s %s %d", fl_flag, fl_type, fl_option, &fl_owner);
+		num = sscanf(buf, "%*s %*d:%15s %15s %15s %d", fl_flag, fl_type, fl_option, &fl_owner);
 		if (num < 4) {
 			pr_perror("Invalid lock info.");
 			break;

--- a/test/zdtm/static/file_locks04.c
+++ b/test/zdtm/static/file_locks04.c
@@ -34,7 +34,7 @@ static int check_file_locks(pid_t child_pid, int fd, int child_fd)
 			continue;
 		test_msg("c: %s", buf);
 
-		num = sscanf(buf, "%*s %*d:%s %s %s %d %*02x:%*02x:%*d %*d %*s", fl_flag, fl_type, fl_option,
+		num = sscanf(buf, "%*s %*d:%15s %15s %15s %d %*02x:%*02x:%*d %*d %*s", fl_flag, fl_type, fl_option,
 			     &fl_owner);
 
 		if (num < 4) {

--- a/test/zdtm/static/netns-dev.c
+++ b/test/zdtm/static/netns-dev.c
@@ -414,7 +414,7 @@ static int check_stable_secret(struct test_conf *tc)
 		return -1;
 	}
 
-	ret = fscanf(fp, "%s", val);
+	ret = fscanf(fp, "%200s", val);
 	if (ret != 1) {
 		pr_perror("fscanf");
 		fclose(fp);

--- a/test/zdtm/static/ofd_file_locks.c
+++ b/test/zdtm/static/ofd_file_locks.c
@@ -16,7 +16,7 @@ static int parse_ofd_lock(char *buf, struct flock *lck)
 	if (strncmp(buf, "lock:\t", 6) != 0)
 		return 1; /* isn't lock, skip record */
 
-	num = sscanf(buf, "%*s %*d: %s %s %s %*d %*x:%*x:%*d %lld %s", fl_flag, fl_type, fl_option, &start, fl_end);
+	num = sscanf(buf, "%*s %*d: %9s %14s %9s %*d %*x:%*x:%*d %lld %31s", fl_flag, fl_type, fl_option, &start, fl_end);
 
 	if (num < 4) {
 		pr_err("Invalid lock info %s\n", buf);


### PR DESCRIPTION
Fixes: #2121

limit the field width of 'scanf' 

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
