### PR TITLE
Optimized shell code with <'s (instead of cat + |)

### DIFF
--- a/test/jenkins/criu-fault.sh
+++ b/test/jenkins/criu-fault.sh
@@ -9,7 +9,7 @@ prep
 ./test/zdtm.py run -t zdtm/static/maps00 --fault 3 --report report -f h || fail
 
 # FIXME: fhandles looks broken on btrfs
-cat /proc/self/mountinfo | grep -P "/.* / " | grep -q btrfs || NOBTRFS=$?
+grep -P "/.* / " /proc/self/mountinfo | grep -q btrfs || NOBTRFS=$?
 if [ $NOBTRFS -eq 1 ] ; then
 	./test/zdtm.py run -t zdtm/static/inotify_irmap --fault 128 --pre 2 -f uns || fail
 fi

--- a/test/others/mem-snap/run-predump-2.sh
+++ b/test/others/mem-snap/run-predump-2.sh
@@ -28,7 +28,7 @@ function stop_test {
 	wtime=1
 	cd ../../zdtm/static/
 	make maps04.stop
-	cat maps04.out | fgrep PASS || fail "Test failed"
+	fgrep PASS maps04.out || fail "Test failed"
 	echo "OK"
 }
 

--- a/test/others/mem-snap/run-predump.sh
+++ b/test/others/mem-snap/run-predump.sh
@@ -72,6 +72,6 @@ ${CRIU} restore -D "${IMGDIR}/$NRSNAP/" -o restore.log -d -v4 || fail "Fail to r
 
 cd ../../zdtm/static/
 make mem-touch.stop
-cat mem-touch.out | fgrep PASS || fail "Test failed"
+fgrep PASS mem-touch.out || fail "Test failed"
 
 echo "Test PASSED"

--- a/test/others/mem-snap/run-snap-auto-dedup.sh
+++ b/test/others/mem-snap/run-snap-auto-dedup.sh
@@ -84,7 +84,7 @@ ${CRIU} restore -D "${IMGDIR}/$NRSNAP/" -o restore.log -d -v4 || fail "Fail to r
 
 cd ../../zdtm/static/
 make mem-touch.stop
-cat mem-touch.out | fgrep PASS || fail "Test failed"
+fgrep PASS mem-touch.out || fail "Test failed"
 
 if [[ $dedup_ok_2 -ne 0 || $dedup_ok_1 -ne 0 ]]; then
 	fail "Dedup test failed"

--- a/test/others/mem-snap/run-snap-dedup-on-restore.sh
+++ b/test/others/mem-snap/run-snap-dedup-on-restore.sh
@@ -78,7 +78,7 @@ fi
 
 cd ../../zdtm/static/
 make mem-touch.stop
-cat mem-touch.out | fgrep PASS || fail "Test failed"
+fgrep PASS mem-touch.out || fail "Test failed"
 
 if [ $restore_dedup_ok -ne 0 ]; then
 	fail "Dedup test failed"

--- a/test/others/mem-snap/run-snap-dedup.sh
+++ b/test/others/mem-snap/run-snap-dedup.sh
@@ -90,7 +90,7 @@ ${CRIU} restore -D "${IMGDIR}/$NRSNAP/" -o restore.log -d -v4 || fail "Fail to r
 
 cd ../../zdtm/static/
 make mem-touch.stop
-cat mem-touch.out | fgrep PASS || fail "Test failed"
+fgrep PASS mem-touch.out || fail "Test failed"
 
 if [[ $dedup_ok_2 -ne 0 || $dedup_ok_1 -ne 0 ]]; then
 	fail "Dedup test failed"

--- a/test/others/mem-snap/run-snap-maps04.sh
+++ b/test/others/mem-snap/run-snap-maps04.sh
@@ -58,7 +58,7 @@ ${CRIU} restore -D "${IMGDIR}/$NRSNAP/" -o restore.log --auto-dedup -d -v4 || fa
 make -C ../../zdtm/static/ maps04.stop
 sleep 1
 
-cat "../zdtm/static/maps04.out" | fgrep PASS || fail "Test failed"
+fgrep PASS "../zdtm/static/maps04.out" || fail "Test failed"
 
 size=$(du -sh -BK  dump/1/pages-*.img | grep -Eo '[0-9]+' | head -1)
 if [ $size -ne 0 ] ; then

--- a/test/others/mem-snap/run-snap.sh
+++ b/test/others/mem-snap/run-snap.sh
@@ -69,6 +69,6 @@ ${CRIU} restore -D "${IMGDIR}/$NRSNAP/" -o restore.log -d -v4 || fail "Fail to r
 
 cd ../../zdtm/static/
 make mem-touch.stop
-cat mem-touch.out | fgrep PASS || fail "Test failed"
+fgrep PASS mem-touch.out || fail "Test failed"
 
 echo "Test PASSED"

--- a/test/others/mounts/mounts.sh
+++ b/test/others/mounts/mounts.sh
@@ -12,7 +12,7 @@ cd $INMNTNS
 
 mount --make-rprivate /
 
-for i in `cat /proc/self/mounts | awk '{ print $2 }'`; do
+for i in `awk '{ print $2 }' < /proc/self/mounts`; do
 	[ '/' = "$i" ] && continue
 	[ '/proc' = "$i" ] && continue
 	[ '/dev' = "$i" ] && continue

--- a/test/others/mounts/run.sh
+++ b/test/others/mounts/run.sh
@@ -12,12 +12,12 @@ kill -0 $pid || exit
 cat /proc/$pid/mountinfo | sort -k 4
 echo "Suspend server"
 ${CRIU} dump -D dump -o dump.log -t $pid -v4 || {
-	cat dump/dump.log | grep Error
+	grep Error dump/dump.log
 	exit 1
 }
 echo "Resume server"
 ${CRIU} restore -d -D dump -o restore.log -v4 || {
-	cat dump/dump.log | grep Error
+	grep Error dump/dump.log 
 	exit 1
 }
 cat /proc/$pid/mountinfo | sort -k 4

--- a/test/others/ns_ext/run.sh
+++ b/test/others/ns_ext/run.sh
@@ -61,7 +61,7 @@ exec 33< $MNT1
 exec 34< $MNT2
 $CRIU dump -v4 -t $pid -o dump.log -D images --external $NS[$ino]:test_ns --external $NS[$ino2]:test_ns2
 RESULT=$?
-cat images/dump.log | grep -B 5 Error || echo ok
+grep -B 5 Error images/dump.log || echo ok
 [ "$RESULT" != "0" ] && {
 	echo "CRIU dump failed"
 	echo FAIL
@@ -70,7 +70,7 @@ cat images/dump.log | grep -B 5 Error || echo ok
 
 $CRIU restore -v4 -o restore.log -D images --inherit-fd fd[33]:test_ns --inherit-fd fd[34]:test_ns2 -d
 RESULT=$?
-cat images/restore.log | grep -B 5 Error || echo ok
+grep -B 5 Error images/restore.log || echo ok
 [ "$RESULT" != "0" ] && {
 	echo "CRIU restore failed"
 	echo FAIL

--- a/test/others/ns_ext/run_pidns.sh
+++ b/test/others/ns_ext/run_pidns.sh
@@ -36,7 +36,7 @@ mkdir -p images_pidns
 echo "$CRIU dump -v4 -o dump.log -t $PID -D images_pidns --external $PIDNS:exti"
 $CRIU dump -v4 -o dump.log -t $PID -D images_pidns --external $PIDNS:exti
 RESULT=$?
-cat images_pidns/dump.log | grep -B 5 Error || echo ok
+grep -B 5 Error images_pidns/dump.log || echo ok
 [ "$RESULT" != "0" ] && {
 	echo "CRIU dump failed"
 	echo FAIL
@@ -48,7 +48,7 @@ exec {pidns_fd}< /proc/self/ns/pid
 echo "$CRIU restore -v4 -o restore.log -D images_pidns --restore-detached --inherit-fd fd[$pidns_fd]:exti"
 $CRIU restore -v4 -o restore.log -D images_pidns --restore-detached --inherit-fd fd[$pidns_fd]:exti --pidfile test.pidfile
 RESULT=$?
-cat images_pidns/restore.log | grep -B 5 Error || echo ok
+grep -B 5 Error images_pidns/restore.log || echo ok
 [ "$RESULT" != "0" ] && {
 	echo "CRIU restore failed"
 	echo FAIL

--- a/test/others/unix-callback/run.sh
+++ b/test/others/unix-callback/run.sh
@@ -40,7 +40,7 @@ done
 ${CRIU} restore -D data -o restore.log -v4 --lib `pwd`/lib -d || exit 1
 kill $pid
 while :; do
-	cat output | grep PASS && break
+	grep PASS output && break
 	sleep 1
 done
 


### PR DESCRIPTION
This PR optimizes shell code as reading a single file as input using a 'cat' command to a program is considered to be a Useless Use of Cat [[UUOC](https://en.wikipedia.org/wiki/Cat_(Unix)#Useless_use_of_cat)]. It's more efficient to simply use redirection. Fixes the issue https://github.com/checkpoint-restore/criu/issues/330.