### PR TITLE
mount: do collect_mntinfo of external mount namespace with no for_dump

### DIFF
--- a/criu/mount.c
+++ b/criu/mount.c
@@ -826,7 +826,7 @@ static struct ns_id *find_ext_ns_id(void)
 
 	for (ns = ns_ids; ns->next; ns = ns->next)
 		if (ns->type == NS_CRIU && ns->nd == &mnt_ns_desc) {
-			if (!ns->mnt.mntinfo_list && !collect_mntinfo(ns, true))
+			if (!ns->mnt.mntinfo_list && !collect_mntinfo(ns, false))
 				break;
 			return ns;
 		}


### PR DESCRIPTION
When we collect external mount namespace we don't want to dump mounts in it, so lets remove this flag. This way we can e.g. use for_dump in ->parse() callbacks to separate in-container mounts from others.

This only affects rare case of `--ext-mount-map auto` but to be absolutely correct let's fix it anyway.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
