### PR TITLE
cgroup-v2: make new fields in image protobuf optional

### DIFF
--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -930,6 +930,7 @@ static int dump_controllers(CgroupEntry *cg)
 	list_for_each_entry(cur, &cgroups, l) {
 		cg_controller_entry__init(ce);
 
+		ce->has_is_threaded = true;
 		ce->is_threaded = cur->is_threaded;
 		ce->cnames = cur->controllers;
 		ce->n_cnames = cur->n_controllers;
@@ -2002,7 +2003,7 @@ static int cgroupd(int sk)
 			 * process must be in this controller. Main thread has been
 			 * restored, so this thread is in this controller already.
 			 */
-			if (!ctrl->is_threaded)
+			if (!ctrl->has_is_threaded || !ctrl->is_threaded)
 				continue;
 
 			aux_off = ctrl_dir_and_opt(ctrl, aux, sizeof(aux), NULL, 0);

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -811,6 +811,7 @@ static int dump_task_core_all(struct parasite_ctl *ctl, struct pstree_item *item
 			goto err;
 	}
 
+	core->thread_core->has_cg_set = true;
 	cg_set = &core->thread_core->cg_set;
 	ret = dump_thread_cgroup(item, cg_set, info, -1);
 	if (ret)
@@ -1436,6 +1437,7 @@ static int dump_task_cgroup(struct parasite_ctl *parasite_ctl, const struct pstr
 				return -1;
 		}
 
+		core->thread_core->has_cg_set = true;
 		if (dump_thread_cgroup(item, &core->thread_core->cg_set, info, i))
 			return -1;
 	}

--- a/images/cgroup.proto
+++ b/images/cgroup.proto
@@ -24,7 +24,7 @@ message cgroup_dir_entry {
 message cg_controller_entry {
 	repeated string			cnames		= 1;
 	repeated cgroup_dir_entry	dirs		= 2;
-	required bool			is_threaded	= 3;
+	optional bool			is_threaded	= 3;
 }
 
 message cg_member_entry {

--- a/images/core.proto
+++ b/images/core.proto
@@ -106,7 +106,7 @@ message thread_core_entry {
 	optional string			comm		= 13;
 	optional uint64			blk_sigset_extended	= 14;
 	optional rseq_entry		rseq_entry	= 15;
-	required uint32			cg_set		= 16;
+	optional uint32			cg_set		= 16;
 }
 
 message task_rlimits_entry {


### PR DESCRIPTION
The newly added fields in image protobuf are currently marked as required. This causes backward compatibility problem when using the newer CRIU version to restore an dumped image from older version which doesn't have these fields. This commit marks these new fields optional and reworks the logic:
- Fallback to cg_set in task_core when it is not in thread_core
- Skip fixing up threaded cgroup controllers if there is no information in dumped image

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
