### PR TITLE
sk-unix: add some missed error printing

### DIFF
--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -595,12 +595,14 @@ static int unix_resolve_name_old(int lfd, uint32_t id, struct unix_sk_desc *d, U
 	else
 		ns = lookup_ns_by_id(root_item->ids->mnt_ns_id, &mnt_ns_desc);
 	if (!ns) {
+		pr_err("Failed to lookup ns by mnt id %d\n", ue->mnt_id);
 		ret = -ENOENT;
 		goto out;
 	}
 
 	mntns_root = mntns_get_root_fd(ns);
 	if (mntns_root < 0) {
+		pr_err("Failed to lookup mntns root for ns %d\n", ns->id);
 		ret = -ENOENT;
 		goto out;
 	}


### PR DESCRIPTION
In Virtuozzo tests we have seen uninformative errors:

(26.575039) 151187 fdinfo 6: pos: 0 flags: 2/0
(26.575076) sockets: Searching for socket 0x346d1 family 1
(666.230281 ----------------------------------------
(666.230586 Error (criu/cr-dump.c:1850): Dump files (pid: 151187) failed with -1

So let's add some error messages to this stack.

This is a port from Virtuozzo criu:
https://src.openvz.org/projects/OVZ/repos/criu/commits/cca9aa8dc

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
