### PR TITLE
Codacy : Conditions always evaluate to T/F

### DIFF
--- a/criu/apparmor.c
+++ b/criu/apparmor.c
@@ -207,8 +207,6 @@ static int by_time(const struct dirent **de1, const struct dirent **de2)
 	} else {
 		if (sb1.st_mtim.tv_sec < sb2.st_mtim.tv_sec)
 			return -1;
-		if (sb1.st_mtim.tv_sec == sb2.st_mtim.tv_sec)
-			return 0;
 		return 1;
 	}
 }

--- a/criu/arch/x86/sigframe.c
+++ b/criu/arch/x86/sigframe.c
@@ -23,7 +23,7 @@ int sigreturn_prep_fpu_frame(struct rt_sigframe *sigframe, struct rt_sigframe *r
 		}
 
 		sigframe->native.uc.uc_mcontext.fpstate = (uint64_t)addr;
-	} else if (!sigframe->is_native) {
+	} else {
 		unsigned long addr = (unsigned long)(void *)&fpu_state->fpu_state_ia32.xsave;
 		sigframe->compat.uc.uc_mcontext.fpstate = (uint32_t)(unsigned long)(void *)&fpu_state->fpu_state_ia32;
 		if ((addr % 64ul)) {

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1608,7 +1608,7 @@ static int root_only_init(void)
 	if (opts.unprivileged)
 		return 0;
 
-	if (!ret && kerndat_loginuid()) {
+	if (kerndat_loginuid()) {
 		pr_err("kerndat_loginuid failed when initializing kerndat.\n");
 		ret = -1;
 	}

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -815,7 +815,7 @@ int page_xfer_predump_pages(int pid, struct page_xfer *xfer, struct page_pipe *p
 		bufvec.iov_len = bytes_read;
 		ret = vmsplice(ppb->p[1], &bufvec, 1, SPLICE_F_NONBLOCK | SPLICE_F_GIFT);
 
-		if (ret == -1 || ret != bytes_read) {
+		if (ret < 0 || ret != bytes_read) {
 			pr_err("vmsplice: Failed to splice user buffer to pipe %ld\n", ret);
 			goto err;
 		}

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -1972,10 +1972,8 @@ static int parse_fdinfo_pid_s(int pid, int fd, int type, void *arg)
 				     " pos:%lli ino:%lx sdev:%x",
 				     &e->tfd, &e->events, (long long *)&e->data, (long long *)&e->pos,
 				     (long *)&e->inode, &e->dev);
-			if (ret < 3 || ret > 6) {
-				eventpoll_tfd_entry__free_unpacked(e, NULL);
-				goto parse_err;
-			} else if (ret == 3) {
+
+			if (ret == 3) {
 				e->has_dev = false;
 				e->has_inode = false;
 				e->has_pos = false;
@@ -1983,7 +1981,7 @@ static int parse_fdinfo_pid_s(int pid, int fd, int type, void *arg)
 				e->has_dev = true;
 				e->has_inode = true;
 				e->has_pos = true;
-			} else if (ret < 6) {
+			} else {
 				eventpoll_tfd_entry__free_unpacked(e, NULL);
 				goto parse_err;
 			}

--- a/test/zdtm/static/cow00.c
+++ b/test/zdtm/static/cow00.c
@@ -29,7 +29,7 @@ static int is_cow(void *addr, pid_t p1, pid_t p2)
 
 	snprintf(buf, sizeof(buf), "/proc/%d/pagemap", p2);
 	fd2 = open(buf, O_RDONLY);
-	if (fd1 < 0) {
+	if (fd2 < 0) {
 		pr_perror("Unable to open file %s", buf);
 		return -1;
 	}

--- a/test/zdtm/static/thread_different_uid_gid.c
+++ b/test/zdtm/static/thread_different_uid_gid.c
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
 	ret = syscall(SYS_setresgid, maingroup, maingroup, maingroup);
 	if (ret >= 0) {
 		ret = syscall(SYS_setresuid, mainuser, mainuser, mainuser);
-	} else if (ret < 0) {
+	} else {
 		pr_perror("Failed to drop privileges");
 		exit(1);
 	}


### PR DESCRIPTION
### This pull request introduces fixes for #2120 

#### criu/appamor.c line 210 (DELETED)
    - if (sb1.st_mtim.tv_sec == sb2.st_mtim.tv_sec)
    - This check is redundant as line 201 checks for this condition. 
    
#### criu/arch/mips/cpu.c line 43 & 45 (UNMODIFIED)
    - if (cpu_init())
    - if (cpu_dump_cpuinfo())
    - These conditions are always false as cpu_init(void) and cpu_dump_cpuinfo() unconditionally returns 0.
    - Left unmodified as it's not clear if cpu_init(void) and cpu_dump_cpuinfo() are function stubs.
 
#### criu/arch/x86/sigframe.c line 26 (MODIFIED)
    - } else if (!sigframe->is_native) {
    - The is_native field is a boolean. Therefore, else if() should can be changed to a simple else{}.

#### criu/kerndat.c line 900 (UNMODIFIED)
    - if (ret < 0)
    - ret is the return value from kdat_x86_has_ptrace_fpu_xsave_bug(void), which unconditionally returns 0.
    - Left unmodified as it's not clear if kdat_x86_has_ptrace_fpu_xsave_bug is a function stub.

#### criu/kerndat.c line 1161 (MODIFIED)
    - if (!ret && kerndat_loginuid()) {
    - ret initially 0, and the first modification happens inside the if statement. Therefore, we can delete !ret

#### criu/mem.c line 333 (UNMODIFIED)
    - if (tps == -1) {
    - tps retrives clock ticks through sysconf(_SC_CLK_TCK).
    - The condition logically evaluates to false, but is necessary as a safety check.

#### criu/page-xfer.c line 818 (MODIFIED)
    - if (ret == -1 || ret != bytes_read) {
    - ret is the return value from syscall vmsplice(), which returns -1 upon error.
    - However, it's modified to if (ret < 0...) to be consistent with the codebase (line 183 of pipe.c, line 466 of cr-check.c, line 90 of parasite.c)

#### criu/proc_parse.c line 1986 (MODIFIED)
    - else if (ret < 6)
    - In the case where ret == 3 || ret == 6, EventpollTfdEntry's fields are set to false or true.
    - The remaining cases could be grouped into an else statement instead of manually checking the values between 3 and 6.

#### test/zdtm/static/cow00.c line 32 (MODIFIED)
    - if (fd1 < 0) {
    - The condition meant to check fd2 instead of fd1, which is checked in line 24.

#### test/zdtm/static/maps03.c line 38 (UNMODIFIED)
    - if (mem[4L << 30] != 1 || mem[8L << 30] != 2) {
    - This condition checks for possible memory corruption. Logically, it should be false, but is necessary to be here.

#### test/zdtm/static/thread_different_uid_gid.c line 133 (MODIFIED)
    - } else if (ret < 0) {
    - line 131 checks if (ret >= 0). line 133 could be replaced by a simple else statem

Signed-off-by : Taemin Ha taemin.ha@utexas.edu