### PR TITLE
zdtm: add MNTNS_ZDTM macro to fix initialization

### DIFF
--- a/test/zdtm/lib/mountinfo.h
+++ b/test/zdtm/lib/mountinfo.h
@@ -24,6 +24,14 @@ struct mntns_zdtm {
 	struct list_head sharing_groups_list;
 };
 
+#define MNTNS_ZDTM_INIT(name)                                                    \
+	{                                                                        \
+		.mountinfo_list = LIST_HEAD_INIT(name.mountinfo_list),           \
+		.topology_list = LIST_HEAD_INIT(name.topology_list),             \
+		.sharing_groups_list = LIST_HEAD_INIT(name.sharing_groups_list), \
+	}
+#define MNTNS_ZDTM(name) struct mntns_zdtm name = MNTNS_ZDTM_INIT(name)
+
 struct sharing_group {
 	int shared_id;
 	int master_id;

--- a/test/zdtm/static/mount_complex_sharing.c
+++ b/test/zdtm/static/mount_complex_sharing.c
@@ -212,7 +212,8 @@ static int mount_loop(void)
 
 int main(int argc, char **argv)
 {
-	struct mntns_zdtm mntns_before, mntns_after;
+	MNTNS_ZDTM(mntns_before);
+	MNTNS_ZDTM(mntns_after);
 	int ret = 1;
 
 	test_init(argc, argv);


### PR DESCRIPTION
With this macro we can easily declare struct mntns_zdtm variables with all lists properly initiallized. Let's use it in mount_complex_sharing as without it we can have segfault on error path when accessing uninitialized list pointers.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
