### PR TITLE
mount: allow bindmounts for external fuse mounts

### DIFF
--- a/criu/filesystems.c
+++ b/criu/filesystems.c
@@ -547,7 +547,8 @@ static int fusectl_dump(struct mount_info *pm)
 		}
 
 		for (it = mntinfo; it; it = it->next) {
-			if (it->fstype->code == FSTYPE__FUSE && id == kdev_minor(it->s_dev) && !it->external) {
+			if (it->fstype->code == FSTYPE__FUSE && id == kdev_minor(it->s_dev) &&
+			    !mnt_is_external_bind(it)) {
 				pr_err("%s is a fuse mount but not external\n", it->ns_mountpoint);
 				goto out;
 			}


### PR DESCRIPTION
Currently we only allow external fuse mount itself, let's allow bindmount for it too. Other mount code is ready for this change and will be able to bindmount it from corresponding external mount.

This is a missing hunk from initial mount-v2 implementation in Virtuozzo criu:
https://src.openvz.org/projects/OVZ/repos/criu/commits/1105e1e3f

note for myself: don't have a test for it, but it can be a good initial GSOC task to add it for detached mount support project
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
