### PR TITLE
zdtm/lib: fix cwd path freeing

### DIFF
--- a/test/zdtm/lib/fs.c
+++ b/test/zdtm/lib/fs.c
@@ -108,6 +108,7 @@ int get_cwd_check_perm(char **result)
 		       "Bit 'x' should be set in all path components of "
 		       "this directory\n",
 		       cwd, getuid(), getgid(), errno, strerror(errno));
+		free(cwd);
 		return -1;
 	}
 

--- a/test/zdtm/lib/unix.c
+++ b/test/zdtm/lib/unix.c
@@ -5,7 +5,7 @@
 
 int unix_fill_sock_name(struct sockaddr_un *name, char *relFilename)
 {
-	char *cwd;
+	cleanup_free char *cwd = NULL;
 
 	if (get_cwd_check_perm(&cwd)) {
 		pr_err("failed to get current working directory with valid permissions.\n");


### PR DESCRIPTION
Fix cwd freeing on error path in get_cwd_check_perm and on non-error-path in unix_fill_sock_name.

This is a port of Virtuozzo patch:
https://src.openvz.org/projects/OVZ/repos/criu/commits/a7916411a

CC: @uravas 
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
