### PR TITLE
Distinguish CRIU crash from CRIU fail in ZDTM

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -900,6 +900,10 @@ class criu_cli:
             return cr
         return cr.wait()
 
+    @staticmethod
+    def signal_exit(ret):
+        return ret < 0
+
 
 class criu_rpc_process:
     def wait(self):
@@ -1031,6 +1035,11 @@ class criu_rpc:
             return p
 
         return ret
+
+    @staticmethod
+    def signal_exit(ret):
+        # TODO
+        return False
 
 
 class criu:
@@ -1233,8 +1242,7 @@ class criu:
                     return
             rst_succeeded = os.access(
                 os.path.join(__ddir, "restore-succeeded"), os.F_OK)
-            if self.__test.blocking() or (self.__sat and action == 'restore' and
-                                          rst_succeeded):
+            if (self.__test.blocking() and not self.__criu.signal_exit(ret)) or (self.__sat and action == 'restore' and rst_succeeded):
                 raise test_fail_expected_exc(action)
             else:
                 raise test_fail_exc("CRIU %s" % action)

--- a/test/zdtm/criu_config.py
+++ b/test/zdtm/criu_config.py
@@ -40,3 +40,7 @@ class criu_config:
         if nowait:
             return cr
         return cr.wait()
+
+    @staticmethod
+    def signal_exit(ret):
+        return ret < 0


### PR DESCRIPTION
This PR distinguishes `criu dump` crash from `criu dump` fail in the `zdtm.py` script. Now, *zdtm* reports `criu dump` crash as a test failure. 
Fixes the issue https://github.com/checkpoint-restore/criu/issues/350.