### PR TITLE
Distinguish criu fail from criu crash in ZDTM

### DIFF
--- a/lib/py/cli.py
+++ b/lib/py/cli.py
@@ -21,7 +21,7 @@ def inf(opts):
 
 def outf(opts, decode):
     # Decode means from protobuf to JSON.
-    # Use text when writing to JSON else use binaray mode
+    # Use text when writing to JSON else use binary mode
     if opts['out']:
         mode = 'wb+'
         if decode:

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -900,6 +900,10 @@ class criu_cli:
             return cr
         return cr.wait()
 
+    @staticmethod
+    def signal_exit(ret):
+        return ret < 0
+
 
 class criu_rpc_process:
     def wait(self):
@@ -1018,8 +1022,11 @@ class criu_rpc:
             else:
                 raise test_fail_exc('RPC for %s required' % action)
         except crpc.CRIUExceptionExternal as e:
-            print("Fail", e)
-            ret = -1
+            if e.errno == errno.EINTR:
+                ret = -2
+            else:
+                print("Fail", e)
+                ret = -1
         else:
             ret = 0
 
@@ -1031,6 +1038,12 @@ class criu_rpc:
             return p
 
         return ret
+
+    @staticmethod
+    def signal_exit(ret):
+        if ret == -2:
+            return True
+        return False
 
 
 class criu:
@@ -1233,8 +1246,7 @@ class criu:
                     return
             rst_succeeded = os.access(
                 os.path.join(__ddir, "restore-succeeded"), os.F_OK)
-            if self.__test.blocking() or (self.__sat and action == 'restore' and
-                                          rst_succeeded):
+            if (self.__test.blocking() and not self.__criu.signal_exit(ret)) or (self.__sat and action == 'restore' and rst_succeeded):
                 raise test_fail_expected_exc(action)
             else:
                 raise test_fail_exc("CRIU %s" % action)

--- a/test/zdtm/criu_config.py
+++ b/test/zdtm/criu_config.py
@@ -40,3 +40,7 @@ class criu_config:
         if nowait:
             return cr
         return cr.wait()
+        
+    @staticmethod
+    def signal_exit(ret):
+        return ret < 0    


### PR DESCRIPTION
This PR distinguishes `criu dump` crash from `criu dump` fail in the `zdtm.py` script. Now, *zdtm* reports `criu dump` crash as a test failure. 
Fixes the issue https://github.com/checkpoint-restore/criu/issues/350.