### PR TITLE
netlink: fix netlink fd flags dump/restore failed

### DIFF
--- a/criu/sk-netlink.c
+++ b/criu/sk-netlink.c
@@ -161,7 +161,7 @@ static int dump_one_netlink_fd(int lfd, u32 id, const struct fd_parms *p)
 
 		ne.protocol = val;
 	}
-
+	ne.flags = p->flags;
 	ne.fown = (FownEntry *)&p->fown;
 	ne.opts = &skopts;
 


### PR DESCRIPTION
During the restore process, netlink fd uses the flags in the NetlinkSkEntry structure to restore the file state, but during the dump process, the flags values is not saved to the structure.

Signed-off-by: zhoujie zhoujie133@huawei.com
Signed-off-by: hejingxian hejingxian@huawei.com
