### PR TITLE
cr-dump: properly apply rseq fixup for all threads

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -906,6 +906,7 @@ static int dump_task_thread(struct parasite_ctl *parasite_ctl, const struct pstr
 
 	close_image(img);
 err:
+	compel_release_thread(tctl);
 	pr_info("----------------------------------------\n");
 	return ret;
 }

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -195,13 +195,13 @@ int parasite_dump_thread_seized(struct parasite_thread_ctl *tctl, struct parasit
 	ret = compel_get_thread_regs(tctl, save_task_regs, core);
 	if (ret) {
 		pr_err("Can't obtain regs for thread %d\n", pid);
-		goto err_rth;
+		return -1;
 	}
 
 	ret = compel_arch_fetch_thread_area(tctl);
 	if (ret) {
 		pr_err("Can't obtain thread area of %d\n", pid);
-		goto err_rth;
+		return -1;
 	}
 
 	compel_arch_get_tls_thread(tctl, &args->tls);
@@ -211,23 +211,17 @@ int parasite_dump_thread_seized(struct parasite_thread_ctl *tctl, struct parasit
 	ret = compel_run_in_thread(tctl, PARASITE_CMD_DUMP_THREAD);
 	if (ret) {
 		pr_err("Can't init thread in parasite %d\n", pid);
-		goto err_rth;
+		return -1;
 	}
 
 	ret = alloc_groups_copy_creds(creds, pc);
 	if (ret) {
 		pr_err("Can't copy creds for thread %d\n", pid);
-		goto err_rth;
+		return -1;
 	}
-
-	compel_release_thread(tctl);
 
 	tid->ns[0].virt = args->tid;
 	return dump_thread_core(pid, core, args);
-
-err_rth:
-	compel_release_thread(tctl);
-	return -1;
 }
 
 int parasite_dump_sigacts_seized(struct parasite_ctl *ctl, struct pstree_item *item)

--- a/test/zdtm/transition/Makefile
+++ b/test/zdtm/transition/Makefile
@@ -84,7 +84,9 @@ ptrace:		LDFLAGS += -pthread
 fork2:		CFLAGS += -D FORK2
 thread-bomb.o:	CFLAGS += -pthread
 thread-bomb:	LDFLAGS += -pthread
+rseq01:		LDLIBS += -pthread
 rseq02:		CFLAGS += -D NORESTART
+rseq02:		LDLIBS += -pthread
 
 %: %.sh
 	cp $< $@


### PR DESCRIPTION
Previously fixup was done before threads' registers were dumped so it
didn't actually work. This commit splits rseq fixup into thread leader
fixup and other threads fixup and applies them after the entities are
seized.