### PR TITLE
proc_parse: fix while condition in parse_pid_status

### DIFF
--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -1043,7 +1043,7 @@ int parse_pid_status(pid_t pid, struct seize_task_status *ss, void *data)
 	if (bfdopenr(&f))
 		return -1;
 
-	while (done < 14) {
+	while (done < 13) {
 		str = breadline(&f);
 		if (str == NULL)
 			break;


### PR DESCRIPTION
In parse_pid_status there are 13 places where we do done++, so when "done" is 13 it means that we have matched each of those 13 places and we are ready to stop. In next lines we are not going to find anything.

So the right condition for the while loop is (done < 13).

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
