### PR TITLE
compel: support XSAVE on newer Intel CPUs

### DIFF
--- a/compel/arch/x86/src/lib/include/uapi/asm/fpu.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/fpu.h
@@ -21,7 +21,28 @@
 #define XSTATE_YMM 0x4
 
 #define FXSAVE_SIZE 512
-#define XSAVE_SIZE  4096
+/*
+ * This used to be 4096 (one page). There is a comment below concerning
+ * this size:
+ *  "One page should be enough for the whole xsave state ;-)"
+ * Which is kind of funny as it is no longer enough ;-)
+ *
+ * Older CPUs:
+ * # cpuid -1 -l 0xd -s 0
+ * ...
+ *     bytes required by XSAVE/XRSTOR area     = 0x00000988 (2440)
+ *
+ * Newer CPUs (Sapphire Rapids):
+ * # cpuid -1 -l 0xd -s 0
+ * ...
+ *     bytes required by XSAVE/XRSTOR area     = 0x00002b00 (11008)
+ *
+ * So one page is no longer enough... But:
+ *
+ * Four pages should be enough for the whole xsave state ;-)
+ */
+
+#define XSAVE_SIZE  4*4096
 
 #define XSAVE_HDR_SIZE	 64
 #define XSAVE_HDR_OFFSET FXSAVE_SIZE
@@ -235,8 +256,11 @@ struct pkru_state {
  *
  *
  * One page should be enough for the whole xsave state ;-)
+ *
+ * Of course it was not ;-) Now using four pages...
+ *
  */
-#define EXTENDED_STATE_AREA_SIZE (4096 - sizeof(struct i387_fxsave_struct) - sizeof(struct xsave_hdr_struct))
+#define EXTENDED_STATE_AREA_SIZE (XSAVE_SIZE - sizeof(struct i387_fxsave_struct) - sizeof(struct xsave_hdr_struct))
 
 /*
  * cpu requires it to be 64 byte aligned


### PR DESCRIPTION
Newer Intel CPUs (Sapphire Rapids) have a much larger xsave area than before. Looking at older CPUs I see 2440 bytes.
```
    # cpuid -1 -l 0xd -s 0
    ...
        bytes required by XSAVE/XRSTOR area     = 0x00000988 (2440)
```
On newer CPUs (Sapphire Rapids) it grows to 11008 bytes.
```
    # cpuid -1 -l 0xd -s 0
    ...
        bytes required by XSAVE/XRSTOR area     = 0x00002b00 (11008)
```
This increases the xsave area from one page to four pages.

Without this patch the fpu03 test fails, with this patch it works again.