### PR TITLE
crit: add --version option

### DIFF
--- a/crit/setup.py
+++ b/crit/setup.py
@@ -1,23 +1,9 @@
-import os
 from setuptools import setup, find_packages
-
-
-def get_version():
-    version = '0.0.1'
-    env = os.environ
-    if 'CRIU_VERSION_MAJOR' in env and 'CRIU_VERSION_MINOR' in env:
-        version = '{}.{}'.format(
-            env['CRIU_VERSION_MAJOR'],
-            env['CRIU_VERSION_MINOR']
-        )
-        if 'CRIU_VERSION_SUBLEVEL' in env and env['CRIU_VERSION_SUBLEVEL']:
-            version += '.' + env['CRIU_VERSION_SUBLEVEL']
-    return version
-
+import pycriu
 
 setup(
     name='crit',
-    version=get_version(),
+    version=pycriu.__version__,
     description='CRiu Image Tool',
     author='CRIU team',
     author_email='criu@openvz.org',

--- a/lib/py/.gitignore
+++ b/lib/py/.gitignore
@@ -1,2 +1,3 @@
 *_pb2.py
 *.pyc
+version.py

--- a/lib/py/Makefile
+++ b/lib/py/Makefile
@@ -1,4 +1,4 @@
-all-y	+= libpy-images rpc_pb2.py
+all-y	+= libpy-images rpc_pb2.py version.py
 
 $(obj)/images/Makefile: ;
 $(obj)/images/%: .FORCE
@@ -11,7 +11,10 @@ libpy-images:
 rpc_pb2.py:
 	$(Q) protoc -I=images/ --python_out=$(obj) images/$(@:_pb2.py=.proto)
 
-cleanup-y	+= $(addprefix $(obj)/,rpc_pb2.py *.pyc)
+version.py:
+	$(Q) echo "__version__ = '${CRIU_VERSION}'" > $(obj)/$@
+
+cleanup-y	+= $(addprefix $(obj)/,rpc_pb2.py *.pyc version.py)
 
 clean-lib-py:
 	$(Q) $(MAKE) $(build)=$(obj)/images clean

--- a/lib/py/__init__.py
+++ b/lib/py/__init__.py
@@ -1,3 +1,4 @@
 from . import rpc_pb2 as rpc
 from . import images
 from .criu import *
+from .version import __version__

--- a/lib/py/cli.py
+++ b/lib/py/cli.py
@@ -364,6 +364,7 @@ def main():
     desc = 'CRiu Image Tool'
     parser = argparse.ArgumentParser(
         description=desc, formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('--version', action='version', version=pycriu.__version__)
 
     subparsers = parser.add_subparsers(
         help='Use crit CMD --help for command-specific help')

--- a/test/others/crit/test.sh
+++ b/test/others/crit/test.sh
@@ -101,6 +101,8 @@ function run_test2 {
 	${CRIT} x ./ rss || exit 1
 }
 
+${CRIT} --version
+
 gen_imgs
 run_test1
 run_test2


### PR DESCRIPTION
This pull request implements `--version` for `crit`.

```
$ crit --version
3.17
```