### PR TITLE
criu/plugin: Add environment variable to cap size of buffers.

### DIFF
--- a/Documentation/amdgpu_plugin.txt
+++ b/Documentation/amdgpu_plugin.txt
@@ -97,6 +97,15 @@ executing criu command.
     E.g:
     KFD_CAPABILITY_CHECK=1
 
+*KFD_MAX_BUFFER_SIZE*::
+    On some systems, VRAM sizes may exceed RAM sizes, and so buffers for dumping
+    and restoring VRAM may be unable to fit. Set to a nonzero value (in bytes)
+    to set a limit on the plugin's memory usage.
+    Default:0 (Disabled)
+
+    E.g:
+    KFD_MAX_BUFFER_SIZE="2G"
+
 
 AUTHOR
 ------


### PR DESCRIPTION
The amdgpu plugin would create a memory buffer at the size of the largest VRAM bo (buffer object). On some systems, VRAM size exceeds RAM size, so the largest bo might be larger than the available memory.

Add an environment variable KFD_MAX_BUFFER_SIZE, which caps the size of this buffer. By default, it is set to 0, and has no effect. When active, any bo larger than its value will be saved to/restored from file in multiple passes.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
