### PR TITLE
lib/c: add empty_ns interfaces to libcriu

### DIFF
--- a/lib/c/criu.c
+++ b/lib/c/criu.c
@@ -2030,3 +2030,14 @@ int criu_feature_check(struct criu_feature_check *features, size_t size)
 {
 	return criu_local_feature_check(global_opts, features, size);
 }
+
+void criu_local_set_empty_ns(criu_opts *opts, int namespaces)
+{
+	opts->rpc->has_empty_ns = true;
+	opts->rpc->empty_ns = namespaces;
+}
+
+void criu_set_empty_ns(int namespaces)
+{
+	criu_local_set_empty_ns(global_opts, namespaces);
+}

--- a/lib/c/criu.h
+++ b/lib/c/criu.h
@@ -322,6 +322,9 @@ struct criu_feature_check {
 int criu_feature_check(struct criu_feature_check *features, size_t size);
 int criu_local_feature_check(criu_opts *opts, struct criu_feature_check *features, size_t size);
 
+void criu_local_set_empty_ns(criu_opts *opts, int namespaces);
+void criu_set_empty_ns(int namespaces);
+
 #ifdef __GNUG__
 }
 #endif


### PR DESCRIPTION
crun wants to set empty_ns and this interface is missing from the library. This adds it to libcriu.

See https://github.com/containers/crun/issues/1210