### PR TITLE
docs: rename amdgpu_plugin.txt to criu-amdgpu-plugin.txt

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -16,7 +16,7 @@ ifeq ($(PYTHON),python3)
 SRC1		+= criu-ns.txt
 endif
 SRC1		+= compel.txt
-SRC1            += amdgpu_plugin.txt
+SRC1            += criu-amdgpu-plugin.txt
 SRC8		+= criu.txt
 SRC		:= $(SRC1) $(SRC8)
 XMLS		:= $(patsubst %.txt,%.xml,$(SRC))

--- a/Documentation/criu-amdgpu-plugin.txt
+++ b/Documentation/criu-amdgpu-plugin.txt
@@ -3,7 +3,7 @@ ROCM Support(1)
 
 NAME
 ----
-amdgpu_plugin - A plugin extension to CRIU to support checkpoint/restore in
+criu-amdgpu-plugin - A plugin extension to CRIU to support checkpoint/restore in
 userspace for AMD GPUs.
 
 
@@ -22,7 +22,7 @@ Though *criu* is a great tool for checkpointing and restoring running
 applications, it has certain limitations such as it cannot handle
 applications that have device files open. In order to support *ROCm* based
 workloads with *criu* we need to augment criu's core functionality with a
-plugin based extension mechanism. *amdgpu_plugin* provides the necessary support
+plugin based extension mechanism. *criu-amdgpu-plugin* provides the necessary support
 to criu to allow Checkpoint / Restore with ROCm.
 
 


### PR DESCRIPTION
By default, the file name `amdgpu_plugin.txt` is used also as the name for the corresponding man page (`man amdgpu_plugin`). However, when this man page is installed system-wide it would be more appropriate to have `criu-` prefix (e.g., `man criu-amdgpu-plugin`).