### PR TITLE
compel/test: Fix success condition check in fdspy

### DIFF
--- a/compel/test/fdspy/spy.c
+++ b/compel/test/fdspy/spy.c
@@ -110,11 +110,11 @@ static int check_pipe_ends(int wfd, int rfd)
 	printf("Check pipe ends are connected\n");
 	if (write(wfd, "1", 2) != 2) {
 		fprintf(stderr, "write to pipe failed\n");
-		return -1;
+		return 0;
 	}
 	if (read(rfd, aux, sizeof(aux)) != sizeof(aux)) {
 		fprintf(stderr, "read from pipe failed\n");
-		return -1;
+		return 0;
 	}
 	if (aux[0] != '1' || aux[1] != '\0') {
 		fprintf(stderr, "Pipe connectivity lost\n");


### PR DESCRIPTION
Found this bug when working on adding riscv64 support to compel #1702 :) Specifically, the bug appeared when the `p_err` pipe became broken after resuming, causing `check_pipe_ends()` to hit either these branches:

```c
if (write(wfd, "1", 2) != 2) {
	fprintf(stderr, "write to pipe failed\n");
	return -1;
}
if (read(rfd, aux, sizeof(aux)) != sizeof(aux)) {
	fprintf(stderr, "read from pipe failed\n");
	return -1;
}
```
The -1 return value was not correctly handled in the final check:
```c
pass = check_pipe_ends(stolen_fd, p_err[0]);

if (pass)
	printf("All OK\n");
else
	printf("Something went WRONG\n");
```

This pull request modified the condition to `pass == 1`, ensuring that "All OK" is printed only when `check_pipe_ends()` returns 1 (indicating a successful case), and any other value will correctly result in "Something went WRONG" being printed.