### PR TITLE
Guarantee run-id uniqueness

### DIFF
--- a/test/zdtm_ct.c
+++ b/test/zdtm_ct.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 	/*
 	 * pidns is used to avoid conflicts
 	 * mntns is used to mount /proc
-	 * net is used to avoid conflicts of parasite sockets
+	 * net is used to avoid conflicts between network tests
 	 */
 	if (!uid)
 		if (unshare(CLONE_NEWNS | CLONE_NEWPID | CLONE_NEWNET | CLONE_NEWIPC))


### PR DESCRIPTION
The first patch improves on run-id generation to make it guaranteed to be unique on a running machine.
Second removes wrapping tests in an empty netns that was working around the lack of run-id uniqueness.