### PR TITLE
test/thp_disable: fix lint

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1325,7 +1325,7 @@ int kerndat_has_thp_disable(void)
 			parse_vmflags(str, &flags, &madv, &io_pf);
 			kdat.has_thp_disable = !(madv & (1 << MADV_NOHUGEPAGE));
 			if (!kdat.has_thp_disable)
-				pr_warn("prctl PR_SET_THP_DISABLE sets MADV_NOHUGEPAGE");
+				pr_warn("prctl PR_SET_THP_DISABLE sets MADV_NOHUGEPAGE\n");
 			break;
 		}
 	}

--- a/test/zdtm/static/thp_disable.c
+++ b/test/zdtm/static/thp_disable.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
 	}
 	if (ret != 1) {
 		errno = 0;
-		fail("prctl(GET_THP_DISABLE) returned unexpected value: %d != 1\n", ret);
+		fail("prctl(GET_THP_DISABLE) returned unexpected value: %d != 1", ret);
 		return -1;
 	}
 
@@ -53,12 +53,12 @@ int main(int argc, char **argv)
 
 	errno = 0;
 	if (orig_flags != new_flags) {
-		fail("Flags changed %lx -> %lx\n", orig_flags, new_flags);
+		fail("Flags changed %lx -> %lx", orig_flags, new_flags);
 		return -1;
 	}
 
 	if (orig_madv != new_madv) {
-		fail("Madvs changed %lx -> %lx\n", orig_madv, new_madv);
+		fail("Madvs changed %lx -> %lx", orig_madv, new_madv);
 		return -1;
 	}
 
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
 	}
 	if (ret != 1) {
 		errno = 0;
-		fail("post-migration prctl(GET_THP_DISABLE) returned unexpected value: %d != 1\n", ret);
+		fail("post-migration prctl(GET_THP_DISABLE) returned unexpected value: %d != 1", ret);
 		return -1;
 	}
 
@@ -87,12 +87,12 @@ int main(int argc, char **argv)
 
 	errno = 0;
 	if (orig_flags != new_flags) {
-		fail("Flags changed %lx -> %lx\n", orig_flags, new_flags);
+		fail("Flags changed %lx -> %lx", orig_flags, new_flags);
 		return -1;
 	}
 
 	if (orig_madv != new_madv) {
-		fail("Madvs changed %lx -> %lx\n", orig_madv, new_madv);
+		fail("Madvs changed %lx -> %lx", orig_madv, new_madv);
 		return -1;
 	}
 


### PR DESCRIPTION
The `fail()` macro provides a new line character at the end of the message. This patch fixes the following lint check that currently fails in CI:

```
$ git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*\\n"'
    test/zdtm/static/thp_disable.c:         fail("prctl(GET_THP_DISABLE) returned unexpected value: %d != 1\n", ret);
    test/zdtm/static/thp_disable.c:         fail("Flags changed %lx -> %lx\n", orig_flags, new_flags);
    test/zdtm/static/thp_disable.c:         fail("Madvs changed %lx -> %lx\n", orig_madv, new_madv);
    test/zdtm/static/thp_disable.c:         fail("post-migration prctl(GET_THP_DISABLE) returned unexpected value: %d != 1\n", ret);
    test/zdtm/static/thp_disable.c:         fail("Flags changed %lx -> %lx\n", orig_flags, new_flags);
    test/zdtm/static/thp_disable.c:         fail("Madvs changed %lx -> %lx\n", orig_madv, new_madv);
```