### PR TITLE
Make socket feature probing work on IPv6-only host.

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1086,6 +1086,8 @@ static int kerndat_tcp_repair_window(void)
 	int sk, val = 1;
 
 	sk = socket(AF_INET, SOCK_STREAM, 0);
+	if (sk < 0 && errno == EAFNOSUPPORT)
+		sk = socket(AF_INET6, SOCK_STREAM, 0);
 	if (sk < 0) {
 		pr_perror("Unable to create inet socket");
 		goto errn;


### PR DESCRIPTION
Try IPv6 if IPv4 sockets are not supported.
