### PR TITLE
cgroup: Remove deprecated property handling.

### DIFF
--- a/criu/cgroup-props.c
+++ b/criu/cgroup-props.c
@@ -427,7 +427,6 @@ static int cgp_parse_builtins(void)
 						"\"memory.move_charge_at_immigrate\", "
 						"\"memory.oom_control\", "
 						"\"memory.use_hierarchy\", "
-						"\"memory.kmem.limit_in_bytes\", "
 						"\"memory.kmem.tcp.limit_in_bytes\" "
 						"]\n"
 						/*


### PR DESCRIPTION
`memory.kmem.limit_in_bytes` knob is deprecated since Linux 5.4 and not writable since Linux 5.16.
