### PR TITLE
kerndat: Don't fail on NETLINK/nsid support missing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,12 +450,12 @@ lint:
 	shellcheck -x test/others/crit/*.sh test/others/criu-coredump/*.sh
 	shellcheck -x test/others/config-file/*.sh
 	codespell -S tags
-	# Do not append \n to pr_perror or fail
-	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>.*\\n"'
-	# Do not use %m with pr_perror or fail
-	! git --no-pager grep -E '^\s*\<(pr_(err|perror|warn|debug|info|msg)|fail)\>.*%m'
-	# Do not use errno with pr_perror or fail
-	! git --no-pager grep -E '^\s*\<(pr_perror|fail)\>\(".*".*errno'
+	# Do not append \n to pr_perror, pr_pwarn or fail
+	! git --no-pager grep -E '^\s*\<(pr_perror|pr_pwarn|fail)\>.*\\n"'
+	# Do not use %m with pr_* or fail
+	! git --no-pager grep -E '^\s*\<(pr_(err|perror|warn|pwarn|debug|info|msg)|fail)\>.*%m'
+	# Do not use errno with pr_perror, pr_pwarn or fail
+	! git --no-pager grep -E '^\s*\<(pr_perror|pr_pwarn|fail)\>\(".*".*errno'
 	# End pr_(err|warn|msg|info|debug) with \n
 	! git --no-pager grep -En '^\s*\<pr_(err|warn|msg|info|debug)\>.*);$$' | grep -v '\\n'
 	# No EOL whitespace for C files

--- a/criu/include/log.h
+++ b/criu/include/log.h
@@ -60,6 +60,8 @@ void flush_early_log_buffer(int fd);
 
 #define pr_perror(fmt, ...) pr_err(fmt ": %s\n", ##__VA_ARGS__, strerror(errno))
 
+#define pr_pwarn(fmt, ...) pr_warn(fmt ": %s\n", ##__VA_ARGS__, strerror(errno))
+
 #endif /* CR_NOGLIBC */
 
 #endif /* __CR_LOG_H__ */

--- a/criu/include/net.h
+++ b/criu/include/net.h
@@ -50,7 +50,6 @@ extern int kerndat_has_newifindex(void);
 extern int kerndat_link_nsid(void);
 extern int net_get_nsid(int rtsk, int fd, int *nsid);
 extern struct ns_id *net_get_root_ns(void);
-extern int kerndat_nsid(void);
 extern void check_has_netns_ioc(int fd, bool *kdat_val, const char *name);
 extern int net_set_ext(struct ns_id *ns);
 extern struct ns_id *get_root_netns(void);

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -703,7 +703,7 @@ err:
 	return exit_code;
 }
 
-int kerndat_nsid(void)
+static int kerndat_nsid(void)
 {
 	int nsid, sk;
 

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -707,16 +707,18 @@ static int kerndat_nsid(void)
 {
 	int nsid, sk;
 
+	kdat.has_nsid = false;
+
 	sk = socket(PF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
 	if (sk < 0) {
-		pr_perror("Unable to create a netlink socket");
-		return -1;
+		pr_pwarn("Unable to create a netlink socket: NSID can't be used.");
+		return 0;
 	}
 
 	if (net_get_nsid(sk, getpid(), &nsid) < 0) {
-		pr_err("NSID is not supported\n");
+		pr_warn("NSID is not supported\n");
 		close(sk);
-		return -1;
+		return 0;
 	}
 
 	kdat.has_nsid = true;

--- a/criu/util.c
+++ b/criu/util.c
@@ -1076,14 +1076,14 @@ void tcp_cork(int sk, bool on)
 {
 	int val = on ? 1 : 0;
 	if (setsockopt(sk, SOL_TCP, TCP_CORK, &val, sizeof(val)))
-		pr_perror("Unable to restore TCP_CORK (%d)", val);
+		pr_pwarn("Unable to restore TCP_CORK (%d)", val);
 }
 
 void tcp_nodelay(int sk, bool on)
 {
 	int val = on ? 1 : 0;
 	if (setsockopt(sk, SOL_TCP, TCP_NODELAY, &val, sizeof(val)))
-		pr_perror("Unable to restore TCP_NODELAY (%d)", val);
+		pr_pwarn("Unable to restore TCP_NODELAY (%d)", val);
 }
 
 static int get_sockaddr_in(struct sockaddr_storage *addr, char *host, unsigned short port)


### PR DESCRIPTION
If not dumping netns nor connections, nsid support is not used. Don't fail the run as if the support is needed, the dumping process will fail later.
