### PR TITLE
action-scripts: allow shell scripts in rpc mode

### DIFF
--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -28,6 +28,9 @@ CRIU_LOG='/criu.log'
 mkdir -p /etc/criu
 echo "log-file=$CRIU_LOG" > /etc/criu/runc.conf
 
+# Test checkpoint/restore with action script
+echo "action-script /usr/bin/true" | sudo tee /etc/criu/default.conf
+
 export SKIP_CI_TEST=1
 
 ./run-ci-tests.sh

--- a/scripts/ci/podman-test.sh
+++ b/scripts/ci/podman-test.sh
@@ -17,6 +17,9 @@ mkdir -p /etc/criu
 echo "manage-cgroups ignore" > /etc/criu/runc.conf
 sed -i 's/#runtime\s*=\s*.*/runtime = "runc"/' /usr/share/containers/containers.conf
 
+# Test checkpoint/restore with action script
+echo "action-script /usr/bin/true" | sudo tee /etc/criu/default.conf
+
 podman info
 
 podman run --name cr -d docker.io/library/alpine /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'


### PR DESCRIPTION
Container runtimes commonly use CRIU with RPC. However, this prevents the use of action-scripts set in a configuration file due to the explicit scripts mode introduced with commit ac78f13bdfaee260dd4234f054bf4c5d2a373783. This pull request enables container checkpoint/restore with action-scripts specified via configuration file.
