### PR TITLE
kerndat: bind ipv6-socket only if ipv6 is enabled

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1577,6 +1577,12 @@ static int kerndat_has_nftables_concat(void)
 static int kerndat_has_ipv6_freebind(void)
 {
 	int sk, val;
+	
+	// if ipv6 is disabled, skip this step
+	if (!kdat.ipv6) {
+		kdat.has_ipv6_freebind = false;
+		return 0;
+	}
 
 	sk = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	if (sk == -1) {


### PR DESCRIPTION
Fixes: #2222
Fixes: f1c8d38 ("kerndat: check if setsockopt IPV6_FREEBIND is supported")

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
