### PR TITLE
test: replace NR_fstat with NR_statx

### DIFF
--- a/test/zdtm/static/seccomp_filter_inheritance.c
+++ b/test/zdtm/static/seccomp_filter_inheritance.c
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
 		if (filter_syscall(__NR_ptrace) < 0)
 			_exit(1);
 
-		if (filter_syscall(__NR_fstat) < 0)
+		if (filter_syscall(__NR_statx) < 0)
 			_exit(1);
 
 		zdtm_seccomp = 1;


### PR DESCRIPTION
`NR_fstat` is a deprecated syscall, usually use `NR_statx` instead. `NR_statx` is supported since linux 4.10. https://github.com/torvalds/linux/commit/a528d35e8bfcc521d7cb70aaf03e1bd296c8493f
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
