### PR TITLE
s390x: fix building with latest Linux kernel

### DIFF
--- a/compel/arch/s390/src/lib/infect.c
+++ b/compel/arch/s390/src/lib/infect.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <elf.h>
 #include <compel/plugins/std/syscall-codes.h>
+#include <linux/const.h>
 #include "uapi/compel/asm/infect-types.h"
 #include "errno.h"
 #include "log.h"

--- a/criu/arch/s390/crtools.c
+++ b/criu/arch/s390/crtools.c
@@ -4,6 +4,7 @@
 #include <sys/user.h>
 #include <asm/unistd.h>
 #include <sys/uio.h>
+#include <linux/const.h>
 
 #include "types.h"
 #include <compel/asm/fpu.h>


### PR DESCRIPTION
Building on the latest Linux kernel (6.5-rc1) fails with:
```
In file included from compel/include/uapi/compel/asm/infect-types.h:7,
                 from compel/arch/s390/src/lib/infect.c:12:
compel/arch/s390/src/lib/infect.c: In function 'rewind_psw': compel/arch/s390/src/lib/infect.c:157:29: error: 'UL' undeclared (first use in this function)
  157 |         mask = (psw->mask & PSW_MASK_EA) ? -1UL : (psw->mask & PSW_MASK_BA) ? (1UL << 31) - 1 : (1UL << 24) - 1;
      |                             ^~~~~~~~~~~
compel/arch/s390/src/lib/infect.c:157:29: note: each undeclared identifier is reported only once for each function it appears in
compel/arch/s390/src/lib/infect.c: In function 'get_ri_cb':
compel/arch/s390/src/lib/infect.c:272:25: error: 'UL' undeclared (first use in this function)
  272 |         if (psw->mask & PSW_MASK_RI)
      |                         ^~~~~~~~~~~
compel/arch/s390/src/lib/infect.c: In function 's390_disable_ri_bit':
compel/arch/s390/src/lib/infect.c:289:23: error: 'UL' undeclared (first use in this function)
  289 |         psw->mask &= ~PSW_MASK_RI;
      |                       ^~~~~~~~~~~
compel/arch/s390/src/lib/infect.c: In function 'arch_can_dump_task':
compel/arch/s390/src/lib/infect.c:523:25: error: 'UL' undeclared (first use in this function)
  523 |         if (psw->mask & PSW_MASK_RI) {
      |
```
This is caused by:

https://github.com/torvalds/linux/commit/b8af5999779d1225c82fcc960223625b279f5f0d

This is fixed with this patch.