### PR TITLE
page-xfer: Pull tcp_cork,nodelay().

### DIFF
--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -278,8 +278,6 @@ static inline int sk_wait_data(int sk)
 }
 
 void fd_set_nonblocking(int fd, bool on);
-void tcp_nodelay(int sk, bool on);
-void tcp_cork(int sk, bool on);
 
 const char *ns_to_string(unsigned int ns);
 

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -2,6 +2,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <linux/falloc.h>
+#include <netinet/tcp.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -155,6 +156,20 @@ static inline int send_psi_flags(int sk, struct page_server_iov *pi, int flags)
 static inline int send_psi(int sk, struct page_server_iov *pi)
 {
 	return send_psi_flags(sk, pi, 0);
+}
+
+static void tcp_cork(int sk, bool on)
+{
+	int val = on ? 1 : 0;
+	if (setsockopt(sk, SOL_TCP, TCP_CORK, &val, sizeof(val)))
+		pr_pwarn("Unable to set TCP_CORK=%d", val);
+}
+
+static void tcp_nodelay(int sk, bool on)
+{
+	int val = on ? 1 : 0;
+	if (setsockopt(sk, SOL_TCP, TCP_NODELAY, &val, sizeof(val)))
+		pr_pwarn("Unable to set TCP_NODELAY=%d", val);
 }
 
 /* page-server xfer */

--- a/criu/util.c
+++ b/criu/util.c
@@ -24,7 +24,6 @@
 #include <sys/resource.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <netinet/tcp.h>
 #include <sched.h>
 #include <ftw.h>
 #include <time.h>
@@ -1153,20 +1152,6 @@ const char *ns_to_string(unsigned int ns)
 	default:
 		return NULL;
 	}
-}
-
-void tcp_cork(int sk, bool on)
-{
-	int val = on ? 1 : 0;
-	if (setsockopt(sk, SOL_TCP, TCP_CORK, &val, sizeof(val)))
-		pr_pwarn("Unable to restore TCP_CORK (%d)", val);
-}
-
-void tcp_nodelay(int sk, bool on)
-{
-	int val = on ? 1 : 0;
-	if (setsockopt(sk, SOL_TCP, TCP_NODELAY, &val, sizeof(val)))
-		pr_pwarn("Unable to restore TCP_NODELAY (%d)", val);
 }
 
 static int get_sockaddr_in(struct sockaddr_storage *addr, char *host, unsigned short port)


### PR DESCRIPTION
Move tcp_cork() and tcp_nodelay() to the only user: page-xfer.c. While at it, fix error messages (as they do not refer to restoring the sockopt values) and demote them as they are not fatal to the page transfer.
