### PR TITLE
apparmor: fix incorrect usage of sizeof on char ptr

### DIFF
--- a/criu/apparmor.c
+++ b/criu/apparmor.c
@@ -551,8 +551,8 @@ static int write_aa_policy(AaNamespace *ns, char *path, int offset, char *rewrit
 			goto fail;
 	}
 
-	ret = snprintf(path + offset + my_offset, sizeof(path) - offset - my_offset, "/.replace");
-	if (ret < 0 || ret >= sizeof(path) - offset - my_offset) {
+	ret = snprintf(path + offset + my_offset, PATH_MAX - offset - my_offset, "/.replace");
+	if (ret < 0 || ret >= PATH_MAX - offset - my_offset) {
 		pr_err("snprintf failed\n");
 		goto fail;
 	}


### PR DESCRIPTION
This makes the apparmor replace file path on riscv64 (#2234) zdtm/static/apparmor_stacking appear as `/sys/kernel/security/apparmor/policy/namespaces/criu_stacking_test/.replac`, where the final e is missing and leads to an error on `open()`. Although here `sizeof(path) - offset - my_offset` should be automatically converted to a quite large unsigned int, and the return value is still 9. Maybe it's due to different glibc implementation? 🤔

As paths are always declared as `char path[PATH_MAX]` when calling this function, I think it's okay to directly use `PATH_MAX` rather than introducing a new argument like size?
