### PR TITLE
irmap: scan user-provided paths in order

### DIFF
--- a/criu/irmap.c
+++ b/criu/irmap.c
@@ -501,6 +501,6 @@ int irmap_scan_path_add(char *path)
 
 	o->ir->path = path;
 	o->ir->nr_kids = -1;
-	list_add(&o->node, &opts.irmap_scan_paths);
+	list_add_tail(&o->node, &opts.irmap_scan_paths);
 	return 0;
 }


### PR DESCRIPTION
Make the scan use the order of paths that came from the user.

This assumes that the order actually matters and makes it easier to construct the list as to speed up inotify-using binaries.