### PR TITLE
tty: don't restore locking with --unprivileged

### DIFF
--- a/criu/tty.c
+++ b/criu/tty.c
@@ -817,8 +817,10 @@ static int do_restore_tty_parms(void *arg, int fd, pid_t pid)
 	 * on termios too. Just to be on the safe side.
 	 */
 
-	if ((p->has & HAS_TERMIOS_L) && ioctl(fd, TIOCSLCKTRMIOS, &p->tl) < 0)
-		goto err;
+	if (!opts.unprivileged) {
+		if ((p->has & HAS_TERMIOS_L) && ioctl(fd, TIOCSLCKTRMIOS, &p->tl) < 0)
+			goto err;
+	}
 
 	if ((p->has & HAS_TERMIOS) && ioctl(fd, TCSETS, &p->t) < 0)
 		goto err;


### PR DESCRIPTION
`TIOCSLCKTRMIOS` requires [CAP_SYS_ADMIN](https://github.com/torvalds/linux/blob/52a93d39b17dc7eb98b6aa3edb93943248e03b2f/drivers/tty/tty_ioctl.c#L863). This causes `criu restore` to fail when used with `--unprivileged`.