### PR TITLE
memfd: make memfd_open() skip fd attributes not needed for vma mapping

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -2508,7 +2508,8 @@ static int open_filemap(int pid, struct vma_area *vma)
 			 */
 			ret = dup(plugin_fd);
 		} else if (vma->e->status & VMA_AREA_MEMFD) {
-			ret = memfd_open(vma->vmfd, &flags);
+			if (!inherited_fd(vma->vmfd, &ret))
+				ret = memfd_open(vma->vmfd, &flags);
 		} else {
 			ret = open_path(vma->vmfd, do_open_reg_noseek_flags, &flags);
 		}


### PR DESCRIPTION
There is only one user of memfd_open() outside of memfd.c: open_filemap(). It is restoring a file-backed mapping and doesn't need to F_SETOWN nor update the fd's position.

An optimization / cleanup.