### PR TITLE
lib/py: add VMA_AREA_MEMFD constant

### DIFF
--- a/coredump/criu_coredump/coredump.py
+++ b/coredump/criu_coredump/coredump.py
@@ -53,6 +53,7 @@ status = {
     "VMA_AREA_SOCKET": 1 << 11,
     "VMA_AREA_VVAR": 1 << 12,
     "VMA_AREA_AIORING": 1 << 13,
+    "VMA_AREA_MEMFD": 1 << 14,
     "VMA_AREA_UNSUPP": 1 << 31
 }
 

--- a/lib/py/images/pb2dict.py
+++ b/lib/py/images/pb2dict.py
@@ -102,6 +102,7 @@ mmap_status_map = [
     ('VMA_AREA_SOCKET', 1 << 11),
     ('VMA_AREA_VVAR', 1 << 12),
     ('VMA_AREA_AIORING', 1 << 13),
+    ('VMA_AREA_MEMFD', 1 << 14),
     ('VMA_UNSUPP', 1 << 31),
 ]
 


### PR DESCRIPTION
`VMA_AREA_MEMFD` was introduced with commit 29a1a88bcebaf9d83591077d2bec424da82c0e71. This pull request extends the status map used in CRIT and coredump with the value of this constant to recognise it.

Before:
```
sudo crit show dump/zdtm/static/maps01/56/1/mm-57.img
...
                {
                    "start": "0x7f224b4d4000",
                    "end": "0x7f224b4d5000",
                    "pgoff": 0,
                    "shmid": 6,
                    "prot": "PROT_READ | PROT_WRITE",
                    "flags": "MAP_SHARED",
                    "status": "VMA_AREA_REGULAR | VMA_FILE_SHARED | 0x4000",
                    "fd": -1,
                    "fdflags": "0x2"
                },
```
After:
```
sudo crit show dump/zdtm/static/maps01/56/1/mm-57.img
...
                {
                    "start": "0x7f224b4d4000",
                    "end": "0x7f224b4d5000",
                    "pgoff": 0,
                    "shmid": 6,
                    "prot": "PROT_READ | PROT_WRITE",
                    "flags": "MAP_SHARED",
                    "status": "VMA_AREA_REGULAR | VMA_FILE_SHARED | VMA_AREA_MEMFD",
                    "fd": -1,
                    "fdflags": "0x2"
                },
```