### PR TITLE
Lint add warnings instead of check failure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,15 +26,15 @@ jobs:
       run: make lint
 
     - name: Run make indent
-      run: >
+      continue-on-error: true
+      run: |
         if [ -z "${{github.base_ref}}" ]; then
-          git fetch --deepen=1 &&
-          if ! make indent OPTS=--diff; then
-            exit 1
-          fi
+          git fetch --deepen=1
+          make indent
         else
-          git fetch origin ${{github.base_ref}} &&
-          if ! make indent OPTS=--diff BASE=origin/${{github.base_ref}}; then
-            exit 1
-          fi
+          git fetch origin ${{github.base_ref}}
+          make indent BASE=origin/${{github.base_ref}}
         fi
+    - name: Raise in-line make indent warnings
+      run: |
+        git diff | ./scripts/github-indent-warnings.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,16 @@ This should create the `./criu/criu` executable.
 
 When you change the source code, please keep in mind the following code conventions:
 
+* code is written to be read, so the code readability is the most important thing you need to have in mind when preparing patches
 * we prefer tabs and indentations to be 8 characters width
-* CRIU mostly follows [Linux kernel coding style](https://www.kernel.org/doc/Documentation/process/coding-style.rst), but we are less strict than the kernel community.
+* we prefer line length of 80 characters or less, more is allowed if it helps with code readability
+* CRIU mostly follows [Linux kernel coding style](https://www.kernel.org/doc/Documentation/process/coding-style.rst), but we are less strict than the kernel community
 
-Other conventions can be learned from the source code itself. In short, make sure your new code
-looks similar to what is already there.
+Other conventions can be learned from the source code itself. In short, make sure your new code looks similar to what is already there.
+
+## Automatic tools to fix coding-style
+
+Important: These tools are there to advise you, but should not be considered as a "source of truth", as tools also make nasty mistakes from time to time which can completely break code readability.
 
 The following command can be used to automatically run a code linter for Python files (flake8), Shell scripts (shellcheck),
 text spelling (codespell), and a number of CRIU-specific checks (usage of print macros and EOL whitespace for C files).
@@ -83,6 +88,41 @@ to check the last *N* commits for formatting errors, without applying the change
 
 Note that for pull requests, the "Run code linter" workflow runs these checks for all commits. If a clang-format error is detected
 we need to review the suggested changes and decide if they should be fixed before merging.
+
+Here are some bad examples of clang-format-ing:
+
+* if clang-format tries to force 120 characters and breaks readability - it is wrong:
+
+```
+@@ -58,8 +59,7 @@ static int register_membarriers(void)
+         }
+ 
+         if (!all_ok) {
+-                fail("can't register membarrier()s - tried %#x, kernel %#x",
+-                     barriers_registered, barriers_supported);
++                fail("can't register membarrier()s - tried %#x, kernel %#x", barriers_registered, barriers_supported);
+                 return -1;
+         }
+```
+
+* if clang-format breaks your beautiful readability friendly alignment in structures, comments or defines - it is wrong:
+
+```
+--- a/test/zdtm/static/membarrier.c
++++ b/test/zdtm/static/membarrier.c
+@@ -27,9 +27,10 @@ static const struct {
+        int register_cmd;
+        int execute_cmd;
+ } membarrier_cmds[] = {
+-       { "",           MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED,           MEMBARRIER_CMD_PRIVATE_EXPEDITED },
+-       { "_SYNC_CORE", MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE, MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE },
+-       { "_RSEQ",      MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ,      MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ },
++       { "", MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED, MEMBARRIER_CMD_PRIVATE_EXPEDITED },
++       { "_SYNC_CORE", MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE,
++         MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE },
++       { "_RSEQ", MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_RSEQ, MEMBARRIER_CMD_PRIVATE_EXPEDITED_RSEQ },
+ };
+```
 
 ## Test your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,12 +46,6 @@ This should create the `./criu/criu` executable.
 
 ## Edit the source code
 
-If you use ctags, you can generate the ctags file by running
-
-```
-        make tags
-```
-
 When you change the source code, please keep in mind the following code conventions:
 
 * we prefer tabs and indentations to be 8 characters width

--- a/Makefile
+++ b/Makefile
@@ -442,6 +442,7 @@ lint:
 	flake8 --config=scripts/flake8.cfg crit/setup.py
 	flake8 --config=scripts/flake8.cfg scripts/uninstall_module.py
 	flake8 --config=scripts/flake8.cfg coredump/ coredump/coredump
+	flake8 --config=scripts/flake8.cfg scripts/github-indent-warnings.py
 	shellcheck --version
 	shellcheck scripts/*.sh
 	shellcheck scripts/ci/*.sh scripts/ci/apt-install

--- a/scripts/github-indent-warnings.py
+++ b/scripts/github-indent-warnings.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+import sys
+import re
+
+re_file = r'^diff --git a/(\S\S*)\s.*$'
+re_line = r'^@@ -(\d\d*)\D.*@@.*$'
+
+if __name__ == '__main__':
+    if len(sys.argv) != 1 and len(sys.argv) != 2:
+        print(f'usage: {sys.argv[0]} <path/to/file>')
+        print(f'usage: <command> | {sys.argv[0]}')
+        exit(1)
+
+    input_file = sys.stdin.fileno()
+    if len(sys.argv) == 2:
+        input_file = sys.argv[1]
+
+    with open(input_file, 'r') as fi:
+        file_name = None
+        line_number = None
+        for line in fi:
+            file_matches = re.findall(re_file, line)
+            if len(file_matches) == 1:
+                file_name = file_matches[0]
+                continue
+
+            if file_name is None:
+                continue
+
+            line_matches = re.findall(re_line, line)
+            if len(line_matches) == 1:
+                line_number = int(line_matches[0]) + 3
+                print(f'::warning file={file_name},line={line_number}::clang-format: Possible coding style problem (https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md#automatic-tools-to-fix-coding-style)')


### PR DESCRIPTION
There are multiple cases where good human readable code block is
converted to an unreadable mess by clang-format, so we don't want to
rely on clang-format completely. Also there is no way, as far as I can
see, to make clang-format only fix what we want it to fix without
breaking something.

So let's just display hints inline where clang-format is unhappy. When
reviewer sees such a warning it's a good sign that something is broken
in codding style around this warning.