### PR TITLE
clang-format: disable column limit constraint

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,7 +53,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma # Unknown to clang-format-4.0
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
-ColumnLimit: 120
+ColumnLimit: 0
 CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false # Unknown to clang-format-4.0
 ConstructorInitializerAllOnOneLineOrOnePerLine: false

--- a/scripts/fetch-clang-format.sh
+++ b/scripts/fetch-clang-format.sh
@@ -8,7 +8,7 @@ URL="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/.c
 curl -s "${URL}" | sed -e "
 	s,^\( *\)#\([A-Z]\),\1\2,g;
 	s,ControlStatements,ControlStatementsExceptForEachMacros,g;
-	s,ColumnLimit: 80,ColumnLimit: 120,g;
+	s,ColumnLimit: 80,ColumnLimit: 0,g;
 	s,Intended for clang-format >= 4,Intended for clang-format >= 11,g;
 	s,ForEachMacros:,ForEachMacros:\n  - 'for_each_bit',g;
 	s,ForEachMacros:,ForEachMacros:\n  - 'for_each_pstree_item',g;


### PR DESCRIPTION
The "ColumnLimit: 120" is not only allowing lines to be longer than 80 characters but it also forces line wrapping at 120 characters. If total expression length is more than 120 characters, clang-format will try to wrap it as close to 120 as it can, it would not even allow to wrap at 80 characters if we really want it. But as we all know 80 characters is Linux kernel coding style default and as far as our coding style is based on it it is really strange to prohibit wrapping lines at 80 characters...

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
