### PR TITLE
compel: Add support for ppc64le scv syscalls

### DIFF
--- a/compel/arch/ppc64/src/lib/infect.c
+++ b/compel/arch/ppc64/src/lib/infect.c
@@ -11,6 +11,7 @@
 #include "log.h"
 #include "common/bug.h"
 #include "common/page.h"
+#include "common/err.h"
 #include "infect.h"
 #include "infect-priv.h"
 
@@ -303,33 +304,58 @@ out_free:
 	return -1; /* still failing the checkpoint */
 }
 
-static int __get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
-{
-	pr_info("Dumping GP/FPU registers for %d\n", pid);
+/*
+ * This is inspired by kernel function check_syscall_restart in
+ * arch/powerpc/kernel/signal.c
+ */
 
-	/*
-	 * This is inspired by kernel function check_syscall_restart in
-	 * arch/powerpc/kernel/signal.c
-	 */
 #ifndef TRAP
 #define TRAP(r) ((r).trap & ~0xF)
 #endif
 
-	if (TRAP(*regs) == 0x0C00 && regs->ccr & 0x10000000) {
-		/* Restart the system call */
-		switch (regs->gpr[3]) {
-		case ERESTARTNOHAND:
-		case ERESTARTSYS:
-		case ERESTARTNOINTR:
-			regs->gpr[3] = regs->orig_gpr3;
-			regs->nip -= 4;
-			break;
-		case ERESTART_RESTARTBLOCK:
-			pr_warn("Will restore %d with interrupted system call\n", pid);
-			regs->gpr[3] = EINTR;
-			break;
-		}
+static bool trap_is_scv(user_regs_struct_t *regs)
+{
+	return TRAP(*regs) == 0x3000;
+}
+
+static bool trap_is_syscall(user_regs_struct_t *regs)
+{
+	return trap_is_scv(regs) || TRAP(*regs) == 0x0C00;
+}
+
+static void handle_syscall(pid_t pid, user_regs_struct_t *regs)
+{
+	unsigned long ret = regs->gpr[3];
+
+	if (trap_is_scv(regs)) {
+		if (!IS_ERR_VALUE(ret))
+			return;
+		ret = -ret;
+	} else if (!(regs->ccr & 0x10000000)) {
+		return;
 	}
+
+	/* Restart or interrupt the system call */
+	switch (ret) {
+	case ERESTARTNOHAND:
+	case ERESTARTSYS:
+	case ERESTARTNOINTR:
+		regs->gpr[3] = regs->orig_gpr3;
+		regs->nip -= 4;
+		break;
+	case ERESTART_RESTARTBLOCK:
+		pr_warn("Will restore %d with interrupted system call\n", pid);
+		regs->gpr[3] = trap_is_scv(regs) ? -EINTR : EINTR;
+		break;
+	}
+}
+
+static int __get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
+{
+	pr_info("Dumping GP/FPU registers for %d\n", pid);
+
+	if (trap_is_syscall(regs))
+		handle_syscall(pid, regs);
 
 	/* Resetting trap since we are now coming from user space. */
 	regs->trap = 0;


### PR DESCRIPTION
Power ISA 3.0 added a new syscall instruction. Kernel 5.9 added corresponding support.

https://github.com/torvalds/linux/commit/912237ea166428edcbf3c137adf12cb987c477f2
https://github.com/torvalds/linux/commit/4e0e45b07d790253643ee05300784ab2156e2d5e
https://github.com/torvalds/linux/commit/7fa95f9adaee7e5cbb195d3359741120829e488b
https://github.com/torvalds/linux/commit/5665bc35c1ed917ac8fd06cb651317bb47a65b10

Add CRIU support to recognize the new instruction and kernel ABI changes to properly dump and restore threads executing in syscalls. Without this change threads executing in syscalls using the scv instruction will not be restored to re-execute the syscall, they will be restored to execute the following instruction and will return unexpected error codes (ERESTARTSYS, etc) to user code.

Problem is caught by `zdtm/static/sigpending` if you run it on a Power 10 in RHEL 9 or UBI 9 because a libpthreads build that will use the new syscall is present.

Output without this patch is:

```
$ sudo ./zdtm.py run -t zdtm/static/sigpending -f h
userns is supported
=== Run 1/1 ================ zdtm/static/sigpending
======================= Run zdtm/static/sigpending in h ========================
Start test
./sigpending --pidfile=sigpending.pid --outfile=sigpending.out
Run criu dump
=[log]=> dump/zdtm/static/sigpending/56/1/dump.log
------------------------ grep Error ------------------------
b"(00.001168) \tSeizing 56's 57 thread"
b'(00.001273) seccomp: Collected tid_real 57 mode 0'
b'(00.001298) Collected (3 attempts, 0 in_progress)'
b'(00.001325) Seized task 58, state 0'
b'(00.001333) Warn  (compel/src/lib/infect.c:133): Unable to interrupt task: 58 (Operation not permitted)'
------------------------ ERROR OVER ------------------------
Run criu restore
Send the 15 signal to  56
Wait for zdtm/static/sigpending(56) to die for 0.100000
tail: cannot open 'zdtm/static/sigpending.out' for reading: No such file or directory
==================== zdtm/static/sigpending.out.inprogress =====================
The futex facility returned an unexpected error code.

==================== zdtm/static/sigpending.out.inprogress =====================
############### Test zdtm/static/sigpending FAIL at result check ###############
Test output: ================================
The futex facility returned an unexpected error code.

 <<< ================================
##################################### FAIL #####################################
```

Error message comes from https://github.com/bminor/glibc/blob/a43003ebf674f7af8c4b8d6d1b682244f1a28719/nptl/futex-internal.c#L119

With the patch it passes. Also checked on a Power 9 machine that does not use the new syscalls and it still works with the patch.

The only question I can't answer definitively is whether we need to do anything to prevent double restarts. Kernel changed from clearing `pt_regs.trap` to setting a bit `0x10` instead to remember that syscall is going to be restarted to not rewind NIP more than once, in case multiple signals arrive at the same time.

CRIU always clears `.trap` before checkpointing the registers. Is that still the correct behaviour?

I don't think CRIU needs to coordinate with the kernel to prevent double restarts since on restore if a signal arrives it should not try to restart the syscall we were executing at checkpoint time, it should just return control to user space so the thread can enter the syscall naturally, so clearing `.trap` seems like it should do the right thing regardless of how the kernel is managing double restarts.