### PR TITLE
dump: use MEMBARRIER_CMD_GET_REGISTRATIONS when available

### DIFF
--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -85,6 +85,7 @@ struct kerndat_s {
 	bool has_ptrace_get_rseq_conf;
 	struct __ptrace_rseq_configuration libc_rseq_conf;
 	bool has_ipv6_freebind;
+	bool has_membarrier_get_registrations;
 };
 
 extern struct kerndat_s kdat;

--- a/criu/include/parasite.h
+++ b/criu/include/parasite.h
@@ -118,6 +118,8 @@ static inline int posix_timers_dump_size(int timer_n)
  */
 
 struct parasite_dump_misc {
+	bool has_membarrier_get_registrations; // this is sent from criu to parasite.
+
 	unsigned long brk;
 
 	u32 pid;

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -433,6 +433,7 @@ int parasite_dump_misc_seized(struct parasite_ctl *ctl, struct parasite_dump_mis
 	struct parasite_dump_misc *ma;
 
 	ma = compel_parasite_args(ctl, struct parasite_dump_misc);
+	ma->has_membarrier_get_registrations = kdat.has_membarrier_get_registrations;
 	if (compel_rpc_call_sync(PARASITE_CMD_DUMP_MISC, ctl) < 0)
 		return -1;
 


### PR DESCRIPTION
MEMBARRIER_CMD_GET_REGISTRATIONS can tell us whether or not the process used MEMBARRIER_CMD_REGISTER_GLOBAL_EXPEDITED unlike the old probing method.

Falls back to the old method when MEMBARRIER_CMD_GET_REGISTRATIONS is unavailable.