### PR TITLE
ci: stop testing ubuntu overlayfs

### DIFF
--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -20,14 +20,6 @@ export CONTAINER_RUNTIME
 
 alpine: ZDTM_OPTS=-x zdtm/static/binfmt_misc -x zdtm/static/sched_policy00
 
-define DOCKER_JSON
-{
-	"storage-driver": "devicemapper"
-}
-endef
-
-export DOCKER_JSON
-
 ifeq ($(GITHUB_ACTIONS),true)
 	# GitHub Actions does not give us a real TTY and errors out with
 	# 'the input device is not a TTY' if using '-t'
@@ -47,34 +39,20 @@ else
 endif
 
 ifeq ($(CONTAINER_RUNTIME),podman)
-	# Just as Docker needs to use devicemapper Podman needs vfs
-	# as graphdriver as overlayfs does not support all test cases
-	STORAGE_DRIVER := vfs
 	# Podman limits the number of processes in a container using cgroups.
 	# Disable it as it breaks the thread-bomb test
 	CONTAINER_OPTS += --pids-limit=0
 endif
 
-export STORAGE_DRIVER
-
-restart-docker:
-	if [ "$$UNAME" = "x86_64" ] && [ "$$CONTAINER_RUNTIME" = "docker" ]; then \
-		echo "$$DOCKER_JSON" > /etc/docker/daemon.json; \
-		cat /etc/docker/daemon.json; \
-		systemctl status docker; \
-		systemctl restart docker; \
-		systemctl status docker; \
-	fi
-
 export ZDTM_OPTS
 
-$(TARGETS): restart-docker
+$(TARGETS):
 	$(MAKE) -C ../build $@$(target-suffix)
-	$(CONTAINER_RUNTIME) run --env-file docker.env $(if $(ZDTM_OPTS),-e ZDTM_OPTS) $(CONTAINER_OPTS) criu-$@ scripts/ci/run-ci-tests.sh
+	$(CONTAINER_RUNTIME) run --env-file docker.env -v `pwd`/../../:/criu $(if $(ZDTM_OPTS),-e ZDTM_OPTS) $(CONTAINER_OPTS) criu-$@ scripts/ci/run-ci-tests.sh
 
-fedora-asan: restart-docker
+fedora-asan:
 	$(MAKE) -C ../build $@$(target-suffix)
-	$(CONTAINER_RUNTIME) run $(CONTAINER_OPTS) criu-$@ ./scripts/ci/asan.sh $(ZDTM_OPTS)
+	$(CONTAINER_RUNTIME) run $(CONTAINER_OPTS) -v `pwd`/../../:/criu criu-$@ ./scripts/ci/asan.sh $(ZDTM_OPTS)
 
 docker-test:
 	./docker-test.sh
@@ -82,10 +60,7 @@ docker-test:
 podman-test:
 	./podman-test.sh
 
-# overlayfs behaves differently on Ubuntu and breaks CRIU
-# https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1857257
-# Switch to devicemapper
-java-test: restart-docker
+java-test:
 	./java-test.sh
 
 setup-vagrant:

--- a/scripts/ci/asan.sh
+++ b/scripts/ci/asan.sh
@@ -4,6 +4,9 @@ set -x
 
 cat /proc/self/mountinfo
 
+time make ASAN=1 -j 4 V=1
+time make -j4 -C test/zdtm V=1
+
 chmod 0777 test
 chmod 0777 test/zdtm/transition/
 chmod 0777 test/zdtm/static


### PR DESCRIPTION
They break it with each kernel rebase. More details are here: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1857257

Last time, it was fixed a few month ago and it has been broken again in 5.15.0-1046-azure.

