### PR TITLE
uffd: Fix page fault address

### DIFF
--- a/compel/plugins/std/infect.c
+++ b/compel/plugins/std/infect.c
@@ -27,7 +27,7 @@ static struct rt_sigframe *sigframe;
  */
 static unsigned __page_size;
 
-unsigned __attribute((weak)) page_size(void)
+unsigned long __attribute((weak)) page_size(void)
 {
 	return __page_size;
 }

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -104,7 +104,7 @@ bool fault_injected(enum faults f)
  * Hint: compel on aarch64 shall learn relocs for that.
  */
 static unsigned __page_size;
-unsigned page_size(void)
+unsigned long page_size(void)
 {
 	return __page_size;
 }

--- a/include/common/arch/aarch64/asm/page.h
+++ b/include/common/arch/aarch64/asm/page.h
@@ -10,7 +10,7 @@
 extern unsigned __page_size;
 extern unsigned __page_shift;
 
-static inline unsigned page_size(void)
+static inline unsigned long page_size(void)
 {
 	if (!__page_size)
 		__page_size = sysconf(_SC_PAGESIZE);
@@ -37,7 +37,7 @@ static inline unsigned page_shift(void)
 
 #else /* CR_NOGLIBC */
 
-extern unsigned page_size(void);
+extern unsigned long page_size(void);
 #define PAGE_SIZE page_size()
 
 #endif /* CR_NOGLIBC */

--- a/include/common/arch/loongarch64/asm/page.h
+++ b/include/common/arch/loongarch64/asm/page.h
@@ -10,7 +10,7 @@
 static unsigned __page_size;
 static unsigned __page_shift;
 
-static inline unsigned page_size(void)
+static inline unsigned long page_size(void)
 {
 	if (!__page_size)
 		__page_size = sysconf(_SC_PAGESIZE);
@@ -31,7 +31,7 @@ static inline unsigned page_shift(void)
 #define PAGE_PFN(addr) ((addr) / PAGE_SIZE)
 #else /* CR_NOGLIBC */
 
-extern unsigned page_size(void);
+extern unsigned long page_size(void);
 #define PAGE_SIZE page_size()
 
 #endif /* CR_NOGLIBC */

--- a/include/common/arch/mips/asm/page.h
+++ b/include/common/arch/mips/asm/page.h
@@ -10,7 +10,7 @@
 static unsigned __page_size;
 static unsigned __page_shift;
 
-static inline unsigned page_size(void)
+static inline unsigned long page_size(void)
 {
 	if (!__page_size)
 		__page_size = sysconf(_SC_PAGESIZE);
@@ -31,7 +31,7 @@ static inline unsigned page_shift(void)
 #define PAGE_PFN(addr) ((addr) / PAGE_SIZE)
 #else /* CR_NOGLIBC */
 
-extern unsigned page_size(void);
+extern unsigned long page_size(void);
 #define PAGE_SIZE page_size()
 
 #endif /* CR_NOGLIBC */

--- a/include/common/arch/ppc64/asm/page.h
+++ b/include/common/arch/ppc64/asm/page.h
@@ -10,7 +10,7 @@
 extern unsigned __page_size;
 extern unsigned __page_shift;
 
-static inline unsigned page_size(void)
+static inline unsigned long page_size(void)
 {
 	if (!__page_size)
 		__page_size = sysconf(_SC_PAGESIZE);
@@ -37,7 +37,7 @@ static inline unsigned page_shift(void)
 
 #else /* CR_NOGLIBC */
 
-extern unsigned page_size(void);
+extern unsigned long page_size(void);
 #define PAGE_SIZE page_size()
 
 #endif /* CR_NOGLIBC */


### PR DESCRIPTION
The page_size() returns unsigned int value that is after "bitwise not"
is promoted to unsigned long (msg->arg.pagefault.address) value. Sinc
e the value is unsigned promotion is done with 0 MSB that results in
lost of MSB pagefault address bits. Cast page_size to unsigned long
first to avoid such situation.