### PR TITLE
ci: enable build with amdgpu plugin

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,7 @@ task:
     ln -sf /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto
     dnf config-manager --set-enabled crb # Same as CentOS 8 powertools
     dnf -y install epel-release epel-next-release
-    dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python-junit_xml python3-importlib-metadata python-flake8 xmlto
+    dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python-junit_xml python3-importlib-metadata python-flake8 xmlto libdrm-devel
     systemctl stop sssd
     # Even with selinux in permissive mode the selinux tests will be executed.
     # The Cirrus CI user runs as a service from selinux point of view and is
@@ -108,7 +108,7 @@ task:
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || :
     yum install -y dnf-plugins-core
     yum config-manager --set-enabled powertools
-    yum install -y --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python3-devel python3-flake8 python3-PyYAML python3-protobuf python3-importlib-metadata python3-junit_xml xmlto
+    yum install -y --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python3-devel python3-flake8 python3-PyYAML python3-protobuf python3-importlib-metadata python3-junit_xml xmlto libdrm-devel
     alternatives --set python /usr/bin/python3
     systemctl stop sssd
     # Even with selinux in permissive mode the selinux tests will be executed

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -914,7 +914,7 @@ void *dump_bo_contents(void *_thread_data)
 	int num_bos = 0;
 	int i, ret = 0;
 	FILE *bo_contents_fp = NULL;
-	void *buffer;
+	void *buffer = NULL;
 	char img_path[40];
 
 	pr_info("Thread[0x%x] started\n", thread_data->gpu_id);
@@ -1003,7 +1003,7 @@ void *restore_bo_contents(void *_thread_data)
 	uint64_t max_copy_size;
 	uint32_t major, minor;
 	FILE *bo_contents_fp = NULL;
-	void *buffer;
+	void *buffer = NULL;
 	char img_path[40];
 	int num_bos = 0;
 	int i, ret = 0;

--- a/plugins/amdgpu/kfd_ioctl.h
+++ b/plugins/amdgpu/kfd_ioctl.h
@@ -23,7 +23,7 @@
 #ifndef KFD_IOCTL_H_INCLUDED
 #define KFD_IOCTL_H_INCLUDED
 
-#include <drm/drm.h>
+#include <libdrm/drm.h>
 #include <linux/ioctl.h>
 
 /*

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -23,6 +23,7 @@ RUN apk update && apk add \
 	python3 \
 	sudo \
 	libcap-utils \
+	libdrm-dev \
 	util-linux
 
 COPY . /criu

--- a/scripts/build/Dockerfile.archlinux
+++ b/scripts/build/Dockerfile.archlinux
@@ -35,6 +35,7 @@ RUN pacman -Syu --noconfirm \
 	asciidoctor \
 	python-junit-xml \
 	python-importlib-metadata \
+	libdrm \
 	diffutils
 
 COPY . /criu

--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -35,6 +35,7 @@ dnf install -y \
 	which \
 	e2fsprogs \
 	rubygem-asciidoctor \
+	libdrm-devel \
 	kmod
 
 # /tmp is no longer 755 in the rawhide container image and breaks CI - fix it

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -6,7 +6,7 @@ CI_PKGS=(protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
 		libnl-3-dev gdb bash libnet-dev util-linux asciidoctor
 		libnl-route-3-dev time flake8 libbsd-dev python3-yaml
 		libperl-dev pkg-config python3-protobuf python3-pip
-		python3-importlib-metadata python3-junit.xml)
+		python3-importlib-metadata python3-junit.xml libdrm-dev)
 
 X86_64_PKGS=(gcc-multilib)
 
@@ -326,3 +326,8 @@ make -C test/others/action-script run
 
 # compel testing
 make -C compel/test
+
+# amdgpu_plugin testing
+make amdgpu_plugin
+make -C plugins/amdgpu/ test_topology_remap
+./plugins/amdgpu/test_topology_remap


### PR DESCRIPTION
This pull request adds the `libdrm-dev` package to the list of CRIU dependencies installed in CI to build CRIU with amdgpu plugin.