### PR TITLE
tun: don't parse buffers that have not been filled with data

### DIFF
--- a/criu/net.c
+++ b/criu/net.c
@@ -111,15 +111,18 @@ int read_ns_sys_file(char *path, char *buf, int len)
 	}
 
 	rlen = read(fd, buf, len);
+	if (rlen == -1)
+		pr_perror("Can't read ns' %s", path);
 	close(fd);
 
 	if (rlen == len) {
+		buf[0] = '\0';
 		pr_err("Too small buffer to read ns sys file %s\n", path);
 		return -1;
 	}
 
-	if (rlen > 0)
-		buf[rlen - 1] = '\0';
+	if (rlen >= 0)
+		buf[rlen] = '\0';
 
 	return rlen;
 }

--- a/criu/tun.c
+++ b/criu/tun.c
@@ -455,27 +455,26 @@ int dump_tun_link(NetDeviceEntry *nde, struct cr_imgset *fds, struct nlattr **in
 	TunLinkEntry tle = TUN_LINK_ENTRY__INIT;
 	char spath[64];
 	char buf[64];
-	int ret = 0;
 	struct tun_link *tl;
 
 	sprintf(spath, "class/net/%s/tun_flags", nde->name);
-	ret |= read_ns_sys_file(spath, buf, sizeof(buf));
+	if (read_ns_sys_file(spath, buf, sizeof(buf)) < 0)
+		return -1;
 	tle.flags = strtol(buf, NULL, 0);
 
 	sprintf(spath, "class/net/%s/owner", nde->name);
-	ret |= read_ns_sys_file(spath, buf, sizeof(buf));
+	if (read_ns_sys_file(spath, buf, sizeof(buf)) < 0)
+		return -1;
 	tle.owner = strtol(buf, NULL, 10);
 
 	sprintf(spath, "class/net/%s/group", nde->name);
-	ret |= read_ns_sys_file(spath, buf, sizeof(buf));
+	if (read_ns_sys_file(spath, buf, sizeof(buf)) < 0)
+		return -1;
 	tle.group = strtol(buf, NULL, 10);
-
-	if (ret < 0)
-		return ret;
 
 	tl = get_tun_link_fd(nde->name, nde->peer_nsid, tle.flags);
 	if (!tl)
-		return ret;
+		return -1;
 
 	tle.vnethdr = tl->dmp.vnethdr;
 	tle.sndbuf = tl->dmp.sndbuf;


### PR DESCRIPTION
read_ns_sys_file() can return an error, but we are trying to parse a buffer before checking a return code.

CID 417395 (#3 of 3): String not null terminated (STRING_NULL)
2. string_null: Passing unterminated string buf to strtol, which expects a null-terminated string.

