### PR TITLE
pie: Mark __export_*() functions as externally_visible

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -688,7 +688,7 @@ static int recv_cg_set_restore_ack(int sk)
  * Threads restoration via sigreturn. Note it's locked
  * routine and calls for unlock at the end.
  */
-long __export_restore_thread(struct thread_restore_args *args)
+__visible long __export_restore_thread(struct thread_restore_args *args)
 {
 	struct rt_sigframe *rt_sigframe;
 	k_rtsigset_t to_block;
@@ -1228,7 +1228,7 @@ unsigned long vdso_rt_size = 0;
 void *bootstrap_start = NULL;
 unsigned int bootstrap_len = 0;
 
-void __export_unmap(void)
+__visible void __export_unmap(void)
 {
 	sys_munmap(bootstrap_start, bootstrap_len - vdso_rt_size);
 }
@@ -1502,7 +1502,7 @@ int cleanup_current_inotify_events(struct task_restore_args *task_args)
  * and jump execution to some predefined ip read from
  * core file.
  */
-long __export_restore_task(struct task_restore_args *args)
+__visible long __export_restore_task(struct task_restore_args *args)
 {
 	long ret = -1;
 	int i;

--- a/include/common/compiler.h
+++ b/include/common/compiler.h
@@ -30,6 +30,17 @@
 #define __always_unused __attribute__((unused))
 #define __must_check	__attribute__((__warn_unused_result__))
 
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+/* Not supported by clang */
+#if __has_attribute(__externally_visible__)
+#define __visible __attribute__((__externally_visible__))
+#else
+#define __visible
+#endif
+
 #define __section(S) __attribute__((__section__(#S)))
 
 #ifndef __always_inline


### PR DESCRIPTION
GCC's lto source:
```
> To avoid this problem the compiler must assume that it sees the
> whole program when doing link-time optimization.  Strictly
> speaking, the whole program is rarely visible even at link-time.
> Standard system libraries are usually linked dynamically or not
> provided with the link-time information.  In GCC, the whole
> program option (@option{-fwhole-program}) asserts that every
> function and variable defined in the current compilation
> unit is static, except for function @code{main} (note: at
> link time, the current unit is the union of all objects compiled
> with LTO).  Since some functions and variables need to
> be referenced externally, for example by another DSO or from an
> assembler file, GCC also provides the function and variable
> attribute @code{externally_visible} which can be used to disable
> the effect of @option{-fwhole-program} on a specific symbol.
```

As far as I read gcc's source, ipa_comdats() will avoid placing symbols that are either already in a user-defined section or have externally_visible attribute into new optimized gcc sections.

