### PR TITLE
Fix migration of fds to ELF files

### DIFF
--- a/test/zdtm/lib/lock.h
+++ b/test/zdtm/lib/lock.h
@@ -7,6 +7,7 @@
 #include <sys/time.h>
 #include <limits.h>
 #include <errno.h>
+#include <signal.h>
 #include "asm/atomic.h"
 
 #define BUG_ON(condition)                                                        \

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -269,6 +269,7 @@ TST_NOFILE	:=				\
 		sigtrap				\
 		sigtrap01			\
 		change_mnt_context		\
+		fd_offset			\
 #		jobctl00			\
 
 PKG_CONFIG ?= pkg-config

--- a/test/zdtm/static/fd_offset.c
+++ b/test/zdtm/static/fd_offset.c
@@ -1,0 +1,42 @@
+#include <fcntl.h>
+
+#include "zdtmtst.h"
+#include "lock.h"
+
+const char *test_doc = "Check that criu properly restores offsets on ELF files";
+const char *test_author = "Michal Clapinski <mclapinski@google.com>";
+
+void check_offset(int fd)
+{
+	int offset = lseek(fd, 0, SEEK_CUR);
+	if (offset < 0) {
+		fail("lseek");
+		exit(1);
+	}
+	if (offset != 0) {
+		fail("wrong offset; expected: 0, got: %d", offset);
+		exit(1);
+	}
+}
+
+int main(int argc, char **argv)
+{
+	int fd;
+
+	test_init(argc, argv);
+
+	fd = open("/proc/self/exe", O_RDONLY);
+	if (fd < 0) {
+		fail("open");
+		exit(1);
+	}
+	check_offset(fd);
+
+	test_daemon();
+	test_waitsig();
+
+	check_offset(fd);
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
https://github.com/checkpoint-restore/criu/commit/9191f8728d6224e3c108063128131c8f219bdd4f ("criu/files-reg.c: add build-id validation functionality") added a feature to verify build-id of ELF files. Unfortunately it also broke the offset migration of such files due to a `read` after `lseek`. This PR fixes that.