### PR TITLE
Makefile: introduce ARCHCFLAGS for arch specific cflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,18 +35,18 @@ ifeq ($(ARCH),arm)
         ARMV		:= $(shell echo $(SUBARCH) | sed -nr 's/armv([[:digit:]]).*/\1/p; t; i7')
 
         ifeq ($(ARMV),6)
-                USERCFLAGS += -march=armv6
+                ARCHCFLAGS += -march=armv6
         endif
 
         ifeq ($(ARMV),7)
-                USERCFLAGS += -march=armv7-a+fp
+                ARCHCFLAGS += -march=armv7-a+fp
         endif
 
         ifeq ($(ARMV),8)
                 # Running 'setarch linux32 uname -m' returns armv8l on travis aarch64.
                 # This tells CRIU to handle armv8l just as armv7hf. Right now this is
                 # only used for compile testing. No further verification of armv8l exists.
-                USERCFLAGS += -march=armv7-a
+                ARCHCFLAGS += -march=armv7-a
                 ARMV := 7
         endif
 
@@ -159,7 +159,7 @@ export GMON GMONLDOPT
 endif
 
 AFLAGS			+= -D__ASSEMBLY__
-CFLAGS			+= $(USERCFLAGS) $(WARNINGS) $(DEFINES) -iquote include/
+CFLAGS			+= $(USERCFLAGS) $(ARCHCFLAGS) $(WARNINGS) $(DEFINES) -iquote include/
 HOSTCFLAGS		+= $(WARNINGS) $(DEFINES) -iquote include/
 export AFLAGS CFLAGS USERCLFAGS HOSTCFLAGS
 

--- a/test/zdtm/Makefile.inc
+++ b/test/zdtm/Makefile.inc
@@ -23,12 +23,12 @@ ifeq ($(ARCH),arm)
         ARMV := $(shell echo $(SUBARCH) | sed -nr 's/armv([[:digit:]]).*/\1/p; t; i7')
 
         ifeq ($(ARMV),6)
-                USERCFLAGS += -march=armv6
+                ARCHCFLAGS += -march=armv6
         else ifeq ($(ARMV),7)
-                USERCFLAGS += -march=armv7-a+fp
+                ARCHCFLAGS += -march=armv7-a+fp
         else ifeq ($(ARMV),8)
                 # To build aarch32 on armv8 Travis-CI (see criu Makefile)
-                USERCFLAGS += -march=armv7-a
+                ARCHCFLAGS += -march=armv7-a
                 ARMV := 7
         endif
 endif
@@ -40,7 +40,7 @@ endif
 PKG_CONFIG ?= pkg-config
 CFLAGS	+= -g -O2 -Wall -Werror -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
 CFLAGS	+= -Wdeclaration-after-statement -Wstrict-prototypes
-CFLAGS	+= $(USERCFLAGS)
+CFLAGS	+= $(USERCFLAGS) $(ARCHCFLAGS)
 CFLAGS	+= -D_GNU_SOURCE
 CPPFLAGS += -iquote $(LIBDIR)/arch/$(ARCH)/include
 

--- a/test/zdtm/lib/Makefile
+++ b/test/zdtm/lib/Makefile
@@ -1,6 +1,6 @@
 LIBDIR	:= .
 
-CFLAGS	+= $(USERCFLAGS)
+CFLAGS	+= $(USERCFLAGS) $(ARCHCFLAGS)
 
 LIB	:= libzdtmtst.a
 


### PR DESCRIPTION
Do not use $(USERCFLAGS) for anything other than what the user provide.

If $(USERCFLAGS) is provided by the user, then the make command will be unable to add machine specific options (used for ARM) resulting in build failures.

Instead, introduce $(ARCHCFLAGS) for such flags.
