### PR TITLE
gitignore: remove historical left-over files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,12 +25,6 @@ images/google/protobuf/*.h
 .gitid
 criu/criu
 criu/unittest/unittest
-criu/arch/*/sys-exec-tbl*.c
-# x86 syscalls-table is not generated
-!criu/arch/x86/sys-exec-tbl.c
-criu/arch/*/syscalls*.S
-criu/include/syscall-codes*.h
-criu/include/syscall*.h
 criu/include/version.h
 criu/pie/restorer-blob.h
 criu/pie/parasite-blob.h


### PR DESCRIPTION
In commit bbc2f133 was introduced a mechanism to auto-generate the files: sys-exec-tbl*.c, syscalls*.S, syscall-codes*.h, and syscall*.h. This commit also updated the gitignore rules to ignore auto-generated files. However, after commit 19fadee9, the path for these files has changed and the patterns specified in gitignore are no longer needed.

Reported-by: @felicitia

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
