### PR TITLE
plugin: Change default max buffer size to 4G

### DIFF
--- a/Documentation/criu-amdgpu-plugin.txt
+++ b/Documentation/criu-amdgpu-plugin.txt
@@ -100,8 +100,8 @@ executing criu command.
 *KFD_MAX_BUFFER_SIZE*::
     On some systems, VRAM sizes may exceed RAM sizes, and so buffers for dumping
     and restoring VRAM may be unable to fit. Set to a nonzero value (in bytes)
-    to set a limit on the plugin's memory usage.
-    Default:0 (Disabled)
+    to set a limit on the plugin's memory usage. Set to 0 to disable.
+    Default:4 Gigabytes
 
     E.g:
     KFD_MAX_BUFFER_SIZE="2G"

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -521,7 +521,7 @@ int amdgpu_plugin_init(int stage)
 		getenv_bool("KFD_NUMA_CHECK", &kfd_numa_check);
 		getenv_bool("KFD_CAPABILITY_CHECK", &kfd_capability_check);
 	}
-	kfd_max_buffer_size = 0;
+	kfd_max_buffer_size = 4 << 30;
 	getenv_size_t("KFD_MAX_BUFFER_SIZE", &kfd_max_buffer_size);
 
 	return 0;


### PR DESCRIPTION
This will, by default, prevent the amdgpu plugin from allocating more than 4G of memory at a time.

This was meant to be part of a previous pull, but got dropped somewhere.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
