### PR TITLE
compel: correct the syscall number of bind on ARM64

### DIFF
--- a/compel/arch/arm/plugins/std/syscalls/syscall.def
+++ b/compel/arch/arm/plugins/std/syscalls/syscall.def
@@ -39,7 +39,7 @@ recvfrom			207	292	(int sockfd, void *ubuf, size_t size, unsigned int flags, str
 sendmsg				211	296	(int sockfd, const struct msghdr *msg, int flags)
 recvmsg				212	297	(int sockfd, struct msghdr *msg, int flags)
 shutdown			210	293	(int sockfd, int how)
-bind				235	282	(int sockfd, const struct sockaddr *addr, int addrlen)
+bind				200	282	(int sockfd, const struct sockaddr *addr, int addrlen)
 setsockopt			208	294	(int sockfd, int level, int optname, const void *optval, socklen_t optlen)
 getsockopt			209	295	(int sockfd, int level, int optname, const void *optval, socklen_t *optlen)
 clone				220	120	(unsigned long flags, void *child_stack, void *parent_tid, unsigned long newtls, void *child_tid)


### PR DESCRIPTION
In the compel/arch/arm/plugins/std/syscalls/syscall.def, the syscall number of bind on ARM64 should be 200 instead of 235
Referring to [this](https://gpages.juszkiewicz.com.pl/syscalls-table/syscalls.html)

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
