### PR TITLE
ci: fix docker test

### DIFF
--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -15,10 +15,11 @@ add-apt-repository \
    $(lsb_release -cs) \
    stable test"
 
-./apt-install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-# shellcheck source=/dev/null
-. /etc/lsb-release
+# checkpoint/restore is broken in Docker Engine (Community) version 25.0.0-beta.1
+# https://github.com/moby/moby/discussions/46816
+# Downgrade to the latest stable version.
+VERSION_STRING=5:24.0.7-1~ubuntu.20.04~focal
+./apt-install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
 
 # docker checkpoint and restore is an experimental feature
 echo '{ "experimental": true }' > /etc/docker/daemon.json


### PR DESCRIPTION
The version of docker-ce on Ubuntu 20.04 has been recently updated to [25.0.0-beta.1](https://github.com/moby/moby/discussions/46816). However, with this version `docker start --checkpoint` fails with the following error:

```
$ docker start --checkpoint=c1 cr
Error response from daemon: failed to create task for container: content digest fdb1054b00a8c07f08574ce52198c5501d1f552b6a5fb46105c688c70a9acb45: not found: unknown
```

As a workaround, we install the most recent stable version of docker-ce. In addition, to improve code readability, the recursive function call used for retrying container restoration has been replaced with a loop.