### PR TITLE
ci: fix rawhide netlink error

### DIFF
--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -57,6 +57,11 @@ fedora-no-vdso() {
 }
 
 fedora-rawhide() {
+	# The 6.2 kernel of Fedora 38 in combination with rawhide userspace breaks
+	# zdtm/static/socket-tcp-nfconntrack. To activate the new kernel previously
+	# installed this reboots the VM.
+	vagrant reload
+	ssh default uname -a
 	#
 	# Workaround the problem:
 	# error running container: error from /usr/bin/crun creating container for [...]: sd-bus call: Transport endpoint is not connected

--- a/test/jenkins/criu-fault.sh
+++ b/test/jenkins/criu-fault.sh
@@ -9,7 +9,7 @@ prep
 ./test/zdtm.py run -t zdtm/static/maps00 --fault 3 --report report -f h || fail
 
 # FIXME: fhandles looks broken on btrfs
-grep -P "/.* / " /proc/self/mountinfo | grep -q btrfs || NOBTRFS=$?
+findmnt --noheadings --target . | grep -q btrfs || NOBTRFS=$?
 if [ $NOBTRFS -eq 1 ] ; then
 	./test/zdtm.py run -t zdtm/static/inotify_irmap --fault 128 --pre 2 -f uns || fail
 fi


### PR DESCRIPTION
The rawhide netlink errors are fixed with a newer kernel than the default 6.2 available in Fedora 38.