### PR TITLE
x86: shadow stack support

### DIFF
--- a/compel/arch/aarch64/src/lib/infect.c
+++ b/compel/arch/aarch64/src/lib/infect.c
@@ -59,10 +59,9 @@ int sigreturn_prep_fpu_frame_plain(struct rt_sigframe *sigframe, struct rt_sigfr
 	return 0;
 }
 
-int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *ext_regs, save_regs_t save,
+int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *fpsimd, save_regs_t save,
 			 void *arg, __maybe_unused unsigned long flags)
 {
-	user_fpregs_struct_t tmp, *fpsimd = ext_regs ? ext_regs : &tmp;
 	struct iovec iov;
 	int ret;
 

--- a/compel/arch/arm/src/lib/infect.c
+++ b/compel/arch/arm/src/lib/infect.c
@@ -65,10 +65,9 @@ int sigreturn_prep_fpu_frame_plain(struct rt_sigframe *sigframe, struct rt_sigfr
 }
 
 #define PTRACE_GETVFPREGS 27
-int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *ext_regs, save_regs_t save,
+int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *vfp, save_regs_t save,
 			 void *arg, __maybe_unused unsigned long flags)
 {
-	user_fpregs_struct_t tmp, *vfp = ext_regs ? ext_regs : &tmp;
 	int ret = -1;
 
 	pr_info("Dumping GP/FPU registers for %d\n", pid);

--- a/compel/arch/mips/src/lib/infect.c
+++ b/compel/arch/mips/src/lib/infect.c
@@ -119,10 +119,9 @@ int sigreturn_prep_fpu_frame_plain(struct rt_sigframe *sigframe, struct rt_sigfr
 	return 0;
 }
 
-int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *ext_regs, save_regs_t save,
+int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *xs, save_regs_t save,
 			 void *arg, __maybe_unused unsigned long flags)
 {
-	user_fpregs_struct_t xsave = {}, *xs = ext_regs ? ext_regs : &xsave;
 	int ret = -1;
 
 	pr_info("Dumping GP/FPU registers for %d\n", pid);

--- a/compel/arch/ppc64/src/lib/infect.c
+++ b/compel/arch/ppc64/src/lib/infect.c
@@ -391,10 +391,9 @@ static int __get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_stru
 	return 0;
 }
 
-int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *ext_regs, save_regs_t save,
+int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs, save_regs_t save,
 			 void *arg, __maybe_unused unsigned long flags)
 {
-	user_fpregs_struct_t tmp, *fpregs = ext_regs ? ext_regs : &tmp;
 	int ret;
 
 	ret = __get_task_regs(pid, regs, fpregs);

--- a/compel/arch/s390/src/lib/infect.c
+++ b/compel/arch/s390/src/lib/infect.c
@@ -293,10 +293,9 @@ static int s390_disable_ri_bit(pid_t pid, user_regs_struct_t *regs)
 /*
  * Prepare task registers for restart
  */
-int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *ext_regs, save_regs_t save,
+int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs, save_regs_t save,
 			 void *arg, __maybe_unused unsigned long flags)
 {
-	user_fpregs_struct_t tmp, *fpregs = ext_regs ? ext_regs : &tmp;
 	struct iovec iov;
 	int rewind;
 

--- a/compel/arch/x86/plugins/std/parasite-head.S
+++ b/compel/arch/x86/plugins/std/parasite-head.S
@@ -34,7 +34,21 @@ END(__export_parasite_head_start_compat)
 .code64
 #endif
 
+/*
+ * When parasite_service() runs in the daemon mode it will return the stack
+ * pointer for the sigreturn frame in %rax and we call sigreturn directly
+ * from here.
+ * Since a valid stack pointer is positive, it is safe to presume that
+ * return value <= 0 means that parasite_service() called parasite_trap_cmd()
+ * in non-daemon mode, and the parasite should stop at int3.
+ */
 ENTRY(__export_parasite_head_start)
 	call	parasite_service
+	cmp	$0, %rax
+	jle	1f
+	movq	%rax, %rsp
+	movq	$15, %rax
+	syscall
+1:
 	int	$0x03
 END(__export_parasite_head_start)

--- a/compel/arch/x86/plugins/std/syscalls/syscall_64.tbl
+++ b/compel/arch/x86/plugins/std/syscalls/syscall_64.tbl
@@ -118,3 +118,4 @@ __NR_openat2		437		sys_openat2		(int dirfd, char *pathname, struct open_how *how
 __NR_pidfd_getfd		438		sys_pidfd_getfd		(int pidfd, int targetfd, unsigned int flags)
 __NR_rseq       		334		sys_rseq		(void *rseq, uint32_t rseq_len, int flags, uint32_t sig)
 __NR_membarrier 		324		sys_membarrier		(int cmd, unsigned int flags, int cpu_id)
+__NR_map_shadow_stack		453		sys_map_shadow_stack	(unsigned long addr, unsigned long size, unsigned int flags)

--- a/compel/arch/x86/src/lib/include/uapi/asm/cpu.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/cpu.h
@@ -244,6 +244,7 @@ enum cpuid_leafs {
 #define X86_FEATURE_PKU		     (11 * 32 + 3)  /* Protection Keys for Userspace */
 #define X86_FEATURE_OSPKE	     (11 * 32 + 4)  /* OS Protection Keys Enable */
 #define X86_FEATURE_AVX512_VBMI2     (11 * 32 + 6)  /* Additional AVX512 Vector Bit Manipulation Instructions */
+#define X86_FEATURE_SHSTK            (11 * 32 + 7)  /* Shadow Stack */
 #define X86_FEATURE_GFNI	     (11 * 32 + 8)  /* Galois Field New Instructions */
 #define X86_FEATURE_VAES	     (11 * 32 + 9)  /* Vector AES */
 #define X86_FEATURE_VPCLMULQDQ	     (11 * 32 + 10) /* Carry-Less Multiplication Double Quadword */

--- a/compel/arch/x86/src/lib/include/uapi/asm/fpu.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/fpu.h
@@ -246,6 +246,14 @@ struct pkru_state {
 } __packed;
 
 /*
+ * State component 11 is Control-flow Enforcement user states
+ */
+struct cet_user_state {
+	uint64_t cet;			/* user control-flow settings */
+	uint64_t ssp;			/* user shadow stack pointer */
+};
+
+/*
  * This is our most modern FPU state format, as saved by the XSAVE
  * and restored by the XRSTOR instructions.
  *
@@ -260,7 +268,7 @@ struct pkru_state {
  * Of course it was not ;-) Now using four pages...
  *
  */
-#define EXTENDED_STATE_AREA_SIZE (XSAVE_SIZE - sizeof(struct i387_fxsave_struct) - sizeof(struct xsave_hdr_struct))
+#define EXTENDED_STATE_AREA_SIZE (XSAVE_SIZE - sizeof(struct i387_fxsave_struct) - sizeof(struct xsave_hdr_struct) - sizeof(struct cet_user_state))
 
 /*
  * cpu requires it to be 64 byte aligned
@@ -276,6 +284,7 @@ struct xsave_struct {
 		struct ymmh_struct ymmh;
 		uint8_t extended_state_area[EXTENDED_STATE_AREA_SIZE];
 	};
+	struct cet_user_state cet;
 } __aligned(FP_MIN_ALIGN_BYTES) __packed;
 
 struct xsave_struct_ia32 {

--- a/compel/arch/x86/src/lib/include/uapi/asm/infect-types.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/infect-types.h
@@ -143,4 +143,7 @@ typedef struct xsave_struct user_fpregs_struct_t;
  */
 #define __NR32_mmap __NR32_mmap2
 
+extern bool __compel_shstk_enabled(user_fpregs_struct_t *ext_regs);
+#define compel_shstk_enabled __compel_shstk_enabled
+
 #endif /* UAPI_COMPEL_ASM_TYPES_H__ */

--- a/compel/arch/x86/src/lib/include/uapi/asm/infect-types.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/infect-types.h
@@ -146,4 +146,8 @@ typedef struct xsave_struct user_fpregs_struct_t;
 extern bool __compel_shstk_enabled(user_fpregs_struct_t *ext_regs);
 #define compel_shstk_enabled __compel_shstk_enabled
 
+extern int __parasite_setup_shstk(struct parasite_ctl *ctl,
+				user_fpregs_struct_t *ext_regs);
+#define parasite_setup_shstk __parasite_setup_shstk
+
 #endif /* UAPI_COMPEL_ASM_TYPES_H__ */

--- a/compel/arch/x86/src/lib/include/uapi/asm/sigframe.h
+++ b/compel/arch/x86/src/lib/include/uapi/asm/sigframe.h
@@ -203,10 +203,18 @@ static inline void rt_sigframe_erase_sigset(struct rt_sigframe *sigframe)
 		: "rdi"(new_sp)						\
 		: "eax", "r8", "r9", "r10", "r11", "memory")
 
-#define ARCH_RT_SIGRETURN(new_sp, rt_sigframe)				\
+#define ARCH_RT_SIGRETURN_RST(new_sp, rt_sigframe)			\
 do {									\
 	if ((rt_sigframe)->is_native)					\
 		ARCH_RT_SIGRETURN_NATIVE(new_sp);			\
+	else								\
+		ARCH_RT_SIGRETURN_COMPAT(new_sp);			\
+} while (0)
+
+#define ARCH_RT_SIGRETURN_DUMP(new_sp, rt_sigframe)			\
+do {									\
+	if ((rt_sigframe)->is_native)					\
+		return new_sp;						\
 	else								\
 		ARCH_RT_SIGRETURN_COMPAT(new_sp);			\
 } while (0)

--- a/compel/arch/x86/src/lib/infect.c
+++ b/compel/arch/x86/src/lib/infect.c
@@ -345,10 +345,9 @@ static int corrupt_extregs(pid_t pid)
 	return 0;
 }
 
-int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *ext_regs, save_regs_t save,
+int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *xs, save_regs_t save,
 			 void *arg, unsigned long flags)
 {
-	user_fpregs_struct_t xsave = {}, *xs = ext_regs ? ext_regs : &xsave;
 	int ret = -1;
 
 	pr_info("Dumping general registers for %d in %s mode\n", pid, user_regs_native(regs) ? "native" : "compat");

--- a/compel/arch/x86/src/lib/infect.c
+++ b/compel/arch/x86/src/lib/infect.c
@@ -26,6 +26,16 @@
 #ifndef NT_X86_XSTATE
 #define NT_X86_XSTATE 0x202 /* x86 extended state using xsave */
 #endif
+
+#ifndef NT_X86_SHSTK
+#define NT_X86_SHSTK 0x204	/* x86 shstk state */
+#endif
+
+#ifndef ARCH_SHSTK_STATUS
+#define ARCH_SHSTK_STATUS	0x5005
+#define ARCH_SHSTK_SHSTK	(1ULL << 0)
+#endif
+
 #ifndef NT_PRSTATUS
 #define NT_PRSTATUS 1 /* Contains copy of prstatus struct */
 #endif
@@ -250,7 +260,49 @@ static int get_task_xsave(pid_t pid, user_fpregs_struct_t *xsave)
 		// [1] Intel® 64 and IA-32 Architectures Software Developer's
 		//     Manual Volume 1: Basic Architecture
 		//     Section 13.6: Processor tracking of XSAVE-managed state
-		return get_task_fpregs(pid, xsave);
+		if (get_task_fpregs(pid, xsave))
+			return -1;
+	}
+
+	/*
+	 * xsave may be on stack, if we don't clear it explicitly we get
+	 * funky shadow stack state
+	 */
+	memset(&xsave->cet, 0, sizeof(xsave->cet));
+	if (compel_cpu_has_feature(X86_FEATURE_SHSTK)) {
+		unsigned long ssp = 0;
+		unsigned long features = 0;
+
+		if (ptrace(PTRACE_ARCH_PRCTL, pid, (unsigned long)&features, ARCH_SHSTK_STATUS)) {
+			/*
+			 * kernels that don't support shadow stack return
+			 * -EINVAL
+			 */
+			if (errno == EINVAL)
+				return 0;
+
+			pr_perror("shstk: can't get shadow stack status for %d", pid);
+			return -1;
+		}
+
+		if (!(features & ARCH_SHSTK_SHSTK))
+			return 0;
+
+		iov.iov_base = &ssp;
+		iov.iov_len = sizeof(ssp);
+
+		if (ptrace(PTRACE_GETREGSET, pid, (unsigned int)NT_X86_SHSTK, &iov) < 0) {
+			/* ENODEV means CET is not supported by the CPU  */
+			if (errno != ENODEV) {
+				pr_perror("shstk: can't get SSP for %d", pid);
+				return -1;
+			}
+		}
+
+		xsave->cet.cet = features;
+		xsave->cet.ssp = ssp;
+
+		pr_debug("%d: shstk: cet: %lx ssp: %lx\n", pid, xsave->cet.cet, xsave->cet.ssp);
 	}
 
 	return 0;
@@ -696,4 +748,15 @@ int ptrace_set_regs(pid_t pid, user_regs_struct_t *regs)
 unsigned long compel_task_size(void)
 {
 	return TASK_SIZE;
+}
+
+bool __compel_shstk_enabled(user_fpregs_struct_t *ext_regs)
+{
+	if (!compel_cpu_has_feature(X86_FEATURE_SHSTK))
+		return false;
+
+	if (ext_regs->cet.cet & ARCH_SHSTK_SHSTK)
+		return true;
+
+	return false;
 }

--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -190,4 +190,13 @@ static inline bool compel_shstk_enabled(user_fpregs_struct_t *ext_regs)
 #define compel_shstk_enabled
 #endif
 
+#ifndef parasite_setup_shstk
+static inline int parasite_setup_shstk(struct parasite_ctl *ctl,
+				       user_fpregs_struct_t *ext_regs)
+{
+	return 0;
+}
+#define parasite_setup_shstk parasite_setup_shstk
+#endif
+
 #endif

--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -182,4 +182,12 @@ void compel_set_thread_ip(struct parasite_thread_ctl *tctl, uint64_t v);
 
 extern void compel_get_stack(struct parasite_ctl *ctl, void **rstack, void **r_thread_stack);
 
+#ifndef compel_shstk_enabled
+static inline bool compel_shstk_enabled(user_fpregs_struct_t *ext_regs)
+{
+	return false;
+}
+#define compel_shstk_enabled
+#endif
+
 #endif

--- a/compel/plugins/include/uapi/std/infect.h
+++ b/compel/plugins/include/uapi/std/infect.h
@@ -7,7 +7,7 @@ extern int parasite_get_rpc_sock(void);
 
 extern unsigned int __export_parasite_service_cmd;
 extern void *__export_parasite_service_args_ptr;
-extern int __must_check parasite_service(void);
+extern unsigned long __must_check parasite_service(void);
 
 /*
  * Must be supplied by user plugins.

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -760,6 +760,9 @@ static int parasite_start_daemon(struct parasite_ctl *ctl)
 	if (ictx->make_sigframe(ictx->regs_arg, ctl->sigframe, ctl->rsigframe, &ctl->orig.sigmask))
 		return -1;
 
+	if (parasite_setup_shstk(ctl, &ext_regs))
+		return -1;
+
 	if (parasite_init_daemon(ctl))
 		return -1;
 

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -739,6 +739,7 @@ static int parasite_start_daemon(struct parasite_ctl *ctl)
 {
 	pid_t pid = ctl->rpid;
 	struct infect_ctx *ictx = &ctl->ictx;
+	user_fpregs_struct_t ext_regs;
 
 	/*
 	 * Get task registers before going daemon, since the
@@ -746,7 +747,7 @@ static int parasite_start_daemon(struct parasite_ctl *ctl)
 	 * while in daemon it is not such.
 	 */
 
-	if (compel_get_task_regs(pid, &ctl->orig.regs, NULL, ictx->save_regs, ictx->regs_arg, ictx->flags)) {
+	if (compel_get_task_regs(pid, &ctl->orig.regs, &ext_regs, ictx->save_regs, ictx->regs_arg, ictx->flags)) {
 		pr_err("Can't obtain regs for thread %d\n", pid);
 		return -1;
 	}

--- a/criu/arch/x86/Makefile
+++ b/criu/arch/x86/Makefile
@@ -9,6 +9,7 @@ obj-y			+= cpu.o
 obj-y			+= crtools.o
 obj-y			+= kerndat.o
 obj-y			+= sigframe.o
+obj-y			+= shstk.o
 ifeq ($(CONFIG_COMPAT),y)
         obj-y		+= sigaction_compat.o
 endif

--- a/criu/arch/x86/crtools.c
+++ b/criu/arch/x86/crtools.c
@@ -133,6 +133,14 @@ int save_task_regs(void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpre
 #undef assign_array
 #undef assign_xsave
 
+	if (compel_cpu_has_feature(X86_FEATURE_SHSTK)) {
+		UserX86CetEntry *cet = core->thread_info->fpregs->xsave->cet;
+		struct cet_user_state *regs = &fpregs->cet;
+
+		cet->cet = regs->cet;
+		cet->ssp = regs->ssp;
+	}
+
 	return 0;
 }
 
@@ -199,6 +207,13 @@ static int alloc_xsave_extends(UserX86XsaveEntry *xsave)
 			goto err;
 	}
 
+	if (compel_cpu_has_feature(X86_FEATURE_SHSTK)) {
+		xsave->cet = xzalloc(sizeof(UserX86CetEntry));
+		if (!xsave->cet)
+			goto err;
+		user_x86_cet_entry__init(xsave->cet);
+	}
+
 	return 0;
 err:
 	return -1;
@@ -220,6 +235,8 @@ int arch_alloc_thread_info(CoreEntry *core)
 		with_xsave = compel_cpu_has_feature(X86_FEATURE_OSXSAVE);
 		if (with_xsave)
 			sz += sizeof(UserX86XsaveEntry);
+		if (compel_cpu_has_feature(X86_FEATURE_SHSTK))
+			sz += sizeof(UserX86CetEntry);
 	}
 
 	m = xmalloc(sz);

--- a/criu/arch/x86/include/asm/kerndat.h
+++ b/criu/arch/x86/include/asm/kerndat.h
@@ -4,5 +4,6 @@
 extern int kdat_compatible_cr(void);
 extern int kdat_can_map_vdso(void);
 extern int kdat_x86_has_ptrace_fpu_xsave_bug(void);
+extern int kdat_has_shstk(void);
 
 #endif /* __CR_ASM_KERNDAT_H__ */

--- a/criu/arch/x86/include/asm/restorer.h
+++ b/criu/arch/x86/include/asm/restorer.h
@@ -8,6 +8,7 @@
 #include <compel/plugins/std/syscall-codes.h>
 #include <compel/asm/sigframe.h>
 #include "asm/compat.h"
+#include "asm/shstk.h"
 
 #ifdef CONFIG_COMPAT
 extern void restore_tls(tls_t *ptls);

--- a/criu/arch/x86/include/asm/shstk.h
+++ b/criu/arch/x86/include/asm/shstk.h
@@ -10,11 +10,11 @@
 #endif
 
 /* arch/x86/include/uapi/asm/prctl.h */
-#define ARCH_SHSTK_ENABLE		0x5001
+#define ARCH_SHSTK_ENABLE	0x5001
 #define ARCH_SHSTK_DISABLE	0x5002
 #define ARCH_SHSTK_LOCK		0x5003
-#define ARCH_SHSTK_UNLOCK		0x5004
-#define ARCH_SHSTK_STATUS		0x5005
+#define ARCH_SHSTK_UNLOCK	0x5004
+#define ARCH_SHSTK_STATUS	0x5005
 
 #define ARCH_SHSTK_SHSTK	(1ULL << 0)
 #define ARCH_SHSTK_WRSS		(1ULL << 1)
@@ -66,13 +66,207 @@ int arch_shstk_prepare(struct pstree_item *item, CoreEntry *core,
 		       struct task_restore_args *ta);
 #define arch_shstk_prepare arch_shstk_prepare
 
-#if 0
 int arch_shstk_unlock(struct pstree_item *item, CoreEntry *core, pid_t pid);
 #define arch_shstk_unlock arch_shstk_unlock
 
 int arch_shstk_trampoline(struct pstree_item *item, CoreEntry *core,
 		      int (*func)(void *arg), void *arg);
 #define arch_shstk_trampoline arch_shstk_trampoline
-#endif
+
+#ifdef CR_NOGLIBC
+
+#include <compel/plugins/std/syscall.h>
+#include <compel/cpu.h>
+#include "vma.h"
+
+#define SHSTK_BUSY_BIT (1UL << 0)	/* BIT(0) */
+
+static inline int shstk_map(unsigned long addr, unsigned long size)
+{
+	long shstk = sys_map_shadow_stack(addr, size, SHADOW_STACK_SET_TOKEN);
+
+	if (shstk < 0) {
+		pr_err("Failed to map shadow stack at %lx: %ld\n", addr, shstk);
+		return -1;
+	}
+
+	if (shstk != addr) {
+		pr_err("Shadow stack address mismatch: need %lx, got %lx\n", addr, shstk);
+		return -1;
+	}
+
+	pr_info("Created shadow stack at %lx\n", shstk);
+
+	return 0;
+}
+
+/* clang-format off */
+static inline unsigned long get_ssp(void)
+{
+	unsigned long ssp;
+
+	asm volatile("rdsspq %0" : "=r"(ssp) :: );
+
+	return ssp;
+}
+
+static inline void wrssq(unsigned long addr, unsigned long val)
+{
+	asm volatile("wrssq %1, (%0)" :: "r"(addr), "r"(val) : "memory");
+}
+/* clang-format off */
+
+static always_inline void shstk_switch_ssp(unsigned long new_ssp)
+{
+	unsigned long old_ssp = get_ssp();
+
+	asm volatile("rstorssp (%0)\n" :: "r"(new_ssp));
+	asm volatile("saveprevssp");
+
+	pr_debug("changed ssp from %lx to %lx\n", old_ssp, new_ssp);
+}
+
+/*
+ * Disable writes to the shadow stack and lock it's disable/enable control
+ */
+static inline int shstk_finalize(void)
+{
+	int ret = 0;
+
+	ret = sys_arch_prctl(ARCH_SHSTK_DISABLE, ARCH_SHSTK_WRSS);
+	if (ret) {
+		pr_err("Failed to disable writes to shadow stack\n");
+		return ret;
+	}
+
+	ret = sys_arch_prctl(ARCH_SHSTK_LOCK, ARCH_SHSTK_SHSTK);
+	if (ret)
+		pr_err("Failed to lock shadow stack controls\n");
+
+	return ret;
+}
+
+/*
+ * Restore contents of the shadow stack and set shadow stack pointer
+ */
+static always_inline int shstk_restore(struct rst_shstk_info *cet)
+{
+	unsigned long *shstk_data = (unsigned long *)cet->premmaped_addr;
+	unsigned long ssp = cet->vma_start + cet->vma_size - 8;
+	unsigned long shstk_top = cet->vma_size / 8 - 1;
+	unsigned long val;
+	long ret;
+
+	if (!(cet->cet & ARCH_SHSTK_SHSTK))
+		return 0;
+
+	if (shstk_map(cet->vma_start, cet->vma_size))
+		return -1;
+
+	/*
+	 * Switch shadow stack from temporary location to the actual task's
+	 * shadow stack VMA
+	 */
+	shstk_switch_ssp(ssp);
+
+	/* restore shadow stack contents */
+	for (; ssp >= cet->ssp; ssp -= 8, shstk_top--)
+		wrssq(ssp, shstk_data[shstk_top]);
+
+	/*
+	 * Add tokens for sigreturn frame and for switch of the shadow stack.
+	 * The sigreturn token will be checked by the kernel during
+	 * processing of sigreturn
+	 * The token for stack switch is required by rstorssp and
+	 * saveprevssp semantics
+	 */
+
+	/* token for sigreturn frame */
+	val = ALIGN_DOWN(cet->ssp, 8) | SHSTK_DATA_BIT;
+	wrssq(ssp, val);
+
+	/* shadow stack switch token */
+	val = ssp | SHSTK_BUSY_BIT;
+	ssp -= 8;
+	wrssq(ssp, val);
+
+	/* reset shadow stack pointer to the proper location */
+	shstk_switch_ssp(ssp);
+
+	ret = sys_munmap(shstk_data, cet->vma_size + PAGE_SIZE);
+	if (ret < 0) {
+		pr_err("Failed to unmap premmaped shadow stack\n");
+		return ret;
+	}
+
+	return shstk_finalize();
+}
+#define arch_shstk_restore shstk_restore
+
+/*
+ * Disable shadow stack
+ */
+static inline int shstk_disable(void)
+{
+	int ret;
+
+	ret = sys_arch_prctl(ARCH_SHSTK_DISABLE, ARCH_SHSTK_WRSS);
+	if (ret) {
+		pr_err("Failed to disable writes to shadow stack\n");
+		return ret;
+	}
+
+	ret = sys_arch_prctl(ARCH_SHSTK_DISABLE, ARCH_SHSTK_SHSTK);
+	if (ret) {
+		pr_err("Failed to disable shadow stack\n");
+		return ret;
+	}
+
+	ret = sys_arch_prctl(ARCH_SHSTK_LOCK, ARCH_SHSTK_SHSTK);
+	if (ret)
+		pr_err("Failed to lock shadow stack controls\n");
+
+	return 0;
+}
+
+/*
+ * Switch to temporary shadow stack
+ */
+static always_inline int shstk_switch_to_restorer(struct rst_shstk_info *cet)
+{
+	unsigned long ssp;
+	long ret;
+
+	if (!(cet->cet & ARCH_SHSTK_SHSTK))
+		return 0;
+
+	ret = sys_munmap((void *)cet->tmp_shstk, PAGE_SIZE);
+	if (ret < 0) {
+		pr_err("Failed to unmap area for temporary shadow stack\n");
+		return -1;
+	}
+
+	ret = shstk_map(cet->tmp_shstk, PAGE_SIZE);
+	if (ret < 0)
+		return -1;
+
+	/*
+	 * Switch shadow stack from the default created by the kernel to a
+	 * temporary shadow stack allocated in the premmaped area
+	 */
+	ssp = cet->tmp_shstk + PAGE_SIZE - 8;
+	shstk_switch_ssp(ssp);
+
+	ret = sys_arch_prctl(ARCH_SHSTK_ENABLE, ARCH_SHSTK_WRSS);
+	if (ret) {
+		pr_err("Failed to enable writes to shadow stack\n");
+		return ret;
+	}
+
+	return 0;
+}
+#define arch_shstk_switch_to_restorer shstk_switch_to_restorer
+
+#endif /* CR_NOGLIBC */
 
 #endif /* __CR_ASM_SHSTK_H__ */

--- a/criu/arch/x86/include/asm/shstk.h
+++ b/criu/arch/x86/include/asm/shstk.h
@@ -1,0 +1,46 @@
+#ifndef __CR_ASM_SHSTK_H__
+#define __CR_ASM_SHSTK_H__
+
+/*
+ * Shadow stack memory cannot be restored with memcpy/pread but only using
+ * a special instruction that can write to shadow stack.
+ * That instruction is only available when shadow stack is enabled,
+ * otherwise it causes #UD.
+ *
+ * Also, shadow stack VMAs cannot be mmap()ed or mrepmap()ed, they must be
+ * created using map_shadow_stack() system call. This pushes creation of
+ * shadow stack VMAs to the restorer blob after CRIU mappings are freed.
+ *
+ * And there is an additional jungling with shadow stacks to ensure that we
+ * don't unmap an active shadow stack
+ *
+ * The overall sequence of restoring shadow stack is
+ * - Enable shadow stack early after clone()ing the task
+ * - Unlock shadow stack features using ptrace
+ * - In the restorer blob:
+ *   - switch to a temporary shadow stack to be able to unmap shadow stack
+ *     with the CRIU mappings
+ *   - after memory mappigns are restored, recreate shadow stack VMAs,
+ *     populate them using wrss instruction and switch to the task shadow
+ *     stack
+ *   - lock shadow stack features
+ */
+struct rst_shstk_info {
+	unsigned long vma_start;	/* start of shadow stack VMA */
+	unsigned long vma_size;		/* size of shadow stack VMA */
+	unsigned long premmaped_addr;	/* address of shadow stack copy in
+					   the premmaped area */
+	unsigned long tmp_shstk;	/* address of temporary shadow stack */
+	u64 ssp;			/* shadow stack pointer */
+	u64 cet;			/* CET conrtol state */
+};
+#define rst_shstk_info rst_shstk_info
+
+struct task_restore_args;
+struct pstree_item;
+
+int arch_shstk_prepare(struct pstree_item *item, CoreEntry *core,
+		       struct task_restore_args *ta);
+#define arch_shstk_prepare arch_shstk_prepare
+
+#endif /* __CR_ASM_SHSTK_H__ */

--- a/criu/arch/x86/include/asm/shstk.h
+++ b/criu/arch/x86/include/asm/shstk.h
@@ -2,6 +2,29 @@
 #define __CR_ASM_SHSTK_H__
 
 /*
+ * Shadow stack constants from Linux
+ */
+/* arch/x86/include/uapi/asm/mman.h */
+#ifndef SHADOW_STACK_SET_TOKEN
+#define SHADOW_STACK_SET_TOKEN 0x1     /* Set up a restore token in the shadow stack */
+#endif
+
+/* arch/x86/include/uapi/asm/prctl.h */
+#define ARCH_SHSTK_ENABLE		0x5001
+#define ARCH_SHSTK_DISABLE	0x5002
+#define ARCH_SHSTK_LOCK		0x5003
+#define ARCH_SHSTK_UNLOCK		0x5004
+#define ARCH_SHSTK_STATUS		0x5005
+
+#define ARCH_SHSTK_SHSTK	(1ULL << 0)
+#define ARCH_SHSTK_WRSS		(1ULL << 1)
+
+#define ARCH_HAS_SHSTK
+
+/* from arch/x86/kernel/shstk.c */
+#define SHSTK_DATA_BIT (1UL << 63)	/* BIT(63) */
+
+/*
  * Shadow stack memory cannot be restored with memcpy/pread but only using
  * a special instruction that can write to shadow stack.
  * That instruction is only available when shadow stack is enabled,
@@ -42,5 +65,14 @@ struct pstree_item;
 int arch_shstk_prepare(struct pstree_item *item, CoreEntry *core,
 		       struct task_restore_args *ta);
 #define arch_shstk_prepare arch_shstk_prepare
+
+#if 0
+int arch_shstk_unlock(struct pstree_item *item, CoreEntry *core, pid_t pid);
+#define arch_shstk_unlock arch_shstk_unlock
+
+int arch_shstk_trampoline(struct pstree_item *item, CoreEntry *core,
+		      int (*func)(void *arg), void *arg);
+#define arch_shstk_trampoline arch_shstk_trampoline
+#endif
 
 #endif /* __CR_ASM_SHSTK_H__ */

--- a/criu/arch/x86/shstk.c
+++ b/criu/arch/x86/shstk.c
@@ -1,3 +1,6 @@
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+
 #include <common/list.h>
 
 #include <compel/cpu.h>
@@ -87,4 +90,134 @@ int arch_shstk_prepare(struct pstree_item *item, CoreEntry *core,
 	}
 
 	return 0;
+}
+
+int arch_shstk_unlock(struct pstree_item *item, CoreEntry *core, pid_t pid)
+{
+	unsigned long features;
+	int status;
+	int ret = -1;
+
+	/*
+	 * CRIU runs with no shadow stack and the task does not need one,
+	 * nothing to do.
+	 */
+	if (!kdat.has_shstk && !task_needs_shstk(item, core))
+		return 0;
+
+	futex_wait_until(&rsti(item)->shstk_enable, 1);
+
+	if (ptrace(PTRACE_SEIZE, pid, 0, 0)) {
+		pr_perror("Cannot attach to %d", pid);
+		goto futex_wake;
+	}
+
+	if (ptrace(PTRACE_INTERRUPT, pid, 0, 0)) {
+		pr_perror("Cannot interrupt the %d task", pid);
+		goto detach;
+	}
+
+	if (wait4(pid, &status, __WALL, NULL) != pid) {
+		pr_perror("waitpid(%d) failed", pid);
+		goto detach;
+	}
+
+	features = ARCH_SHSTK_SHSTK | ARCH_SHSTK_WRSS;
+	if (ptrace(PTRACE_ARCH_PRCTL, pid, features, ARCH_SHSTK_UNLOCK)) {
+		pr_perror("Cannot unlock CET for %d task", pid);
+		goto detach;
+	}
+
+detach:
+	if (ptrace(PTRACE_DETACH, pid, NULL, 0)) {
+		pr_perror("Unable to detach %d", pid);
+		goto futex_wake;
+	}
+
+	ret = 0;
+
+futex_wake:
+	futex_set_and_wake(&rsti(item)->shstk_unlock, 1);
+
+	return ret;
+}
+
+static void shstk_sync_unlock(struct pstree_item *item)
+{
+	/* notify parent that shadow stack is enabled ... */
+	futex_set_and_wake(&rsti(item)->shstk_enable, 1);
+
+	/* ... and wait until it unlocks its features with ptrace */
+	futex_wait_until(&rsti(item)->shstk_unlock, 1);
+}
+
+static void __arch_shstk_enable(struct pstree_item *item,
+				int (*func)(void *arg), void *arg)
+{
+	int ret;
+
+	shstk_sync_unlock(item);
+
+	/* return here would cause #CP, use exit() instead */
+	ret = func(arg);
+	exit(ret);
+}
+
+static int shstk_disable(struct pstree_item *item)
+{
+	shstk_sync_unlock(item);
+
+	/* disable shadow stack, implicitly clears ARCH_SHSTK_WRSS */
+	if (syscall(__NR_arch_prctl, ARCH_SHSTK_DISABLE, ARCH_SHSTK_SHSTK)) {
+		pr_perror("Failed to disable shadow stack");
+		return -1;
+	}
+
+	if (syscall(__NR_arch_prctl, ARCH_SHSTK_LOCK,
+		    ARCH_SHSTK_SHSTK | ARCH_SHSTK_WRSS)) {
+		pr_perror("Failed to lock shadow stack controls");
+		return -1;
+	}
+
+	return 0;
+}
+
+int arch_shstk_trampoline(struct pstree_item *item, CoreEntry *core,
+		      int (*func)(void *arg), void *arg)
+{
+	unsigned long features = ARCH_SHSTK_SHSTK;
+	int code = ARCH_SHSTK_ENABLE;
+
+	/*
+	 * If task does not need shadow stack but CRIU runs with shadow
+	 * stack enabled, we should disable it before continuing with
+	 * restore
+	 */
+	if (!task_needs_shstk(item, core)) {
+		if (kdat.has_shstk && shstk_disable(item))
+			return -1;
+		return func(arg);
+	}
+
+	/*
+	 * Calling sys_arch_prctl() means there will be use of retq
+	 * instruction after shadow stack is enabled and this will cause
+	 * Control Protectiond fault. Open code sys_arch_prctl() in
+	 * assembly.
+	 *
+	 * code and addr should be in %rdi and %rsi and will be passed to
+	 * the system call as is.
+	 */
+	asm volatile("movq $"__stringify(__NR_arch_prctl)", %%rax	\n"
+		     "syscall						\n"
+		     "cmpq $0, %%rax					\n"
+		     "je 1f						\n"
+		     "retq						\n"
+		     "1:						\n"
+		     :: "D"(code), "S"(features));
+
+	__arch_shstk_enable(item, func, arg);
+
+	/* never reached */
+	return -1;
 }

--- a/criu/arch/x86/shstk.c
+++ b/criu/arch/x86/shstk.c
@@ -1,0 +1,90 @@
+#include <common/list.h>
+
+#include <compel/cpu.h>
+
+#include "pstree.h"
+#include "restorer.h"
+#include "rst-malloc.h"
+#include "vma.h"
+
+static bool task_needs_shstk(struct pstree_item *item, CoreEntry *core)
+{
+	UserX86FpregsEntry *fpregs;
+
+	if (!task_alive(item))
+		return false;
+
+	fpregs = core->thread_info->fpregs;
+	if (fpregs->xsave && fpregs->xsave->cet) {
+		if (!compel_cpu_has_feature(X86_FEATURE_SHSTK)) {
+			pr_warn_once("Restoring task with shadow stack on non-CET machine\n");
+			return false;
+		}
+
+		if (fpregs->xsave->cet->cet & ARCH_SHSTK_SHSTK)
+			return true;
+	}
+
+	return false;
+}
+
+static int shstk_prepare_task(struct vm_area_list *vmas,
+			      struct rst_shstk_info *shstk)
+{
+	struct vma_area *vma;
+
+	list_for_each_entry(vma, &vmas->h, list) {
+		if (vma_area_is(vma, VMA_AREA_SHSTK) &&
+		    in_vma_area(vma, shstk->ssp)) {
+			unsigned long premmaped_addr = vma->premmaped_addr;
+			unsigned long size = vma_area_len(vma);
+
+			shstk->vma_start = vma->e->start;
+			shstk->vma_size = size;
+			shstk->premmaped_addr = premmaped_addr;
+			shstk->tmp_shstk = premmaped_addr + size;
+
+			break;
+		}
+	}
+
+	return 0;
+}
+
+int arch_shstk_prepare(struct pstree_item *item, CoreEntry *core,
+		       struct task_restore_args *ta)
+{
+	struct thread_restore_args *args_array = (struct thread_restore_args *)(&ta[1]);
+	UserX86FpregsEntry *fpregs = core->thread_info->fpregs;
+	struct vm_area_list *vmas = &rsti(item)->vmas;
+	struct rst_shstk_info *shstk = &ta->shstk;
+	int i;
+
+	if (!task_needs_shstk(item, core))
+		return 0;
+
+	shstk->cet = fpregs->xsave->cet->cet;
+	shstk->ssp = fpregs->xsave->cet->ssp;
+
+	if (shstk_prepare_task(vmas, shstk)) {
+		pr_err("Failed to prepare shadow stack memory\n");
+		return -1;
+	}
+
+	for (i = 0; i < item->nr_threads; i++) {
+		struct thread_restore_args *thread_args = &args_array[i];
+
+		core = item->core[i];
+		fpregs = core->thread_info->fpregs;
+		shstk = &thread_args->shstk;
+
+		shstk->cet = fpregs->xsave->cet->cet;
+		shstk->ssp = fpregs->xsave->cet->ssp;
+		if (shstk_prepare_task(vmas, shstk)) {
+			pr_err("Failed to prepare shadow stack memory\n");
+			return -1;
+		}
+	}
+
+	return 0;
+}

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -975,6 +975,9 @@ static int restore_one_alive_task(int pid, CoreEntry *core)
 	if (setup_uffd(pid, ta))
 		return -1;
 
+	if (arch_shstk_prepare(current, core, ta))
+		return -1;
+
 	return sigreturn_restore(pid, ta, args_len, core);
 }
 

--- a/criu/include/image.h
+++ b/criu/include/image.h
@@ -35,6 +35,8 @@
  *  - stack
  *  	the memory area is used in application stack so we
  *  	should be careful about guard page here
+ *  - shadow stack
+ *      the memory area is used by shadow stack
  *  - vsyscall
  *  	special memory area injected into the task memory
  *  	space by the kernel itself, represent virtual syscall
@@ -84,6 +86,7 @@
 #define VMA_AREA_VVAR	 (1 << 12)
 #define VMA_AREA_AIORING (1 << 13)
 #define VMA_AREA_MEMFD	 (1 << 14)
+#define VMA_AREA_SHSTK	 (1 << 15)
 
 #define VMA_EXT_PLUGIN	  (1 << 27)
 #define VMA_CLOSE	  (1 << 28)

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -86,6 +86,7 @@ struct kerndat_s {
 	struct __ptrace_rseq_configuration libc_rseq_conf;
 	bool has_ipv6_freebind;
 	bool has_membarrier_get_registrations;
+	bool has_shstk;
 };
 
 extern struct kerndat_s kdat;

--- a/criu/include/restore.h
+++ b/criu/include/restore.h
@@ -20,4 +20,22 @@ static inline int arch_shstk_prepare(struct pstree_item *item,
 #define arch_shstk_prepare arch_shstk_prepare
 #endif
 
+#ifndef arch_shstk_unlock
+static inline int arch_shstk_unlock(struct pstree_item *item,
+				    CoreEntry *core, pid_t pid)
+{
+	return 0;
+}
+#define arch_shstk_unlock arch_shstk_unlock
+#endif
+
+#ifndef arch_shstk_trampoline
+static inline int arch_shstk_trampoline(struct pstree_item *item, CoreEntry *core,
+				    int (*func)(void *arg), void *arg)
+{
+	return func(arg);
+}
+#define arch_shstk_trampoline arch_shstk_trampoline
+#endif
+
 #endif

--- a/criu/include/restore.h
+++ b/criu/include/restore.h
@@ -7,4 +7,17 @@
 
 extern int arch_set_thread_regs_nosigrt(struct pid *pid);
 
+struct task_restore_args;
+struct pstree_item;
+
+#ifndef arch_shstk_prepare
+static inline int arch_shstk_prepare(struct pstree_item *item,
+				     CoreEntry *core,
+				     struct task_restore_args *ta)
+{
+	return 0;
+}
+#define arch_shstk_prepare arch_shstk_prepare
+#endif
+
 #endif

--- a/criu/include/restorer.h
+++ b/criu/include/restorer.h
@@ -56,6 +56,10 @@ struct restore_posix_timer {
 	int overrun;
 };
 
+#ifndef rst_shstk_info
+struct rst_shstk_info {};
+#endif
+
 /*
  * We should be able to construct fpu sigframe in sigreturn_prep_fpu_frame,
  * so the mem_zone.rt_sigframe should be 64-bytes aligned. To make things
@@ -118,6 +122,8 @@ struct thread_restore_args {
 	void *seccomp_filters_data;
 	unsigned int seccomp_filters_n;
 	bool seccomp_force_tsync;
+
+	struct rst_shstk_info shstk;
 
 	char comm[TASK_COMM_LEN];
 	int cg_set;
@@ -240,6 +246,8 @@ struct task_restore_args {
 
 	uid_t uid;
 	u32 cap_eff[CR_CAP_SIZE];
+
+	struct rst_shstk_info shstk;
 } __aligned(64);
 
 /*

--- a/criu/include/restorer.h
+++ b/criu/include/restorer.h
@@ -339,4 +339,20 @@ enum {
 #define __r_sym(name)		  restorer_sym##name
 #define restorer_sym(rblob, name) (void *)(rblob + __r_sym(name))
 
+#ifndef arch_shstk_switch_to_restorer
+static inline int arch_shstk_switch_to_restorer(struct rst_shstk_info *shstk)
+{
+	return 0;
+}
+#define arch_shstk_switch_to_restorer arch_shstk_switch_to_restorer
+#endif
+
+#ifndef arch_shstk_restore
+static inline int arch_shstk_restore(struct rst_shstk_info *shstk)
+{
+	return 0;
+}
+#define arch_shstk_restore arch_shstk_restore
+#endif
+
 #endif /* __CR_RESTORER_H__ */

--- a/criu/include/rst_info.h
+++ b/criu/include/rst_info.h
@@ -75,6 +75,9 @@ struct rst_info {
 
 	struct rst_rseq *rseqe;
 
+	futex_t shstk_enable;
+	futex_t shstk_unlock;
+
 	void *breakpoint;
 };
 

--- a/criu/include/vma.h
+++ b/criu/include/vma.h
@@ -106,6 +106,7 @@ static inline bool vma_entry_is_private(VmaEntry *entry, unsigned long task_size
 	return (vma_entry_is(entry, VMA_AREA_REGULAR) &&
 		(vma_entry_is(entry, VMA_ANON_PRIVATE) || vma_entry_is(entry, VMA_FILE_PRIVATE)) &&
 		(entry->end <= task_size)) ||
+	       vma_entry_is(entry, VMA_AREA_SHSTK) ||
 	       vma_entry_is(entry, VMA_AREA_AIORING);
 }
 

--- a/criu/pie/Makefile
+++ b/criu/pie/Makefile
@@ -18,6 +18,11 @@ ifeq ($(ARCH),mips)
 	ccflags-y	+= -mno-abicalls -fno-pic
 endif
 
+# -mshstk required for CET instructions
+ifeq ($(ARCH),x86)
+	ccflags-y	+= -mshstk
+endif
+
 LDS		:= compel/arch/$(ARCH)/scripts/compel-pack.lds.S
 
 restorer-obj-y	+= parasite-vdso.o ./$(ARCH_DIR)/vdso-pie.o

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -78,6 +78,10 @@
 #define FALLOC_FL_PUNCH_HOLE 0x02
 #endif
 
+#ifndef ARCH_RT_SIGRETURN_RST
+#define ARCH_RT_SIGRETURN_RST ARCH_RT_SIGRETURN
+#endif
+
 #define sys_prctl_safe(opcode, val1, val2, val3)                                \
 	({                                                                      \
 		long __ret = sys_prctl(opcode, val1, val2, val3, 0);            \
@@ -631,7 +635,7 @@ static int restore_thread_common(struct thread_restore_args *args)
 
 static void noinline rst_sigreturn(unsigned long new_sp, struct rt_sigframe *sigframe)
 {
-	ARCH_RT_SIGRETURN(new_sp, sigframe);
+	ARCH_RT_SIGRETURN_RST(new_sp, sigframe);
 }
 
 static int send_cg_set(int sk, int cg_set)

--- a/images/core-x86.proto
+++ b/images/core-x86.proto
@@ -41,6 +41,11 @@ message user_x86_regs_entry {
 	optional user_x86_regs_mode	mode		= 28 [default = NATIVE];
 }
 
+message user_x86_cet_entry {
+	required uint64			cet		=  1[(criu).hex = true];
+	required uint64			ssp		=  2[(criu).hex = true];
+}
+
 message user_x86_xsave_entry {
 	/* standard xsave features */
 	required uint64			xstate_bv	=  1;
@@ -59,6 +64,9 @@ message user_x86_xsave_entry {
 
 	/* Protected keys */
 	repeated uint32			pkru		=  8;
+
+	/* CET */
+	optional user_x86_cet_entry	cet		=  9;
 
 	/*
 	 * Processor trace (PT) and hardware duty cycling (HDC)

--- a/include/common/compiler.h
+++ b/include/common/compiler.h
@@ -89,6 +89,7 @@
 #define round_down(x, y)   ((x) & ~__round_mask(x, y))
 #define DIV_ROUND_UP(n, d) (((n) + (d)-1) / (d))
 #define ALIGN(x, a)	   (((x) + (a)-1) & ~((a)-1))
+#define ALIGN_DOWN(x, a)   ALIGN((x) - ((a) - 1), (a))
 
 #define min(x, y)                              \
 	({                                     \

--- a/lib/pycriu/images/pb2dict.py
+++ b/lib/pycriu/images/pb2dict.py
@@ -103,6 +103,7 @@ mmap_status_map = [
     ('VMA_AREA_VVAR', 1 << 12),
     ('VMA_AREA_AIORING', 1 << 13),
     ('VMA_AREA_MEMFD', 1 << 14),
+    ('VMA_AREA_SHSTK', 1 << 15),
     ('VMA_UNSUPP', 1 << 31),
 ]
 


### PR DESCRIPTION
Shadow stack support for userspace finally made it to the kernel and varying level of success to glibc.

This PR enables shadow stack support in CRIU.

Aside from saving/restoring the actual shadow stack contents and control, there are some changes to the way CRIU calls rt_sigreturn and a bit of black magic around restoring of the shadow stack contents.

As it's still unclear what will be glibc policy about making shadow stack on or off by default, this patchset takes care of both cases and lets CRIU fully control shadow stack for the restored tasks.

Testing:
* kernel v6.6 or later
* glibc from https://gitlab.com/x86-glibc/glibc/-/tree/users/hjl/cet/v9/master
* to run zdtm tests with shadow stack enabled:

```
cd /path/to/criu
USERCFLAGS="-fcf-protection" make -C test/zdtm  -j$(nproc)
export GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK
```