### PR TITLE
ci: do not use 'tail' for skip-file-rwx-check test

### DIFF
--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -18,6 +18,7 @@ dnf install -y \
 	libnet-devel \
 	libnl3-devel \
 	libbsd-devel \
+	libselinux-utils \
 	make \
 	procps-ng \
 	protobuf-c-devel \

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -70,6 +70,10 @@ fedora-rawhide() {
 	#
 	ssh default 'sudo dnf remove -y crun || true'
 	ssh default sudo dnf install -y podman runc
+	# Some tests in the container need selinux to be disabled.
+	# In the container it is not possible to change the state of selinux.
+	# Let's just disable it for this test run completely.
+	ssh default 'sudo setenforce Permissive'
 	ssh default 'cd /vagrant; tar xf criu.tar; cd criu; sudo -E make -C scripts/ci fedora-rawhide CONTAINER_RUNTIME=podman BUILD_OPTIONS="--security-opt seccomp=unconfined"'
 }
 


### PR DESCRIPTION
Newer versions of 'tail' rely on inotify and after a restore 'tail' is unhappy with the state of inotify and just stops.

This replaces 'tail' with a minimal test in C which just keeps a file open to still be able to test how CRIU reacts if the file mode has changed.

The skip-file-rwx-check test sometimes fails if `kill` is slower than `tail` ending itself.