### PR TITLE
Makefile: Use common warnings settings for loongarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ WARNINGS		:= -rdynamic
 endif
 
 ifeq ($(ARCH),loongarch64)
-WARNINGS		:= -Wno-implicit-function-declaration
+WARNINGS		+= -Wno-implicit-function-declaration
 endif
 
 ifneq ($(GCOV),)


### PR DESCRIPTION
WARNINGS variable should be amended, not redefined. We still need, e.g.,  `-Wno-dangling-pointer` to build criu on loongarch64 with gcc13.