### PR TITLE
make: fix compilation on alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ export PROTOUFIX DEFINES
 #
 # Independent options for all tools.
 DEFINES			+= -D_FILE_OFFSET_BITS=64
+DEFINES			+= -D_LARGEFILE64_SOURCE
 DEFINES			+= -D_GNU_SOURCE
 
 WARNINGS		:= -Wall -Wformat-security -Wdeclaration-after-statement -Wstrict-prototypes

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -47,6 +47,6 @@ RUN apk add \
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 -D test
 
-RUN pip3 install junit_xml
+RUN pip3 install junit_xml --break-system-packages
 
 RUN make -C test/zdtm

--- a/test/zdtm/Makefile.inc
+++ b/test/zdtm/Makefile.inc
@@ -41,7 +41,7 @@ PKG_CONFIG ?= pkg-config
 CFLAGS	+= -g -O2 -Wall -Werror -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
 CFLAGS	+= -Wdeclaration-after-statement -Wstrict-prototypes
 CFLAGS	+= $(USERCFLAGS) $(ARCHCFLAGS)
-CFLAGS	+= -D_GNU_SOURCE
+CFLAGS	+= -D_GNU_SOURCE -D_LARGEFILE64_SOURCE
 CPPFLAGS += -iquote $(LIBDIR)/arch/$(ARCH)/include
 
 ifeq ($(strip $(V)),)


### PR DESCRIPTION
Starting with the musl v1.2.4~69, _GNU_SOURCE doesn't set _LARGEFILE64_SOURCE.

