### PR TITLE
build/alpine: install iptables-legacy

### DIFF
--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -33,6 +33,7 @@ RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 RUN apk add \
 	ip6tables \
 	iptables \
+	iptables-legacy \
 	nftables \
 	iproute2 \
 	tar \


### PR DESCRIPTION
It is required to C/R iptables rules.

