### PR TITLE
irmap: hardcode some more interesting paths

### DIFF
--- a/criu/irmap.c
+++ b/criu/irmap.c
@@ -67,6 +67,7 @@ static struct irmap hints[] = {
 		.path = "/var/log",
 		.nr_kids = -1,
 	},
+	{ .path = "/usr/share/dbus-1/services", .nr_kids = -1 },
 	{ .path = "/usr/share/dbus-1/system-services", .nr_kids = -1 },
 	{ .path = "/var/lib/polkit-1/localauthority", .nr_kids = -1 },
 	{ .path = "/usr/share/polkit-1/actions", .nr_kids = -1 },


### PR DESCRIPTION
Hardcoding irmap hint for: `/usr/share/dbus-1/services`

Fixes issue described at: https://github.com/checkpoint-restore/criu/issues/77#issuecomment-1257183193

Uses approach as in this commit: https://github.com/checkpoint-restore/criu/commit/7f44f1dbf9935582a21e8b1f24a5b4396f2c3795

Tested locally and worked ok, checkpoint was successfully created.

Signed-off-by: Robert Ayrapetyan <robert.ayrapetyan@gmail.com>