### PR TITLE
zdtm: socket-tcp-nft-nfconntrack: add a hook to the chain in nft case

### DIFF
--- a/test/zdtm/static/socket-tcp.c
+++ b/test/zdtm/static/socket-tcp.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
 
 	if (system("nft add table ip filter"))
 		return 1;
-	if (system("nft add chain ip filter INPUT"))
+	if (system("nft 'add chain ip filter INPUT { type filter hook input priority 0 ; }'"))
 		return 1;
 	if (system("nft add rule ip filter INPUT iifname \"lo\" ip protocol tcp ct state new,established counter accept"))
 		return 1;


### PR DESCRIPTION
Let's use hooked nft chain which actually affects packets.

Fixes: e5f4d8c6f ("test/nfconntrack: use nft or iptables-legacy")

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
