### PR TITLE
criu-log: remove unused declaration

### DIFF
--- a/criu/include/criu-log.h
+++ b/criu/include/criu-log.h
@@ -26,7 +26,6 @@
 extern int log_init(const char *output);
 extern void log_fini(void);
 extern int log_init_by_pid(pid_t pid);
-extern void log_closedir(void);
 extern int log_keep_err(void);
 extern char *log_first_err(void);
 


### PR DESCRIPTION
This pull request removes a leftover declaration for `log_closedir()`. This function has been removed in commit dc80d6f125e1e919363a0b8f938b8679ff0dbc2b.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
