### PR TITLE
plugin/amdgpu: Also don't print 'plugin failed' in criu

### DIFF
--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -1985,7 +1985,7 @@ CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__UPDATE_VMA_MAP, amdgpu_plugin_update_vma
 int amdgpu_plugin_resume_devices_late(int target_pid)
 {
 	struct kfd_ioctl_criu_args args = { 0 };
-	int fd, ret = 0;
+	int fd, exit_code = 0;
 
 	pr_info("Inside %s for target pid = %d\n", __func__, target_pid);
 
@@ -1999,15 +1999,16 @@ int amdgpu_plugin_resume_devices_late(int target_pid)
 	args.op = KFD_CRIU_OP_RESUME;
 	pr_info("Calling IOCTL to start notifiers and queues\n");
 	if (kmtIoctl(fd, AMDKFD_IOC_CRIU_OP, &args) == -1) {
-		if (errno == ESRCH)
+		if (errno == ESRCH) {
 			pr_info("Pid %d has no kfd process info\n", target_pid);
-		else
+		} else {
 			pr_perror("restore late ioctl failed");
-		ret = -1;
+			exit_code = -1;
+		}
 	}
 
 	close(fd);
-	return ret;
+	return exit_code;
 }
 
 CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESUME_DEVICES_LATE, amdgpu_plugin_resume_devices_late)


### PR DESCRIPTION
We already don't treat it as error in the plugin itself, but after returning -1 from RESUME_DEVICES_LATE hook we print debug message in criu about failed plugin, let's return 0 instead.

While on it let's replace ret to exit_code.

Fixes: a9cbdad76 ("plugin/amdgpu: Don't print error for "No such process" during resume")

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
