### PR TITLE
sk-inet: fix codding style in restore_ip_opts

### DIFF
--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -821,8 +821,7 @@ int restore_ip_opts(int sk, int family, int proto, IpOptsEntry *ioe)
 			ret |= restore_opt(sk, SOL_IP, IP_TOS, &ioe->tos);
 		if (ioe->has_ttl)
 			ret |= restore_opt(sk, SOL_IP, IP_TTL, &ioe->ttl);
-
-    }
+	}
 
 	if (ioe->raw)
 		ret |= restore_ip_raw_opts(sk, family, proto, ioe->raw);


### PR DESCRIPTION
Commit [1] introduced codding-style breackage, let's fix it.

Fixes: 66cab1f49 ("sk-inet: Added IP_TTL socket option") [1]

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
