### PR TITLE
make: replace flake8 with ruff

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,7 @@ task:
     ln -sf /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto
     dnf config-manager --set-enabled crb # Same as CentOS 8 powertools
     dnf -y install epel-release epel-next-release
-    dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python-junit_xml python3-importlib-metadata python-flake8 xmlto libdrm-devel
+    dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python-junit_xml python3-importlib-metadata xmlto libdrm-devel
     # The image has a too old version of nettle which does not work with gnutls.
     # Just upgrade to the latest to make the error go away.
     dnf -y upgrade nettle nettle-devel
@@ -111,7 +111,7 @@ task:
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || :
     yum install -y dnf-plugins-core
     yum config-manager --set-enabled powertools
-    yum install -y --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python3-devel python3-flake8 python3-PyYAML python3-protobuf python3-importlib-metadata python3-junit_xml xmlto libdrm-devel
+    yum install -y --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python3-devel python3-PyYAML python3-protobuf python3-importlib-metadata python3-junit_xml xmlto libdrm-devel
     alternatives --set python /usr/bin/python3
     systemctl stop sssd
     # Even with selinux in permissive mode the selinux tests will be executed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       image: registry.fedoraproject.org/fedora:latest
     steps:
     - name: Install tools
-      run: sudo dnf -y install git make python3-flake8 xz clang-tools-extra which codespell git-clang-format ShellCheck
+      run: sudo dnf -y install git make ruff xz clang-tools-extra which codespell git-clang-format ShellCheck
 
     - uses: actions/checkout@v2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Other conventions can be learned from the source code itself. In short, make sur
 
 Important: These tools are there to advise you, but should not be considered as a "source of truth", as tools also make nasty mistakes from time to time which can completely break code readability.
 
-The following command can be used to automatically run a code linter for Python files (flake8), Shell scripts (shellcheck),
+The following command can be used to automatically run a code linter for Python files (ruff), Shell scripts (shellcheck),
 text spelling (codespell), and a number of CRIU-specific checks (usage of print macros and EOL whitespace for C files).
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -436,20 +436,23 @@ help:
 	@echo '      amdgpu_plugin   - Make AMD GPU plugin'
 .PHONY: help
 
-lint:
-	flake8 --version
-	flake8 --config=scripts/flake8.cfg test/zdtm.py
-	flake8 --config=scripts/flake8.cfg test/inhfd/*.py
-	flake8 --config=scripts/flake8.cfg test/others/rpc/config_file.py
-	flake8 --config=scripts/flake8.cfg lib/pycriu/images/pb2dict.py
-	flake8 --config=scripts/flake8.cfg lib/pycriu/images/images.py
-	flake8 --config=scripts/flake8.cfg scripts/criu-ns
-	flake8 --config=scripts/flake8.cfg test/others/criu-ns/run.py
-	flake8 --config=scripts/flake8.cfg crit/*.py
-	flake8 --config=scripts/flake8.cfg crit/crit/*.py
-	flake8 --config=scripts/flake8.cfg scripts/uninstall_module.py
-	flake8 --config=scripts/flake8.cfg coredump/ coredump/coredump
-	flake8 --config=scripts/flake8.cfg scripts/github-indent-warnings.py
+ruff:
+	@ruff --version
+	ruff ${RUFF_FLAGS} --config=scripts/ruff.toml \
+		test/zdtm.py \
+		test/inhfd/*.py \
+		test/others/rpc/config_file.py \
+		lib/pycriu/images/pb2dict.py \
+		lib/pycriu/images/images.py \
+		scripts/criu-ns \
+		test/others/criu-ns/run.py \
+		crit/*.py \
+		crit/crit/*.py \
+		scripts/uninstall_module.py \
+		coredump/ coredump/coredump \
+		scripts/github-indent-warnings.py
+
+shellcheck:
 	shellcheck --version
 	shellcheck scripts/*.sh
 	shellcheck scripts/ci/*.sh scripts/ci/apt-install
@@ -458,7 +461,11 @@ lint:
 	shellcheck -x test/others/crit/*.sh test/others/criu-coredump/*.sh
 	shellcheck -x test/others/config-file/*.sh
 	shellcheck -x test/others/action-script/*.sh
+
+codespell:
 	codespell -S tags
+
+lint: ruff shellcheck codespell
 	# Do not append \n to pr_perror, pr_pwarn or fail
 	! git --no-pager grep -E '^\s*\<(pr_perror|pr_pwarn|fail)\>.*\\n"'
 	# Do not use %m with pr_* or fail
@@ -469,7 +476,7 @@ lint:
 	! git --no-pager grep -En '^\s*\<pr_(err|warn|msg|info|debug)\>.*);$$' | grep -v '\\n'
 	# No EOL whitespace for C files
 	! git --no-pager grep -E '\s+$$' \*.c \*.h
-.PHONY: lint
+.PHONY: lint ruff shellcheck codespell
 
 codecov: SHELL := $(shell which bash)
 codecov:

--- a/lib/pycriu/images/pb2dict.py
+++ b/lib/pycriu/images/pb2dict.py
@@ -358,7 +358,10 @@ def pb2dict(pb, pretty=False, is_hex=False):
         else:
             d_val = _pb2dict_cast(field, value, pretty, is_hex)
 
-        d[field.name] = d_val.decode() if type(d_val) == bytes else d_val
+        try:
+            d[field.name] = d_val.decode()
+        except (UnicodeDecodeError, AttributeError):
+            d[field.name] = d_val
     return d
 
 

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -41,7 +41,6 @@ RUN apk add \
 	go \
 	e2fsprogs \
 	py-yaml \
-	py3-flake8 \
 	py3-importlib-metadata \
 	asciidoctor
 

--- a/scripts/build/Dockerfile.archlinux
+++ b/scripts/build/Dockerfile.archlinux
@@ -31,7 +31,6 @@ RUN pacman -Syu --noconfirm \
 	bash \
 	go \
 	python-yaml \
-	flake8 \
 	asciidoctor \
 	python-junit-xml \
 	python-importlib-metadata \

--- a/scripts/build/Dockerfile.centos8
+++ b/scripts/build/Dockerfile.centos8
@@ -26,7 +26,6 @@ RUN yum install -y --allowerasing \
 	protobuf-c-devel \
 	protobuf-devel \
 	python3-devel \
-	python3-flake8 \
 	python3-PyYAML \
 	python3-protobuf \
 	python3-pip \

--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -23,7 +23,6 @@ dnf install -y \
 	procps-ng \
 	protobuf-c-devel \
 	protobuf-devel \
-	python3-flake8 \
 	python3-PyYAML \
 	python3-protobuf \
 	python3-junit_xml \

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -4,7 +4,7 @@ set -x -e
 CI_PKGS=(protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
 		libgnutls30 libprotobuf-dev protobuf-compiler libcap-dev
 		libnl-3-dev gdb bash libnet-dev util-linux asciidoctor
-		libnl-route-3-dev time flake8 libbsd-dev python3-yaml
+		libnl-route-3-dev time libbsd-dev python3-yaml
 		libperl-dev pkg-config python3-protobuf python3-pip
 		python3-importlib-metadata python3-junit.xml libdrm-dev)
 

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -38,8 +38,8 @@ setup() {
 	ssh default sudo dnf upgrade -y
 	ssh default sudo dnf install -y gcc git gnutls-devel nftables-devel libaio-devel \
 		libasan libcap-devel libnet-devel libnl3-devel libbsd-devel make protobuf-c-devel \
-		protobuf-devel python3-flake8 python3-protobuf python3-importlib-metadata \
-		python3-junit_xml rubygem-asciidoctor iptables libselinux-devel libbpf-devel
+		protobuf-devel python3-protobuf python3-importlib-metadata python3-junit_xml \
+		rubygem-asciidoctor iptables libselinux-devel libbpf-devel
 	# Disable sssd to avoid zdtm test failures in pty04 due to sssd socket
 	ssh default sudo systemctl mask sssd
 	ssh default cat /proc/cmdline

--- a/scripts/criu-ns
+++ b/scripts/criu-ns
@@ -216,7 +216,7 @@ def wrap_restore():
 
 def get_varg(args):
     for i in range(1, len(sys.argv)):
-        if not sys.argv[i] in args:
+        if sys.argv[i] not in args:
             continue
 
         if i + 1 >= len(sys.argv):

--- a/scripts/ruff.toml
+++ b/scripts/ruff.toml
@@ -1,0 +1,4 @@
+# Ignore `E401` (import violations) in all `__init__.py` files
+[lint.per-file-ignores]
+"__init__.py" = ["F401"]
+


### PR DESCRIPTION
This pull request is rebased on https://github.com/checkpoint-restore/criu/pull/2333 and https://github.com/checkpoint-restore/criu/pull/2345.

[Ruff](https://github.com/astral-sh/ruff) is a Python linter written in Rust, designed to replace flake8. It is significantly faster and actively maintained.
