### PR TITLE
criu: fix tempdir recycle : Fixes: #2351

### DIFF
--- a/criu/apparmor.c
+++ b/criu/apparmor.c
@@ -622,13 +622,14 @@ static int do_suspend(bool suspend)
 int suspend_aa(void)
 {
 	int ret;
-	if (!mkdtemp(policydir)) {
+	char *tempdirname;
+	if (!(tempdirname = mkdtemp(policydir))) {
 		pr_perror("failed to make AA policy dir");
 		return -1;
 	}
 
 	ret = do_suspend(true);
-	if (rmrf(policydir) < 0)
+	if (rmrf(tempdirname) < 0)
 		pr_err("failed removing policy dir %s\n", policydir);
 
 	return ret;


### PR DESCRIPTION

As #2351 say
When many duḿps failed in #2348, it created a bunch of empty directories

```txt
drwx------ 2 root   root   4096 Feb 12 23:48 .criu.temp-aa-policy.8uhTbO
drwx------ 2 root   root   4096 Feb 12 23:51 .criu.temp-aa-policy.90Vqt9
drwx------ 2 root   root   4096 Feb 12 23:29 .criu.temp-aa-policy.9an3IS
drwx------ 2 root   root   4096 Feb 12 23:51 .criu.temp-aa-policy.CBz1ud
drwx------ 2 root   root   4096 Feb 12 23:39 .criu.temp-aa-policy.eA0Kj6
drwx------ 2 root   root   4096 Feb 12 23:34 .criu.temp-aa-policy.GD04gM
drwx------ 2 root   root   4096 Feb 12 23:38 .criu.temp-aa-policy.ItnOKf
drwx------ 2 root   root   4096 Feb 12 23:57 .criu.temp-aa-policy.NuRSjL
drwx------ 2 root   root   4096 Feb 12 23:57 .criu.temp-aa-policy.nUX8Kq
drwx------ 2 root   root   4096 Feb 12 23:36 .criu.temp-aa-policy.PGi24L
drwx------ 2 root   root   4096 Feb 12 23:35 .criu.temp-aa-policy.QNuwGp
drwx------ 2 root   root   4096 Feb 12 23:28 .criu.temp-aa-policy.RyvBPt
drwx------ 2 root   root   4096 Feb 12 23:41 .criu.temp-aa-policy.TXQpQv
drwx------ 2 root   root   4096 Feb 12 23:41 .criu.temp-aa-policy.URYvi0
drwx------ 2 root   root   4096 Feb 12 23:34 .criu.temp-aa-policy.VJixh8
drwx------ 2 root   root   4096 Feb 12 23:48 .criu.temp-aa-policy.whT8gi
```
delete the directories after aborting

Signed-off-by: YarBor <yarbor.ww@gmail.com>
 
Fixes: #2351
