### PR TITLE
Add support for reset-on-fork scheduling flag

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -157,6 +157,11 @@ static int dump_sched_info(int pid, ThreadCoreEntry *tc)
 	tc->has_sched_policy = true;
 	tc->sched_policy = ret;
 
+	/* The reset-on-fork flag might be used in combination
+	 * with SCHED_FIFO or SCHED_RR to reset the scheduling
+	 * policy/priority in child processes.
+	 */
+	ret &= ~SCHED_RESET_ON_FORK;
 	if ((ret == SCHED_RR) || (ret == SCHED_FIFO)) {
 		ret = syscall(__NR_sched_getparam, pid, &sp);
 		if (ret < 0) {

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3057,7 +3057,7 @@ static int validate_sched_parm(struct rst_sched_param *sp)
 	if ((sp->nice < -20) || (sp->nice > 19))
 		return 0;
 
-	switch (sp->policy) {
+	switch (sp->policy & ~SCHED_RESET_ON_FORK) {
 	case SCHED_RR:
 	case SCHED_FIFO:
 		return ((sp->prio > 0) && (sp->prio < 100));

--- a/test/zdtm/static/sched_policy00.c
+++ b/test/zdtm/static/sched_policy00.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
 	}
 
 	p.sched_priority = param;
-	if (sched_setscheduler(pid, SCHED_RR, &p)) {
+	if (sched_setscheduler(pid, SCHED_RR | SCHED_RESET_ON_FORK, &p)) {
 		pr_perror("Can't set policy");
 		kill(pid, SIGKILL);
 		return -1;
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
 	test_waitsig();
 
 	ret = sched_getscheduler(pid);
-	if (ret != SCHED_RR) {
+	if (ret != (SCHED_RR | SCHED_RESET_ON_FORK)) {
 		fail("Broken/No policy");
 		err++;
 	}


### PR DESCRIPTION
This pull request extends CRIU with checkpoint/restore support for the reset-on-fork scheduling flag ([`SCHED_RESET_ON_FORK`](https://lwn.net/Articles/335203/)). When this flag is set, the following rules apply for subsequently created children:

- If the calling thread has a scheduling policy of `SCHED_FIFO` or `SCHED_RR`, the policy is reset to `SCHED_OTHER` in child processes.

- If the calling process has a negative nice value, the nice value is reset to zero in child processes.

(See `man 7 sched`)

Fixes: #2359