### PR TITLE
timer: fix wrapping allignment in function declaration

### DIFF
--- a/criu/include/timer.h
+++ b/criu/include/timer.h
@@ -13,5 +13,5 @@ extern int prepare_posix_timers(int pid, struct task_restore_args *ta, CoreEntry
 
 extern int parasite_dump_itimers_seized(struct parasite_ctl *ctl, struct pstree_item *item);
 extern int parasite_dump_posix_timers_seized(struct proc_posix_timers_stat *proc_args, struct parasite_ctl *ctl,
-				      struct pstree_item *item);
+					     struct pstree_item *item);
 #endif


### PR DESCRIPTION
Currently we have tabs + spaces on the wrapped line but the wrapped part is not alligned to the opening bracket.

Fixes: bbe26d1b7 ("timer: fix allignment in function definition")

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
