### PR TITLE
Makefile.config: fix/improve feature warnings.

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -2,12 +2,15 @@ include $(__nmk_dir)utils.mk
 include $(__nmk_dir)msg.mk
 include scripts/feature-tests.mak
 
+# This is a kludge for $(info ...) to not eat spaces.
+S :=
+
 ifeq ($(call try-cc,$(FEATURE_TEST_LIBBSD_DEV),-lbsd),true)
         LIBS_FEATURES	+= -lbsd
         FEATURE_DEFINES	+= -DCONFIG_HAS_LIBBSD
 else
         $(info Note: Building without setproctitle() and strlcpy() support.)
-        $(info $(info)      To enable these features, please install libbsd-devel (RPM) / libbsd-dev (DEB).)
+        $(info $S      Install libbsd-devel (RPM) / libbsd-dev (DEB) to fix.)
 endif
 
 ifeq ($(call pkg-config-check,libselinux),y)
@@ -23,10 +26,10 @@ endif
 
 ifeq ($(call pkg-config-check,libdrm),y)
         export CONFIG_AMDGPU := y
-        $(info Note: Building criu with amdgpu_plugin.)
+        $(info Note: Building with amdgpu_plugin.)
 else
-        $(info Note: Building criu without amdgpu_plugin.)
-        $(info Note: libdrm and libdrm_amdgpu are required to build amdgpu_plugin.)
+        $(info Note: Building without amdgpu_plugin.)
+        $(info $S      Install libdrm-devel (RPM) or libdrm-dev (DEB) to fix.)
 endif
 
 ifeq ($(NO_GNUTLS)x$(call pkg-config-check,gnutls),xy)
@@ -34,7 +37,8 @@ ifeq ($(NO_GNUTLS)x$(call pkg-config-check,gnutls),xy)
         export CONFIG_GNUTLS := y
         FEATURE_DEFINES	+= -DCONFIG_GNUTLS
 else
-        $(info Note: Building without GnuTLS support)
+        $(info Note: Building without GnuTLS support.)
+        $(info $S      Install gnutls-devel (RPM) or gnutls-dev (DEB) to fix.)
 endif
 
 ifeq ($(call pkg-config-check,libnftables),y)
@@ -46,12 +50,11 @@ ifeq ($(call pkg-config-check,libnftables),y)
                 LIBS_FEATURES	+= $(LIB_NFTABLES)
                 FEATURE_DEFINES	+= -DCONFIG_HAS_NFTABLES_LIB_API_1
         else
-                $(warning Warn: you have libnftables installed but it has incompatible API)
-                $(warning Warn: Building without nftables support)
+                $(info Warn: Building without nftables support (incompatible API version).)
         endif
 else
-        $(warning Warn: you have no libnftables installed)
-        $(warning Warn: Building without nftables support)
+        $(info Warn: Building without nftables support.)
+        $(info $S      Install nftables-devel (RPM) or libnftables-dev (DEB) to fix.)
 endif
 
 export LIBS += $(LIBS_FEATURES)
@@ -67,10 +70,10 @@ ifeq ($(call try-asm,$(FEATURE_TEST_X86_COMPAT)),true)
         export CONFIG_COMPAT := y
         FEATURE_DEFINES	+= -DCONFIG_COMPAT
 else
-        $(info Note: Building without ia32 C/R, missed ia32 support in gcc)
-        $(info $(info)      That may be related to missing gcc-multilib in your)
-        $(info $(info)      distribution or you may have Debian with buggy toolchain)
-        $(info $(info)      (issue https://github.com/checkpoint-restore/criu/issues/315))
+        $(info Note: Building without ia32 C/R, missing ia32 support in gcc.)
+        $(info $S      It may be related to missing gcc-multilib in your)
+        $(info $S      distribution, or you may have Debian with buggy toolchain.)
+        $(info $S      See https://github.com/checkpoint-restore/criu/issues/315.)
 endif
 endif
 


### PR DESCRIPTION
1. Tell which RPMs or DEBs are required in all cases.

2. Use `$(info ...)` everywhere.

3. Drop extra nested $(info), instead use (a document) a simpler kludge.

4. Simplify and unify the language, add missing periods.

Before:
```
Note: Building without setproctitle() and strlcpy() support.
      To enable these features, please install libbsd-devel (RPM) / libbsd-dev (DEB).
Note: Building criu without amdgpu_plugin.
Note: libdrm and libdrm_amdgpu are required to build amdgpu_plugin.
Makefile.config:53: Warn: you have no libnftables installed
Makefile.config:54: Warn: Building without nftables support
```

After:
```
Note: Building without setproctitle() and strlcpy() support.
      Install libbsd-devel (RPM) / libbsd-dev (DEB) to fix.
Note: Building without amdgpu_plugin.
      Install libdrm-devel (RPM) or libdrm-dev (DEB) to fix.
Warn: Building without nftables support.
      Install nftables-devel (RPM) or libnftables-dev (DEB) to fix.
```