### PR TITLE
mem: optimize debug logging of enqueued pages

### DIFF
--- a/criu/mem.c
+++ b/criu/mem.c
@@ -1087,6 +1087,7 @@ static int restore_priv_vma_content(struct pstree_item *t, struct page_read *pr)
 	unsigned int nr_shared = 0;
 	unsigned int nr_dropped = 0;
 	unsigned int nr_compared = 0;
+	unsigned int nr_enqueued = 0;
 	unsigned int nr_lazy = 0;
 	unsigned long va;
 
@@ -1162,7 +1163,8 @@ static int restore_priv_vma_content(struct pstree_item *t, struct page_read *pr)
 				len >>= PAGE_SHIFT;
 				nr_restored += len;
 				i += len - 1;
-				pr_debug("Enqueue page-read\n");
+
+				nr_enqueued++;
 				continue;
 			}
 
@@ -1258,7 +1260,8 @@ err_read:
 
 	pr_info("nr_restored_pages: %d\n", nr_restored);
 	pr_info("nr_shared_pages:   %d\n", nr_shared);
-	pr_info("nr_dropped_pages:   %d\n", nr_dropped);
+	pr_info("nr_dropped_pages:  %d\n", nr_dropped);
+	pr_info("nr_enqueued:       %d\n", nr_enqueued);
 	pr_info("nr_lazy:           %d\n", nr_lazy);
 
 	return 0;


### PR DESCRIPTION
During restore, CRIU prints `"Enqueue page-read"` messages for each page-read request (https://github.com/checkpoint-restore/criu/commit/91388fc). However, this message does not provide useful information, increases performance overhead during restore and the size of log file.

```
$ ./zdtm.py run -t zdtm/static/maps06 -f h -k always
$ grep 'Enqueue page-read' dump/zdtm/static/maps06/56/1/restore.log | wc -l
20493
```

This pull request replaces these messages with a single message that shows the number of enqueued page-read requests.

```
$ grep 'enqueued' dump/zdtm/static/maps06/56/1/restore.log
(00.061449)     56: nr_enqueued:   20493
```