### PR TITLE
ci: update check for SELinux

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -306,14 +306,19 @@ if [ "$skip" == 0 ]; then
 	if [ -d /sys/fs/selinux ] && command -v getenforce &>/dev/null; then
 		# Note: selinux in Enforcing mode prevents us from calling clone3() or writing to ns_last_pid on restore; hence set to Permissive for the test and then set back.
 		selinuxmode=$(getenforce)
-		setenforce Permissive
+		if [ "$selinuxmode" != "Disabled" ]; then
+			setenforce Permissive
+		fi
+
 	fi
 	# Run it as non-root in a user namespace. Since CAP_CHECKPOINT_RESTORE behaves differently in non-user namespaces (e.g. no access to map_files) this tests that we can dump and restore
 	# under those conditions. Note that the "... && true" part is necessary; we need at least one statement after the tests so that bash can reap zombies in the user namespace,
 	# otherwise it will exec the last statement and get replaced and nobody will be left to reap our zombies.
 	sudo --user=#65534 --group=#65534 unshare -Ucfpm --mount-proc -- bash -c "./test/zdtm.py run -t zdtm/static/maps00 -f h --rootless && true"
 	if [ -d /sys/fs/selinux ] && command -v getenforce &>/dev/null; then
-		setenforce "$selinuxmode"
+		if [ "$selinuxmode" != "Disabled" ]; then
+			setenforce "$selinuxmode"
+		fi
 	fi
 	setcap -r criu/criu
 else


### PR DESCRIPTION
The rawhide tests runs in a container. Containers always have SELinux disabled from the inside. Somehow `/sys/fs/selinux` is now mounted. We used the existence of that directory if SELinux is available. This seems to be no longer true.

Signed-off-by: Adrian Reber <areber@redhat.com>
Fixes: #2406
