### PR TITLE
make: improve check for externally managed Python

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -29,6 +29,29 @@ LIBDIR ?= $(PREFIX)/lib
 export PREFIX BINDIR SBINDIR MANDIR RUNDIR
 export LIBDIR INCLUDEDIR LIBEXECDIR PLUGINDIR
 
+# Detect externally managed Python environment (PEP 668).
+PYTHON_EXTERNALLY_MANAGED := $(shell $(PYTHON) -c 'import os, sysconfig; print(int(os.path.isfile(os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED"))))')
+PIP_BREAK_SYSTEM_PACKAGES ?= 0
+
+# If Python environment is externally managed and PIP_BREAK_SYSTEM_PACKAGES is not set, skip pip install.
+SKIP_PIP_INSTALL := 0
+ifeq ($(PYTHON_EXTERNALLY_MANAGED),1)
+ifeq ($(PIP_BREAK_SYSTEM_PACKAGES),0)
+
+SKIP_PIP_INSTALL := 1
+$(info Warn: Externally managed python environment)
+$(info Consider using PIP_BREAK_SYSTEM_PACKAGES=1)
+
+endif
+endif
+
+# Default flags for pip install:
+# --upgrade: Upgrade crit/pycriu packages
+# --ignore-installed: Ignore existing packages and reinstall them
+PIPFLAGS ?= --upgrade --ignore-installed
+
+export SKIP_PIP_INSTALL PIPFLAGS
+
 install-man:
 	$(Q) $(MAKE) -C Documentation install
 .PHONY: install-man

--- a/crit/Makefile
+++ b/crit/Makefile
@@ -1,6 +1,3 @@
-PYTHON_EXTERNALLY_MANAGED := $(shell $(PYTHON) -c 'import os, sysconfig; print(int(os.path.isfile(os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED"))))')
-PIP_BREAK_SYSTEM_PACKAGES := 0
-
 VERSION_FILE := $(if $(obj),$(addprefix $(obj)/,crit/version.py),crit/version.py)
 
 all-y	+= ${VERSION_FILE}
@@ -10,31 +7,19 @@ ${VERSION_FILE}:
 	$(Q) echo "__version__ = '${CRIU_VERSION}'" > $@
 
 install: ${VERSION_FILE}
-ifeq ($(PYTHON_EXTERNALLY_MANAGED),1)
-ifeq ($(PIP_BREAK_SYSTEM_PACKAGES),0)
-	$(E) "  SKIP INSTALL crit: Externally managed python environment (See PEP 668 for more information)"
-	$(E) "  Consider using PIP_BREAK_SYSTEM_PACKAGES=1 make install"
-else
+ifeq ($(SKIP_PIP_INSTALL),0)
 	$(E) "  INSTALL " crit
-	$(Q) $(PYTHON) -m pip install --upgrade --ignore-installed --prefix=$(DESTDIR)$(PREFIX) ./crit
-endif
+	$(Q) $(PYTHON) -m pip install $(PIPFLAGS) --prefix=$(DESTDIR)$(PREFIX) ./crit
 else
-	$(E) "  INSTALL " crit
-	$(Q) $(PYTHON) -m pip install --upgrade --ignore-installed --prefix=$(DESTDIR)$(PREFIX) ./crit
+	$(E) " SKIP INSTALL crit"
 endif
 .PHONY: install
 
 uninstall:
-ifeq ($(PYTHON_EXTERNALLY_MANAGED),1)
-ifeq ($(PIP_BREAK_SYSTEM_PACKAGES),0)
-	$(E) " SKIP UNINSTALL crit: Externally managed python environment (See PEP 668 for more information)"
-	$(E) " Consider using PIP_BREAK_SYSTEM_PACKAGES=1 make uninstall"
-else
+ifeq ($(SKIP_PIP_INSTALL),0)
 	$(E) " UNINSTALL" crit
 	$(Q) $(PYTHON) ./scripts/uninstall_module.py --prefix=$(DESTDIR)$(PREFIX) crit
-endif
 else
-	$(E) " UNINSTALL" crit
-	$(Q) $(PYTHON) ./scripts/uninstall_module.py --prefix=$(DESTDIR)$(PREFIX) crit
+	$(E) " SKIP UNINSTALL crit"
 endif
 .PHONY: uninstall

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -4,9 +4,6 @@ UAPI_HEADERS		:= lib/c/criu.h images/rpc.proto images/rpc.pb-c.h criu/include/ve
 
 all-y	+= lib-c lib-a lib-py
 
-PYTHON_EXTERNALLY_MANAGED := $(shell $(PYTHON) -c 'import os, sysconfig; print(int(os.path.isfile(os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED"))))')
-PIP_BREAK_SYSTEM_PACKAGES := 0
-
 #
 # C language bindings.
 lib/c/Makefile: ;
@@ -57,17 +54,11 @@ install: lib-c lib-a lib-py lib/c/criu.pc.in
 	$(Q) mkdir -p $(DESTDIR)$(LIBDIR)/pkgconfig
 	$(Q) sed -e 's,@version@,$(CRIU_VERSION),' -e 's,@libdir@,$(LIBDIR),' -e 's,@includedir@,$(dir $(INCLUDEDIR)/criu/),' lib/c/criu.pc.in > lib/c/criu.pc
 	$(Q) install -m 644 lib/c/criu.pc $(DESTDIR)$(LIBDIR)/pkgconfig
-ifeq ($(PYTHON_EXTERNALLY_MANAGED),1)
-ifeq ($(PIP_BREAK_SYSTEM_PACKAGES),0)
-	$(E) "  SKIP INSTALL pycriu: Externally managed python environment (See PEP 668 for more information)"
-	$(E) "  Consider using PIP_BREAK_SYSTEM_PACKAGES=1 make install"
-else
+ifeq ($(SKIP_PIP_INSTALL),0)
 	$(E) "  INSTALL " pycriu
-	$(Q) $(PYTHON) -m pip install --upgrade --ignore-installed --prefix=$(DESTDIR)$(PREFIX) ./lib
-endif
+	$(Q) $(PYTHON) -m pip install $(PIPFLAGS) --prefix=$(DESTDIR)$(PREFIX) ./lib
 else
-	$(E) "  INSTALL " pycriu
-	$(Q) $(PYTHON) -m pip install --upgrade --ignore-installed --prefix=$(DESTDIR)$(PREFIX) ./lib
+	$(E) " SKIP INSTALL pycriu"
 endif
 .PHONY: install
 
@@ -80,16 +71,10 @@ uninstall:
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(INCLUDEDIR)/criu/,$(notdir $(UAPI_HEADERS)))
 	$(E) " UNINSTALL" pkgconfig/criu.pc
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/pkgconfig/,criu.pc)
-ifeq ($(PYTHON_EXTERNALLY_MANAGED),1)
-ifeq ($(PIP_BREAK_SYSTEM_PACKAGES),0)
-	$(E) " SKIP UNINSTALL pycriu: Externally managed python environment (See PEP 668 for more information)"
-	$(E) " Consider using PIP_BREAK_SYSTEM_PACKAGES=1 make uninstall"
-else
+ifeq ($(SKIP_PIP_INSTALL),0)
 	$(E) " UNINSTALL" pycriu
 	$(Q) $(PYTHON) ./scripts/uninstall_module.py --prefix=$(DESTDIR)$(PREFIX) pycriu
-endif
 else
-	$(E) " UNINSTALL" pycriu
-	$(Q) $(PYTHON) ./scripts/uninstall_module.py --prefix=$(DESTDIR)$(PREFIX) pycriu
+	$(E) " SKIP UNINSTALL pycriu"
 endif
 .PHONY: uninstall


### PR DESCRIPTION
This pull request moves `PYTHON_EXTERNALLY_MANAGED` and `PIP_BREAK_SYSTEM_PACKAGES` into `Makefile.install` to avoid code duplication and adds `PIPFLAGS` variable to enable specifying pip options during installation. This is particularly useful for packaging where it is common for `pip install` to run in an environment with pre-installed dependencies and without internet.

Related to https://github.com/checkpoint-restore/criu/issues/2404

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
