### PR TITLE
test/make: remove unused target

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -45,10 +45,6 @@ zdtm-freezer:
 	./zdtm.py run --test zdtm/transition/thread-bomb --pre 3 --freezecg zdtm:f
 .PHONY: zdtm-freezer
 
-fault-injection:
-	$(MAKE) -C fault-injection
-.PHONY: fault-injection
-
 override CFLAGS += -D_GNU_SOURCE
 
 clean_root:


### PR DESCRIPTION
A fault-injection test was introduced in b95407e264fcf58f4f73f78abef6dac60436e7dd and later removed in 2cb4532e266d0c9f8e87839d5b5eb728a3e4d10d. This pull request removes the obsolete Makefile target for this test.
