### PR TITLE
pagemap-cache: handle short reads

### DIFF
--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -262,6 +262,9 @@ make -C test/others/rpc/ run
 
 ./test/zdtm.py run -t zdtm/static/env00 --sibling
 
+./test/zdtm.py run -t zdtm/static/maps00 --preload-libfault
+./test/zdtm.py run -t zdtm/static/maps02 --preload-libfault
+
 ./test/zdtm.py run -t zdtm/transition/maps007 --pre 2 --dedup
 ./test/zdtm.py run -t zdtm/transition/maps007 --pre 2 --noauto-dedup
 ./test/zdtm.py run -t zdtm/transition/maps007 --pre 2 --page-server

--- a/test/libfault/Makefile
+++ b/test/libfault/Makefile
@@ -1,0 +1,21 @@
+CC = gcc
+CFLAGS = -c -fPIC -ldl
+
+SRC = libfault.c
+OBJ = $(SRC:.c=.o)
+
+LIB = libfault.so
+
+.PHONY: all clean run
+
+all: $(LIB)
+
+$(LIB): $(OBJ)
+	$(CC) -shared -o $(LIB) $(OBJ)
+
+$(OBJ): $(SRC)
+	$(CC) $(CFLAGS) $<
+
+clean:
+	rm -f $(OBJ) $(LIB)
+

--- a/test/libfault/libfault.c
+++ b/test/libfault/libfault.c
@@ -1,0 +1,31 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <dlfcn.h>
+#include <errno.h>
+
+ssize_t (*original_pread)(int fd, void *buf, size_t count, off_t offset) = NULL;
+
+/**
+ * This function is a wrapper around pread() that is used for testing CRIU's
+ * handling of cases where pread() returns less data than requested.
+ *
+ * pmc_fill() in criu/pagemap.c is a good example of where this can happen.
+ */
+ssize_t pread64(int fd, void *buf, size_t count, off_t offset)
+{
+	if (!original_pread) {
+		original_pread = dlsym(RTLD_NEXT, "pread");
+		if (!original_pread) {
+			errno = EIO;
+			return -1;
+		}
+	}
+
+	/* The following aims to simulate the case when pread() returns less
+	 * data than requested. We need to ensure that CRIU handles such cases. */
+	if (count > 2048) {
+		count -= 1024;
+	}
+
+	return original_pread(fd, buf, count, offset);
+}

--- a/test/zdtm/criu_config.py
+++ b/test/zdtm/criu_config.py
@@ -11,6 +11,7 @@ class criu_config:
             fault=None,
             strace=[],
             preexec=None,
+            preload=False,
             nowait=False):
 
         config_path = tempfile.mktemp(".conf", "criu-%s-" % action)


### PR DESCRIPTION
It is possible for `pread()` to return fewer number of bytes than requested. In such case, we need to repeat the read operation with appropriate offset.

Fixes: https://github.com/checkpoint-restore/criu/issues/2365