### PR TITLE
net: Fix TOCTOU race condition in unix_conf_op

### DIFF
--- a/scripts/build/Dockerfile.x86_64.hdr
+++ b/scripts/build/Dockerfile.x86_64.hdr
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:24.04
 
 COPY scripts/ci/apt-install /bin/apt-install
 


### PR DESCRIPTION
The unix_conf_op function reads the size of the sysctl entry array twice. gcc thinks that it can lead to a time-of-check to time-of-use (TOCTOU) race condition if the array size changes between the two reads.

Fixes #2398

