### PR TITLE
criu: use proper format-specified to accommodate time_t 64-bit change

### DIFF
--- a/criu/autofs.c
+++ b/criu/autofs.c
@@ -658,7 +658,7 @@ static int autofs_mnt_make_catatonic(const char *mnt_path, int mnt_fd)
 
 static int autofs_mnt_set_timeout(time_t timeout, const char *mnt_path, int mnt_fd)
 {
-	pr_info("%s: set timeout %ld for %s\n", __func__, timeout, mnt_path);
+	pr_info("%s: set timeout %" PRId64 " for %s\n", __func__, (int64_t)timeout, mnt_path);
 	return autofs_ioctl(mnt_path, mnt_fd, AUTOFS_IOC_SETTIMEOUT, &timeout);
 }
 
@@ -770,7 +770,7 @@ static int autofs_post_mount(const char *mnt_path, dev_t mnt_dev, time_t timeout
 	}
 
 	if (autofs_mnt_set_timeout(timeout, mnt_path, mnt_fd)) {
-		pr_err("Failed to set timeout %ld for %s\n", timeout, mnt_path);
+		pr_err("Failed to set timeout %" PRId64 " for %s\n", (int64_t)timeout, mnt_path);
 		return -1;
 	}
 

--- a/criu/timens.c
+++ b/criu/timens.c
@@ -96,8 +96,8 @@ int prepare_timens(int id)
 	ts.tv_nsec = te->monotonic->tv_nsec - ts.tv_nsec;
 	normalize_timespec(&ts);
 
-	pr_debug("timens: monotonic %ld %ld\n", ts.tv_sec, ts.tv_nsec);
-	if (dprintf(fd, "%d %ld %ld\n", CLOCK_MONOTONIC, ts.tv_sec, ts.tv_nsec) < 0) {
+	pr_debug("timens: monotonic %" PRId64 " %ld\n", (int64_t)ts.tv_sec, ts.tv_nsec);
+	if (dprintf(fd, "%d %" PRId64 " %ld\n", CLOCK_MONOTONIC, (int64_t)ts.tv_sec, ts.tv_nsec) < 0) {
 		pr_perror("Unable to set a monotonic clock offset");
 		goto err;
 	}
@@ -111,8 +111,8 @@ int prepare_timens(int id)
 	ts.tv_nsec = te->boottime->tv_nsec - ts.tv_nsec;
 	normalize_timespec(&ts);
 
-	pr_debug("timens: boottime %ld %ld\n", ts.tv_sec, ts.tv_nsec);
-	if (dprintf(fd, "%d %ld %ld\n", CLOCK_BOOTTIME, ts.tv_sec, ts.tv_nsec) < 0) {
+	pr_debug("timens: boottime %" PRId64 " %ld\n", (int64_t)ts.tv_sec, ts.tv_nsec);
+	if (dprintf(fd, "%d %" PRId64 " %ld\n", CLOCK_BOOTTIME, (int64_t)ts.tv_sec, ts.tv_nsec) < 0) {
 		pr_perror("Unable to set a boottime clock offset");
 		goto err;
 	}

--- a/criu/timer.c
+++ b/criu/timer.c
@@ -46,8 +46,9 @@ static inline int decode_itimer(char *n, ItimerEntry *ie, struct itimerval *val)
 		return -1;
 	}
 
-	pr_info("Restored %s timer to %ld.%ld -> %ld.%ld\n", n, val->it_value.tv_sec, val->it_value.tv_usec,
-		val->it_interval.tv_sec, val->it_interval.tv_usec);
+	pr_info("Restored %s timer to %" PRId64 ".%ld -> %" PRId64 ".%ld\n", n,
+		(int64_t)val->it_value.tv_sec, val->it_value.tv_usec,
+		(int64_t)val->it_interval.tv_sec, val->it_interval.tv_usec);
 
 	return 0;
 }


### PR DESCRIPTION
See also:
https://wiki.debian.org/ReleaseGoals/64bit-time

Needed for:
https://github.com/checkpoint-restore/criu/issues/2404