### PR TITLE
irmap: duplicate string in irmap_scan_path_add

### DIFF
--- a/criu/irmap.c
+++ b/criu/irmap.c
@@ -500,7 +500,7 @@ int irmap_scan_path_add(char *path)
 		return -1;
 	}
 
-	o->ir->path = path;
+	o->ir->path = strdup(path);
 	o->ir->nr_kids = -1;
 	list_add_tail(&o->node, &opts.irmap_scan_paths);
 	return 0;


### PR DESCRIPTION
Duplicate string in irmap_scan_path_add, otherwise it will free before parsing next configuration input.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
