### PR TITLE
compel: fix build on Amazon Linux 2 due to missing PTRACE_ARCH_PRCTL

### DIFF
--- a/compel/include/uapi/ptrace.h
+++ b/compel/include/uapi/ptrace.h
@@ -86,6 +86,19 @@ struct __ptrace_rseq_configuration {
 #define PTRACE_EVENT_STOP 128
 #endif
 
+/*
+ * Amazon Linux 2 uses glibc 2.26. PTRACE_ARCH_PRCTL was added in glibc 2.27.
+ * This allows CRIU to build on Amazon Linux 2.
+ *
+ * Note that in sys/ptrace.h, PTRACE_ARCH_PRCTL is an enum value so the
+ * preprocessor doesn't know about it. PT_ARCH_PRCTL is the preprocessor symbol
+ * that matches the value of PTRACE_ARCH_PRCTL. So look for PT_ARCH_PRCTL to
+ * decide if PTRACE_ARCH_PRCTL is available or not.
+ */
+#if defined(__x86_64__) && !defined(PT_ARCH_PRCTL)
+#define PTRACE_ARCH_PRCTL 30 /* From asm/ptrace-abi.h. */
+#endif
+
 extern int ptrace_suspend_seccomp(pid_t pid);
 
 extern int __must_check ptrace_peek_area(pid_t pid, void *dst, void *addr, long bytes);


### PR DESCRIPTION
Hi,

This PR fixes build failure on Amazon Linux 2 (and any other distro using glibc 2.26 or older). Further explanation is already in the commit message, which I have pasted below.

Regards,
Pratyush Yadav

------
Commit fc683cb01 ("compel: shstk: save CET state when CPU supports it") started using PTRACE_ARCH_PRCTL to query shadow stack status. While PTRACE_ARCH_PRCTL has existed in the kernel for a long time, it was only added to glibc in version 2.27. Amazon Linux 2 (AL2) has glibc 2.26, which does not have this definition. As a result, build on AL2 fails with the below error:

    compel/arch/x86/src/lib/infect.c: In function ‘get_task_xsave’:
    compel/arch/x86/src/lib/infect.c:276:14: error: ‘PTRACE_ARCH_PRCTL’ undeclared (first use in this function)
    276 |   if (ptrace(PTRACE_ARCH_PRCTL, pid, (unsigned long)&features, ARCH_SHSTK_STATUS)) {
        |              ^~~~~~~~~~~~~~~~~

While the definition is present on the system via the kernel headers (in asm/ptrace-abi.h) which can be reached by including linux/ptrace.h, the comment in compel/include/uapi/ptrace.h says:

    We'd want to include both sys/ptrace.h and linux/ptrace.h, hoping
    that most definitions come from either one or another. Alas, on
    Alpine/musl both files declare struct ptrace_peeksiginfo_args, so
    there is no way they can be used together. Let's rely on libc one.

Since including linux/ptrace.h is not an option, define PTRACE_ARCH_PRCTL if it doesn't already exist. An interesting point to note is that in sys/ptrace.h, PTRACE_ARCH_PRCTL is an enum value so the preprocessor doesn't know about it. PT_ARCH_PRCTL is the preprocessor symbol that matches the value of PTRACE_ARCH_PRCTL. So look for PT_ARCH_PRCTL to decide if PTRACE_ARCH_PRCTL is available or not.

Another interesting point to note is that AL2 ships with GCC 7 by default, which does not support the -mshstk option, causing other build failures. Luckily, it also ships GCC 10 which does have the option. Using GCC 10 lets the build succeed.

Fixes: fc683cb01 ("compel: shstk: save CET state when CPU supports it")
