### PR TITLE
ci: run aarch64 tests native via actuated

### DIFF
--- a/.github/workflows/actuated-aarch64-test.yaml
+++ b/.github/workflows/actuated-aarch64-test.yaml
@@ -1,0 +1,52 @@
+name: Actuated aarch64 test
+
+on: [push, pull_request]
+
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: actuated-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/criu-dev' }}
+
+jobs:
+  build:
+    # Actuated runners are not available in all repositories.
+    if: ${{ github.repository == 'checkpoint-restore/criu' }}
+    # The memory size and the number of CPUs can be freely selected.
+    # 3GB and 4 CPUs seems to be enough according to the result from 'vmmeter'.
+    runs-on: actuated-arm64-4cpu-3gb
+    strategy:
+      matrix:
+        target: [GCC=1, CLANG=1]
+
+    steps:
+    # https://gist.github.com/alexellis/1f33e581c75e11e161fe613c46180771#file-metering-gha-md
+    # vmmeter start
+    - name: Prepare arkade
+      uses: alexellis/arkade-get@master
+      with:
+        crane: latest
+        print-summary: false
+
+    - name: Install vmmeter
+      run: |
+        crane export --platform linux/arm64 ghcr.io/openfaasltd/vmmeter:latest | sudo tar -xvf - -C /usr/local/bin
+
+    - name: Run vmmeter
+      uses: self-actuated/vmmeter-action@master
+    # vmmeter end
+
+    - uses: actions/checkout@v4
+    - name: Run Tests ${{ matrix.target }}
+      # Following tests are failing on the actuated VMs:
+      #  ./change_mnt_context --pidfile=change_mnt_context.pid --outfile=change_mnt_context.out
+      #   45: ERR: change_mnt_context.c:23: mount (errno = 22 (Invalid argument))
+      #
+      # In combination with '--remote-lazy-pages' following error occurs:
+      #  138: FAIL: maps05.c:84: Data corrupted at page 1639 (errno = 11 (Resource temporarily unavailable))
+      run: |
+        # The 'sched_policy00' needs the following:
+        sudo sysctl -w kernel.sched_rt_runtime_us=-1
+        # etc/hosts entry is needed for netns_lock_iptables
+        echo "127.0.0.1   localhost" | sudo tee -a /etc/hosts
+        sudo -E make -C scripts/ci local ${{ matrix.target }} RUN_TESTS=1 \
+          ZDTM_OPTS="-x zdtm/static/change_mnt_context -x zdtm/static/maps05"

--- a/coredump/coredump
+++ b/coredump/coredump
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import platform
 import argparse
 import os
 import sys
@@ -35,6 +36,10 @@ def main():
                         help='directory to write coredumps to')
 
     opts = vars(parser.parse_args())
+
+    if platform.machine() != 'x86_64':
+        print('ERROR: %s only supported on x86_64' % sys.argv[0])
+        sys.exit(1)
 
     try:
         coredump(opts)

--- a/crit/crit/__main__.py
+++ b/crit/crit/__main__.py
@@ -323,12 +323,12 @@ def explore_rss(opts):
         pvmi = -1
         for pm in pms[1:]:
             pstr = '\t%lx / %-8d' % (pm['vaddr'], pm['nr_pages'])
-            while vmas[vmi]['end'] <= pm['vaddr']:
+            while vmi < len(vmas) and vmas[vmi]['end'] <= pm['vaddr']:
                 vmi += 1
 
             pme = pm['vaddr'] + (pm['nr_pages'] << 12)
             vstr = ''
-            while vmas[vmi]['start'] < pme:
+            while vmi < len(vmas) and vmas[vmi]['start'] < pme:
                 vma = vmas[vmi]
                 if vmi == pvmi:
                     vstr += ' ~'

--- a/test/others/criu-coredump/test.sh
+++ b/test/others/criu-coredump/test.sh
@@ -43,5 +43,13 @@ function run_test {
 	echo "= done"
 }
 
+UNAME_M=$(uname -m)
+
+if [ "$UNAME_M" != "x86_64" ]; then
+	# the criu-coredump script is only x86_64 aware
+	echo "criu-coredump only support x86_64. skipping."
+	exit 0
+fi
+
 gen_imgs
 run_test

--- a/test/others/ns_ext/run.sh
+++ b/test/others/ns_ext/run.sh
@@ -2,6 +2,11 @@
 
 set -x
 
+if ! ../../zdtm/static/macvlan.checkskip; then
+	echo "No macvlan support. Skipping"
+	exit 0
+fi
+
 if [[ "$1" == "pid" ]]; then
 	NS=pid
 else

--- a/test/zdtm/static/macvlan.checkskip
+++ b/test/zdtm/static/macvlan.checkskip
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+FAIL=0
+
+create_macvlan_device() {
+	if ! ip link add test_mvlan1 type veth >/dev/null 2>&1; then
+		FAIL=1
+	fi
+	if ! ip link add mymacvlan1 link test_mvlan1 type macvlan >/dev/null 2>&1; then
+		FAIL=1
+	fi
+
+	return "${FAIL}"
+}
+
+cleanup() {
+	ip link del test_mvlan1 >/dev/null 2>&1
+	ip link del mymacvlan1 >/dev/null 2>&1
+}
+
+trap "cleanup" QUIT TERM INT HUP EXIT
+
+# Test once without loading the module
+if create_macvlan_device; then
+	exit 0
+fi
+
+# Test once more with explicitly loading the module
+if ! modprobe macvlan >/dev/null 2>&1; then
+	exit 1
+fi
+create_macvlan_device
+
+if [ "${FAIL}" == "1" ]; then
+	exit 1
+fi
+
+exit 0

--- a/test/zdtm/static/selinux00.checkskip
+++ b/test/zdtm/static/selinux00.checkskip
@@ -2,6 +2,19 @@
 
 test -d /sys/fs/selinux || exit 1
 
+# check if necessary commands are installed
+if ! command -v setenforce &>/dev/null; then
+	exit 1
+fi
+
+if ! command -v setsebool &>/dev/null; then
+	exit 1
+fi
+
+if ! command -v getsebool &>/dev/null; then
+	exit 1
+fi
+
 # See selinux00.hook for details
 
 getsebool unconfined_dyntrans_all > /dev/null 2>&1


### PR DESCRIPTION
This brings aarch64 based tests to CRIU GitHub CI setup. The difference to the previous configurations is that now actually all tests (almost) are being run.

The tests on the actuated runners are with following limitations:
* tests using macvlan have to be skipped as that module is not available
* the coredump python script is x86_64 only (register names and other arch specific code)
* the `change_mnt_context` test fails with
   ```
      #    ./change_mnt_context --pidfile=change_mnt_context.pid --outfile=change_mnt_context.out
      #    45: ERR: change_mnt_context.c:23: mount (errno = 22 (Invalid argument))
   ```
* the `sched_policy00` test fails with
   ```
      #    5: ERR: sched_policy00.c:55: Can't set policy (errno = 1 (Operation not permitted))
      #    4: ERR: test.c:320: Test exited unexpectedly with code 255
   ```
* in combination with '--remote-lazy-pages' following error occurs:
  ```
      #  138: FAIL: maps05.c:84: Data corrupted at page 1639 (errno = 11 (Resource temporarily unavailable))
   ```
* the crit test case triggers an out of range error when displaying rss on aarch64 which was fixed based on an old commit from @rst0git 