### PR TITLE
scripts/build: Drop CentOS 7 makefile targets

### DIFF
--- a/scripts/build/Makefile
+++ b/scripts/build/Makefile
@@ -1,4 +1,4 @@
-ARCHES := x86_64 fedora-asan fedora-rawhide centos7 armv7hf centos8
+ARCHES := x86_64 fedora-asan fedora-rawhide armv7hf centos8
 STABLE_CROSS_ARCHES := armv7-stable-cross aarch64-stable-cross ppc64-stable-cross mips64el-stable-cross
 UNSTABLE_CROSS_ARCHES := armv7-unstable-cross aarch64-unstable-cross ppc64-unstable-cross mips64el-unstable-cross
 NON_CLANG := $(UNSTABLE_CROSS_ARCHES) $(STABLE_CROSS_ARCHES)

--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -11,7 +11,7 @@ ifdef CLANG
 	target-suffix = -clang
 endif
 
-TARGETS := alpine fedora-rawhide centos7 centos8 archlinux
+TARGETS := alpine fedora-rawhide centos8 archlinux
 ZDTM_OPTS :=
 UNAME := $(shell uname -m)
 export UNAME


### PR DESCRIPTION
The CI tests with CentOS 7 have been disabled and removed (https://github.com/checkpoint-restore/criu/commit/24bc083653f7d2b984653194e921b1ff32292b3b, https://github.com/checkpoint-restore/criu/commit/f8466ca798acd124eebbba2655894ebd2f777879, https://github.com/checkpoint-restore/criu/commit/42a5b640f658771d2ddf238045bf4fa54569a64a). This pull request removes the obsolete Makefile targets for these tests.
