### PR TITLE
plugins: set executable bit on .so files

### DIFF
--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -54,7 +54,7 @@ install:
 ifeq ($(CONFIG_AMDGPU),y)
 	$(Q) mkdir -p $(DESTDIR)$(PLUGINDIR)
 	$(E) "  INSTALL " $(PLUGIN_NAME)
-	$(Q) install -m 644 $(PLUGIN_SOBJ) $(DESTDIR)$(PLUGINDIR)
+	$(Q) install -m 755 $(PLUGIN_SOBJ) $(DESTDIR)$(PLUGINDIR)
 endif
 .PHONY: install
 

--- a/plugins/cuda/Makefile
+++ b/plugins/cuda/Makefile
@@ -31,11 +31,10 @@ mrproper: clean
 install:
 	$(Q) mkdir -p $(DESTDIR)$(PLUGINDIR)
 	$(E) "  INSTALL " $(PLUGIN_NAME)
-	$(Q) install -m 644 $(PLUGIN_SOBJ) $(DESTDIR)$(PLUGINDIR)
+	$(Q) install -m 755 $(PLUGIN_SOBJ) $(DESTDIR)$(PLUGINDIR)
 .PHONY: install
 
 uninstall:
 	$(E) " UNINSTALL" $(PLUGIN_NAME)
 	$(Q) $(RM) $(DESTDIR)$(PLUGINDIR)/$(PLUGIN_SOBJ)
 .PHONY: uninstall
-


### PR DESCRIPTION
For historical reasons, some tools like [rpm](https://docs.fedoraproject.org/en-US/package-maintainers/CommonRpmlintIssues/#unstripped_binary_or_object) or [ldd](https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/ldd.bash.in;h=d6b640df;hb=HEAD#l154) may expect the executable bit to be present for the correct identification of shared libraries. The executable bit on .so files is set by default by compilers (e.g., GCC). It is not strictly necessary but primarily a convention.

```
$ sudo ldd /usr/lib/criu/*.so
/usr/lib/criu/amdgpu_plugin.so:
ldd: warning: you do not have execution permission for `/usr/lib/criu/amdgpu_plugin.so'
	linux-vdso.so.1 (0x00007fd0a2a3e000)
	libdrm.so.2 => /lib64/libdrm.so.2 (0x00007fd0a29eb000)
	libdrm_amdgpu.so.1 => /lib64/libdrm_amdgpu.so.1 (0x00007fd0a29de000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fd0a27fc000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fd0a2a40000)
/usr/lib/criu/cuda_plugin.so:
ldd: warning: you do not have execution permission for `/usr/lib/criu/cuda_plugin.so'
	linux-vdso.so.1 (0x00007f1806e13000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f1806c08000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f1806e15000)
```
