### PR TITLE
Adjust to glibc __rseq_size semantic change

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2618,7 +2618,15 @@ static void prep_libc_rseq_info(struct rst_rseq_param *rseq)
 	if (!kdat.has_ptrace_get_rseq_conf) {
 #if defined(__GLIBC__) && defined(RSEQ_SIG)
 		rseq->rseq_abi_pointer = encode_pointer(__criu_thread_pointer() + __rseq_offset);
+		/*
+		 * Current glibc reports the feature/active size in
+		 * __rseq_size, not the size passed to the kernel.
+		 * This could be 20, but older kernels expect 32 for
+		 * the size argument even if only 20 bytes are used.
+		 */
 		rseq->rseq_abi_size = __rseq_size;
+		if (rseq->rseq_abi_size < 32)
+			rseq->rseq_abi_size = 32;
 		rseq->signature = RSEQ_SIG;
 #else
 		rseq->rseq_abi_pointer = 0;

--- a/test/zdtm/static/rseq00.c
+++ b/test/zdtm/static/rseq00.c
@@ -46,12 +46,15 @@ static inline void *__criu_thread_pointer(void)
 static inline void unregister_glibc_rseq(void)
 {
 	struct rseq *rseq = (struct rseq *)((char *)__criu_thread_pointer() + __rseq_offset);
+	unsigned int size = __rseq_size;
 
 	/* hack: mark glibc rseq structure as failed to register */
 	rseq->cpu_id = RSEQ_CPU_ID_REGISTRATION_FAILED;
 
 	/* unregister rseq */
-	syscall(__NR_rseq, (void *)rseq, __rseq_size, 1, RSEQ_SIG);
+	if (__rseq_size < 32)
+		size = 32;
+	syscall(__NR_rseq, (void *)rseq, size, 1, RSEQ_SIG);
 }
 #else
 static inline void unregister_glibc_rseq(void)

--- a/test/zdtm/transition/rseq01.c
+++ b/test/zdtm/transition/rseq01.c
@@ -33,7 +33,10 @@ static inline void *thread_pointer(void)
 static inline void unregister_old_rseq(void)
 {
 	/* unregister rseq */
-	syscall(__NR_rseq, (void *)((char *)thread_pointer() + __rseq_offset), __rseq_size, 1, RSEQ_SIG);
+	unsigned int size = __rseq_size;
+	if (__rseq_size < 32)
+		size = 32;
+	syscall(__NR_rseq, (void *)((char *)thread_pointer() + __rseq_offset), size, 1, RSEQ_SIG);
 }
 #else
 static inline void unregister_old_rseq(void)


### PR DESCRIPTION
We plan to backport this glibc change all the way to glibc 2.35. Most distributions use the stable release branches, so they will get this change eventually. I hope this is still fine from a CRIU perspective because the non-`ptrace` fallback path is not used.