### PR TITLE
zdtm: make cgroup testcases run non-parallel

### DIFF
--- a/test/zdtm/static/cgroup00.desc
+++ b/test/zdtm/static/cgroup00.desc
@@ -1,1 +1,1 @@
-{'flavor': 'h', 'flags': 'suid', 'opts': '--manage-cgroups'}
+{'flavor': 'h', 'flags': 'suid excl', 'opts': '--manage-cgroups'}

--- a/test/zdtm/static/cgroup01.desc
+++ b/test/zdtm/static/cgroup01.desc
@@ -1,1 +1,1 @@
-{'flavor': 'h', 'flags': 'suid', 'opts': '--manage-cgroups'}
+{'flavor': 'h', 'flags': 'suid excl', 'opts': '--manage-cgroups'}

--- a/test/zdtm/static/cgroup02.desc
+++ b/test/zdtm/static/cgroup02.desc
@@ -1,4 +1,4 @@
 {   'dopts': '--manage-cgroups --cgroup-root name=zdtmtst:/prefix',
-    'flags': 'suid',
+    'flags': 'suid excl',
     'flavor': 'h',
     'ropts': '--manage-cgroups --cgroup-root /newroot --cgroup-root name=zdtmtst:/prefix'}

--- a/test/zdtm/static/cgroup_threads.desc
+++ b/test/zdtm/static/cgroup_threads.desc
@@ -1,1 +1,1 @@
-{'flavor': 'h', 'flags': 'suid', 'opts': '--manage-cgroups'}
+{'flavor': 'h', 'flags': 'suid excl', 'opts': '--manage-cgroups'}

--- a/test/zdtm/static/cgroup_yard.desc
+++ b/test/zdtm/static/cgroup_yard.desc
@@ -1,6 +1,6 @@
 {
 'flavor': 'h',
-'flags': 'suid',
+'flags': 'suid excl',
 # We create the external cgroup yard in working directory during --pre-dump
 # hook. We have to go up a few directories to find the yard.
 'opts': '--manage-cgroups --cgroup-yard ../../../../../../external_yard'

--- a/test/zdtm/static/cgroupns.desc
+++ b/test/zdtm/static/cgroupns.desc
@@ -1,4 +1,4 @@
 {   'feature': 'cgroupns',
-    'flags': 'suid',
+    'flags': 'suid excl',
     'flavor': 'h',
     'opts': '--manage-cgroups'}

--- a/test/zdtm/static/cgroupv2_00.desc
+++ b/test/zdtm/static/cgroupv2_00.desc
@@ -1,1 +1,1 @@
-{'flavor': 'h ns', 'flags': 'suid', 'opts': '--manage-cgroups=full'}
+{'flavor': 'h ns', 'flags': 'suid excl', 'opts': '--manage-cgroups=full'}

--- a/test/zdtm/static/cgroupv2_01.desc
+++ b/test/zdtm/static/cgroupv2_01.desc
@@ -1,1 +1,1 @@
-{'flavor': 'h ns', 'flags': 'suid', 'opts': '--manage-cgroups=full'}
+{'flavor': 'h ns', 'flags': 'suid excl', 'opts': '--manage-cgroups=full'}


### PR DESCRIPTION
cgroup testcases live in the same cgroup root zdtmtst and zdtmtst.defaultroot controller then create child subgroup for testing. This can cause problems when cgroup testcases run in parallel. For example, testcase A dumps the child subgroup of testcase B since it's in the cgroup root but in the middle of restoring of testcase A, testcase B completes and cleans up the subgroup directory. This causes error in testcase A restore. This commit adds excl flag to all cgroup testcases description so that these don't run parallel.

Fixes: #2405 