### PR TITLE
zdtm: verify that criu repo file system allows resolving device files

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -283,6 +283,14 @@ class ns_flavor:
                     self.__construct_root()
                     os.mknod(self.root + "/.constructed", stat.S_IFREG | 0o600)
 
+        try:
+            with open(self.root + "/dev/null"):
+                pass
+        except IOError as e:
+            if e.errno != errno.EACCES:
+                raise e
+            raise test_fail_exc("The filesystem of CRIU repo should not have 'nodev' flag. Consider putting CRIU on appropriate file system to run ZDTM.")
+
         for b in l_bins:
             self.__copy_libs(b)
         for b in x_bins:


### PR DESCRIPTION
We put several device files into zdtm container through its root file system which is the same file system criu git resides in.

We do it like this to overcome inability to create character and block device files in user namespaces. So even if we put those device files into zdtm container in any other way, in 'uns' flavor CRIU would not be able to restore those device files.

Other option can be - creating auxiliary tmpfs mount and add it into zdtm container as external mount, but that looks like an overkill for this problem. Let's print a clear error so that user can either mount current file system without 'nodev" or put criu somewhere else.

Fixes: #2441

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
