### PR TITLE
plugin: enable multiple plugins for the same hook

### DIFF
--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -1809,7 +1809,7 @@ int amdgpu_plugin_resume_devices_late(int target_pid)
 	fd = open(AMDGPU_KFD_DEVICE, O_RDWR | O_CLOEXEC);
 	if (fd < 0) {
 		pr_perror("failed to open kfd in plugin");
-		return -1;
+		return -ENOTSUP;
 	}
 
 	args.pid = target_pid;
@@ -1818,6 +1818,7 @@ int amdgpu_plugin_resume_devices_late(int target_pid)
 	if (kmtIoctl(fd, AMDKFD_IOC_CRIU_OP, &args) == -1) {
 		if (errno == ESRCH) {
 			pr_info("Pid %d has no kfd process info\n", target_pid);
+			exit_code = -ENOTSUP;
 		} else {
 			pr_perror("restore late ioctl failed");
 			exit_code = -1;

--- a/plugins/cuda/cuda_plugin.c
+++ b/plugins/cuda/cuda_plugin.c
@@ -408,7 +408,7 @@ interrupt:
 int cuda_plugin_resume_devices_late(int pid)
 {
 	if (plugin_disabled) {
-		return 0;
+		return -ENOTSUP;
 	}
 
 	return resume_device(pid, 1);


### PR DESCRIPTION
CRIU provides two plugins for checkpoint/restore of GPU applications: amdgpu and cuda. Both plugins use the `RESUME_DEVICES_LATE` hook to enable restore:

    CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESUME_DEVICES_LATE, amdgpu_plugin_resume_devices_late)
    CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESUME_DEVICES_LATE, cuda_plugin_resume_devices_late)

However, CRIU currently [does not support](https://github.com/checkpoint-restore/criu/blob/93746eb25014f21287f2edc5f5dd7545ce19ab52/criu/include/plugin.h#L42) running more than one plugin for the same hook. As a result, when both plugins are installed, the resume function for CUDA applications is not executed. To fix this, we need to make sure that both `plugin_resume_devices_late()` functions return `-ENOTSUP` when restore is not supported.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
