### PR TITLE
timer: fix printf specifiers for __suseconds64_t

### DIFF
--- a/criu/timer.c
+++ b/criu/timer.c
@@ -46,9 +46,9 @@ static inline int decode_itimer(char *n, ItimerEntry *ie, struct itimerval *val)
 		return -1;
 	}
 
-	pr_info("Restored %s timer to %" PRId64 ".%ld -> %" PRId64 ".%ld\n", n,
-		(int64_t)val->it_value.tv_sec, val->it_value.tv_usec,
-		(int64_t)val->it_interval.tv_sec, val->it_interval.tv_usec);
+	pr_info("Restored %s timer to %" PRId64 ".%" PRId64 " -> %" PRId64 ".%" PRId64 "\n", n,
+		(int64_t)val->it_value.tv_sec, (int64_t)val->it_value.tv_usec,
+		(int64_t)val->it_interval.tv_sec, (int64_t)val->it_interval.tv_usec);
 
 	return 0;
 }

--- a/test/zdtm/lib/msg.c
+++ b/test/zdtm/lib/msg.c
@@ -1,4 +1,5 @@
 #include <stdarg.h>
+#include <inttypes.h>
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -55,7 +56,7 @@ void test_msg(const char *format, ...)
 		off += strftime(buf, sizeof(buf), "%H:%M:%S", tm);
 	}
 
-	off += sprintf(buf + off, ".%.3ld: ", tv.tv_usec / 1000);
+	off += sprintf(buf + off, ".%.3" PRId64 ": ", (int64_t)(tv.tv_usec / 1000));
 	off += sprintf(buf + off, "%5d: ", getpid());
 
 skip:

--- a/test/zdtm/lib/ns.c
+++ b/test/zdtm/lib/ns.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include <grp.h>
 #include <string.h>
 #include <errno.h>
@@ -231,7 +232,7 @@ static inline int _settime(clockid_t clk_id, time_t offset)
 	if (clk_id == CLOCK_MONOTONIC_COARSE || clk_id == CLOCK_MONOTONIC_RAW)
 		clk_id = CLOCK_MONOTONIC;
 
-	len = snprintf(buf, sizeof(buf), "%d %ld 0", clk_id, offset);
+	len = snprintf(buf, sizeof(buf), "%d %" PRId64 " 0", clk_id, (int64_t)offset);
 
 	fd = open("/proc/self/timens_offsets", O_WRONLY);
 	if (fd < 0) {

--- a/test/zdtm/static/mtime_mmap.c
+++ b/test/zdtm/static/mtime_mmap.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <inttypes.h>
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -77,7 +78,7 @@ int main(int argc, char **argv)
 	mtime_new = fst.st_mtime;
 	/* time of last modification */
 	if (mtime_new <= mtime_old) {
-		fail("mtime %ld wasn't updated on mmapped %s file", mtime_new, filename);
+		fail("mtime %" PRId64 " wasn't updated on mmapped %s file", (int64_t)mtime_new, filename);
 		goto failed;
 	}
 
@@ -98,7 +99,7 @@ int main(int argc, char **argv)
 
 	/* time of last modification */
 	if (fst.st_mtime != mtime_new) {
-		fail("After migration, mtime changed to %ld", fst.st_mtime);
+		fail("After migration, mtime changed to %" PRId64, (int64_t)fst.st_mtime);
 		goto failed;
 	}
 

--- a/test/zdtm/static/pthread_timers.c
+++ b/test/zdtm/static/pthread_timers.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <string.h>
 #include <signal.h>
 #include <time.h>
@@ -69,7 +70,8 @@ int main(int argc, char **argv)
 	}
 
 	if (itimerspec.it_interval.tv_nsec != TEST_INTERVAL_NSEC || itimerspec.it_interval.tv_sec) {
-		pr_perror("wrong interval: %ld:%ld", itimerspec.it_interval.tv_sec, itimerspec.it_interval.tv_nsec);
+		pr_perror("wrong interval: %" PRId64 ":%" PRId64,
+			  (int64_t)itimerspec.it_interval.tv_sec, (int64_t)itimerspec.it_interval.tv_nsec);
 		return 1;
 	}
 

--- a/test/zdtm/static/vdso00.c
+++ b/test/zdtm/static/vdso00.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-
+#include <inttypes.h>
 #include <unistd.h>
 
 #include <sys/time.h>
@@ -19,14 +19,14 @@ int main(int argc, char *argv[])
 	test_msg("%s pid %d\n", argv[0], getpid());
 
 	gettimeofday(&tv, &tz);
-	test_msg("%d time: %10li\n", getpid(), tv.tv_sec);
+	test_msg("%d time: %10" PRId64 "\n", getpid(), (int64_t)tv.tv_sec);
 
 	test_daemon();
 	test_waitsig();
 
 	/* this call will fail if vDSO is corrupted */
 	gettimeofday(&tv, &tz);
-	test_msg("%d time: %10li\n", getpid(), tv.tv_sec);
+	test_msg("%d time: %10" PRId64 "\n", getpid(), (int64_t)tv.tv_sec);
 
 	pass();
 

--- a/test/zdtm/static/vdso01.c
+++ b/test/zdtm/static/vdso01.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
@@ -324,7 +325,8 @@ static int vdso_clock_gettime_handler(void *func)
 	clock_gettime(CLOCK_REALTIME, &ts1);
 	vdso_clock_gettime(CLOCK_REALTIME, &ts2);
 
-	test_msg("clock_gettime: tv_sec %li vdso_clock_gettime: tv_sec %li\n", ts1.tv_sec, ts2.tv_sec);
+	test_msg("clock_gettime: tv_sec %" PRId64 " vdso_clock_gettime: tv_sec %" PRId64 "\n",
+		 (int64_t)ts1.tv_sec, (int64_t)ts2.tv_sec);
 
 	if (labs(ts1.tv_sec - ts2.tv_sec) > TIME_DELTA_SEC) {
 		pr_perror("Delta is too big");
@@ -354,7 +356,8 @@ static int vdso_gettimeofday_handler(void *func)
 	gettimeofday(&tv1, &tz);
 	vdso_gettimeofday(&tv2, &tz);
 
-	test_msg("gettimeofday: tv_sec %li vdso_gettimeofday: tv_sec %li\n", tv1.tv_sec, tv2.tv_sec);
+	test_msg("gettimeofday: tv_sec %" PRId64 " vdso_gettimeofday: tv_sec %" PRId64 "\n",
+		 (int64_t)tv1.tv_sec, (int64_t)tv2.tv_sec);
 
 	if (labs(tv1.tv_sec - tv2.tv_sec) > TIME_DELTA_SEC) {
 		pr_perror("Delta is too big");


### PR DESCRIPTION
New internal glibc types [__timeval64](https://sourceware.org/git/?p=glibc.git;h=504c98717062cb9bcbd4b3e59e932d04331ddca5) and [__suseconds64_t](https://sourceware.org/git/?p=glibc.git;h=3fced064f23562ec24f8312ffbc14950993969e6) have been introduced as a solution for the [Y2038 problem](https://en.wikipedia.org/wiki/Year_2038_problem). These 64-bit types are used across all architectures. However, this change causes build errors when cross-compiling on ARMv7 (armhf). This pull request updates the printf format specifiers to support 64-bit integer types.