### PR TITLE
support user set remote mmap vma address

### DIFF
--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -120,6 +120,7 @@ struct infect_ctx {
 	open_proc_fn open_proc;
 
 	int log_fd; /* fd for parasite code to send messages to */
+	unsigned long remote_map_addr; /* User-specified address where to mmap parasitic code, default not set */
 };
 
 extern struct infect_ctx *compel_infect_ctx(struct parasite_ctl *);


### PR DESCRIPTION
1. os auto assignment vma addr maybe conflict with vma in gpu living migrate scene;
2. so, we should give choice to user;
3. default, user_set_remote_map is 0L, so we donot change default behave;

user set vma usecase:
```
// we use compel/test/infect/spy.c to show example

static int do_infection(int pid)
{
       ... ....
	ictx = compel_infect_ctx(ctl);
	ictx->log_fd = STDERR_FILENO;

       // TODO: use should set assignment vma addr at here
      ictx->user_set_remote_map = xxxxL;

	parasite_setup_c_header(ctl);
       .... .....
}
```
