### PR TITLE
delete redundant include header file

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -49,7 +49,6 @@
 #include "images/inventory.pb-c.h"
 
 #include "shmem.h"
-#include "restorer.h"
 
 /*
  * sys_getgroups() buffer size. Not too much, to avoid stack overflow.


### PR DESCRIPTION
restorer.h has been included in line 43.
Fixes: 22963d282729 ("Hide asm/restorer.h from sources")
