### PR TITLE
[WIP] keep consistent of pid in all pid namespace

### DIFF
--- a/criu/clone-noasan.c
+++ b/criu/clone-noasan.c
@@ -46,9 +46,10 @@ int clone_noasan(int (*fn)(void *), int flags, void *arg)
 	return clone(fn, stack_ptr, flags, arg);
 }
 
-int clone3_with_pid_noasan(int (*fn)(void *), void *arg, int flags, int exit_signal, pid_t pid)
+int clone3_with_pid_noasan(int (*fn)(void *), void *arg, int flags, int exit_signal, pid_t *ns_tids, size_t ns_tids_len)
 {
 	struct _clone_args c_args = {};
+	pid_t pid;
 
 	BUG_ON(flags & CLONE_VM);
 
@@ -75,8 +76,8 @@ int clone3_with_pid_noasan(int (*fn)(void *), void *arg, int flags, int exit_sig
 		c_args.exit_signal = exit_signal;
 	}
 	c_args.flags = flags;
-	c_args.set_tid = ptr_to_u64(&pid);
-	c_args.set_tid_size = 1;
+	c_args.set_tid = ptr_to_u64(ns_tids);
+	c_args.set_tid_size = ns_tids_len;
 	pid = syscall(__NR_clone3, &c_args, sizeof(c_args));
 	if (pid == 0)
 		exit(fn(arg));

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1203,9 +1203,15 @@ static inline int fork_with_pid(struct pstree_item *item)
 	}
 
 	if (kdat.has_clone3_set_tid) {
+		pid_t ns_tids[2] = {pid};
+		size_t ns_tids_len = 1;
+		if (item->pid->real > 0 && item->pid->real != pid) {
+			ns_tids[ns_tids_len] = item->pid->real;
+			ns_tids_len++;
+		}
 		ret = clone3_with_pid_noasan(restore_task_with_children, &ca,
 					     (ca.clone_flags & ~(CLONE_NEWNET | CLONE_NEWCGROUP | CLONE_NEWTIME)),
-					     SIGCHLD, pid);
+					     SIGCHLD, ns_tids, ns_tids_len);
 	} else {
 		/*
 		 * Some kernel modules, such as network packet generator

--- a/criu/include/clone-noasan.h
+++ b/criu/include/clone-noasan.h
@@ -2,6 +2,6 @@
 #define __CR_CLONE_NOASAN_H__
 
 int clone_noasan(int (*fn)(void *), int flags, void *arg);
-int clone3_with_pid_noasan(int (*fn)(void *), void *arg, int flags, int exit_signal, pid_t pid);
+int clone3_with_pid_noasan(int (*fn)(void *), void *arg, int flags, int exit_signal, pid_t *ns_tids, size_t ns_tids_len);
 
 #endif /* __CR_CLONE_NOASAN_H__ */

--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -313,6 +313,7 @@ int dump_pstree(struct pstree_item *root_item)
 		e.pgid = item->pgid;
 		e.sid = item->sid;
 		e.n_threads = item->nr_threads;
+		e.realpid = item->pid->real;
 
 		e.threads = xmalloc(sizeof(e.threads[0]) * e.n_threads);
 		if (!e.threads)
@@ -577,6 +578,7 @@ static int read_one_pstree_item(struct cr_img *img, pid_t *pid_max)
 	if (e->sid > *pid_max)
 		*pid_max = e->sid;
 	pi->pid->state = TASK_ALIVE;
+	pi->pid->real = e->realpid;
 
 	if (e->ppid == 0) {
 		if (root_item) {

--- a/images/pstree.proto
+++ b/images/pstree.proto
@@ -8,4 +8,5 @@ message pstree_entry {
 	required uint32			pgid		= 3;
 	required uint32			sid		= 4;
 	repeated uint32			threads		= 5;
+	required uint32			realpid		= 6;
 }


### PR DESCRIPTION
Currently, containerd uses criu for container live migration, but there is an inconsistency issue with the root pid namespace of the container process. This PR aims to fix this problem.

current logs：
```
[root@localhost CRIU]# ctr run -d --net-host openeuler:22.03 test bash
[root@localhost CRIU]# cat /sys/fs/cgroup/cpu/default/test/tasks
67635
[root@localhost CRIU]# ctr t exec -t --exec-id=1 test ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   3624  2604 ?        Ss   17:22   0:00 bash
root           7  0.0  0.0   5900  2452 pts/0    Rs+  17:23   0:00 ps aux
[root@localhost CRIU]# ctr c checkpoint --rw --task test checkpoint/test
[root@localhost CRIU]# ctr t del -f test
WARN[0000] task test exit with non-zero exit code 137
[root@localhost CRIU]# ctr c del test
[root@localhost CRIU]# ctr c restore --rw --live test checkpoint/test
[root@localhost CRIU]# cat /sys/fs/cgroup/cpu/default/test/tasks
67850
[root@localhost CRIU]# ctr t exec -t --exec-id=1 test ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   3624   244 ?        Ss   17:24   0:00 bash
root          22  0.0  0.0   5900  2348 pts/0    Rs+  17:24   0:00 ps aux
```

fixed log
```
[root@localhost CRIU]# ctr run -d --net-host openeuler:22.03 test bash
[root@localhost CRIU]# cat /sys/fs/cgroup/cpu/default/test/tasks
71699
[root@localhost CRIU]# ctr t exec -t --exec-id=1 test ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   3624  2616 ?        Ss   17:25   0:00 bash
root           7  0.0  0.0   5900  2344 pts/0    Rs+  17:25   0:00 ps aux
[root@localhost CRIU]# ctr c checkpoint --rw --task test checkpoint/test
[root@localhost CRIU]# ctr t del -f test
WARN[0000] task test exit with non-zero exit code 137
[root@localhost CRIU]# ctr c del test
[root@localhost CRIU]# ctr c restore --rw --live test checkpoint/test
[root@localhost CRIU]#  cat /sys/fs/cgroup/cpu/default/test/tasks
71699
[root@localhost CRIU]#  ctr t exec -t --exec-id=1 test ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   3624   244 ?        Ss   17:26   0:00 bash
root          22  0.0  0.0   5900  2416 pts/0    Rs+  17:26   0:00 ps aux
```
