### PR TITLE
codespell: fix typos

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -834,7 +834,7 @@ static int kerndat_detect_stack_guard_gap(void)
 		 * (see kernel commit 1be7107fbe18ee).
 		 *
 		 * Same time there was semi-complete
-		 * patch released which hitted a number
+		 * patch released which hit a number
 		 * of repos (Ubuntu, Fedora) where instead
 		 * of PAGE_SIZE the 1M gap is cut off.
 		 */

--- a/test/others/bers/bers.c
+++ b/test/others/bers/bers.c
@@ -391,7 +391,7 @@ usage:
 	pr_msg("    -f|--files <num>         create <num> files for each task\n");
 	pr_msg("    -m|--memory <num>        allocate <num> megabytes for each task\n");
 	pr_msg("    --memory-chunks <num>    split memory to <num> equal parts\n");
-	pr_msg("    --mem-fill <mode>        fill memory with data dependin on <mode>:\n");
+	pr_msg("    --mem-fill <mode>        fill memory with data depending on <mode>:\n");
 	pr_msg("                all          fill every byte of memory\n");
 	pr_msg("                light        fill first bytes of every page\n");
 	pr_msg("                dirtify      fill every page\n");


### PR DESCRIPTION
This pull request fixes the following typos reported by codespell:

```
./test/others/bers/bers.c:394: dependin ==> depending, depend in
./criu/kerndat.c:837: hitted ==> hit
```
