### PR TITLE
Fdavid/mi300 fixes

### DIFF
--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -608,6 +608,7 @@ static int sdma_copy_bo(struct kfd_criu_bo_bucket bo_bucket, FILE *storage_fp,
 	while (bytes_remain > 0) {
 		memset(&cs_req, 0, sizeof(cs_req));
 		memset(&fence, 0, sizeof(fence));
+		memset(&ib_info, 0, sizeof(ib_info));
 		memset(ib, 0, packets_per_buffer * 28);
 
 		if (type == SDMA_OP_VRAM_WRITE) {

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -20,6 +20,7 @@
 #include "amdgpu_plugin_topology.h"
 
 #define TOPOLOGY_PATH "/sys/class/kfd/kfd/topology/nodes/"
+#define MAX_PARAMETER_LEN 64
 
 /* User override options */
 /* Skip firmware version check */
@@ -417,7 +418,9 @@ struct tp_node *sys_add_node(struct tp_system *sys, uint32_t id, uint32_t gpu_id
 
 static bool get_prop(char *line, char *name, uint64_t *value)
 {
-	if (sscanf(line, " %29s %lu", name, value) != 2)
+	char format[16];
+	sprintf(format, " %%%ds %%lu", MAX_PARAMETER_LEN);
+	if (sscanf(line, format, name, value) != 2)
 		return false;
 	return true;
 }
@@ -437,7 +440,7 @@ static int parse_topo_node_properties(struct tp_node *dev, const char *dir_path)
 	}
 
 	while (fgets(line, sizeof(line), file)) {
-		char name[30];
+		char name[MAX_PARAMETER_LEN + 1];
 		uint64_t value;
 
 		memset(name, 0, sizeof(name));
@@ -565,7 +568,7 @@ static int parse_topo_node_mem_banks(struct tp_node *node, const char *dir_path)
 			}
 
 			while (fgets(line, sizeof(line), file)) {
-				char name[30];
+				char name[MAX_PARAMETER_LEN + 1];
 				uint64_t value;
 
 				memset(name, 0, sizeof(name));
@@ -654,7 +657,7 @@ static int parse_topo_node_iolinks(struct tp_node *node, const char *dir_path)
 			}
 
 			while (fgets(line, sizeof(line), file)) {
-				char name[30];
+				char name[MAX_PARAMETER_LEN + 1];
 				uint64_t value;
 
 				memset(name, 0, sizeof(name));


### PR DESCRIPTION
These are two problems that have come up while testing CRIU with latest MI300 hardware.

The first is an unitialized access left over from last year's SDMA copy rework.

The second increases the maximum length of topology parameters to accommodate some new io_link parameters.