### PR TITLE
Makefile.config: set CR_PLUGIN_DEFAULT variable

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -59,6 +59,10 @@ endif
 
 export LIBS += $(LIBS_FEATURES)
 
+ifneq ($(PLUGINDIR),)
+                FEATURE_DEFINES	+= -DCR_PLUGIN_DEFAULT="\"$(PLUGINDIR)\""
+endif
+
 CONFIG_FILE = .config
 
 $(CONFIG_FILE):

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -15,7 +15,7 @@ DEPS_NOK 		:= ;
 __nmk_dir ?= ../../scripts/nmk/scripts/
 include $(__nmk_dir)msg.mk
 
-PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC -DCR_PLUGIN_DEFAULT="$(PLUGINDIR)"
+PLUGIN_CFLAGS  		:= -g -Wall -Werror -D _GNU_SOURCE -shared -nostartfiles -fPIC
 PLUGIN_LDFLAGS		:= -lpthread -lrt -ldrm -ldrm_amdgpu
 
 ifeq ($(CONFIG_AMDGPU),y)


### PR DESCRIPTION
By default, CRIU uses the path `/usr/lib/criu` to install and load plugins at runtime. This path is defined by the `PLUGINDIR` variable in `Makefile.install` and `CR_PLUGIN_DEFAULT` in `criu/include/plugin.h`. However, some distribution packages might install the CRIU plugins at `/usr/lib64/criu` instead. This patch updates the makefile to align the path defined by `CR_PLUGIN_DEFAULT` with the value of `PLUGINDIR`.