### PR TITLE
images/inventory: add field for enabled plugins

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2354,11 +2354,11 @@ int cr_restore_tasks(void)
 	if (init_service_fd())
 		return 1;
 
-	if (cr_plugin_init(CR_PLUGIN_STAGE__RESTORE))
-		return -1;
-
 	if (check_img_inventory(/* restore = */ true) < 0)
 		goto err;
+
+	if (cr_plugin_init(CR_PLUGIN_STAGE__RESTORE))
+		return -1;
 
 	if (init_stats(RESTORE_STATS))
 		goto err;

--- a/criu/image.c
+++ b/criu/image.c
@@ -26,6 +26,14 @@ TaskKobjIdsEntry *root_ids;
 u32 root_cg_set;
 Lsmtype image_lsm;
 
+struct inventory_plugin {
+	struct list_head node;
+	char *name;
+};
+
+struct list_head inventory_plugins_list = LIST_HEAD_INIT(inventory_plugins_list);
+static int n_inventory_plugins;
+
 int check_img_inventory(bool restore)
 {
 	int ret = -1;
@@ -99,6 +107,19 @@ int check_img_inventory(bool restore)
 		} else {
 			opts.network_lock_method = he->network_lock_method;
 		}
+
+		if (!he->plugins_entry) {
+			/* backwards compatibility: if the 'plugins_entry' field is missing,
+			 * all plugins should be enabled during restore.
+			 */
+			n_inventory_plugins = -1;
+		} else {
+			PluginsEntry *pe = he->plugins_entry;
+			for (int i = 0; i < pe->n_plugins; i++) {
+				if (add_inventory_plugin(pe->plugins[i]))
+					goto out_err;
+			}
+		}
 	}
 
 	ret = 0;
@@ -110,8 +131,92 @@ out_close:
 	return ret;
 }
 
+/**
+ * Check if the 'plugins' field in the inventory image contains
+ * the specified plugin name. If found, the plugin is removed
+ * from the linked list.
+ */
+bool check_and_remove_inventory_plugin(const char *name, size_t n)
+{
+	if (n_inventory_plugins == -1)
+		return true; /* backwards compatibility */
+
+	if (n_inventory_plugins > 0) {
+		struct inventory_plugin *p, *tmp;
+
+		list_for_each_entry_safe(p, tmp, &inventory_plugins_list, node) {
+			if (!strncmp(name, p->name, n)) {
+				xfree(p->name);
+				list_del(&p->node);
+				xfree(p);
+				n_inventory_plugins--;
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/**
+ * We expect during restore all loaded plugins to be removed from
+ * the inventory_plugins_list. If the list is not empty, show an
+ * error message for each missing plugin.
+ */
+int check_inventory_plugins(void)
+{
+	struct inventory_plugin *p;
+
+	if (n_inventory_plugins <= 0)
+		return 0;
+
+	list_for_each_entry(p, &inventory_plugins_list, node) {
+		pr_err("Missing required plugin: %s\n", p->name);
+	}
+
+	return -1;
+}
+
+/**
+ * Add plugin name to the inventory image. These values
+ * can be used to identify required plugins during restore.
+ */
+int add_inventory_plugin(const char *name)
+{
+	struct inventory_plugin *p;
+
+	p = xmalloc(sizeof(struct inventory_plugin));
+	if (p == NULL)
+		return -1;
+
+	p->name = xstrdup(name);
+	if (!p->name) {
+		xfree(p);
+		return -1;
+	}
+	list_add(&p->node, &inventory_plugins_list);
+	n_inventory_plugins++;
+
+	return 0;
+}
+
+void free_inventory_plugins_list(void)
+{
+	struct inventory_plugin *p, *tmp;
+
+	if (!list_empty(&inventory_plugins_list)) {
+		list_for_each_entry_safe(p, tmp, &inventory_plugins_list, node) {
+			xfree(p->name);
+			list_del(&p->node);
+			xfree(p);
+		}
+	}
+	n_inventory_plugins = 0;
+}
+
 int write_img_inventory(InventoryEntry *he)
 {
+	PluginsEntry pe = PLUGINS_ENTRY__INIT;
 	struct cr_img *img;
 	int ret;
 
@@ -121,7 +226,26 @@ int write_img_inventory(InventoryEntry *he)
 	if (!img)
 		return -1;
 
+	if (!list_empty(&inventory_plugins_list)) {
+		struct inventory_plugin *p;
+		int i = 0;
+
+		pe.n_plugins = n_inventory_plugins;
+		pe.plugins = xmalloc(n_inventory_plugins * sizeof(char *));
+		if (!pe.plugins)
+			return -1;
+
+		list_for_each_entry(p, &inventory_plugins_list, node) {
+			pe.plugins[i] = p->name;
+			i++;
+		}
+	}
+	he->plugins_entry = &pe;
+
 	ret = pb_write_one(img, he, PB_INVENTORY);
+
+	free_inventory_plugins_list();
+	xfree(pe.plugins);
 
 	xfree(he->root_ids);
 	close_image(img);

--- a/criu/include/image.h
+++ b/criu/include/image.h
@@ -177,4 +177,8 @@ extern int read_img_str(struct cr_img *, char **pstr, int size);
 
 extern void close_image(struct cr_img *);
 
+extern int add_inventory_plugin(const char *name);
+extern int check_inventory_plugins(void);
+extern bool check_and_remove_inventory_plugin(const char *name, size_t n);
+
 #endif /* __CR_IMAGE_H__ */

--- a/criu/plugin.c
+++ b/criu/plugin.c
@@ -256,6 +256,9 @@ int cr_plugin_init(int stage)
 			goto err;
 	}
 
+	if (stage == CR_PLUGIN_STAGE__RESTORE && check_inventory_plugins())
+		goto err;
+
 	exit_code = 0;
 err:
 	closedir(d);

--- a/images/inventory.proto
+++ b/images/inventory.proto
@@ -10,6 +10,13 @@ enum lsmtype {
 	APPARMOR	= 2;
 }
 
+// It is not possible to distinguish between an empty repeated field
+// and unset repeated field. To solve this problem and provide backwards
+// compabibility, we use the 'plugins_entry' message.
+message plugins_entry {
+	repeated string			plugins = 12;
+};
+
 message inventory_entry {
 	required uint32			img_version	= 1;
 	optional bool			fdinfo_per_id	= 2;
@@ -21,4 +28,5 @@ message inventory_entry {
 	optional uint32			pre_dump_mode	= 9;
 	optional bool			tcp_close	= 10;
 	optional uint32			network_lock_method	= 11;
+	optional plugins_entry		plugins_entry = 12;
 }

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -362,5 +362,6 @@ make -C plugins/amdgpu/ test_topology_remap
 ./test/zdtm.py run -t zdtm/static/maps00 -t zdtm/static/maps02 --criu-plugin cuda
 ./test/zdtm.py run -t zdtm/static/maps00 -t zdtm/static/maps02 --criu-plugin amdgpu
 ./test/zdtm.py run -t zdtm/static/maps00 -t zdtm/static/maps02 --criu-plugin amdgpu cuda
+./test/zdtm.py run -t zdtm/static/busyloop00 --criu-plugin inventory_test_enabled inventory_test_disabled
 
 ./test/zdtm.py run -t zdtm/static/sigpending -t zdtm/static/pthread00 --mocked-cuda-checkpoint --fault 138

--- a/test/plugins/Makefile
+++ b/test/plugins/Makefile
@@ -1,5 +1,13 @@
 SRC_DIR := ../../plugins
-PLUGIN_TARGETS := amdgpu_plugin.so cuda_plugin.so
+PLUGIN_TARGETS := inventory_test_enabled_plugin.so inventory_test_disabled_plugin.so amdgpu_plugin.so cuda_plugin.so
+
+ARCH	:= x86
+
+PLUGIN_INCLUDE	:= -iquote../../include
+PLUGIN_INCLUDE	+= -iquote../../criu/include
+PLUGIN_INCLUDE	+= -iquote../../criu/arch/$(ARCH)/include/
+PLUGIN_INCLUDE	+= -iquote../../
+PLUGIN_CFLAGS	:= -g -Wall -Werror -shared -nostartfiles -fPIC
 
 # Silent make rules.
 Q := @
@@ -11,6 +19,12 @@ amdgpu_plugin.so: $(SRC_DIR)/amdgpu/amdgpu_plugin.so
 
 cuda_plugin.so: $(SRC_DIR)/cuda/cuda_plugin.so
 	$(Q) cp $< $@
+
+inventory_test_enabled_plugin.so: inventory_test_enabled_plugin.c
+	$(Q) $(CC) $(PLUGIN_CFLAGS) $< -o $@ $(PLUGIN_INCLUDE)
+
+inventory_test_disabled_plugin.so: inventory_test_disabled_plugin.c
+	$(Q) $(CC) $(PLUGIN_CFLAGS) $< -o $@ $(PLUGIN_INCLUDE)
 
 clean:
 	$(Q) $(RM) $(PLUGIN_TARGETS)

--- a/test/plugins/inventory_test_disabled_plugin.c
+++ b/test/plugins/inventory_test_disabled_plugin.c
@@ -1,0 +1,17 @@
+#include "criu-plugin.h"
+#include "image.h"
+
+int inventory_test_disabled_plugin_init(int stage)
+{
+	if (stage == CR_PLUGIN_STAGE__RESTORE)
+		return check_and_remove_inventory_plugin(CR_PLUGIN_DESC.name, strlen(CR_PLUGIN_DESC.name));
+
+	return 0;
+}
+
+void inventory_test_disabled_plugin_fini(int stage, int ret)
+{
+	return;
+}
+
+CR_PLUGIN_REGISTER("inventory_test_disabled_plugin", inventory_test_disabled_plugin_init, inventory_test_disabled_plugin_fini)

--- a/test/plugins/inventory_test_enabled_plugin.c
+++ b/test/plugins/inventory_test_enabled_plugin.c
@@ -1,0 +1,17 @@
+#include "criu-plugin.h"
+#include "image.h"
+
+int inventory_test_enabled_plugin_init(int stage)
+{
+	if (stage == CR_PLUGIN_STAGE__RESTORE)
+		return !check_and_remove_inventory_plugin(CR_PLUGIN_DESC.name, strlen(CR_PLUGIN_DESC.name));
+
+	return add_inventory_plugin(CR_PLUGIN_DESC.name);
+}
+
+void inventory_test_enabled_plugin_fini(int stage, int ret)
+{
+	return;
+}
+
+CR_PLUGIN_REGISTER("inventory_test_enabled_plugin", inventory_test_enabled_plugin_init, inventory_test_enabled_plugin_fini)

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -2877,7 +2877,7 @@ def get_cli_args():
     rp.add_argument("--preload-libfault", action="store_true", help="Run criu with library preload to simulate special cases")
     rp.add_argument("--criu-plugin",
                     help="Run tests with CRIU plugin",
-                    choices=['amdgpu', 'cuda'],
+                    choices=['amdgpu', 'cuda', 'inventory_test_enabled', 'inventory_test_disabled'],
                     nargs='+',
                     default=None)
     rp.add_argument("--mocked-cuda-checkpoint",


### PR DESCRIPTION
This pull request extends the inventory image with a `plugins` field that contains an array of names indicating which plugins were used during checkpointing, for example, to save GPU state. In particular, the CUDA and AMDGPU plugins are added to this field *only* when the checkpoint contains GPU state. This allows to disable unnecessary plugins during restore, show appropriate error messages if required CRIU plugins are missing, and migrate a process that does not use GPU from a GPU-enabled system to CPU-only environment.

Examples:
1. The checkpoint contains AMDGPU state and requires `amdgpu_plugin` for restore.
```json
{
    "magic": "INVENTORY",
    "entries": [
        {
            "plugins_entry": {
                "plugins": [
                    "amdgpu_plugin"
                ]
            }
        }
    ]
}
```
2. The checkpoint contains CUDA state and requires `cuda_plugin` for restore.
```json
{
    "magic": "INVENTORY",
    "entries": [
        {
            "plugins_entry": {
                "plugins": [
                    "cuda_plugin"
                ]
            }
        }
    ]
}
```
3.  The checkpoint does not contain GPU state (i.e., no plugins are required for restore).
```json
{
    "magic": "INVENTORY",
    "entries": [
        {
            "plugins_entry": {}
        }
    ]
}
```