### PR TITLE
uffd: Disable image deduplication after fork

### DIFF
--- a/criu/include/pagemap.h
+++ b/criu/include/pagemap.h
@@ -58,6 +58,9 @@ struct page_read {
 	/* Whether or not pages can be read in PIE code */
 	bool pieok;
 
+	/* Whether or not disable image deduplication*/
+	bool disable_dedup;
+
 	/* Private data of reader */
 	struct cr_img *pmi;
 	struct cr_img *pi;
@@ -111,6 +114,8 @@ int pagemap_render_iovec(struct list_head *from, struct task_restore_args *ta);
  * maintains its own set of references to those structures.
  */
 extern void dup_page_read(struct page_read *src, struct page_read *dst);
+
+extern void page_read_disable_dedup(struct page_read *pr);
 
 extern int dedup_one_iovec(struct page_read *pr, unsigned long base, unsigned long len);
 

--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -1098,6 +1098,8 @@ static int handle_fork(struct lazy_pages_info *parent_lpi, struct uffd_msg *msg)
 
 	lpi_get(lpi->parent);
 
+	page_read_disable_dedup(&parent_lpi->pr);
+	page_read_disable_dedup(&lpi->pr);
 	return 1;
 
 out:


### PR DESCRIPTION
After a fork, both the child and parent processes may trigger a page fault (#PF) at the same virtual address, referencing the same position in the page image. If deduplication is enabled, the last process to trigger the page fault will fail.

Therefore, deduplication should be disabled after a fork to prevent this issue.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
