### PR TITLE
compel: when pre-dump, handle ERESTART_RESTARTBLOCK as ERESTARTNOINTR

### DIFF
--- a/compel/arch/aarch64/src/lib/infect.c
+++ b/compel/arch/aarch64/src/lib/infect.c
@@ -60,7 +60,7 @@ int sigreturn_prep_fpu_frame_plain(struct rt_sigframe *sigframe, struct rt_sigfr
 }
 
 int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *fpsimd, save_regs_t save,
-			 void *arg, __maybe_unused unsigned long flags)
+			 void *arg, __maybe_unused unsigned long flags, __maybe_unused bool pre_dump)
 {
 	struct iovec iov;
 	int ret;

--- a/compel/arch/arm/src/lib/infect.c
+++ b/compel/arch/arm/src/lib/infect.c
@@ -66,7 +66,7 @@ int sigreturn_prep_fpu_frame_plain(struct rt_sigframe *sigframe, struct rt_sigfr
 
 #define PTRACE_GETVFPREGS 27
 int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *vfp, save_regs_t save,
-			 void *arg, __maybe_unused unsigned long flags)
+			 void *arg, __maybe_unused unsigned long flags, __maybe_unused bool pre_dump)
 {
 	int ret = -1;
 

--- a/compel/arch/loongarch64/src/lib/infect.c
+++ b/compel/arch/loongarch64/src/lib/infect.c
@@ -49,7 +49,7 @@ int sigreturn_prep_fpu_frame_plain(struct rt_sigframe *sigframe, struct rt_sigfr
 }
 
 int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *ext_regs, save_regs_t save,
-			 void *arg, __maybe_unused unsigned long flags)
+			 void *arg, __maybe_unused unsigned long flags, __maybe_unused bool pre_dump)
 {
 	user_fpregs_struct_t tmp, *fpregs = ext_regs ? ext_regs : &tmp;
 	struct iovec iov;

--- a/compel/arch/mips/src/lib/infect.c
+++ b/compel/arch/mips/src/lib/infect.c
@@ -120,7 +120,7 @@ int sigreturn_prep_fpu_frame_plain(struct rt_sigframe *sigframe, struct rt_sigfr
 }
 
 int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *xs, save_regs_t save,
-			 void *arg, __maybe_unused unsigned long flags)
+			 void *arg, __maybe_unused unsigned long flags, __maybe_unused bool pre_dump)
 {
 	int ret = -1;
 

--- a/compel/arch/ppc64/src/lib/infect.c
+++ b/compel/arch/ppc64/src/lib/infect.c
@@ -392,7 +392,7 @@ static int __get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_stru
 }
 
 int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs, save_regs_t save,
-			 void *arg, __maybe_unused unsigned long flags)
+			 void *arg, __maybe_unused unsigned long flags, __maybe_unused bool pre_dump)
 {
 	int ret;
 

--- a/compel/arch/s390/src/lib/infect.c
+++ b/compel/arch/s390/src/lib/infect.c
@@ -294,7 +294,7 @@ static int s390_disable_ri_bit(pid_t pid, user_regs_struct_t *regs)
  * Prepare task registers for restart
  */
 int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs, save_regs_t save,
-			 void *arg, __maybe_unused unsigned long flags)
+			 void *arg, __maybe_unused unsigned long flags, __maybe_unused bool pre_dump)
 {
 	struct iovec iov;
 	int rewind;

--- a/compel/include/infect-priv.h
+++ b/compel/include/infect-priv.h
@@ -70,7 +70,7 @@ extern bool arch_can_dump_task(struct parasite_ctl *ctl);
  * @pid:	mystery
  */
 extern int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct_t *ext_regs, save_regs_t save,
-				void *arg, unsigned long flags);
+				void *arg, unsigned long flags, bool pre_dump);
 extern int compel_set_task_ext_regs(pid_t pid, user_fpregs_struct_t *ext_regs);
 extern int arch_fetch_sas(struct parasite_ctl *ctl, struct rt_sigframe *s);
 extern int sigreturn_prep_regs_plain(struct rt_sigframe *sigframe, user_regs_struct_t *regs,

--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -103,6 +103,7 @@ typedef int (*make_sigframe_t)(void *, struct rt_sigframe *, struct rt_sigframe 
 struct infect_ctx {
 	int sock;
 
+	bool pre_dump;
 	/*
 	 * Regs manipulation context.
 	 */

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -747,7 +747,7 @@ static int parasite_start_daemon(struct parasite_ctl *ctl)
 	 * while in daemon it is not such.
 	 */
 
-	if (compel_get_task_regs(pid, &ctl->orig.regs, &ext_regs, ictx->save_regs, ictx->regs_arg, ictx->flags)) {
+	if (compel_get_task_regs(pid, &ctl->orig.regs, &ext_regs, ictx->save_regs, ictx->regs_arg, ictx->flags, ictx->pre_dump)) {
 		pr_err("Can't obtain regs for thread %d\n", pid);
 		return -1;
 	}
@@ -1751,7 +1751,7 @@ k_rtsigset_t *compel_task_sigmask(struct parasite_ctl *ctl)
 
 int compel_get_thread_regs(struct parasite_thread_ctl *tctl, save_regs_t save, void *arg)
 {
-	return compel_get_task_regs(tctl->tid, &tctl->th.regs, &tctl->th.ext_regs, save, arg, tctl->ctl->ictx.flags);
+	return compel_get_task_regs(tctl->tid, &tctl->th.regs, &tctl->th.ext_regs, save, arg, tctl->ctl->ictx.flags, tctl->ctl->ictx.pre_dump);
 }
 
 struct infect_ctx *compel_infect_ctx(struct parasite_ctl *ctl)

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1488,7 +1488,7 @@ static int pre_dump_one_task(struct pstree_item *item, InventoryEntry *parent_ie
 	}
 
 	ret = -1;
-	parasite_ctl = parasite_infect_seized(pid, item, &vmas);
+	parasite_ctl = parasite_infect_seized(pid, item, &vmas, true);
 	if (!parasite_ctl) {
 		pr_err("Can't infect (pid: %d) with parasite\n", pid);
 		goto err_free;
@@ -1605,7 +1605,7 @@ static int dump_one_task(struct pstree_item *item, InventoryEntry *parent_ie)
 		goto err;
 	}
 
-	parasite_ctl = parasite_infect_seized(pid, item, &vmas);
+	parasite_ctl = parasite_infect_seized(pid, item, &vmas, opts.final_state == TASK_ALIVE);
 	if (!parasite_ctl) {
 		pr_err("Can't infect (pid: %d) with parasite\n", pid);
 		goto err;

--- a/criu/include/parasite-syscall.h
+++ b/criu/include/parasite-syscall.h
@@ -33,7 +33,7 @@ extern int parasite_drain_fds_seized(struct parasite_ctl *ctl, struct parasite_d
 extern int parasite_get_proc_fd_seized(struct parasite_ctl *ctl);
 
 extern struct parasite_ctl *parasite_infect_seized(pid_t pid, struct pstree_item *item,
-						   struct vm_area_list *vma_area_list);
+						   struct vm_area_list *vma_area_list, bool pre_dump);
 extern void parasite_ensure_args_size(unsigned long sz);
 extern unsigned long get_exec_start(struct vm_area_list *);
 

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -375,7 +375,7 @@ free_ctls:
 	return -1;
 }
 
-struct parasite_ctl *parasite_infect_seized(pid_t pid, struct pstree_item *item, struct vm_area_list *vma_area_list)
+struct parasite_ctl *parasite_infect_seized(pid_t pid, struct pstree_item *item, struct vm_area_list *vma_area_list, bool pre_dump)
 {
 	struct parasite_ctl *ctl;
 	struct infect_ctx *ictx;
@@ -400,6 +400,7 @@ struct parasite_ctl *parasite_infect_seized(pid_t pid, struct pstree_item *item,
 
 	ictx = compel_infect_ctx(ctl);
 
+	ictx->pre_dump = pre_dump;
 	ictx->open_proc = do_open_proc;
 	ictx->child_handler = sigchld_handler;
 	ictx->orig_handler.sa_handler = SIG_DFL;


### PR DESCRIPTION
When pre-dump, if thread is in syscall like sleep or poll, it will return -ERESTART_RESTARTBLOCK. In that case, if we set ax register to -EINTR, it will break the original syscall. Instead, we can restore original syscall.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
