### PR TITLE
cuda: enable checkpoint support for paused tasks

### DIFF
--- a/test/cuda-checkpoint/cuda-checkpoint.c
+++ b/test/cuda-checkpoint/cuda-checkpoint.c
@@ -11,6 +11,7 @@ int main(int argc, char *argv[])
 		int option_index = 0;
 		static struct option long_options[] = {
 			{ "pid", required_argument, 0, 'p' },
+			{ "get-state", no_argument, 0, 's' },
 			{ "get-restore-tid", no_argument, 0, 'g' },
 			{ "action", required_argument, 0, 'a' },
 			{ "timeout", required_argument, 0, 't' },
@@ -30,6 +31,9 @@ int main(int argc, char *argv[])
 		case 'g':
 		case 'a':
 		case 't':
+			break;
+		case 's':
+			printf("running\n");
 			break;
 		case 'h':
 			printf("--action - execute an action");


### PR DESCRIPTION
If a CUDA process is already in a "locked" or "checkpointed" state during `criu dump`, the CUDA plugin fails with an error because it attempts an unnecessary "lock" action using the `cuda-checkpoint` tool. This pull request extends the CUDA plugin to handle such case by first checking the original state of the CUDA process and skipping unnecessary "lock" and "checkpoint" actions if the process was already locked or checkpointed before CRIU was invoked.