### PR TITLE
pidfd: add missing include

### DIFF
--- a/criu/pidfd.c
+++ b/criu/pidfd.c
@@ -11,6 +11,8 @@
 #include "common/bug.h"
 #include "rst-malloc.h"
 
+#include "compel/plugins/std/syscall-codes.h"
+
 #undef LOG_PREFIX
 #define LOG_PREFIX "pidfd: "
 


### PR DESCRIPTION
This pull request fixes the following error when building CRIU on Rocky Linux 8:
```
criu/pidfd.c: In function ‘pidfd_open’:
criu/pidfd.c:119:17: error: ‘__NR_pidfd_open’ undeclared (first use in this function); did you mean ‘pidfd_open’?
  return syscall(__NR_pidfd_open, pid, flags);
                 ^~~~~~~~~~~~~~~
                 pidfd_open
criu/pidfd.c:119:17: note: each undeclared identifier is reported only once for each function it appears in criu/pidfd.c:120:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
criu/pidfd.c: At top level:
cc1: error: unrecognized command line option ‘-Wno-unknown-warning-option’ [-Werror] cc1: error: unrecognized command line option ‘-Wno-dangling-pointer’ [-Werror] cc1: all warnings being treated as errors
```
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
