### PR TITLE
vdso: handle vvar_vclock vma-s

### DIFF
--- a/criu/include/util-vdso.h
+++ b/criu/include/util-vdso.h
@@ -30,6 +30,7 @@ struct vdso_symbol {
 struct vdso_symtable {
 	unsigned long vdso_size;
 	unsigned long vvar_size;
+	unsigned long vvar_vclock_size;
 	struct vdso_symbol symbols[VDSO_SYMBOL_MAX];
 	bool vdso_before_vvar; /* order of vdso/vvar pair */
 };


### PR DESCRIPTION
The vvar_vclock was introduced by [1]. Basically, the old vvar vma has been splited on two parts. In term of C/R, these two vma-s can be still treated as one.

[1] e93d2521b27f ("x86/vdso: Split virtual clock pages into dedicated mapping")

Fixes #2532