### PR TITLE
cuda: Fix return value from CHECKPOINT_DEVICES

### DIFF
--- a/plugins/cuda/cuda_plugin.c
+++ b/plugins/cuda/cuda_plugin.c
@@ -402,7 +402,7 @@ int cuda_plugin_checkpoint_devices(int pid)
 interrupt:
 	int_ret = interrupt_restore_thread(restore_tid, &save_sigset);
 
-	return status != 0 ? status : int_ret;
+	return status != 0 ? -1 : int_ret;
 }
 CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__CHECKPOINT_DEVICES, cuda_plugin_checkpoint_devices);
 


### PR DESCRIPTION
When cuda-checkpoint fails an operation it always returns the positive CUDA error code. In CHECKPOINT_DEVICES that was getting passed up as the failure code from one of the calls so if the operation failed we would write the failure to the log but not stop the dump since that checked for error values less than 0.