### PR TITLE
test/java: increate the ghost file limit

### DIFF
--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -24,9 +24,10 @@ RUN apt-install protobuf-c-compiler \
 	gcc \
 	maven
 
+RUN mkdir -p /etc/criu && echo 'ghost-limit 16777216' > /etc/criu/default.conf
 COPY . /criu
 WORKDIR /criu
 
 RUN make mrproper && make -j $(nproc) CC="$CC"
 
-ENTRYPOINT mvn -q -f test/javaTests/pom.xml test
+ENTRYPOINT mvn -f test/javaTests/pom.xml test


### PR DESCRIPTION
Right now, this test fails with this error:
```
Error (criu/files-reg.c:1031): Can't dump ghost file
  /criu/test/javaTests/omrvmem_000000626_Mlm48x of 2097152 size,
  increase limit
```
