### PR TITLE
cuda: prevent task lockup on timeout error

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -2192,6 +2192,9 @@ int cr_dump_tasks(pid_t pid)
 	if (collect_pstree())
 		goto err;
 
+	if (checkpoint_devices())
+		goto err;
+
 	if (collect_pstree_ids())
 		goto err;
 

--- a/criu/include/seize.h
+++ b/criu/include/seize.h
@@ -2,6 +2,7 @@
 #define __CR_SEIZE_H__
 
 extern int collect_pstree(void);
+extern int checkpoint_devices(void);
 struct pstree_item;
 extern void pstree_switch_state(struct pstree_item *root_item, int st);
 extern const char *get_real_freezer_state(void);

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -1050,7 +1050,6 @@ int collect_pstree(void)
 	pid_t pid = root_item->pid->real;
 	int ret, exit_code = -1;
 	struct proc_status_creds creds;
-	struct pstree_item *iter;
 
 	timing_start(TIME_FREEZING);
 
@@ -1111,6 +1110,21 @@ int collect_pstree(void)
 		goto err;
 	}
 
+	exit_code = 0;
+	timing_stop(TIME_FREEZING);
+	timing_start(TIME_FROZEN);
+
+err:
+	/* Freezing stage finished in time - disable timer. */
+	alarm(0);
+	return exit_code;
+}
+
+int checkpoint_devices(void)
+{
+	struct pstree_item *iter;
+	int ret, exit_code = -1;
+
 	for_each_pstree_item(iter) {
 		if (!task_alive(iter))
 			continue;
@@ -1120,11 +1134,6 @@ int collect_pstree(void)
 	}
 
 	exit_code = 0;
-	timing_stop(TIME_FREEZING);
-	timing_start(TIME_FROZEN);
-
 err:
-	/* Freezing stage finished in time - disable timer. */
-	alarm(0);
 	return exit_code;
 }

--- a/plugins/cuda/cuda_plugin.c
+++ b/plugins/cuda/cuda_plugin.c
@@ -565,6 +565,12 @@ int cuda_plugin_init(int stage)
 {
 	int ret;
 
+	/* Disable CUDA checkpointing with pre-dump */
+	if (stage == CR_PLUGIN_STAGE__PRE_DUMP) {
+		plugin_disabled = true;
+		return 0;
+	}
+
 	if (stage == CR_PLUGIN_STAGE__RESTORE) {
 		if (!check_and_remove_inventory_plugin(CR_PLUGIN_DESC.name, strlen(CR_PLUGIN_DESC.name))) {
 			plugin_disabled = true;

--- a/plugins/cuda/cuda_plugin.c
+++ b/plugins/cuda/cuda_plugin.c
@@ -391,13 +391,13 @@ int cuda_plugin_checkpoint_devices(int pid)
 	if (resume_restore_thread(restore_tid, &save_sigset)) {
 		return -1;
 	}
+
+	task_info->checkpointed = 1;
 	status = cuda_process_checkpoint_action(pid, ACTION_CHECKPOINT, 0, msg_buf, sizeof(msg_buf));
 	if (status) {
 		pr_err("CHECKPOINT_DEVICES failed with %s\n", msg_buf);
 		goto interrupt;
 	}
-
-	task_info->checkpointed = 1;
 
 interrupt:
 	int_ret = interrupt_restore_thread(restore_tid, &save_sigset);


### PR DESCRIPTION
When creating a checkpoint of large models, the `checkpoint` action of `cuda-checkpoint` can exceed the CRIU timeout. This causes CRIU to fail with the following error, leaving the CUDA task in a locked state:

	cuda_plugin: Checkpointing CUDA devices on pid 84145 restore_tid 84202
	Error (criu/cr-dump.c:1791): Timeout reached. Try to interrupt: 0
	Error (cuda_plugin.c:139): cuda_plugin: Unable to read output of cuda-checkpoint: Interrupted system call
	Error (cuda_plugin.c:396): cuda_plugin: CHECKPOINT_DEVICES failed with
	net: Unlock network
	cuda_plugin: finished cuda_plugin stage 0 err -1
	cuda_plugin: resuming devices on pid 84145
	cuda_plugin: Restore thread pid 84202 found for real pid 84145
	Unfreezing tasks into 1
		Unseizing 84145 into 1
	Error (criu/cr-dump.c:2111): Dumping FAILED.

To fix this, we set `task_info->checkpointed` before invoking the `checkpoint` action to ensure that the CUDA task is resumed even if CRIU times out.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
