### PR TITLE
net: remember the name of the lock chain (nftables)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,7 @@ task:
     ln -sf /usr/include/google/protobuf/descriptor.proto images/google/protobuf/descriptor.proto
     dnf config-manager --set-enabled crb # Same as CentOS 8 powertools
     dnf -y install epel-release epel-next-release
-    dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python-junit_xml python3-importlib-metadata xmlto libdrm-devel
+    dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python-junit_xml python3-importlib-metadata xmlto libdrm-devel libuuid-devel
     # The image has a too old version of nettle which does not work with gnutls.
     # Just upgrade to the latest to make the error go away.
     dnf -y upgrade nettle nettle-devel

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -19,7 +19,7 @@ jobs:
         # Checkout pull request HEAD commit instead of merge commit
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Install dependencies
-      run: sudo scripts/ci/apt-install libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf libnl-3-dev libnet-dev libcap-dev
+      run: sudo scripts/ci/apt-install libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf libnl-3-dev libnet-dev libcap-dev uuid-dev
     - name: Configure git user details
       run: |
         git config --global user.email "checkpoint-restore@users.noreply.github.com"

--- a/compel/include/uapi/infect-util.h
+++ b/compel/include/uapi/infect-util.h
@@ -3,11 +3,20 @@
 
 #include "common/compiler.h"
 
+/**
+ * The length of the hash is based on what libuuid provides.
+ * According to the manpage this is:
+ *
+ * The uuid_unparse() function converts the supplied UUID uu from the binary
+ * representation into a 36-byte string (plus trailing '\0')
+ */
+#define RUN_ID_HASH_LENGTH 37
+
 /*
  * compel_run_id is a unique value of the current run. It can be used to
  * generate resource ID-s to avoid conflicts with other processes.
  */
-extern uint64_t compel_run_id;
+extern char compel_run_id[RUN_ID_HASH_LENGTH];
 
 struct parasite_ctl;
 extern int __must_check compel_util_send_fd(struct parasite_ctl *ctl, int fd);

--- a/compel/src/lib/infect-util.c
+++ b/compel/src/lib/infect-util.c
@@ -7,7 +7,7 @@
 #include "infect-rpc.h"
 #include "infect-util.h"
 
-uint64_t compel_run_id;
+char compel_run_id[RUN_ID_HASH_LENGTH];
 
 int compel_util_send_fd(struct parasite_ctl *ctl, int fd)
 {

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -427,7 +427,7 @@ static int gen_parasite_saddr(struct sockaddr_un *saddr, int key)
 	int sun_len;
 
 	saddr->sun_family = AF_UNIX;
-	snprintf(saddr->sun_path, UNIX_PATH_MAX, "X/crtools-pr-%d-%" PRIx64, key, compel_run_id);
+	snprintf(saddr->sun_path, UNIX_PATH_MAX, "X/crtools-pr-%d-%s", key, compel_run_id);
 
 	sun_len = SUN_LEN(saddr);
 	*saddr->sun_path = '\0';

--- a/criu/Makefile.packages
+++ b/criu/Makefile.packages
@@ -6,6 +6,7 @@ REQ-RPM-PKG-NAMES	+= protobuf-devel
 REQ-RPM-PKG-NAMES	+= protobuf-python
 REQ-RPM-PKG-NAMES	+= libnl3-devel
 REQ-RPM-PKG-NAMES	+= libcap-devel
+REQ-RPM-PKG-NAMES	+= libuuid-devel
 
 REQ-RPM-PKG-TEST-NAMES  += libaio-devel
 
@@ -16,6 +17,7 @@ REQ-DEB-PKG-NAMES	+= protobuf-compiler
 REQ-DEB-PKG-NAMES	+= $(PYTHON)-protobuf
 REQ-DEB-PKG-NAMES	+= libnl-3-dev
 REQ-DEB-PKG-NAMES	+= libcap-dev
+REQ-DEB-PKG-NAMES	+= uuid-dev
 
 REQ-DEB-PKG-TEST-NAMES	+= $(PYTHON)-yaml
 REQ-DEB-PKG-TEST-NAMES	+= libaio-dev
@@ -25,7 +27,7 @@ REQ-DEB-PKG-TEST-NAMES	+= libaio-dev
 REQ-RPM-PKG-TEST-NAMES	+= $(PYTHON)-PyYAML
 
 
-export LIBS		+= -lprotobuf-c -ldl -lnl-3 -lsoccr -Lsoccr/ -lnet
+export LIBS		+= -lprotobuf-c -ldl -lnl-3 -lsoccr -Lsoccr/ -lnet -luuid
 
 check-packages-failed:
 	$(warning Can not find some of the required libraries)

--- a/criu/fdstore.c
+++ b/criu/fdstore.c
@@ -58,7 +58,7 @@ int fdstore_init(void)
 	}
 
 	addr.sun_family = AF_UNIX;
-	addrlen = snprintf(addr.sun_path, sizeof(addr.sun_path), "X/criu-fdstore-%" PRIx64 "-%" PRIx64, st.st_ino,
+	addrlen = snprintf(addr.sun_path, sizeof(addr.sun_path), "X/criu-fdstore-%" PRIx64 "-%s", st.st_ino,
 			   criu_run_id);
 	addrlen += sizeof(addr.sun_family);
 

--- a/criu/files.c
+++ b/criu/files.c
@@ -978,7 +978,7 @@ static int receive_fd(struct fdinfo_list_entry *fle);
 static void transport_name_gen(struct sockaddr_un *addr, int *len, int pid)
 {
 	addr->sun_family = AF_UNIX;
-	snprintf(addr->sun_path, UNIX_PATH_MAX, "x/crtools-fd-%d-%" PRIx64, pid, criu_run_id);
+	snprintf(addr->sun_path, UNIX_PATH_MAX, "x/crtools-fd-%d-%s", pid, criu_run_id);
 	*len = SUN_LEN(addr);
 	*addr->sun_path = '\0';
 }

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -424,6 +424,8 @@ extern int run_command(char *buf, size_t buf_size, int (*child_fn)(void *), void
  */
 extern char criu_run_id[RUN_ID_HASH_LENGTH];
 extern void util_init(void);
+#define NO_DUMP_CRIU_RUN_ID 0x7f
+extern char dump_criu_run_id[RUN_ID_HASH_LENGTH];
 
 extern char *resolve_mountpoint(char *path);
 

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -21,6 +21,8 @@
 #include "log.h"
 #include "common/err.h"
 
+#include "compel/infect-util.h"
+
 #define PREF_SHIFT_OP(pref, op, size) ((size)op(pref##BYTES_SHIFT))
 #define KBYTES_SHIFT		      10
 #define MBYTES_SHIFT		      20
@@ -420,7 +422,7 @@ extern int run_command(char *buf, size_t buf_size, int (*child_fn)(void *), void
  * criu_run_id is a unique value of the current run. It can be used to
  * generate resource ID-s to avoid conflicts with other CRIU processes.
  */
-extern uint64_t criu_run_id;
+extern char criu_run_id[RUN_ID_HASH_LENGTH];
 extern void util_init(void);
 
 extern char *resolve_mountpoint(char *path);

--- a/criu/pidfd-store.c
+++ b/criu/pidfd-store.c
@@ -99,7 +99,7 @@ int init_pidfd_store_sk(pid_t pid, int sk)
 			goto err;
 		}
 
-		addrlen = snprintf(addr.sun_path, sizeof(addr.sun_path), "X/criu-pidfd-store-%d-%d-%" PRIx64, pid, sk,
+		addrlen = snprintf(addr.sun_path, sizeof(addr.sun_path), "X/criu-pidfd-store-%d-%d-%s", pid, sk,
 				   criu_run_id);
 		addrlen += sizeof(addr.sun_family);
 

--- a/criu/unittest/mock.c
+++ b/criu/unittest/mock.c
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "compel/infect-util.h"
+
 int add_external(char *key)
 {
 	return 0;
@@ -141,4 +143,4 @@ int check_mount_v2(void)
 	return 0;
 }
 
-uint64_t compel_run_id;
+char compel_run_id[RUN_ID_HASH_LENGTH];

--- a/images/inventory.proto
+++ b/images/inventory.proto
@@ -29,4 +29,8 @@ message inventory_entry {
 	optional bool			tcp_close	= 10;
 	optional uint32			network_lock_method	= 11;
 	optional plugins_entry		plugins_entry = 12;
+	// Remember the criu_run_id when CRIU dumped the process.
+	// This is currently used to delete the correct nftables
+	// network locking rule.
+	optional string                 dump_criu_run_id        = 13;
 }

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -24,7 +24,8 @@ RUN apk update && apk add \
 	sudo \
 	libcap-utils \
 	libdrm-dev \
-	util-linux
+	util-linux \
+	util-linux-dev
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/build/Dockerfile.amd-rocm
+++ b/scripts/build/Dockerfile.amd-rocm
@@ -56,6 +56,7 @@ RUN apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-insta
 	python-protobuf \
 	python3-minimal \
 	python-ipaddress \
+	uuid-dev \
 	curl \
 	wget \
 	vim \

--- a/scripts/build/Dockerfile.archlinux
+++ b/scripts/build/Dockerfile.archlinux
@@ -35,6 +35,7 @@ RUN pacman -Syu --noconfirm \
 	python-junit-xml \
 	python-importlib-metadata \
 	libdrm \
+	util-linux-libs \
 	diffutils
 
 COPY . /criu

--- a/scripts/build/Dockerfile.hotspot-alpine
+++ b/scripts/build/Dockerfile.hotspot-alpine
@@ -19,6 +19,7 @@ RUN apk update && apk add \
 	maven \
 	ip6tables \
 	iptables \
+	util-linux-dev \
 	bash
 
 COPY . /criu

--- a/scripts/build/Dockerfile.hotspot-ubuntu
+++ b/scripts/build/Dockerfile.hotspot-ubuntu
@@ -22,6 +22,7 @@ RUN apt-install protobuf-c-compiler \
 	pkg-config \
 	iptables \
 	gcc \
+	uuid-dev \
 	maven
 
 COPY . /criu

--- a/scripts/build/Dockerfile.linux32.tmpl
+++ b/scripts/build/Dockerfile.linux32.tmpl
@@ -21,6 +21,7 @@ RUN apt-install \
 	pkg-config \
 	protobuf-c-compiler \
 	protobuf-compiler \
+	uuid-dev \
 	python3-minimal
 
 COPY . /criu

--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -22,6 +22,7 @@ RUN apt-install protobuf-c-compiler \
 	pkg-config \
 	iptables \
 	gcc \
+	uuid-dev \
 	maven
 
 RUN mkdir -p /etc/criu && echo 'ghost-limit 16777216' > /etc/criu/default.conf

--- a/scripts/build/Dockerfile.riscv64-stable-cross.tmpl
+++ b/scripts/build/Dockerfile.riscv64-stable-cross.tmpl
@@ -33,6 +33,7 @@ RUN apt-get install -y --no-install-recommends \
 	libprotobuf-c-dev:${DEBIAN_ARCH}	\
 	libcap-dev:${DEBIAN_ARCH}		\
 	libaio-dev:${DEBIAN_ARCH}		\
+	uuid-dev:${DEBIAN_ARCH}			\
 	libnl-route-3-dev:${DEBIAN_ARCH}	\
 	libnftables-dev:${DEBIAN_ARCH}	\
 	libgnutls28-dev:${DEBIAN_ARCH}	\

--- a/scripts/build/Dockerfile.stable-cross.tmpl
+++ b/scripts/build/Dockerfile.stable-cross.tmpl
@@ -18,6 +18,7 @@ RUN apt-install \
 	libnl-3-dev:${DEBIAN_ARCH}		\
 	libprotobuf-dev:${DEBIAN_ARCH}		\
 	libnet-dev:${DEBIAN_ARCH}		\
+	uuid-dev:${DEBIAN_ARCH}			\
 	libprotobuf-c-dev:${DEBIAN_ARCH}	\
 	libcap-dev:${DEBIAN_ARCH}		\
 	libaio-dev:${DEBIAN_ARCH}		\

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -29,6 +29,7 @@ RUN apt-install \
 	protobuf-compiler \
 	python3-minimal \
 	python3-protobuf \
+	uuid-dev \
 	python3-yaml
 
 COPY . /criu

--- a/scripts/build/Dockerfile.unstable-cross.tmpl
+++ b/scripts/build/Dockerfile.unstable-cross.tmpl
@@ -17,6 +17,7 @@ RUN apt-install \
 	python3-protobuf			\
 	libnl-3-dev:${DEBIAN_ARCH}		\
 	libprotobuf-dev:${DEBIAN_ARCH}		\
+	uuid-dev:${DEBIAN_ARCH}			\
 	libnet-dev:${DEBIAN_ARCH}		\
 	libprotobuf-c-dev:${DEBIAN_ARCH}	\
 	libcap-dev:${DEBIAN_ARCH}		\

--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -36,6 +36,7 @@ dnf install -y \
 	e2fsprogs \
 	rubygem-asciidoctor \
 	libdrm-devel \
+	libuuid-devel \
 	kmod
 
 # /tmp is no longer 755 in the rawhide container image and breaks CI - fix it

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -4,7 +4,7 @@ set -x -e
 CI_PKGS=(protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
 		libgnutls30 libprotobuf-dev protobuf-compiler libcap-dev
 		libnl-3-dev gdb bash libnet-dev util-linux asciidoctor
-		libnl-route-3-dev time libbsd-dev python3-yaml
+		libnl-route-3-dev time libbsd-dev python3-yaml uuid-dev
 		libperl-dev pkg-config python3-protobuf python3-pip
 		python3-importlib-metadata python3-junit.xml libdrm-dev)
 

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -39,7 +39,7 @@ setup() {
 	ssh default sudo dnf install -y gcc git gnutls-devel nftables-devel libaio-devel \
 		libasan libcap-devel libnet-devel libnl3-devel libbsd-devel make protobuf-c-devel \
 		protobuf-devel python3-protobuf python3-importlib-metadata python3-junit_xml \
-		rubygem-asciidoctor iptables libselinux-devel libbpf-devel python3-yaml
+		rubygem-asciidoctor iptables libselinux-devel libbpf-devel python3-yaml libuuid-devel
 	# Disable sssd to avoid zdtm test failures in pty04 due to sssd socket
 	ssh default sudo systemctl mask sssd
 	ssh default cat /proc/cmdline


### PR DESCRIPTION
Using libnftables the chain to lock the network is composed of ("CRIU-%d", real_pid). This leads to around 40 zdtm tests failing with errors like this:
```
Error: No such file or directory; did you mean table 'CRIU-62' in family inet?
delete table inet CRIU-86
```
The reason is that as soon as a process is running in a namespace the real PID can be anything and only the PID in the namespace is restored correctly. Relying on the real PID does not work for the chain name.

Using the PID of the innermost namespace would lead to the chain be called 'CRIU-1' most of the time which is also not really unique.

The uniqueness of the name was always problematic. With this change all tests are working again which rely on network locking if the nftables backend is used for network locking.