### PR TITLE
seize: Adjust the position of the log message

### DIFF
--- a/criu/seize.c
+++ b/criu/seize.c
@@ -674,8 +674,6 @@ static int collect_children(struct pstree_item *item)
 			goto free;
 		}
 
-		pr_info("Seized task %d, state %d\n", pid, ret);
-
 		c = alloc_pstree_item();
 		if (c == NULL) {
 			ret = -1;
@@ -712,6 +710,8 @@ static int collect_children(struct pstree_item *item)
 
 		if (ret == TASK_STOPPED)
 			c->pid->stop_signo = compel_parse_stop_signo(pid);
+
+		pr_info("Seized task %d, state %d\n", pid, ret);
 
 		c->pid->real = pid;
 		c->parent = item;


### PR DESCRIPTION
Based on the code, the `ret` variable at this point does not represent the task state, so this log message should be moved to a position after the `compel_wait_task()` function.