### PR TITLE
sk-inet: Add support for checkpoint/restore of ICMP sockets

### DIFF
--- a/criu/include/sysctl.h
+++ b/criu/include/sysctl.h
@@ -37,6 +37,6 @@ enum {
 #define CTL_FLAGS_OPTIONAL	  1
 #define CTL_FLAGS_HAS		  2
 #define CTL_FLAGS_READ_EIO_SKIP	  4
-#define CTL_FLAGS_IPC_EACCES_SKIP 5
+#define CTL_FLAGS_IPC_EACCES_SKIP 8
 
 #endif /* __CR_SYSCTL_H__ */

--- a/criu/net.c
+++ b/criu/net.c
@@ -2147,7 +2147,7 @@ static int ipv4_sysctls_op(SysctlEntry ***rsysctl, size_t *pn, int op)
 	size_t n = *pn;
 
 	if (n != ARRAY_SIZE(ipv4_sysctl_entries)) {
-		pr_err("unix: Unexpected entries in sysctlig (%zu %zu)\n", n, ARRAY_SIZE(ipv4_sysctl_entries));
+		pr_err("unix: Unexpected entries in sysctl (%zu %zu)\n", n, ARRAY_SIZE(ipv4_sysctl_entries));
 		return -EINVAL;
 	}
 

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -130,6 +130,8 @@ static int can_dump_ipproto(unsigned int ino, int proto, int type)
 	case IPPROTO_TCP:
 	case IPPROTO_UDP:
 	case IPPROTO_UDPLITE:
+	case IPPROTO_ICMP:
+	case IPPROTO_ICMPV6:
 		break;
 	default:
 		pr_err("Unsupported proto %d for socket %x\n", proto, ino);
@@ -922,8 +924,9 @@ static int open_inet_sk(struct file_desc *d, int *new_fd)
 	}
 
 	if (ie->src_port) {
-		if (inet_bind(sk, ii))
-			goto err;
+		if (ie->proto != IPPROTO_ICMP && ie->proto != IPPROTO_ICMPV6)
+			if (inet_bind(sk, ii))
+				goto err;
 	}
 
 	/*

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -65,7 +65,7 @@ const char *socket_proto_name(unsigned int proto, char *nm, size_t size)
 		[IPPROTO_IPV6] = __stringify_1(IPPROTO_IPV6), [IPPROTO_RSVP] = __stringify_1(IPPROTO_RSVP),
 		[IPPROTO_GRE] = __stringify_1(IPPROTO_GRE),   [IPPROTO_ESP] = __stringify_1(IPPROTO_ESP),
 		[IPPROTO_AH] = __stringify_1(IPPROTO_AH),     [IPPROTO_UDPLITE] = __stringify_1(IPPROTO_UDPLITE),
-		[IPPROTO_RAW] = __stringify_1(IPPROTO_RAW),
+		[IPPROTO_RAW] = __stringify_1(IPPROTO_RAW),   [IPPROTO_ICMPV6] = __stringify_1(IPPROTO_ICMPV6),
 	};
 	return __socket_const_name(nm, size, protos, ARRAY_SIZE(protos), proto);
 }
@@ -131,10 +131,12 @@ enum socket_cl_bits {
 	INET_UDP_CL_BIT,
 	INET_UDPLITE_CL_BIT,
 	INET_RAW_CL_BIT,
+	INET_ICMP_CL_BIT,
 	INET6_TCP_CL_BIT,
 	INET6_UDP_CL_BIT,
 	INET6_UDPLITE_CL_BIT,
 	INET6_RAW_CL_BIT,
+	INET6_ICMP_CL_BIT,
 	UNIX_CL_BIT,
 	PACKET_CL_BIT,
 	_MAX_CL_BIT,
@@ -161,6 +163,8 @@ static inline enum socket_cl_bits get_collect_bit_nr(unsigned int family, unsign
 			return INET_UDPLITE_CL_BIT;
 		if (proto == IPPROTO_RAW)
 			return INET_RAW_CL_BIT;
+		if (proto == IPPROTO_ICMP)
+			return INET_ICMP_CL_BIT;
 	}
 	if (family == AF_INET6) {
 		if (proto == IPPROTO_TCP)
@@ -171,6 +175,8 @@ static inline enum socket_cl_bits get_collect_bit_nr(unsigned int family, unsign
 			return INET6_UDPLITE_CL_BIT;
 		if (proto == IPPROTO_RAW)
 			return INET6_RAW_CL_BIT;
+		if (proto == IPPROTO_ICMPV6)
+			return INET6_ICMP_CL_BIT;
 	}
 
 	pr_err("Unknown pair family %d proto %d\n", family, proto);
@@ -280,6 +286,12 @@ void preload_socket_modules(void)
 	probe_diag(nl, &req, -ENOENT);
 
 	req.r.i.sdiag_protocol = IPPROTO_RAW;
+	probe_diag(nl, &req, -ENOENT);
+
+	req.r.i.sdiag_protocol = IPPROTO_ICMP;
+	probe_diag(nl, &req, -ENOENT);
+
+	req.r.i.sdiag_protocol = IPPROTO_ICMPV6;
 	probe_diag(nl, &req, -ENOENT);
 
 	close(nl);
@@ -773,6 +785,10 @@ static int inet_receive_one(struct nlmsghdr *h, struct ns_id *ns, void *arg)
 	case IPPROTO_RAW:
 		type = SOCK_RAW;
 		break;
+	case IPPROTO_ICMP:
+	case IPPROTO_ICMPV6:
+		type = SOCK_DGRAM;
+		break;
 	default:
 		BUG_ON(1);
 		return -1;
@@ -797,7 +813,7 @@ static int collect_err(int err, struct ns_id *ns, void *arg)
 	char family[32], proto[32];
 	char msg[256];
 
-	snprintf(msg, sizeof(msg), "Sockects collect procedure family %s proto %s",
+	snprintf(msg, sizeof(msg), "Sockets collect procedure family %s proto %s",
 		 socket_family_name(gr->family, family, sizeof(family)),
 		 socket_proto_name(gr->protocol, proto, sizeof(proto)));
 
@@ -905,6 +921,13 @@ int collect_sockets(struct ns_id *ns)
 	if (tmp)
 		err = tmp;
 
+	/* Collect IPv4 ICMP sockets */
+	req.r.i.sdiag_family = AF_INET;
+	req.r.i.sdiag_protocol = IPPROTO_ICMP;
+	req.r.i.idiag_ext = 0;
+	req.r.i.idiag_states = -1; /* All */
+	set_collect_bit(req.r.n.sdiag_family, req.r.n.sdiag_protocol);
+
 	/* Collect IPv6 TCP sockets */
 	req.r.i.sdiag_family = AF_INET6;
 	req.r.i.sdiag_protocol = IPPROTO_TCP;
@@ -943,6 +966,13 @@ int collect_sockets(struct ns_id *ns)
 	tmp = do_collect_req(nl, &req, sizeof(req), inet_receive_one, collect_err, ns, &req.r.i);
 	if (tmp)
 		err = tmp;
+
+	/* Collect IPv6 ICMP sockets */
+	req.r.i.sdiag_family = AF_INET6;
+	req.r.i.sdiag_protocol = IPPROTO_ICMPV6;
+	req.r.i.idiag_ext = 0;
+	req.r.i.idiag_states = -1; /* All */
+	set_collect_bit(req.r.n.sdiag_family, req.r.n.sdiag_protocol);
 
 	req.r.p.sdiag_family = AF_PACKET;
 	req.r.p.sdiag_protocol = 0;

--- a/test/zdtm/Makefile.inc
+++ b/test/zdtm/Makefile.inc
@@ -76,7 +76,7 @@ endef
 
 %.d: %.c
 	$(E) " DEP      " $@
-	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -MM -MP -c $< -o $@
+	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -MM -MP $< -o $@
 
 %.o: %.c | %.d
 	$(E) " CC       " $@

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -37,6 +37,8 @@ TST_NOFILE	:=				\
 		socket_udp-corked		\
 		socket6_udp			\
 		socket_udp_shutdown		\
+		socket_icmp			\
+		socket6_icmp			\
 		sk-freebind			\
 		sk-freebind-false		\
 		socket_udplite			\
@@ -630,6 +632,7 @@ socket-tcp6-closed:	CFLAGS += -D ZDTM_IPV6
 socket-tcp6-closed:	CFLAGS += -D ZDTM_IPV4V6
 socket-tcp-closed-last-ack:	CFLAGS += -D ZDTM_TCP_LAST_ACK
 socket-tcp-skip-in-flight:	CFLAGS += -D ZDTM_IPV4V6
+socket6-icmp:		CFLAGS += -DZDTM_IPV6
 sock_ip_opts01:		CFLAGS += -DZDTM_VAL_ZERO
 sock_tcp_opts01:	CFLAGS += -DZDTM_VAL_ZERO
 tun_ns:			CFLAGS += -DTUN_NS

--- a/test/zdtm/static/netns_sub_sysctl.desc
+++ b/test/zdtm/static/netns_sub_sysctl.desc
@@ -1,4 +1,4 @@
 {
-    'flavor': 'ns',
+    'flavor': 'ns uns',
     'flags': 'suid'
 }

--- a/test/zdtm/static/socket6_icmp.c
+++ b/test/zdtm/static/socket6_icmp.c
@@ -1,0 +1,1 @@
+socket_icmp.c

--- a/test/zdtm/static/socket_icmp.c
+++ b/test/zdtm/static/socket_icmp.c
@@ -1,0 +1,128 @@
+#include "zdtmtst.h"
+
+const char *test_doc = "static test for ICMP socket\n";
+const char *test_author = "समीर सिंह Sameer Singh <lumarzeli30@gmail.com>\n";
+
+/* Description:
+ * Send a ping to localhost using ICMP socket
+ */
+
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#if defined(ZDTM_IPV6)
+#include <netinet/icmp6.h>
+#else
+#include <netinet/ip_icmp.h>
+#endif
+#include <arpa/inet.h>
+#include <sys/time.h>
+#include <netdb.h>
+
+#include "sysctl.h"
+
+#define PACKET_SIZE  64
+#define RECV_TIMEOUT 1
+
+static int echo_id = 1234;
+
+#if defined(ZDTM_IPV6)
+#define TEST_ICMP_ECHOREPLY ICMP6_ECHOREPLY
+#else
+#define TEST_ICMP_ECHOREPLY ICMP_ECHOREPLY
+#endif
+int main(int argc, char **argv)
+{
+	int ret, sock, seq = 0;
+	char packet[PACKET_SIZE], recv_packet[PACKET_SIZE];
+
+	struct timeval tv;
+#if defined(ZDTM_IPV6)
+	struct sockaddr_in6 addr, recv_addr;
+#else
+	struct icmphdr icmp_header, *icmp_reply;
+#endif
+	struct sockaddr_in addr, recv_addr;
+	socklen_t addr_len;
+
+	// Allow GIDs 0-58468 to open an unprivileged ICMP socket
+	if (sysctl_write_str("/proc/sys/net/ipv4/ping_group_range", "0 58468"))
+		return -1;
+
+	test_init(argc, argv);
+
+#if defined(ZDTM_IPV6)
+	sock = socket(PF_INET6, SOCK_DGRAM, IPPROTO_ICMPV6);
+#else
+	sock = socket(PF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+#endif
+	if (sock < 0) {
+		pr_perror("Can't create socket");
+		return 1;
+	}
+
+	tv.tv_sec = RECV_TIMEOUT;
+	tv.tv_usec = 0;
+	if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+		pr_perror("Can't set socket option");
+		return 1;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+	memset(&icmp_header, 0, sizeof(icmp_header));
+#if defined(ZDTM_IPV6)
+	addr.sin6_family = AF_INET6;
+	inet_pton(AF_INET6, "::1", &addr.sin6_addr);
+
+	icmp_header.icmp6_type = ICMP6_ECHO_REQUEST;
+	icmp_header.icmp6_code = 0;
+	icmp_header.icmp6_id = echo_id;
+	icmp_header.icmp6_seq = seq;
+#else
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+	icmp_header.type = ICMP_ECHO;
+	icmp_header.code = 0;
+	icmp_header.un.echo.id = echo_id;
+	icmp_header.un.echo.sequence = seq;
+#endif
+
+	memcpy(packet, &icmp_header, sizeof(icmp_header));
+	memset(packet + sizeof(icmp_header), 0xa5,
+	       PACKET_SIZE - sizeof(icmp_header));
+
+	test_daemon();
+	test_waitsig();
+
+	ret = sendto(sock, packet, PACKET_SIZE, 0,
+		     (struct sockaddr *)&addr, sizeof(addr));
+
+	if (ret < 0) {
+		fail("Can't send");
+		return 1;
+	}
+
+	addr_len = sizeof(recv_addr);
+
+	ret = recvfrom(sock, recv_packet, sizeof(recv_packet), 0,
+		       (struct sockaddr *)&recv_addr, &addr_len);
+
+	if (ret < 0) {
+		fail("Can't recv");
+		return 1;
+	}
+
+	icmp_reply = (struct icmphdr *)recv_packet;
+
+	if (icmp_reply->type != ICMP_ECHOREPLY) {
+		fail("Got no ICMP_ECHO_REPLY");
+		return 1;
+	}
+
+	close(sock);
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
Currently there is no option to checkpoint/restore programs that use ICMP sockets, such as `ping`. This patch adds support for the same.

Fixes #2557

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
