### PR TITLE
Update timer handling to properly respect the it_value field

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -2210,7 +2210,7 @@ __visible long __export_restore_task(struct task_restore_args *args)
 	 * code below doesn't fail due to bad timing values.
 	 */
 
-#define itimer_armed(args, i) (args->itimers[i].it_interval.tv_sec || args->itimers[i].it_interval.tv_usec)
+#define itimer_armed(args, i) (args->itimers[i].it_interval.tv_sec || args->itimers[i].it_interval.tv_usec || args->itimers[i].it_value.tv_sec || args->itimers[i].it_value.tv_usec)
 
 	if (itimer_armed(args, 0))
 		sys_setitimer(ITIMER_REAL, &args->itimers[0], NULL);

--- a/criu/timer.c
+++ b/criu/timer.c
@@ -16,7 +16,7 @@ static inline int timeval_valid(struct timeval *tv)
 
 static inline int decode_itimer(char *n, ItimerEntry *ie, struct itimerval *val)
 {
-	if (ie->isec == 0 && ie->iusec == 0) {
+	if (ie->isec == 0 && ie->iusec == 0 && ie->vsec == 0 && ie->vusec == 0) {
 		memzero_p(val);
 		return 0;
 	}
@@ -29,17 +29,8 @@ static inline int decode_itimer(char *n, ItimerEntry *ie, struct itimerval *val)
 		return -1;
 	}
 
-	if (ie->vsec == 0 && ie->vusec == 0) {
-		/*
-		 * Remaining time was too short. Set it to
-		 * interval to make the timer armed and work.
-		 */
-		val->it_value.tv_sec = ie->isec;
-		val->it_value.tv_usec = ie->iusec;
-	} else {
-		val->it_value.tv_sec = ie->vsec;
-		val->it_value.tv_usec = ie->vusec;
-	}
+	val->it_value.tv_sec = ie->vsec;
+	val->it_value.tv_usec = ie->vusec;
 
 	if (!timeval_valid(&val->it_value)) {
 		pr_err("Invalid timer value\n");


### PR DESCRIPTION
- Modify itimer_armed macro in restorer.c to consider it_value
- Simplify decode_itimer function in timer.c to use provided it_value
- Remove conditional logic that set it_value to interval

Fixes #2559 
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
