### PR TITLE
test: fix cmdlinenv00 on aarch64

### DIFF
--- a/criu/arch/aarch64/include/asm/types.h
+++ b/criu/arch/aarch64/include/asm/types.h
@@ -33,7 +33,16 @@ static inline uint64_t encode_pointer(void *p)
 	return (uint64_t)p;
 }
 
-#define AT_VECTOR_SIZE 40
+/**
+ * See also:
+ *   * arch/arm64/include/uapi/asm/auxvec.h
+ *   * include/linux/auxvec.h
+ *   * include/linux/mm_types.h
+ */
+#define AT_VECTOR_SIZE_BASE 22
+#define AT_VECTOR_SIZE_ARCH 2
+#define AT_VECTOR_SIZE (2*(AT_VECTOR_SIZE_ARCH + AT_VECTOR_SIZE_BASE + 1))
+
 typedef uint64_t auxv_t;
 typedef uint64_t tls_t;
 


### PR DESCRIPTION
On aarch64 the test cmdlinenv00 was failing with:
```
  FAIL: cmdlinenv00.c:120: auxv corrupted on restore (errno = 11 (Resource temporarily unavailable))
```
Starting with Linux kernel version 6.3 the size of AUXV was changed:
```
    commit 28c8e088427ad30b4260953f3b6f908972b77c2d
    Author: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
    Date:   Wed Jan 4 14:20:54 2023 -0500

        rseq: Increase AT_VECTOR_SIZE_BASE to match rseq auxvec entries

        Two new auxiliary vector entries are introduced for rseq without
        matching increment of the AT_VECTOR_SIZE_BASE, which causes failures
        with CONFIG_HARDENED_USERCOPY=y.

        Fixes: 317c8194e6ae ("rseq: Introduce feature size and alignment ELF auxiliary vector entries")
```

https://github.com/torvalds/linux/commit/28c8e088427ad30b4260953f3b6f908972b77c2d

With this change AT_VECTOR_SIZE increases from 40 to 50 on aarch64. CRIU uses AT_VECTOR_SIZE to read the content of /proc/PID/auxv
```C
        auxv_t mm_saved_auxv[AT_VECTOR_SIZE];
        ret = read(fd, mm_saved_auxv, sizeof(mm_saved_auxv));
```
Now the tests works again on aarch64.