### PR TITLE
.gitignore: Add compilation database file and directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ compel/include/asm
 include/common/asm
 include/common/config.h
 build/**
+
+# Clang's compilation database file and directory.
+/.cache
+/compile_commands.json


### PR DESCRIPTION
The tool 'bear'[1] can be used to generate the C language server protocol database file while compiling: 'bear -- make'

Add the database file into .gitignore as Linux Kernel [2] does.

The clangd will parse the compile_commands.json language metadata into the .cache directory. Add it for clean git status track.

[1]: https://github.com/rizsotto/Bear
[2]: https://git.kernel.org/torvalds/c/26c4c71bcd9a

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
