### PR TITLE
Makefile: move codespell options to .codespellrc

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = ./.git,./test/pki
+skip = ./.git,./test/pki,./tags
 ignore-words-list = creat,fpr,fle,ue,bord,parms,nd,te,testng,inh,wronly,renderd,bui,clen,sems

--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ shellcheck:
 	shellcheck -x test/others/action-script/*.sh
 
 codespell:
-	codespell -S tags
+	codespell
 
 lint: ruff shellcheck codespell
 	# Do not append \n to pr_perror, pr_pwarn or fail


### PR DESCRIPTION
This way,
 - Makefile is less cluttered;
 - one can run codespell from the command line.

Fixes: fd7e97fcf ("lint: exclude tags file from codespell")

