### PR TITLE
optimize: make mntinfo_add_list O(1) by adding a tail pointer

### DIFF
--- a/criu/mount.c
+++ b/criu/mount.c
@@ -110,18 +110,17 @@ static char *ext_mount_lookup(char *key)
  * Single linked list of mount points get from proc/images
  */
 struct mount_info *mntinfo;
+struct mount_info *mntinfo_tail;
 
 static void mntinfo_add_list(struct mount_info *new)
 {
-	if (!mntinfo)
+	if (!mntinfo) {
 		mntinfo = new;
+        mntinfo_tail = mntinfo;
+    }
 	else {
-		struct mount_info *pm;
-
-		/* Add to the tail. (FIXME -- make O(1) ) */
-		for (pm = mntinfo; pm->next != NULL; pm = pm->next)
-			;
-		pm->next = new;
+        mntinfo_tail->next = new;
+        mntinfo_tail = mntinfo_tail->next;     
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
The `mntinfo_add_list` function previously traversed the entire linked list to find the tail node, resulting in a **time complexity** of **O(n)**. This commit introduces a `mntinfo_tail` pointer to track the last node of the list, reducing the **time complexity** of insertion to **O(1)**.

This change addresses the `FIXME` comment in the code and improves performance for large lists.
