### PR TITLE
Fixes: internal representation of cgroups hierarchical structure

### DIFF
--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -248,7 +248,7 @@ static int find_dir(const char *path, struct list_head *dirs, struct cgroup_dir 
 			return EXACT_MATCH;
 		}
 
-		if (strstartswith(path, d->path)) {
+		if (issubpath(path, d->path)) {
 			int ret = find_dir(path, &d->children, rdir);
 			if (ret == NO_MATCH) {
 				*rdir = d;


### PR DESCRIPTION
What do i want:
 
I want to fix bug in function "find_dir()". Then CRIU add cgroups it search
parent directory for cgroup to add it in the correct place. But function
that check it - "strstartswith()" is incorrent in this context. For example:
 
New cgroup: /dsch_tasks
Existent cgroup: /dsch
 
The "strstartswith" will return TRUE (which is ok) but in our context
/dsch is not parent directory for /dsch_tasks.
 
Thats why i cannot restore my application. So i want to fix this bug:
"(00.002162) Error (criu/cgroup.c:1766): cg: failed to open cg dir fd
(freezer//dsch/tasks) for chowning: Not a directory"
 
How i want to do it:
  
I replace "strstartswith()" on to "issubpath()" function.
It is written exactly for this purpose.

Signed-off-by: Dmitrii Chervov <dschervov1@yandex.ru>
