### PR TITLE
lsm: use the user provided lsm label

### DIFF
--- a/criu/lsm.c
+++ b/criu/lsm.c
@@ -370,7 +370,7 @@ int render_lsm_profile(char *profile, char **val)
 	case LSMTYPE__APPARMOR:
 		return render_aa_profile(val, profile);
 	case LSMTYPE__SELINUX:
-		if (asprintf(val, "%s", profile) < 0) {
+		if (asprintf(val, "%s", opts.lsm_supplied ? opts.lsm_profile : profile) < 0) {
 			*val = NULL;
 			return -1;
 		}


### PR DESCRIPTION
Currently CRIU has the possibility to specify a LSM label during restore. Unfortunately the information is completely ignored in the case of SELinux.

This change selects the lsm label from the user if it is provided and else the label from the checkpoint image is used.