### PR TITLE
ci: install gawk for Fedora based tests

### DIFF
--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -4,6 +4,7 @@ set -e -x
 dnf install -y \
 	diffutils \
 	findutils \
+	gawk \
 	gcc \
 	git \
 	gnutls-devel \


### PR DESCRIPTION
Currently Fedora rawhide based CI runs fail with:

 /bin/sh: line 1: awk: command not found

Let's install it.