### PR TITLE
optimize: make mntinfo_add_list O(1) by adding a tail pointer

### DIFF
--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -90,6 +90,7 @@ struct mount_info {
 	int deleted_level;
 	struct list_head deleted_list;
 	struct mount_info *next;
+	struct mount_info *tail;
 	struct ns_id *nsid;
 
 	char *external;

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -113,21 +113,25 @@ struct mount_info *mntinfo;
 
 static void mntinfo_add_list(struct mount_info *new)
 {
-	if (!mntinfo)
+	if (!mntinfo) {
 		mntinfo = new;
+                mntinfo->tail = new->tail;
+        }
 	else {
-		struct mount_info *pm;
-
-		/* Add to the tail. (FIXME -- make O(1) ) */
-		for (pm = mntinfo; pm->next != NULL; pm = pm->next)
-			;
-		pm->next = new;
+                mntinfo->tail->next = new;
+                mntinfo->tail = new->tail;
 	}
 }
 
+struct mount_info *tail_buffer;
+
 void mntinfo_add_list_before(struct mount_info **head, struct mount_info *new)
 {
-	new->next = *head;
+    if(!*head)
+        tail_buffer = new;
+
+        new->next = *head;
+	new->tail = tail_buffer;
 	*head = new;
 }
 

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -115,11 +115,10 @@ static void mntinfo_add_list(struct mount_info *new)
 {
 	if (!mntinfo) {
 		mntinfo = new;
-                mntinfo->tail = new->tail;
-        }
-	else {
-                mntinfo->tail->next = new;
-                mntinfo->tail = new->tail;
+		mntinfo->tail = new->tail;
+	} else {
+		mntinfo->tail->next = new;
+		mntinfo->tail = new->tail;
 	}
 }
 
@@ -127,10 +126,11 @@ struct mount_info *tail_buffer;
 
 void mntinfo_add_list_before(struct mount_info **head, struct mount_info *new)
 {
-    if(!*head)
-        tail_buffer = new;
+	if (!*head) {
+		tail_buffer = new;
+	}
 
-        new->next = *head;
+	new->next = *head;
 	new->tail = tail_buffer;
 	*head = new;
 }
@@ -1202,7 +1202,7 @@ int __check_mountpoint_fd(struct mount_info *pm, int mnt_fd, bool parse_mountinf
 			return 0;
 
 		pr_warn("The file system %#x %#x (%#x) %s %s is inaccessible\n", pm->s_dev, pm->s_dev_rt, dev,
-		        pm->fstype->name, pm->ns_mountpoint);
+			pm->fstype->name, pm->ns_mountpoint);
 		return -1;
 	}
 
@@ -1959,7 +1959,7 @@ err:
 				_mi = list_entry(_mi->children._el, struct mount_info, siblings); \
 				continue;                                                         \
 			}                                                                         \
-		up:                                                                               \
+up:                                                                                               \
 			if (_fn_r(_mi))                                                           \
 				return -1;                                                        \
 			if (_mi == _r)                                                            \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
The mntinfo_add_list function previously traversed the entire linked list to find the tail node, resulting in a time complexity of O(n). This commit introduces a mntinfo_tail pointer to track the last node of the list, reducing the time complexity of insertion to O(1).