### PR TITLE
mnt: Optimize mntinfo_add_list to O(1) using a tail pointer

### DIFF
--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -90,6 +90,7 @@ struct mount_info {
 	int deleted_level;
 	struct list_head deleted_list;
 	struct mount_info *next;
+        struct list_head tail;
 	struct ns_id *nsid;
 
 	char *external;

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -110,23 +110,29 @@ static char *ext_mount_lookup(char *key)
  * Single linked list of mount points get from proc/images
  */
 struct mount_info *mntinfo;
+struct mount_info *tailbuffer;
 
 static void mntinfo_add_list(struct mount_info *new)
 {
 	if (!mntinfo)
 		mntinfo = new;
 	else {
-		struct mount_info *pm;
+                struct list_head *_tail = mntinfo->tail.next;
+                tailbuffer = list_entry(_tail, struct mount_info, tail);
 
-		/* Add to the tail. (FIXME -- make O(1) ) */
-		for (pm = mntinfo; pm->next != NULL; pm = pm->next)
-			;
-		pm->next = new;
+                tailbuffer->next = new;
+                mntinfo->tail = new->tail;
 	}
 }
 
 void mntinfo_add_list_before(struct mount_info **head, struct mount_info *new)
 {
+        if (!*head)
+                tailbuffer = new;
+
+        INIT_LIST_HEAD(&new->tail);
+        list_add_tail(&tailbuffer->tail, &new->tail);
+
 	new->next = *head;
 	*head = new;
 }


### PR DESCRIPTION
This patch optimizes the `mntinfo_add_list` function from O(n) to O(1) by introducing a tail pointer (`tailbuffer`) to track the end of the linked list. Previously, adding a new `mount_info` node required traversing the entire list to find the tail, which was inefficient for large lists.

Changes:
1. Added a `struct list_head tail` to the `mount_info` struct to maintain the tail pointer.
2. Introduced a global `tailbuffer` to store the current tail of the list.
3. Modified `mntinfo_add_list` to use `tailbuffer` for O(1) insertion at the tail.
4. Updated `mntinfo_add_list_before` to initialize the tail pointer and maintain consistency when adding nodes at the head.

The optimization significantly improves performance for operations involving large lists of mount information. This change also ensures that the list remains consistent and correctly updated during insertions.