### PR TITLE
kerndat: run iptables with -n to not resolve service names

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -646,7 +646,7 @@ static int kerndat_loginuid(void)
 static int kerndat_iptables_has_xtlocks(void)
 {
 	int fd;
-	char *argv[4] = { "sh", "-c", "iptables -w -L", NULL };
+	char *argv[4] = { "sh", "-c", "iptables -n -w -L", NULL };
 
 	fd = open("/dev/null", O_RDWR);
 	if (fd < 0) {


### PR DESCRIPTION
Resolving service names can be slow and it isn't needed here.

Fixes #2032

