### PR TITLE
kerndat: use numeric output with iptables

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -646,7 +646,7 @@ static int kerndat_loginuid(void)
 static int kerndat_iptables_has_xtlocks(void)
 {
 	int fd;
-	char *argv[4] = { "sh", "-c", "iptables -w -L", NULL };
+	char *argv[4] = { "sh", "-c", "iptables -n -w -L", NULL };
 
 	fd = open("/dev/null", O_RDWR);
 	if (fd < 0) {


### PR DESCRIPTION
When CRIU checks if the iptables command supports xtables locks, it triggers hostname resolution, and this causes the dump/restore commands to hang.

Fixes: #2032
