### PR TITLE
arm64: C/R PAC keys

### DIFF
--- a/compel/arch/aarch64/src/lib/infect.c
+++ b/compel/arch/aarch64/src/lib/infect.c
@@ -81,7 +81,7 @@ int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct
 		goto err;
 	}
 
-	ret = save(arg, regs, fpsimd);
+	ret = save(pid, arg, regs, fpsimd);
 err:
 	return ret;
 }

--- a/compel/arch/arm/src/lib/infect.c
+++ b/compel/arch/arm/src/lib/infect.c
@@ -94,7 +94,7 @@ int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct
 		}
 	}
 
-	ret = save(arg, regs, vfp);
+	ret = save(pid, arg, regs, vfp);
 err:
 	return ret;
 }

--- a/compel/arch/loongarch64/src/lib/infect.c
+++ b/compel/arch/loongarch64/src/lib/infect.c
@@ -91,7 +91,7 @@ int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct
 		goto err;
 	}
 
-	ret = save(arg, regs, fpregs);
+	ret = save(pid, arg, regs, fpregs);
 err:
 	return 0;
 }

--- a/compel/arch/mips/src/lib/infect.c
+++ b/compel/arch/mips/src/lib/infect.c
@@ -149,7 +149,7 @@ int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct
 		regs->regs[0] = 0;
 	}
 
-	ret = save(arg, regs, xs);
+	ret = save(pid, arg, regs, xs);
 	return ret;
 }
 

--- a/compel/arch/ppc64/src/lib/infect.c
+++ b/compel/arch/ppc64/src/lib/infect.c
@@ -400,7 +400,7 @@ int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct
 	if (ret)
 		return ret;
 
-	return save(arg, regs, fpregs);
+	return save(pid, arg, regs, fpregs);
 }
 
 int compel_set_task_ext_regs(pid_t pid, user_fpregs_struct_t *ext_regs)

--- a/compel/arch/riscv64/src/lib/infect.c
+++ b/compel/arch/riscv64/src/lib/infect.c
@@ -92,7 +92,7 @@ int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct
 		return -1;
 	}
 
-	ret = save(arg, regs, fpsimd);
+	ret = save(pid, arg, regs, fpsimd);
 	return ret;
 }
 

--- a/compel/arch/s390/src/lib/infect.c
+++ b/compel/arch/s390/src/lib/infect.c
@@ -348,7 +348,7 @@ int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct
 		}
 	}
 	/* Call save_task_regs() */
-	return save(arg, regs, fpregs);
+	return save(pid, arg, regs, fpregs);
 }
 
 int compel_set_task_ext_regs(pid_t pid, user_fpregs_struct_t *ext_regs)

--- a/compel/arch/x86/src/lib/infect.c
+++ b/compel/arch/x86/src/lib/infect.c
@@ -453,7 +453,7 @@ int compel_get_task_regs(pid_t pid, user_regs_struct_t *regs, user_fpregs_struct
 		goto err;
 
 out:
-	ret = save(arg, regs, xs);
+	ret = save(pid, arg, regs, xs);
 err:
 	return ret;
 }

--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -97,7 +97,7 @@ extern k_rtsigset_t *compel_thread_sigmask(struct parasite_thread_ctl *tctl);
 struct rt_sigframe;
 
 typedef int (*open_proc_fn)(int pid, int mode, const char *fmt, ...) __attribute__((__format__(__printf__, 3, 4)));
-typedef int (*save_regs_t)(void *, user_regs_struct_t *, user_fpregs_struct_t *);
+typedef int (*save_regs_t)(pid_t pid, void *, user_regs_struct_t *, user_fpregs_struct_t *);
 typedef int (*make_sigframe_t)(void *, struct rt_sigframe *, struct rt_sigframe *, k_rtsigset_t *);
 
 struct infect_ctx {

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -1300,7 +1300,7 @@ struct plain_regs_struct {
 	user_fpregs_struct_t fpregs;
 };
 
-static int save_regs_plain(void *to, user_regs_struct_t *r, user_fpregs_struct_t *f)
+static int save_regs_plain(pid_t pid, void *to, user_regs_struct_t *r, user_fpregs_struct_t *f)
 {
 	struct plain_regs_struct *prs = to;
 

--- a/criu/arch/aarch64/include/asm/dump.h
+++ b/criu/arch/aarch64/include/asm/dump.h
@@ -1,7 +1,7 @@
 #ifndef __CR_ASM_DUMP_H__
 #define __CR_ASM_DUMP_H__
 
-extern int save_task_regs(void *, user_regs_struct_t *, user_fpregs_struct_t *);
+extern int save_task_regs(pid_t pid, void *, user_regs_struct_t *, user_fpregs_struct_t *);
 extern int arch_alloc_thread_info(CoreEntry *core);
 extern void arch_free_thread_info(CoreEntry *core);
 

--- a/criu/arch/aarch64/include/asm/restore.h
+++ b/criu/arch/aarch64/include/asm/restore.h
@@ -26,4 +26,14 @@ static inline void core_get_tls(CoreEntry *pcore, tls_t *ptls)
 
 int restore_fpu(struct rt_sigframe *sigframe, CoreEntry *core);
 
+#define ARCH_RST_INFO y
+struct rst_arch_info {
+	bool has_paca, has_pacg;
+	PacAddressKeys pac_address_keys;
+	PacGenericKeys pac_generic_keys;
+};
+
+int arch_ptrace_restore(int pid, struct pstree_item *item);
+void arch_rsti_init(struct pstree_item *current);
+
 #endif

--- a/criu/arch/arm/crtools.c
+++ b/criu/arch/arm/crtools.c
@@ -22,7 +22,7 @@
 
 #define assign_reg(dst, src, e) dst->e = (__typeof__(dst->e))((src)->ARM_##e)
 
-int save_task_regs(void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
+int save_task_regs(pid_t pid, void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
 {
 	CoreEntry *core = x;
 

--- a/criu/arch/arm/include/asm/dump.h
+++ b/criu/arch/arm/include/asm/dump.h
@@ -1,7 +1,7 @@
 #ifndef __CR_ASM_DUMP_H__
 #define __CR_ASM_DUMP_H__
 
-extern int save_task_regs(void *, user_regs_struct_t *, user_fpregs_struct_t *);
+extern int save_task_regs(pid_t pid, void *, user_regs_struct_t *, user_fpregs_struct_t *);
 extern int arch_alloc_thread_info(CoreEntry *core);
 extern void arch_free_thread_info(CoreEntry *core);
 

--- a/criu/arch/loongarch64/crtools.c
+++ b/criu/arch/loongarch64/crtools.c
@@ -29,7 +29,7 @@
 
 #define assign_reg(dst, src, e) (dst)->e = (__typeof__(dst->e))(src)->e
 
-int save_task_regs(void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
+int save_task_regs(pid_t pid, void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
 {
 	int i;
 	CoreEntry *core = x;

--- a/criu/arch/loongarch64/include/asm/dump.h
+++ b/criu/arch/loongarch64/include/asm/dump.h
@@ -1,7 +1,7 @@
 #ifndef __CR_ASM_DUMP_H__
 #define __CR_ASM_DUMP_H__
 
-extern int save_task_regs(void *, user_regs_struct_t *, user_fpregs_struct_t *);
+extern int save_task_regs(pid_t pid, void *, user_regs_struct_t *, user_fpregs_struct_t *);
 extern int arch_alloc_thread_info(CoreEntry *core);
 extern void arch_free_thread_info(CoreEntry *core);
 

--- a/criu/arch/mips/crtools.c
+++ b/criu/arch/mips/crtools.c
@@ -27,7 +27,7 @@
 #include "images/core.pb-c.h"
 #include "images/creds.pb-c.h"
 
-int save_task_regs(void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
+int save_task_regs(pid_t pid, void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
 {
 	CoreEntry *core = x;
 

--- a/criu/arch/mips/include/asm/dump.h
+++ b/criu/arch/mips/include/asm/dump.h
@@ -1,7 +1,7 @@
 #ifndef __CR_ASM_DUMP_H__
 #define __CR_ASM_DUMP_H__
 
-extern int save_task_regs(void *, user_regs_struct_t *, user_fpregs_struct_t *);
+extern int save_task_regs(pid_t pid, void *, user_regs_struct_t *, user_fpregs_struct_t *);
 extern int arch_alloc_thread_info(CoreEntry *core);
 extern void arch_free_thread_info(CoreEntry *core);
 extern int get_task_futex_robust_list_compat(pid_t pid, ThreadCoreEntry *info);

--- a/criu/arch/ppc64/crtools.c
+++ b/criu/arch/ppc64/crtools.c
@@ -404,7 +404,7 @@ static int __copy_task_regs(user_regs_struct_t *regs, user_fpregs_struct_t *fpre
 	return 0;
 }
 
-int save_task_regs(void *arg, user_regs_struct_t *u, user_fpregs_struct_t *f)
+int save_task_regs(pid_t pid, void *arg, user_regs_struct_t *u, user_fpregs_struct_t *f)
 {
 	return __copy_task_regs(u, f, (CoreEntry *)arg);
 }

--- a/criu/arch/ppc64/include/asm/dump.h
+++ b/criu/arch/ppc64/include/asm/dump.h
@@ -1,7 +1,7 @@
 #ifndef __CR_ASM_DUMP_H__
 #define __CR_ASM_DUMP_H__
 
-extern int save_task_regs(void *, user_regs_struct_t *, user_fpregs_struct_t *);
+extern int save_task_regs(pid_t pid, void *, user_regs_struct_t *, user_fpregs_struct_t *);
 extern int arch_alloc_thread_info(CoreEntry *core);
 extern void arch_free_thread_info(CoreEntry *core);
 

--- a/criu/arch/riscv64/crtools.c
+++ b/criu/arch/riscv64/crtools.c
@@ -23,7 +23,7 @@
 
 #define assign_reg(dst, src, e) dst->e = (__typeof__(dst->e))(src)->e
 
-int save_task_regs(void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpsimd)
+int save_task_regs(pid_t pid, void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpsimd)
 {
 	int i;
 	CoreEntry *core = x;

--- a/criu/arch/riscv64/include/asm/dump.h
+++ b/criu/arch/riscv64/include/asm/dump.h
@@ -1,7 +1,7 @@
 #ifndef __CR_ASM_DUMP_H__
 #define __CR_ASM_DUMP_H__
 
-extern int save_task_regs(void *, user_regs_struct_t *, user_fpregs_struct_t *);
+extern int save_task_regs(pid_t pid, void *, user_regs_struct_t *, user_fpregs_struct_t *);
 extern int arch_alloc_thread_info(CoreEntry *core);
 extern void arch_free_thread_info(CoreEntry *core);
 

--- a/criu/arch/s390/crtools.c
+++ b/criu/arch/s390/crtools.c
@@ -282,7 +282,7 @@ static void free_ri_cb(UserS390RiEntry *ri_cb)
 /*
  * Copy internal structures into Google Protocol Buffers
  */
-int save_task_regs(void *arg, user_regs_struct_t *u, user_fpregs_struct_t *f)
+int save_task_regs(pid_t pid, void *arg, user_regs_struct_t *u, user_fpregs_struct_t *f)
 {
 	UserS390VxrsHighEntry *vxrs_high = NULL;
 	UserS390VxrsLowEntry *vxrs_low = NULL;

--- a/criu/arch/s390/include/asm/dump.h
+++ b/criu/arch/s390/include/asm/dump.h
@@ -1,7 +1,7 @@
 #ifndef __CR_ASM_DUMP_H__
 #define __CR_ASM_DUMP_H__
 
-int save_task_regs(void *arg, user_regs_struct_t *u, user_fpregs_struct_t *f);
+int save_task_regs(pid_t pid, void *arg, user_regs_struct_t *u, user_fpregs_struct_t *f);
 int arch_alloc_thread_info(CoreEntry *core);
 void arch_free_thread_info(CoreEntry *core);
 

--- a/criu/arch/x86/crtools.c
+++ b/criu/arch/x86/crtools.c
@@ -15,7 +15,7 @@
 
 #define XSAVE_PB_NELEMS(__s, __obj, __member) (sizeof(__s) / sizeof(*(__obj)->__member))
 
-int save_task_regs(void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
+int save_task_regs(pid_t pid, void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpregs)
 {
 	CoreEntry *core = x;
 	UserX86RegsEntry *gpregs = core->thread_info->gpregs;

--- a/criu/arch/x86/include/asm/compat.h
+++ b/criu/arch/x86/include/asm/compat.h
@@ -11,6 +11,8 @@
 
 #include <sys/mman.h>
 
+#include "log.h"
+
 static inline void *alloc_compat_syscall_stack(void)
 {
 	void *mem = (void *)sys_mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_32BIT | MAP_ANONYMOUS | MAP_PRIVATE,

--- a/criu/arch/x86/include/asm/dump.h
+++ b/criu/arch/x86/include/asm/dump.h
@@ -1,7 +1,7 @@
 #ifndef __CR_ASM_DUMP_H__
 #define __CR_ASM_DUMP_H__
 
-extern int save_task_regs(void *, user_regs_struct_t *, user_fpregs_struct_t *);
+extern int save_task_regs(pid_t pid, void *, user_regs_struct_t *, user_fpregs_struct_t *);
 extern int arch_alloc_thread_info(CoreEntry *core);
 extern void arch_free_thread_info(CoreEntry *core);
 extern int get_task_futex_robust_list_compat(pid_t pid, ThreadCoreEntry *info);

--- a/criu/include/rst_info.h
+++ b/criu/include/rst_info.h
@@ -1,6 +1,7 @@
 #ifndef __CR_RST_INFO_H__
 #define __CR_RST_INFO_H__
 
+#include "asm/restore.h"
 #include "common/lock.h"
 #include "common/list.h"
 #include "vma.h"
@@ -31,6 +32,11 @@ struct rst_rseq {
 	uint64_t rseq_abi_pointer;
 	uint64_t rseq_cs_pointer;
 };
+
+#ifndef ARCH_RST_INFO
+struct rst_arch_info {
+};
+#endif
 
 struct rst_info {
 	struct list_head fds;
@@ -79,6 +85,8 @@ struct rst_info {
 	futex_t shstk_unlock;
 
 	void *breakpoint;
+
+	struct rst_arch_info arch_info;
 };
 
 extern struct task_entries *task_entries;

--- a/images/core-aarch64.proto
+++ b/images/core-aarch64.proto
@@ -17,9 +17,32 @@ message user_aarch64_fpsimd_context_entry {
 	required uint32 fpcr	= 3;
 }
 
+message pac_address_keys {
+	required uint64 apiakey_lo = 1;
+	required uint64 apiakey_hi = 2;
+	required uint64 apibkey_lo = 3;
+	required uint64 apibkey_hi = 4;
+	required uint64 apdakey_lo = 5;
+	required uint64 apdakey_hi = 6;
+	required uint64 apdbkey_lo = 7;
+	required uint64 apdbkey_hi = 8;
+	required uint64 pac_enabled_key = 9;
+}
+
+message pac_generic_keys {
+	required uint64 apgakey_lo = 1;
+	required uint64 apgakey_hi = 2;
+}
+
+message pac_keys {
+	optional pac_address_keys pac_address_keys = 6;
+	optional pac_generic_keys pac_generic_keys = 7;
+}
+
 message thread_info_aarch64 {
 	required uint64			 		clear_tid_addr	= 1[(criu).hex = true];
 	required uint64					tls		= 2;
 	required user_aarch64_regs_entry		gpregs		= 3[(criu).hex = true];
 	required user_aarch64_fpsimd_context_entry	fpsimd		= 4;
+	optional pac_keys				pac_keys = 5;
 }

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -66,6 +66,7 @@ TST_NOFILE	:=				\
 		pipe01				\
 		pipe02				\
 		pthread00			\
+		pthread00-pac			\
 		pthread01			\
 		pthread02			\
 		pthread_timers			\
@@ -497,6 +498,12 @@ STATE_OUT	= $(TST_STATE:%=%.out)
 
 include ../Makefile.inc
 
+ifeq ($(ARCH),aarch64)
+	PAC_CFLAGS := -mbranch-protection=standard
+else
+	PAC_CFLAGS :=
+endif
+
 all:	$(TST) criu-rtc.so
 install: all
 .PHONY: all install
@@ -588,6 +595,8 @@ uptime_grow:		LDLIBS += -lrt -pthread
 unlink_largefile:	CFLAGS += -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE
 inotify_system_nodel:	CFLAGS += -DNO_DEL
 pthread00:		LDLIBS += -pthread
+pthread00-pac:		CFLAGS += ${PAC_CFLAGS}
+pthread00-pac:		LDLIBS += -pthread
 pthread01:		LDLIBS += -pthread
 pthread02:		LDLIBS += -pthread
 pthread_timers:		LDLIBS += -lrt -pthread

--- a/test/zdtm/static/pthread00-pac.c
+++ b/test/zdtm/static/pthread00-pac.c
@@ -1,0 +1,1 @@
+pthread00.c


### PR DESCRIPTION
    
    PAC stands for Pointer Authentication Code. Each process has 5 PAC keys
    and a mask of enabled keys. All this properties have to be C/R-ed.
    
    As they are per-process protperties, we can save/restore them just for
    one thread.

Fixes #2595