### PR TITLE
replace hardcoded sscanf constants with __stringify and macro

### DIFF
--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -67,6 +67,15 @@
 
 #define BUF_SIZE 4096 /* Good enough value - can be changed */
 
+#define DEC(n, buf) DEC##n##_##buf
+
+#define DEC1(buf) DEC(1, buf)
+#define DEC2(buf) DEC(2, buf)
+
+#define DEC1_4096 4095
+
+#define DEC2_4096 4094
+
 struct buffer {
 	char buf[BUF_SIZE];
 	char end; /* '\0' */
@@ -1442,7 +1451,7 @@ static int parse_mountinfo_ent(char *str, struct mount_info *new, char **fsname)
 		goto err;
 
 	new->mountpoint[0] = '.';
-	ret = sscanf(str, "%i %i %u:%u %ms %4094s %ms %n", &new->mnt_id, &new->parent_mnt_id, &kmaj, &kmin, &new->root,
+	ret = sscanf(str, "%i %i %u:%u %ms %"__stringify(DEC2(BUF_SIZE))"s %ms %n", &new->mnt_id, &new->parent_mnt_id, &kmaj, &kmin, &new->root,
 		     new->mountpoint + 1, &opt, &n);
 	if (ret != 7)
 		goto err;


### PR DESCRIPTION
fixes #2154
Implemented macros DEC1 to decrease by 1 and DEC2 to decrease by 2 the BUF_LEN, as suggested in the issue.