### PR TITLE
Add a lock around cgroupd communication.

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2329,6 +2329,7 @@ int prepare_task_entries(void)
 	task_entries->nr_helpers = 0;
 	futex_set(&task_entries->start, CR_STATE_FAIL);
 	mutex_init(&task_entries->userns_sync_lock);
+	mutex_init(&task_entries->cgroupd_sync_lock);
 	mutex_init(&task_entries->last_pid_mutex);
 
 	return 0;

--- a/criu/include/rst_info.h
+++ b/criu/include/rst_info.h
@@ -14,6 +14,7 @@ struct task_entries {
 	futex_t start;
 	atomic_t cr_err;
 	mutex_t userns_sync_lock;
+	mutex_t cgroupd_sync_lock;
 	mutex_t last_pid_mutex;
 };
 


### PR DESCRIPTION
Threads are put into cgroups through the cgroupd thread, which communicates with other threads using a socketpair.  Each thread received a dup'd copy of the socket, and did the following

    sendmsg(socket_dup_fd, my_cgroup_set);

    // wait for ack.
    while (1) {
        recvmsg(socket_dup_fd, &h, MSG_PEEK);
        if (h.pid != my_pid) continue;
        recvmsg(socket_dup_fd, &h, 0);
    }
    close(socket_dup_fd);

When restoring many threads, most threads would be spinning in the above loop waiting for their PID to appear.

In my test-case, restoring a process with a 11.5G heap and 491 threads could take anywhere between 10 seconds and 60 seconds to complete.

To avoid the spinning, we drop the loop and MSG_PEEK, and add a lock around the above code. This does not decrease parallelism, as the cgroupd daemon uses a single thread anyway.

With the lock in place, the same restore takes a consistent 9.2 seconds on my machine (Thinkpad P14s, AMD Ryzen 8840HS).

There is a similar "daemon" thread for user namespaces. That already is protected with a similar userns_sync_lock in __userns_call().

Fixes #2614
