### PR TITLE
criu: fix log_keep_err signal deadlock

### DIFF
--- a/criu/log.c
+++ b/criu/log.c
@@ -132,10 +132,11 @@ static void log_note_err(char *msg)
 		 * anyway, so it doesn't make much sense to try hard
 		 * and optimize this out.
 		 */
-		mutex_lock(&first_err->l);
-		if (first_err->s[0] == '\0')
-			__strlcpy(first_err->s, msg, sizeof(first_err->s));
-		mutex_unlock(&first_err->l);
+		if (mutex_trylock(&first_err->l)) {
+			if (first_err->s[0] == '\0')
+				__strlcpy(first_err->s, msg, sizeof(first_err->s));
+			mutex_unlock(&first_err->l);
+		}
 	}
 }
 

--- a/include/common/lock.h
+++ b/include/common/lock.h
@@ -2,6 +2,7 @@
 #define __CR_COMMON_LOCK_H__
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <linux/futex.h>
 #include <sys/time.h>
 #include <limits.h>
@@ -160,6 +161,11 @@ static inline void mutex_lock(mutex_t *m)
 		ret = sys_futex((uint32_t *)&m->raw.counter, FUTEX_WAIT, c, NULL, NULL, 0);
 		LOCK_BUG_ON(ret < 0 && ret != -EWOULDBLOCK);
 	}
+}
+
+static inline bool mutex_trylock(mutex_t *m)
+{
+	return atomic_inc_return(&m->raw) == 1;
 }
 
 static inline void mutex_unlock(mutex_t *m)


### PR DESCRIPTION
When using pr_err in signal handler, locking is used in an unsafe manner. If another signal happens while holding the lock, deadlock can happen.

To fix this, we can introduce mutex_trylock similar to pthread_mutex_trylock that returns immediately. Due to the fact that lock is used only for writing first_err, this change garantees that deadlock cannot happen.

Fixes: #358 