### PR TITLE
restore: use the new kernel interface to restore timers

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1392,6 +1392,14 @@ static int check_pagemap_scan(void)
 	return 0;
 }
 
+static int check_timer_cr_ids(void)
+{
+	if (!kdat.has_timer_cr_ids)
+		return -1;
+
+	return 0;
+}
+
 /* musl doesn't have a statx wrapper... */
 struct staty {
 	__u32 stx_dev_major;
@@ -1703,6 +1711,7 @@ int cr_check(void)
 		ret |= check_ipv6_freebind();
 		ret |= check_pagemap_scan();
 		ret |= check_overlayfs_maps();
+		ret |= check_timer_cr_ids();
 
 		if (kdat.lsm == LSMTYPE__APPARMOR)
 			ret |= check_apparmor_stacking();
@@ -1825,6 +1834,7 @@ static struct feature_list feature_list[] = {
 	{ "get_rseq_conf", check_ptrace_get_rseq_conf },
 	{ "ipv6_freebind", check_ipv6_freebind },
 	{ "pagemap_scan", check_pagemap_scan },
+	{ "timer_cr_ids", check_timer_cr_ids },
 	{ "overlayfs_maps", check_overlayfs_maps },
 	{ NULL, NULL },
 };

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -89,6 +89,7 @@ struct kerndat_s {
 	bool has_pagemap_scan;
 	bool has_shstk;
 	bool has_close_range;
+	bool has_timer_cr_ids;
 };
 
 extern struct kerndat_s kdat;

--- a/criu/include/prctl.h
+++ b/criu/include/prctl.h
@@ -97,4 +97,11 @@ struct prctl_mm_map {
 #define PR_GET_THP_DISABLE 42
 #endif
 
+#ifndef PR_TIMER_CREATE_RESTORE_IDS
+#define PR_TIMER_CREATE_RESTORE_IDS             77
+# define PR_TIMER_CREATE_RESTORE_IDS_OFF        0
+# define PR_TIMER_CREATE_RESTORE_IDS_ON         1
+# define PR_TIMER_CREATE_RESTORE_IDS_GET        2
+#endif
+
 #endif /* __CR_PRCTL_H__ */

--- a/criu/include/restorer.h
+++ b/criu/include/restorer.h
@@ -170,6 +170,7 @@ struct task_restore_args {
 
 	struct restore_posix_timer *posix_timers;
 	unsigned int posix_timers_n;
+	bool posix_timer_cr_ids;
 
 	struct restore_timerfd *timerfd;
 	unsigned int timerfd_n;

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1720,6 +1720,22 @@ static int kerndat_has_close_range(void)
 	return 0;
 }
 
+static int kerndat_has_timer_cr_ids(void)
+{
+	if (prctl(PR_TIMER_CREATE_RESTORE_IDS,
+		  PR_TIMER_CREATE_RESTORE_IDS_GET, 0, 0, 0) == -1) {
+		if (errno == EINVAL) {
+			pr_debug("PR_TIMER_CREATE_RESTORE_IDS isn't supported\n");
+			return 0;
+		}
+		pr_perror("prctl returned unexpected error code");
+		return -1;
+	}
+
+	kdat.has_timer_cr_ids = true;
+	return 0;
+}
+
 /*
  * Some features depend on resource that can be dynamically changed
  * at the OS runtime. There are cases that we cannot determine the
@@ -1979,6 +1995,10 @@ int kerndat_init(void)
 	}
 	if (!ret && kerndat_has_close_range()) {
 		pr_err("kerndat_has_close_range has failed when initializing kerndat.\n");
+		ret = -1;
+	}
+	if (!ret && kerndat_has_timer_cr_ids()) {
+		pr_err("kerndat_has_timer_cr_ids has failed when initializing kerndat.\n");
 		ret = -1;
 	}
 

--- a/criu/timer.c
+++ b/criu/timer.c
@@ -195,6 +195,7 @@ int prepare_posix_timers_from_fd(int pid, struct task_restore_args *ta)
 	if (!img)
 		return -1;
 
+	ta->posix_timer_cr_ids = kdat.has_timer_cr_ids;
 	ta->posix_timers_n = 0;
 	while (1) {
 		PosixTimerEntry *pte;
@@ -234,6 +235,7 @@ int prepare_posix_timers(int pid, struct task_restore_args *ta, CoreEntry *core)
 		return prepare_posix_timers_from_fd(pid, ta);
 
 	ta->posix_timers_n = tte->n_posix;
+	ta->posix_timer_cr_ids = kdat.has_timer_cr_ids;
 	for (i = 0; i < ta->posix_timers_n; i++) {
 		t = rst_mem_alloc(sizeof(struct restore_posix_timer), RM_PRIVATE);
 		if (!t)


### PR DESCRIPTION
Thomas Gleixner introduced the new interface to create posix timers with specified timer IDs:
https://github.com/torvalds/linux/commit/ec2d0c04624b3c8a7eb1682e006717fa20cfbe24

Previously, CRIU recreated timers by repeatedly creating and deleting them until the desired ID was reached. This approach isn't fast, especially for timers with large IDs. For example, restoring two timers with IDs 1000000 and 2000000 took approximately 1.5 seconds.

The new `prctl()` based interface allows direct creation of timers with specified IDs, reducing the restoration time to around 3 microseconds for the same example.

