### PR TITLE
Preserve root mount flags

### DIFF
--- a/criu/mount-v2.c
+++ b/criu/mount-v2.c
@@ -443,6 +443,7 @@ err:
 /* Mounts root container mount. */
 static int do_mount_root_v2(struct mount_info *mi)
 {
+	unsigned long mflags = mi->flags & (~MS_PROPAGATE);
 	unsigned long flags = MS_BIND;
 	int fd;
 
@@ -474,6 +475,11 @@ static int do_mount_root_v2(struct mount_info *mi)
 	 */
 	if (mount(NULL, mi->plain_mountpoint, NULL, MS_PRIVATE, NULL)) {
 		pr_perror("Can't remount %s with MS_PRIVATE", mi->plain_mountpoint);
+		return -1;
+	}
+
+	if (mflags && mount(NULL, mi->plain_mountpoint, NULL, MS_REMOUNT | MS_BIND | mflags, NULL)) {
+		pr_perror("Unable to apply root mount options");
 		return -1;
 	}
 

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -2690,8 +2690,15 @@ shared:
 
 static int do_mount_root(struct mount_info *mi)
 {
+	unsigned long mflags = mi->flags & (~MS_PROPAGATE);
+
 	if (restore_shared_options(mi, !mi->shared_id && !mi->master_id, mi->shared_id, mi->master_id))
 		return -1;
+
+	if (mflags && mount(NULL, service_mountpoint(mi), NULL, MS_REMOUNT | MS_BIND | mflags, NULL)) {
+		pr_perror("Unable to apply root mount options");
+		return -1;
+	}
 
 	return fetch_rt_stat(mi, service_mountpoint(mi));
 }

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -443,6 +443,7 @@ class zdtm_test:
         self._bins = [name]
         self._env = {'TMPDIR': os.environ.get('TMPDIR', '/tmp')}
         self._deps = desc.get('deps', [])
+        self._bind = desc.get('bind')
         self.auto_reap = True
 
     def __make_action(self, act, env=None, root=None):
@@ -513,6 +514,8 @@ class zdtm_test:
         if self.__flavor.ns:
             env['ZDTM_NEWNS'] = "1"
             env['ZDTM_ROOT'] = self.__flavor.root
+            if self._bind:
+                env['ZDTM_BIND'] = self._bind
             env['ZDTM_DEV'] = self.__flavor.devpath
             env['PATH'] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/test/zdtm/lib/ns.c
+++ b/test/zdtm/lib/ns.c
@@ -57,6 +57,9 @@ static int prepare_mntns(void)
 	if (zdtm_bind) {
 		/*
 		 * Bindmount the directory to itself.
+		 * e.g.: The mnt_ro_root test makes "/" mount readonly, but we
+		 * still want to write logs to /zdtm/static/ so let's make it
+		 * separate writable bind mount.
 		 */
 		snprintf(bind_path, sizeof(bind_path),  "%s/%s", root, zdtm_bind);
 		if (mount(bind_path, bind_path, NULL, MS_BIND, NULL)) {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -423,6 +423,7 @@ TST_DIR		=				\
 		mntns_ghost			\
 		mntns_ghost01			\
 		mntns_ro_root			\
+		mnt_ro_root			\
 		mntns_link_ghost		\
 		mntns_shared_bind		\
 		mntns_shared_bind02		\

--- a/test/zdtm/static/mnt_ro_root.c
+++ b/test/zdtm/static/mnt_ro_root.c
@@ -1,0 +1,32 @@
+#include <sys/mount.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check if root mount remains read-only after c/r";
+const char *test_author = "Pavel Tikhomirov <ptikhomirov@virtuozzo.com>";
+
+char *dirname;
+TEST_OPTION(dirname, string, "directory name", 1);
+
+int main(int argc, char **argv)
+{
+	test_init(argc, argv);
+
+	if (mount(NULL, "/", NULL, MS_REMOUNT | MS_RDONLY | MS_BIND, NULL)) {
+		pr_perror("mount");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	/*
+	 * Note: In zdtm.py:check_visible_state() we already check for all
+	 * tests, that all mounts in the test's mount namespace remain the
+	 * same, by comparing mountinfo before and after c/r. So rw/ro mount
+	 * option inconsistency will be detected there and we don't need to
+	 * check it in the test itself.
+	 */
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/mnt_ro_root.desc
+++ b/test/zdtm/static/mnt_ro_root.desc
@@ -1,0 +1,6 @@
+{
+	'flavor': 'ns uns',
+	'flags': 'suid',
+	'feature': 'mnt_id',
+	'bind': 'zdtm/static',
+}


### PR DESCRIPTION
mount-v2: restore root mount flags

Mount flags belong to mount and mount namespace of the Container, so we
should preserve them, as Container user will not expect mounts switching
between ro and rw over c/r.

Fixes: https://github.com/checkpoint-restore/criu/issues/2632
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
