### PR TITLE
compel: fix the stack test

### DIFF
--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -13,6 +13,15 @@
 
 #define PARASITE_START_AREA_MIN (4096)
 
+#define PARASITE_STACK_SIZE (16 << 10)
+/*
+ * A stack redzone is a small, protected region of memory located immediately
+ * after a parasite stack. It is intended to remain unchanged. While it can be
+ * implemented as a guard page, we want to avoid the overhead of additional
+ * remote system calls.
+ */
+#define PARASITE_STACK_REDZONE 128
+
 extern int __must_check compel_interrupt_task(int pid);
 
 struct seize_task_status {

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -38,8 +38,6 @@
 #define UNIX_PATH_MAX (sizeof(struct sockaddr_un) - (size_t)((struct sockaddr_un *)0)->sun_path)
 #endif
 
-#define PARASITE_STACK_SIZE (16 << 10)
-
 #ifndef SECCOMP_MODE_DISABLED
 #define SECCOMP_MODE_DISABLED 0
 #endif
@@ -1064,7 +1062,7 @@ int compel_infect_no_daemon(struct parasite_ctl *ctl, unsigned long nr_threads, 
 
 	p += RESTORE_STACK_SIGFRAME;
 	p += PARASITE_STACK_SIZE;
-	ctl->rstack = ctl->remote_map + p;
+	ctl->rstack = ctl->remote_map + p - PARASITE_STACK_REDZONE;
 
 	/*
 	 * x86-64 ABI requires a 16 bytes aligned stack.
@@ -1078,7 +1076,7 @@ int compel_infect_no_daemon(struct parasite_ctl *ctl, unsigned long nr_threads, 
 
 	if (nr_threads > 1) {
 		p += PARASITE_STACK_SIZE;
-		ctl->r_thread_stack = ctl->remote_map + p;
+		ctl->r_thread_stack = ctl->remote_map + p - PARASITE_STACK_REDZONE;
 	}
 
 	ret = arch_fetch_sas(ctl, ctl->rsigframe);


### PR DESCRIPTION
The stack test incorrectly assumed the page immediately following the stack pointer could never be changed. This doesn't work, because this page can be a part of another mapping.

This commit introduces a dedicated "stack redzone," a small guard region directly after the stack. The stack test is modified to specifically check for corruption within this redzone.

