### PR TITLE
Support MADV_GUARD_INSTALL

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1599,6 +1599,12 @@ static int check_breakpoints(void)
 	return 0;
 }
 
+static int check_pagemap_scan_guard_pages(void)
+{
+	kerndat_warn_about_madv_guards();
+
+	return kdat.has_pagemap_scan_guard_pages ? 0 : -1;
+}
 
 static int (*chk_feature)(void);
 
@@ -1724,6 +1730,7 @@ int cr_check(void)
 		ret |= check_pagemap_scan();
 		ret |= check_overlayfs_maps();
 		ret |= check_timer_cr_ids();
+		ret |= check_pagemap_scan_guard_pages();
 
 		if (kdat.lsm == LSMTYPE__APPARMOR)
 			ret |= check_apparmor_stacking();
@@ -1853,6 +1860,7 @@ static struct feature_list feature_list[] = {
 	{ "timer_cr_ids", check_timer_cr_ids },
 	{ "overlayfs_maps", check_overlayfs_maps },
 	{ "breakpoints", check_breakpoints },
+	{ "pagemap_scan_guard_pages", check_pagemap_scan_guard_pages },
 	{ NULL, NULL },
 };
 

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -2124,6 +2124,8 @@ int cr_dump_tasks(pid_t pid)
 	int pre_dump_ret = 0;
 	int ret = -1;
 
+	kerndat_warn_about_madv_guards();
+
 	pr_info("========================================\n");
 	pr_info("Dumping processes (pid: %d comm: %s)\n", pid, __task_comm_info(pid));
 	pr_info("========================================\n");

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2447,7 +2447,8 @@ static long restorer_get_vma_hint(struct list_head *tgt_vma_list, struct list_he
 
 	while (1) {
 		if (prev_vma_end + vma_len > s_vma->e->start) {
-			if (s_vma->list.next == self_vma_list) {
+			if ((s_vma->list.next == self_vma_list) ||
+			    vma_area_is(vma_next(s_vma), VMA_AREA_GUARD)) {
 				s_vma = &end_vma;
 				continue;
 			}
@@ -2460,7 +2461,8 @@ static long restorer_get_vma_hint(struct list_head *tgt_vma_list, struct list_he
 		}
 
 		if (prev_vma_end + vma_len > t_vma->e->start) {
-			if (t_vma->list.next == tgt_vma_list) {
+			if ((t_vma->list.next == tgt_vma_list) ||
+			    vma_area_is(vma_next(t_vma), VMA_AREA_GUARD)) {
 				t_vma = &end_vma;
 				continue;
 			}

--- a/criu/include/image.h
+++ b/criu/include/image.h
@@ -68,6 +68,12 @@
  *  	processing exiting with error; while the rest of bits
  *  	are part of image ABI, this particular one must never
  *  	be used in image.
+ *  - guard
+ *  	stands for a fake VMA (not represented in the kernel
+ *  	by a struct vm_area_struct). Used to keep an information
+ *  	about virtual address space ranges covered by
+ *  	MADV_GUARD_INSTALL guards. These ones must be always at
+ *  	the end of the vma_area_list and properly skipped a.e.
  */
 #define VMA_AREA_NONE	  (0 << 0)
 #define VMA_AREA_REGULAR  (1 << 0)
@@ -87,6 +93,7 @@
 #define VMA_AREA_AIORING (1 << 13)
 #define VMA_AREA_MEMFD	 (1 << 14)
 #define VMA_AREA_SHSTK	 (1 << 15)
+#define VMA_AREA_GUARD	 (1 << 16)
 
 #define VMA_EXT_PLUGIN	  (1 << 27)
 #define VMA_CLOSE	  (1 << 28)

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -91,6 +91,7 @@ struct kerndat_s {
 	bool has_close_range;
 	bool has_timer_cr_ids;
 	bool has_breakpoints;
+	bool has_madv_guard;
 };
 
 extern struct kerndat_s kdat;

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -92,6 +92,7 @@ struct kerndat_s {
 	bool has_timer_cr_ids;
 	bool has_breakpoints;
 	bool has_madv_guard;
+	bool has_pagemap_scan_guard_pages;
 };
 
 extern struct kerndat_s kdat;
@@ -113,5 +114,7 @@ enum {
 extern int kerndat_fs_virtualized(unsigned int which, u32 kdev);
 
 extern int kerndat_has_nspid(void);
+
+extern void kerndat_warn_about_madv_guards(void);
 
 #endif /* __CR_KERNDAT_H__ */

--- a/criu/include/mem.h
+++ b/criu/include/mem.h
@@ -35,6 +35,7 @@ extern int parasite_dump_pages_seized(struct pstree_item *item, struct vm_area_l
 #define PME_PRESENT	  (1ULL << 63)
 #define PME_SWAP	  (1ULL << 62)
 #define PME_FILE	  (1ULL << 61)
+#define PME_GUARD_REGION  (1ULL << 58)
 #define PME_SOFT_DIRTY	  (1ULL << 55)
 #define PME_PSHIFT_BITS	  (6)
 #define PME_STATUS_BITS	  (3)

--- a/criu/include/mem.h
+++ b/criu/include/mem.h
@@ -49,5 +49,11 @@ int prepare_vmas(struct pstree_item *t, struct task_restore_args *ta);
 int unmap_guard_pages(struct pstree_item *t);
 int prepare_mappings(struct pstree_item *t);
 
-u64 should_dump_page(pmc_t *pmc, VmaEntry *vmae, u64 vaddr, bool *softdirty);
+struct page_info {
+	u64 next;
+	bool softdirty;
+};
+
+int should_dump_page(pmc_t *pmc, VmaEntry *vmae, u64 vaddr, struct page_info *page_info);
+
 #endif /* __CR_MEM_H__ */

--- a/criu/include/mem.h
+++ b/criu/include/mem.h
@@ -31,6 +31,7 @@ extern int do_task_reset_dirty_track(int pid);
 extern unsigned long dump_pages_args_size(struct vm_area_list *vmas);
 extern int parasite_dump_pages_seized(struct pstree_item *item, struct vm_area_list *vma_area_list,
 				      struct mem_dump_ctl *mdc, struct parasite_ctl *ctl);
+extern int collect_madv_guards(pid_t pid, struct vm_area_list *vma_area_list);
 
 #define PME_PRESENT	  (1ULL << 63)
 #define PME_SWAP	  (1ULL << 62)

--- a/criu/include/mman.h
+++ b/criu/include/mman.h
@@ -19,5 +19,8 @@
 #ifndef MADV_WIPEONFORK
 #define MADV_WIPEONFORK 18
 #endif
+#ifndef MADV_GUARD_INSTALL
+#define MADV_GUARD_INSTALL 102
+#endif
 
 #endif /* __CR_MMAN_H__ */

--- a/criu/include/pagemap_scan.h
+++ b/criu/include/pagemap_scan.h
@@ -14,6 +14,7 @@
 #define PAGE_IS_PFNZERO	   (1 << 5)
 #define PAGE_IS_HUGE	   (1 << 6)
 #define PAGE_IS_SOFT_DIRTY (1 << 7)
+#define PAGE_IS_GUARD	   (1 << 8)
 
 /*
  * struct page_region - Page region with flags

--- a/criu/pagemap-cache.c
+++ b/criu/pagemap-cache.c
@@ -194,6 +194,9 @@ int pmc_fill(pmc_t *pmc, u64 start, u64 end)
 		};
 		long ret;
 
+		if (kdat.has_pagemap_scan_guard_pages)
+			args.return_mask |= PAGE_IS_GUARD;
+
 		ret = ioctl(pmc->fd, PAGEMAP_SCAN, &args);
 		if (ret == -1) {
 			pr_perror("PAGEMAP_SCAN");

--- a/criu/vdso.c
+++ b/criu/vdso.c
@@ -145,6 +145,9 @@ static void drop_rt_vdso(struct vm_area_list *vma_area_list, struct vdso_quarter
 	 * Also BTW search for rt-vvar to remove it later.
 	 */
 	list_for_each_entry(vma, &vma_area_list->h, list) {
+		if (vma_area_is(vma, VMA_AREA_GUARD))
+			continue;
+
 		if (vma->e->start == addr->orig_vdso) {
 			vma->e->status |= VMA_AREA_REGULAR | VMA_AREA_VDSO;
 			pr_debug("vdso: Restore orig vDSO status at %lx\n", (long)vma->e->start);
@@ -276,6 +279,9 @@ int parasite_fixup_vdso(struct parasite_ctl *ctl, pid_t pid, struct vm_area_list
 	}
 
 	list_for_each_entry(vma, &vma_area_list->h, list) {
+		if (vma_area_is(vma, VMA_AREA_GUARD))
+			continue;
+
 		/*
 		 * Defer handling marked vdso until we walked over
 		 * all vmas and restore potentially remapped vDSO

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -66,6 +66,10 @@ fedora-no-vdso() {
 }
 
 fedora-rawhide() {
+	# Upgrade the kernel to the latest vanilla one
+	ssh default sudo dnf -y copr enable @kernel-vanilla/stable
+	ssh default sudo dnf upgrade -y
+
 	# The 6.2 kernel of Fedora 38 in combination with rawhide userspace breaks
 	# zdtm/static/socket-tcp-nfconntrack. To activate the new kernel previously
 	# installed this reboots the VM.

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -315,6 +315,7 @@ TST_FILE	=				\
 		write_read02			\
 		write_read10			\
 		maps00				\
+		maps12				\
 		link10				\
 		file_attr			\
 		deleted_unix_sock		\

--- a/test/zdtm/static/maps12.c
+++ b/test/zdtm/static/maps12.c
@@ -1,0 +1,350 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <setjmp.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <linux/limits.h>
+#include "zdtmtst.h"
+
+const char *test_doc = "Test madvise(MADV_GUARD_INSTALL)";
+const char *test_author = "Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>";
+/* some parts of code were taken from Linux kernel's kselftest guard-pages.c
+   written by Lorenzo Stoakes <lorenzo.stoakes@oracle.com> */
+
+char *filename;
+int fd;
+TEST_OPTION(filename, string, "file name", 1);
+
+#ifndef MADV_GUARD_INSTALL
+#define MADV_GUARD_INSTALL 102
+#endif
+
+uint8_t *map_base;
+
+struct {
+	unsigned int pages_num;
+	bool filemap;
+} vmas[] = {
+	{ 2, false },
+	{ 2, false },
+	{ 2, false },
+	{ 2, true },
+	{ 2, true },
+	{ 2, true },
+};
+
+struct {
+	bool guarded;
+	bool wipeonfork;
+} pages[] = {
+	{ false, false }, /* vmas[0] */
+	{ true, false },
+	{ true, false }, /* vmas[1] */
+	{ false, false },
+	{ false, false }, /* vmas[2] */
+	{ true, true },
+	{ true, false }, /* vmas[3] */
+	{ false, false },
+	{ true, false }, /* vmas[4] */
+	{ true, false },
+	{ false, false }, /* vmas[5] */
+	{ true, false },
+};
+
+static volatile sig_atomic_t signal_jump_set;
+static sigjmp_buf signal_jmp_buf;
+
+static void handle_sigsegv(int signo)
+{
+	if (!signal_jump_set)
+		return;
+
+	siglongjmp(signal_jmp_buf, 1);
+}
+
+static bool try_write_to_addr(uint8_t *ptr)
+{
+	bool failed;
+
+	/* Tell signal handler to jump back here on fatal signal. */
+	signal_jump_set = true;
+	/* If a fatal signal arose, we will jump back here and failed is set. */
+	failed = sigsetjmp(signal_jmp_buf, 1) != 0;
+
+	if (!failed)
+		*ptr = 'x';
+
+	signal_jump_set = false;
+	return !failed;
+}
+
+static int setup_sigsegv_handler(void)
+{
+	uint8_t write_me;
+
+	if (signal(SIGSEGV, handle_sigsegv) == SIG_ERR) {
+		pr_perror("setting SIGSEGV handler failed");
+		return 1;
+	}
+
+	/* ensure that try_write_to_addr() works properly */
+	if (!try_write_to_addr(&write_me)) {
+		pr_err("Failed to write at valid addr. Buggy try_write_to_addr()?\n");
+		return 1;
+	}
+
+	if (try_write_to_addr(NULL)) {
+		pr_err("Failed to detect an invalid write. Buggy try_write_to_addr()?\n");
+		return 1;
+	}
+
+	return 0;
+}
+
+static inline void *mmap_pages(void *addr_hint, unsigned int count, bool filemap)
+{
+	char *map;
+
+	map = mmap(addr_hint, count * PAGE_SIZE, PROT_WRITE | PROT_READ,
+		   MAP_PRIVATE | (filemap ? 0 : MAP_ANONYMOUS) | (addr_hint ? MAP_FIXED : 0),
+		   filemap ? fd : -1, filemap ? ((off_t)addr_hint - (off_t)map_base) : 0);
+	if (map == MAP_FAILED || (addr_hint && (map != addr_hint)))
+		return MAP_FAILED;
+
+	return map;
+}
+
+static int __check_guards(const char *when, bool in_child)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(pages); i++) {
+		/*
+		 * Skip pages that were never guarded, and also those
+		 * that were, but have MADV_WIPEONFORK which means that
+		 * guards were removed on fork.
+		 */
+		if (!pages[i].guarded || (in_child && pages[i].wipeonfork))
+			continue;
+
+		if (try_write_to_addr(&map_base[i * PAGE_SIZE])) {
+			pr_err("successful write to a guarded area %d %s C/R\n",
+			       i, when);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static int check_guards(const char *when)
+{
+	int status;
+	pid_t pid;
+
+	/*
+	 * First of all, check that guards are on their places
+	 * in a main test process.
+	 */
+	if (__check_guards(when, false)) {
+		return 1;
+	}
+
+	/*
+	 * Now, check that guards are on their places
+	 * after fork(). This allows to ensure that
+	 * combo MADV_WIPEONFORK + MADV_GUARD_INSTALL
+	 * is restored properly too.
+	 */
+
+	pid = test_fork();
+	if (pid < 0) {
+		pr_perror("check_guards: fork failed");
+		return 1;
+	}
+
+	if (pid == 0) {
+		if (__check_guards(when, true)) {
+			pr_err("check_guards(\"%s\") failed in child\n", when);
+			exit(1);
+		}
+
+		exit(0);
+	}
+
+	if (waitpid(pid, &status, 0) != pid) {
+		pr_perror("check_guards: waitpid");
+		return 1;
+	}
+
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		pr_err("check_guards: process didn't exit cleanly: status=%d\n", status);
+		return 1;
+	}
+
+	return 0;
+}
+
+static void gen_pages_data(void)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(pages); i++) {
+		uint32_t crc;
+
+		if (pages[i].guarded)
+			continue;
+
+		crc = ~0;
+		datagen(&map_base[i * PAGE_SIZE], PAGE_SIZE, &crc);
+	}
+}
+
+static int set_pages_madvs(void)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(pages); i++) {
+		if (pages[i].guarded) {
+			if (madvise(&map_base[i * PAGE_SIZE], PAGE_SIZE,
+				    MADV_GUARD_INSTALL)) {
+				pr_perror("MADV_GUARD_INSTALL failed on page %d", i);
+				return 1;
+			}
+		}
+
+		if (pages[i].wipeonfork) {
+			if (madvise(&map_base[i * PAGE_SIZE], PAGE_SIZE,
+				    MADV_WIPEONFORK)) {
+				pr_perror("MADV_WIPEONFORK failed on page %d", i);
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int check_pages_data(void)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(pages); i++) {
+		uint32_t crc;
+
+		if (pages[i].guarded)
+			continue;
+
+		crc = ~0;
+		if (datachk(&map_base[i * PAGE_SIZE], PAGE_SIZE, &crc)) {
+			pr_err("Page %d is corrupted\n", i);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static int prepare_vmas(void)
+{
+	char *map;
+	int i, shift;
+
+	shift = 0;
+	for (i = 0; i < ARRAY_SIZE(vmas); i++) {
+		map = mmap_pages(&map_base[shift * PAGE_SIZE],
+				 vmas[i].pages_num, vmas[i].filemap);
+		if (map == MAP_FAILED) {
+			pr_err("mmap of [%d,%d] pages failed\n",
+			       shift, shift + vmas[i].pages_num);
+			return 1;
+		}
+
+		shift += vmas[i].pages_num;
+	}
+
+	if (shift != ARRAY_SIZE(pages)) {
+		pr_err("Different number of pages in vmas and pages arrays.\n");
+		return 1;
+	}
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	unsigned int pages_num = ARRAY_SIZE(pages);
+
+	test_init(argc, argv);
+
+	fd = open(filename, O_TRUNC | O_CREAT | O_RDWR, 0600);
+	if (fd < 0) {
+		pr_perror("Unable to create a test file");
+		return -1;
+	}
+
+	if (ftruncate(fd, pages_num * PAGE_SIZE)) {
+		pr_perror("Unable to ftruncate a test file");
+		return -1;
+	}
+
+	if (setup_sigsegv_handler()) {
+		pr_err("setup_sigsegv_handler() failed\n");
+		return 1;
+	}
+
+	/* let's find a large enough area in address space */
+	map_base = mmap_pages(NULL, pages_num, false);
+	if (map_base == MAP_FAILED) {
+		pr_err("mmap of %d pages failed\n", pages_num);
+		return 1;
+	}
+
+	/*
+	 * Now we know that we have a free vm address space area
+	 * [map_base, map_base + pages_num * PAGE_SIZE).
+	 * We can use (map_base) as a hint for our further mmaps.
+	 */
+	if (prepare_vmas()) {
+		pr_err("prepare_vmas() failed\n");
+		return 1;
+	}
+
+	/* fill non-guarded pages with data and preserve checksums */
+	gen_pages_data();
+
+	if (set_pages_madvs()) {
+		pr_err("set_pages_madvs() failed\n");
+		return 1;
+	}
+
+	/* ensure that madvise(MADV_GUARD_INSTALL) works like expected */
+	if (check_guards("before")) {
+		pr_err("check_guards(\"before\") failed\n");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	/* ensure that guards are at their places */
+	if (check_guards("after")) {
+		fail("check_guards(\"after\") failed");
+		return 1;
+	}
+
+	/* check that non-guarded pages still contain original data */
+	if (check_pages_data()) {
+		fail("check_pages_data() failed");
+		return 1;
+	}
+
+	pass();
+	munmap(map_base, pages_num * PAGE_SIZE);
+	close(fd);
+	return 0;
+}

--- a/test/zdtm/static/maps12.desc
+++ b/test/zdtm/static/maps12.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h', 'feature': 'pagemap_scan_guard_pages'}


### PR DESCRIPTION
Ready for review / merge.

Linux kernel 6.16+ is required to support dump for `MADV_GUARD_INSTALL`-protected pages.

Change-log:
05.08.2025: completely reworked to support file mappings and shared mappings

ToDo:
- [x] support file-backed and read-only mappings https://github.com/torvalds/linux/commit/f807123d578df4218e2580a1e1bb3436f4567c4a
- [x] handle VM_WIPEONFORK in CRIU & test
- [x] some more code cleanup needed
- [x] ensure that `./test/zdtm.py run -t zdtm/static/maps12 -f h --page-server` works

Closes #2626