### PR TITLE
zdtm.py: add an option to change pycriu import path

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1611,6 +1611,7 @@ class criu:
     def available():
         if not os.access(opts['criu_bin'], os.X_OK):
             print("CRIU binary not found at %s" % opts['criu_bin'])
+            print("Consider building CRIU or using '--criu-bin' option.")
             sys.exit(1)
 
     def kill(self):
@@ -2972,7 +2973,7 @@ if __name__ == '__main__':
     if opts['debug']:
         sys.settrace(traceit)
 
-    if opts['action'] == 'run':
+    if opts['action'] == run_tests:
         criu.available()
     for tst in test_classes.values():
         tst.available()


### PR DESCRIPTION
By default zdtm expects that criu is built from source first and only then you can run zdtm tests against it. But what if you really want to run tests against a criu version installed on the system? Yes there is already a nice option for zdtm to change the criu binary it uses "--criu-bin", but it would still end up using the pycriu module from source and you would still have to build everything beforehand.

Let's add an option to change the path where zdtm searches for pycriu module "--pycriu-search-path". This way we can run zdtm tests on the criu installed on the system directly without building criu from source, e.g. on Fedora it works like:
```
test/zdtm.py run --criu-bin /usr/sbin/criu \
  --pycriu-search-path /usr/lib/python3.13/site-packages \
  -t zdtm/static/env00
```
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
