### PR TITLE
mem: support VM_WIPEONFORK/MAP_DROPPABLE

### DIFF
--- a/criu/include/mman.h
+++ b/criu/include/mman.h
@@ -13,5 +13,8 @@
 #ifndef MADV_DONTDUMP
 #define MADV_DONTDUMP 16
 #endif
+#ifndef MADV_WIPEONFORK
+#define MADV_WIPEONFORK 18
+#endif
 
 #endif /* __CR_MMAN_H__ */

--- a/criu/include/mman.h
+++ b/criu/include/mman.h
@@ -4,6 +4,9 @@
 #ifndef MAP_HUGETLB
 #define MAP_HUGETLB 0x40000
 #endif
+#ifndef MAP_DROPPABLE
+#define MAP_DROPPABLE 0x08
+#endif
 #ifndef MADV_HUGEPAGE
 #define MADV_HUGEPAGE 14
 #endif

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -10,6 +10,7 @@
 #include "cr_options.h"
 #include "servicefd.h"
 #include "mem.h"
+#include "mman.h"
 #include "parasite-syscall.h"
 #include "parasite.h"
 #include "page-pipe.h"
@@ -396,6 +397,17 @@ static int generate_vma_iovs(struct pstree_item *item, struct vma_area *vma, str
 	 * be remapped into proper place..
 	 */
 	if (vma_entry_is(vma->e, VMA_AREA_VVAR))
+		return 0;
+
+	/*
+	 * 9651fcedf7b9 ("mm: add MAP_DROPPABLE for designating always lazily freeable mappings")
+	 * tells us that:
+	 * Under memory pressure, mm can just drop the pages (so that they're
+	 * zero when read back again).
+	 *
+	 * Let's just skip MAP_DROPPABLE mappings pages dump logic.
+	 */
+	if (vma->e->flags & MAP_DROPPABLE)
 		return 0;
 
 	/*

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -160,6 +160,8 @@ static void __parse_vmflags(char *buf, u32 *flags, u64 *madv, int *io_pf,
 			*madv |= (1ul << MADV_HUGEPAGE);
 		else if (_vmflag_match(tok, "nh"))
 			*madv |= (1ul << MADV_NOHUGEPAGE);
+		else if (_vmflag_match(tok, "wf"))
+			*madv |= (1ul << MADV_WIPEONFORK);
 
 		/* vmsplice doesn't work for VM_IO and VM_PFNMAP mappings. */
 		if (_vmflag_match(tok, "io") || _vmflag_match(tok, "pf"))

--- a/lib/pycriu/images/pb2dict.py
+++ b/lib/pycriu/images/pb2dict.py
@@ -83,6 +83,7 @@ mmap_prot_map = [
 mmap_flags_map = [
     ('MAP_SHARED', 0x1),
     ('MAP_PRIVATE', 0x2),
+    ('MAP_DROPPABLE', 0x08),
     ('MAP_ANON', 0x20),
     ('MAP_GROWSDOWN', 0x0100),
 ]

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -150,6 +150,7 @@ TST_NOFILE	:=				\
 		maps05				\
 		maps09				\
 		maps10				\
+		maps11				\
 		mlock_setuid			\
 		xids00				\
 		groups				\

--- a/test/zdtm/static/get_smaps_bits.c
+++ b/test/zdtm/static/get_smaps_bits.c
@@ -18,6 +18,10 @@
 #define MADV_DONTDUMP 16
 #endif
 
+#ifndef MADV_WIPEONFORK
+#define MADV_WIPEONFORK 18
+#endif
+
 static void parse_vmflags(char *buf, unsigned long *flags, unsigned long *madv)
 {
 	char *tok;
@@ -57,6 +61,8 @@ static void parse_vmflags(char *buf, unsigned long *flags, unsigned long *madv)
 			*madv |= (1ul << MADV_HUGEPAGE);
 		else if (_vmflag_match(tok, "nh"))
 			*madv |= (1ul << MADV_NOHUGEPAGE);
+		else if (_vmflag_match(tok, "wf"))
+			*madv |= (1ul << MADV_WIPEONFORK);
 
 		/*
 		 * Anything else is just ignored.

--- a/test/zdtm/static/get_smaps_bits.c
+++ b/test/zdtm/static/get_smaps_bits.c
@@ -6,6 +6,10 @@
 #define MAP_HUGETLB 0x40000
 #endif
 
+#ifndef MAP_DROPPABLE
+#define MAP_DROPPABLE 0x08
+#endif
+
 #ifndef MADV_HUGEPAGE
 #define MADV_HUGEPAGE 14
 #endif
@@ -45,6 +49,8 @@ static void parse_vmflags(char *buf, unsigned long *flags, unsigned long *madv)
 			*flags |= MAP_NORESERVE;
 		else if (_vmflag_match(tok, "ht"))
 			*flags |= MAP_HUGETLB;
+		else if (_vmflag_match(tok, "dp"))
+			*flags |= MAP_DROPPABLE;
 
 		/* madvise() block */
 		if (_vmflag_match(tok, "sr"))

--- a/test/zdtm/static/maps02.c
+++ b/test/zdtm/static/maps02.c
@@ -6,7 +6,11 @@
 #define MADV_DONTDUMP 16
 #endif
 
-const char *test_doc = "Test shared memory with advises";
+#ifndef MADV_WIPEONFORK
+#define MADV_WIPEONFORK 18
+#endif
+
+const char *test_doc = "Test private memory with advises";
 const char *test_author = "Cyrill Gorcunov <gorcunov@openvz.org>";
 
 struct mmap_data {
@@ -43,12 +47,12 @@ static int alloc_anon_mmap(struct mmap_data *m, int flags, int adv)
 
 int main(int argc, char **argv)
 {
-	struct mmap_data m[5] = {};
+	struct mmap_data m[6] = {};
 	size_t i;
 
 	test_init(argc, argv);
 
-	test_msg("Alloc growsdown\n");
+	test_msg("Alloc dontfork\n");
 	if (alloc_anon_mmap(&m[0], MAP_PRIVATE | MAP_ANONYMOUS, MADV_DONTFORK))
 		return -1;
 
@@ -64,8 +68,12 @@ int main(int argc, char **argv)
 	if (alloc_anon_mmap(&m[3], MAP_PRIVATE | MAP_ANONYMOUS, MADV_HUGEPAGE))
 		return -1;
 
-	test_msg("Alloc dontfork/random|mergeable\n");
+	test_msg("Alloc mergeable\n");
 	if (alloc_anon_mmap(&m[4], MAP_PRIVATE | MAP_ANONYMOUS, MADV_MERGEABLE))
+		return -1;
+
+	test_msg("Alloc wipeonfork\n");
+	if (alloc_anon_mmap(&m[5], MAP_PRIVATE | MAP_ANONYMOUS, MADV_WIPEONFORK))
 		return -1;
 
 	test_msg("Fetch existing flags/adv\n");

--- a/test/zdtm/static/maps11.c
+++ b/test/zdtm/static/maps11.c
@@ -1,0 +1,205 @@
+#include <stdint.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include "zdtmtst.h"
+
+#ifndef MAP_DROPPABLE
+#define MAP_DROPPABLE 0x08
+#endif
+
+#ifndef MADV_WIPEONFORK
+#define MADV_WIPEONFORK 18
+#endif
+
+const char *test_doc = "Test MAP_DROPPABLE/MADV_WIPEONFORK mappings with 2 processes";
+const char *test_author = "Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>";
+
+bool mem_is_zero(const uint8_t *buffer, size_t length)
+{
+	size_t i;
+
+	for (i = 0; i < length; i++)
+		if (buffer[i] != 0)
+			return false;
+
+	return true;
+}
+
+int main(int argc, char **argv)
+{
+	uint8_t *p1, *p2;
+	pid_t pid;
+	int status;
+	const char data[] = "MADV_WIPEONFORK vma data";
+	bool criu_was_there = false;
+	struct stat st1, st2;
+
+	test_init(argc, argv);
+
+	p1 = mmap(NULL, sizeof(data), PROT_READ | PROT_WRITE,
+		  MAP_DROPPABLE | MAP_ANONYMOUS, 0, 0);
+	if (p1 == MAP_FAILED) {
+		if (errno == EINVAL) {
+			skip("mmap failed, no kernel support for MAP_DROPPABLE\n");
+			goto skip;
+		} else {
+			pr_perror("mmap failed");
+			return -1;
+		}
+	}
+
+	p2 = mmap(NULL, sizeof(data), PROT_READ | PROT_WRITE,
+		  MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+	if (p2 == MAP_FAILED) {
+		pr_perror("mmap failed");
+		return 1;
+	}
+
+	if (madvise(p2, sizeof(data), MADV_WIPEONFORK)) {
+		pr_perror("madvise failed");
+		return -1;
+	}
+
+	/* contents of this mapping is supposed to be dropped after C/R */
+	memcpy(p1, data, sizeof(data));
+
+	/* contents of this mapping is supposed to be dropped after fork() */
+	memcpy(p2, data, sizeof(data));
+
+	/*
+	 * Let's spawn a process before C/R so our mappings get inherited
+	 * then, after C/R we need to ensure that CRIU memory premapping
+	 * machinery works properly.
+	 *
+	 * It is important, because we restore MADV_WIPEONFORK on a later
+	 * stages (after vma premapping happens) and we need to ensure that
+	 * CRIU handles everything in a right way.
+	 */
+	pid = test_fork();
+	if (pid < 0) {
+		pr_perror("fork failed");
+		return 1;
+	}
+
+	if (pid == 0) {
+		test_waitsig();
+
+		/*
+		 * Both mappings have VM_WIPEONFORK flag set,
+		 * so we expect to have it null-ified after fork().
+		 */
+		if (!mem_is_zero(p1, sizeof(data)) ||
+		    !mem_is_zero(p2, sizeof(data))) {
+			pr_err("1st child: memory check failed\n");
+			return 1;
+		}
+
+		return 0;
+	}
+
+	/*
+	 * A simple way to detect if C/R happened is to compare st_ino
+	 * fields of stat() on the procfs files of the current task.
+	 *
+	 * Hopefully, this terrible hack is never used in real-world
+	 * applications ;-) Here, we only need this to make test
+	 * to pass with/without --nocr option.
+	 */
+	if (stat("/proc/self/status", &st1)) {
+		pr_perror("stat");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	/* signal a child process to continue */
+	if (kill(pid, SIGTERM)) {
+		pr_perror("kill");
+		goto err;
+	}
+
+	if (waitpid(pid, &status, 0) != pid) {
+		pr_perror("1st waitpid");
+		goto err;
+	}
+
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		fail("1st process didn't exit cleanly: status=%d", status);
+		goto err;
+	}
+
+	if (stat("/proc/self/status", &st2)) {
+		pr_perror("stat");
+		return 1;
+	}
+
+	/* detect CRIU */
+	criu_was_there = st1.st_ino != st2.st_ino;
+
+	/*
+	 * We should mark failure if one of the following happens:
+	 * 1. MAP_DROPPABLE memory is not zero after C/R
+	 * 2. MAP_DROPPABLE memory somehow changed without C/R
+	 *    (kernel issue? memory pressure?)
+	 * 3. MADV_WIPEONFORK memory is not preserved
+	 *
+	 * We care about 2nd case only because we would like test
+	 * to pass even with --nocr zdtm.py option.
+	 */
+	if ((criu_was_there && !mem_is_zero(p1, sizeof(data))) ||
+	    (!criu_was_there && memcmp(p1, data, sizeof(data))) ||
+	    memcmp(p2, data, sizeof(data))) {
+		fail("Data mismatch");
+		return 1;
+	}
+
+	/* contents of these mappings is supposed to be dropped after fork() */
+	memcpy(p1, data, sizeof(data));
+	memcpy(p2, data, sizeof(data));
+
+	pid = test_fork();
+	if (pid < 0) {
+		pr_perror("fork failed");
+		return 1;
+	}
+
+	if (pid == 0) {
+		if (!mem_is_zero(p1, sizeof(data)) ||
+		    !mem_is_zero(p2, sizeof(data))) {
+			pr_err("2nd child: memory check failed\n");
+			return 1;
+		}
+
+		return 0;
+	}
+
+	if (waitpid(pid, &status, 0) != pid) {
+		pr_perror("2nd waitpid");
+		goto err;
+	}
+
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		fail("2nd process didn't exit cleanly: status=%d", status);
+		goto err;
+	}
+
+	pass();
+
+	return 0;
+err:
+	if (waitpid(-1, NULL, WNOHANG) == 0) {
+		kill(pid, SIGTERM);
+		wait(NULL);
+	}
+	return 1;
+
+skip:
+	test_daemon();
+	test_waitsig();
+	pass();
+	return 0;
+}


### PR DESCRIPTION
It would be good to have this before https://github.com/checkpoint-restore/criu/pull/2652 as I would like to test how these two can co-exist.

ToDo:
- [x] add test with `fork()` to ensure that premap/cow detection logic is fine
- [x] decide if we have to forbid premapping for these mappings? (Nope, we don't.)
- [x] address code review comments from Bui Quang Minh and Andrei