### PR TITLE
kerndat: check that hardware breakpoints work

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1589,6 +1589,17 @@ static int check_overlayfs_maps(void)
 	return status == 0 ? 0 : -1;
 }
 
+static int check_breakpoints(void)
+{
+	if (!kdat.has_breakpoints) {
+		pr_warn("Hardware breakpoints don't seem to work\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+
 static int (*chk_feature)(void);
 
 /*
@@ -1616,6 +1627,7 @@ static int (*chk_feature)(void);
 			return ret;                 \
 		}                                   \
 	} while (0)
+
 int cr_check(void)
 {
 	struct ns_id *ns;
@@ -1724,6 +1736,10 @@ int cr_check(void)
 		ret |= check_autofs();
 		ret |= check_compat_cr();
 	}
+	/*
+	 * Category 4 - optional.
+	 */
+	check_breakpoints();
 
 	pr_msg("%s\n", ret ? CHECK_MAYBE : CHECK_GOOD);
 	return ret;
@@ -1836,6 +1852,7 @@ static struct feature_list feature_list[] = {
 	{ "pagemap_scan", check_pagemap_scan },
 	{ "timer_cr_ids", check_timer_cr_ids },
 	{ "overlayfs_maps", check_overlayfs_maps },
+	{ "breakpoints", check_breakpoints },
 	{ NULL, NULL },
 };
 

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1820,6 +1820,7 @@ static int restore_rseq_cs(void)
 static int catch_tasks(bool root_seized)
 {
 	struct pstree_item *item;
+	bool nobp = fault_injected(FI_NO_BREAKPOINTS) || !kdat.has_breakpoints;
 
 	for_each_pstree_item(item) {
 		int status, i, ret;
@@ -1847,7 +1848,7 @@ static int catch_tasks(bool root_seized)
 				return -1;
 			}
 
-			ret = compel_stop_pie(pid, rsti(item)->breakpoint, fault_injected(FI_NO_BREAKPOINTS));
+			ret = compel_stop_pie(pid, rsti(item)->breakpoint, nobp);
 			if (ret < 0)
 				return -1;
 		}

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -90,6 +90,7 @@ struct kerndat_s {
 	bool has_shstk;
 	bool has_close_range;
 	bool has_timer_cr_ids;
+	bool has_breakpoints;
 };
 
 extern struct kerndat_s kdat;

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -421,7 +421,7 @@ struct parasite_ctl *parasite_infect_seized(pid_t pid, struct pstree_item *item,
 		ictx->flags |= INFECT_NO_MEMFD;
 	if (fault_injected(FI_PARASITE_CONNECT))
 		ictx->flags |= INFECT_FAIL_CONNECT;
-	if (fault_injected(FI_NO_BREAKPOINTS))
+	if (fault_injected(FI_NO_BREAKPOINTS) || !kdat.has_breakpoints)
 		ictx->flags |= INFECT_NO_BREAKPOINTS;
 	if (kdat.compat_cr)
 		ictx->flags |= INFECT_COMPATIBLE;


### PR DESCRIPTION
In some cases, they might not work in virtual machines if the hypervisor doesn't virtualize them. For example, they don't work in AMD SEV virtual machines if the Debug Virtualization extension isn't supported or isn't enabled in SEV_FEATURES.

Fixes #2658

