### PR TITLE
sk-inet: add message how to disable MPTCP in Go

### DIFF
--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -128,6 +128,8 @@ static int can_dump_ipproto(unsigned int ino, int proto, int type)
 		break;
 	default:
 		pr_err("Unsupported proto %d for socket %x\n", proto, ino);
+		if (proto == IPPROTO_MPTCP)
+			pr_err("For Go programs, consider using \"GODEBUG=multipathtcp=0\" to disable MPTCP\n");
 		return 0;
 	}
 


### PR DESCRIPTION
With Go version 1.24, `ListenConfig` now uses MPTCP [by default](https://go.dev/doc/go1.24#netpkgnet). Checkpoint/restore for this protocol is not currently supported and adding support requires kernel changes that are not trivial to implement. As a result, checkpointing of many containers that run Go programs is likely to fail with the following error (https://github.com/checkpoint-restore/criu/issues/2655):

```
(00.026522) Error (criu/sk-inet.c:130): inet: Unsupported proto 262 for socket 2f9bc5
```

This patch adds a message with suggested workaround for this problem.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
