### PR TITLE
make: remove checks and warnings for bsd strlcat and strlcpy

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -9,7 +9,7 @@ ifeq ($(call try-cc,$(FEATURE_TEST_LIBBSD_DEV),-lbsd),true)
         LIBS_FEATURES	+= -lbsd
         FEATURE_DEFINES	+= -DCONFIG_HAS_LIBBSD
 else
-        $(info Note: Building without setproctitle() and strlcpy() support.)
+        $(info Note: Building without setproctitle() support.)
         $(info $S      Install libbsd-devel (RPM) / libbsd-dev (DEB) to fix.)
 endif
 
@@ -84,7 +84,7 @@ endif
 export DEFINES += $(FEATURE_DEFINES)
 export CFLAGS += $(FEATURE_DEFINES)
 
-FEATURES_LIST	:= TCP_REPAIR STRLCPY STRLCAT PTRACE_PEEKSIGINFO \
+FEATURES_LIST	:= TCP_REPAIR PTRACE_PEEKSIGINFO \
 	SETPROCTITLE_INIT TCP_REPAIR_WINDOW MEMFD_CREATE \
 	OPENAT2 NO_LIBC_RSEQ_DEFS
 

--- a/scripts/feature-tests.mak
+++ b/scripts/feature-tests.mak
@@ -35,34 +35,6 @@ int main(void)
 }
 endef
 
-define FEATURE_TEST_STRLCPY
-
-#include <string.h>
-
-#ifdef CONFIG_HAS_LIBBSD
-# include <bsd/string.h>
-#endif
-
-int main(void)
-{
-	return strlcpy(NULL, NULL, 0);
-}
-endef
-
-define FEATURE_TEST_STRLCAT
-
-#include <string.h>
-
-#ifdef CONFIG_HAS_LIBBSD
-# include <bsd/string.h>
-#endif
-
-int main(void)
-{
-	return strlcat(NULL, NULL, 0);
-}
-endef
-
 define FEATURE_TEST_PTRACE_PEEKSIGINFO
 
 #include <sys/ptrace.h>


### PR DESCRIPTION
In 0a7c5fd1bd8d1e49e273b51ff39af473d6c68cbc we swapped the BSD implementation of strlcat and strlcpy in favor of our own replacement.

The checks and the predefined macros are not needed anymore.