### PR TITLE
sk-inet: add MPTCP definition

### DIFF
--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -44,6 +44,11 @@
 #define PB_ALEN_INET  1
 #define PB_ALEN_INET6 4
 
+/* Definition for older kernels without MPTCP support (e.g. Ubuntu 20.04) */
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP 262
+#endif
+
 static LIST_HEAD(inet_ports);
 
 struct inet_port {


### PR DESCRIPTION
Ubuntu 20.04 ships with kernel 5.4 by default, which does not include MPTCP support. As a result, building CRIU fails with the following error:

```
criu/sk-inet.c: In function 'can_dump_ipproto':
criu/sk-inet.c:131:16: error: 'IPPROTO_MPTCP' undeclared (first use in this function); did you mean 'IPPROTO_MTP'?
  131 |   if (proto == IPPROTO_MPTCP)
      |                ^~~~~~~~~~~~~
      |                IPPROTO_MTP
```

This pull request add definition for `IPPROTO_MPTCP` to fix this error.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
