### PR TITLE
image: use `protoc` instead of `protoc-c`

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -58,7 +58,7 @@ proto-obj-y	+= ext-file.o
 proto-obj-y	+= cgroup.o
 proto-obj-y	+= userns.o
 proto-obj-y	+= pidns.o
-proto-obj-y	+= google/protobuf/descriptor.o # To make protoc-c happy and compile opts.proto
+proto-obj-y	+= google/protobuf/descriptor.o # To make protoc happy and compile opts.proto
 proto-obj-y	+= opts.o
 proto-obj-y	+= seccomp.o
 proto-obj-y	+= binfmt-misc.o
@@ -96,7 +96,7 @@ makefile-deps := Makefile $(obj)/Makefile
 define gen-proto-rules
 $(obj)/$(1).pb-c.c $(obj)/$(1).pb-c.h: $(obj)/$(1).proto $(addsuffix .pb-c.c,$(addprefix $(obj)/,$(2))) $(makefile-deps)
 	$$(E) "  PBCC    " $$@
-	$$(Q) protoc-c --proto_path=$(obj)/ --c_out=$(obj)/ $$<
+	$$(Q) protoc --proto_path=$(obj)/ --c_out=$(obj)/ $$<
 ifeq ($(PROTOUFIX),y)
 	$$(Q) sed -i -e 's/4294967295/0xFFFFFFFF/g' $$@
 	$$(Q) sed -i -e 's/4294967295/0xFFFFFFFF/g' $$(patsubst %.c,%.h,$$@)

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -25,7 +25,7 @@ else
 endif
 
 criu-amdgpu.pb-c.c: criu-amdgpu.proto
-		protoc-c --proto_path=. --c_out=. criu-amdgpu.proto
+		protoc --proto_path=. --c_out=. criu-amdgpu.proto
 
 amdgpu_plugin.so: amdgpu_plugin.c amdgpu_plugin_drm.c amdgpu_plugin_topology.c amdgpu_plugin_util.c criu-amdgpu.pb-c.c
 	$(CC) $(PLUGIN_CFLAGS) $(shell $(COMPEL) includes) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS) $(LIBDRM_INC)

--- a/test/others/rpc/Makefile
+++ b/test/others/rpc/Makefile
@@ -47,7 +47,7 @@ rpc_pb2.py: rpc.proto
 	protoc --proto_path=. --python_out=. rpc.proto
 
 rpc.pb-c.c: rpc.proto
-	protoc-c --proto_path=. --c_out=. rpc.proto
+	protoc --proto_path=. --c_out=. rpc.proto
 
 clean:
 	rm -rf build rpc.pb-c.o test-c.o test-c rpc.pb-c.c rpc.pb-c.h rpc_pb2.py rpc_pb2.pyc criu

--- a/test/others/unix-callback/Makefile
+++ b/test/others/unix-callback/Makefile
@@ -4,7 +4,7 @@ run: all
 	./run.sh
 
 unix.pb-c.c: unix.proto
-	protoc-c --proto_path=. --c_out=. unix.proto
+	protoc --proto_path=. --c_out=. unix.proto
 
 unix-lib.so: unix-lib.c unix.pb-c.c
 	gcc -g -Werror -Wall -shared -nostartfiles unix-lib.c unix.pb-c.c -o unix-lib.so -iquote ../../../criu/include -fPIC

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -734,7 +734,7 @@ criu-rtc.pb-c.c: criu-rtc.proto
 	$(Q)echo $@ >> .gitignore
 	$(Q)echo $(@:%.c=%.h) >> .gitignore
 	$(E) " PBCC     " $@
-	$(Q)protoc-c --proto_path=. --c_out=. criu-rtc.proto
+	$(Q)protoc --proto_path=. --c_out=. criu-rtc.proto
 
 criu-rtc.so: criu-rtc.c criu-rtc.pb-c.c
 	$(E) " LD       " $@


### PR DESCRIPTION
The new protoc 1.5.2 reports warnings:
`protoc-c` is deprecated. Please use `protoc` instead!

