### PR TITLE
test/zdtm: remove unused argument during compilation

### DIFF
--- a/test/zdtm/Makefile.inc
+++ b/test/zdtm/Makefile.inc
@@ -76,7 +76,7 @@ endef
 
 %.d: %.c
 	$(E) " DEP      " $@
-	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -MM -MP -c $< -o $@
+	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -MM -MP $< -o $@
 
 %.o: %.c | %.d
 	$(E) " CC       " $@


### PR DESCRIPTION
Fixes a clang compile-time error: "argument unused during compilation: '-c'".
