### PR TITLE
Fix SIGILL during checkpoint

### DIFF
--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -1054,6 +1054,12 @@ int compel_infect_no_daemon(struct parasite_ctl *ctl, unsigned long nr_threads, 
 
 	memcpy(ctl->local_map, ctl->pblob.hdr.mem, ctl->pblob.hdr.bsize);
 	compel_relocs_apply(ctl->local_map, ctl->remote_map, &ctl->pblob);
+	/*
+	 * Ensure the infected thread sees the updated code by flushing instruction and/or data caches as required by the
+	 * target architecture.
+	 * For arm64, it is important that the code in d-cache is flushed to RAM.
+ 	*/
+	__builtin___clear_cache(ctl->local_map, ctl->local_map + ctl->pblob.hdr.bsize);
 
 	p = parasite_size;
 

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2569,6 +2569,13 @@ static int remap_restorer_blob(void *addr)
 	restorer_setup_c_header_desc(&pbd, true);
 	compel_relocs_apply(addr, addr, &pbd);
 
+	/*
+	 * Ensure the infected thread sees the updated code by flushing instruction and/or data caches as required by the
+	 * target architecture.
+	 * For arm64, it is important that the code in d-cache is flushed to RAM.
+ 	*/
+	__builtin___clear_cache(addr, addr + pbd.hdr.bsize);
+
 	return 0;
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->

This PR addresses an issue where some parasited threads received SIGILL signals while communicating with the CRIU process in RPC mode. The problem was previously reported and analyzed in #2641

Following a suggestion by @adrianreber, this PR applies a similar fix as in commit 6be10a2, targeting locations where executable code is modified in memory. This helps prevent instruction cache incoherency, a behavior that is documented for the `arm` architecture.
