### PR TITLE
images/Makefile: fix using $(Q)

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -96,13 +96,13 @@ PROTOBUF_DIR := images/google
 DESCRIPTOR_DIR := $(PROTOBUF_DIR)/protobuf
 GOOGLE_INCLUDE=$(shell pkg-config protobuf --variable=includedir)/google/protobuf
 $(DESCRIPTOR_DIR)/descriptor.pb-c.c: $(GOOGLE_INCLUDE)/descriptor.proto
-	$$(Q) echo "Generating descriptor.pb-c.c"
-	$$(Q) protoc --proto_path=/usr/include --proto_path=$(obj)/ --c_out=$(obj)/ $<
+	$(Q) echo "Generating descriptor.pb-c.c"
+	$(Q) protoc --proto_path=/usr/include --proto_path=$(obj)/ --c_out=$(obj)/ $<
 
 cleanup-y += $(DESCRIPTOR_DIR)/descriptor.pb-c.d
 
 submrproper:
-	$$(Q) rm -rf $(PROTOBUF_DIR)
+	$(Q) rm -rf $(PROTOBUF_DIR)
 .PHONY: submrproper
 mrproper: submrproper
 


### PR DESCRIPTION
Commit 68f92b551 used `$$(Q)` instead of `$(Q)` in the Makefile target,
which resulted in the following error:

```
$(Q) echo "Generating descriptor.pb-c.c"
/bin/sh: 1: Q: not found
Generating descriptor.pb-c.c
$(Q) protoc --proto_path=/usr/include --proto_path=images/ --c_out=images/ /usr/include/google/protobuf/descriptor.proto
/bin/sh: 1: Q: not found
```

as well as

```
$(Q) rm -rf images/google
/bin/sh: line 1: Q: command not found
```

Fix both.