### PR TITLE
test/zdtm/static/maps12: fix pointer-to-int cast

### DIFF
--- a/test/zdtm/static/maps12.c
+++ b/test/zdtm/static/maps12.c
@@ -111,7 +111,8 @@ static inline void *mmap_pages(void *addr_hint, unsigned int count, bool filemap
 
 	map = mmap(addr_hint, count * PAGE_SIZE, PROT_WRITE | PROT_READ,
 		   MAP_PRIVATE | (filemap ? 0 : MAP_ANONYMOUS) | (addr_hint ? MAP_FIXED : 0),
-		   filemap ? fd : -1, filemap ? ((off_t)addr_hint - (off_t)map_base) : 0);
+		   filemap ? fd : -1,
+		   filemap ? (off_t)((intptr_t)addr_hint - (intptr_t)map_base) : 0);
 	if (map == MAP_FAILED || (addr_hint && (map != addr_hint)))
 		return MAP_FAILED;
 


### PR DESCRIPTION
The `offset` argument to `mmap()` was computed with a direct cast from pointer to `off_t`:
    
    (off_t)addr_hint - (off_t)map_base
    
This causes a build failure when compiling since pointers and `off_t` may differ in size on some platforms. The fix in this patch is to cast both pointers to `intptr_t`, perform the subtraction in that type, and then cast the result back to `off_t`.
