### PR TITLE
Socket restrict sopasscred sopasssec to unix and netlink

### DIFF
--- a/criu/include/sockets.h
+++ b/criu/include/sockets.h
@@ -25,7 +25,7 @@ struct socket_desc {
 };
 
 extern int dump_socket(struct fd_parms *p, int lfd, FdinfoEntry *);
-extern int dump_socket_opts(int sk, SkOptsEntry *soe);
+extern int dump_socket_opts(int sk, int family, SkOptsEntry *soe);
 extern int restore_socket_opts(int sk, SkOptsEntry *soe);
 extern int sk_setbufs(int sk, uint32_t *bufs);
 extern void release_skopts(SkOptsEntry *);

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -581,7 +581,7 @@ static int do_dump_one_inet_fd(int lfd, u32 id, const struct fd_parms *p, int fa
 	if (dump_ip_opts(lfd, family, type, proto, &ipopts))
 		goto err;
 
-	if (dump_socket_opts(lfd, &skopts))
+	if (dump_socket_opts(lfd, family, &skopts))
 		goto err;
 
 	pr_info("Dumping inet socket at %d\n", p->fd);

--- a/criu/sk-netlink.c
+++ b/criu/sk-netlink.c
@@ -165,7 +165,7 @@ static int dump_one_netlink_fd(int lfd, u32 id, const struct fd_parms *p)
 	ne.fown = (FownEntry *)&p->fown;
 	ne.opts = &skopts;
 
-	if (dump_socket_opts(lfd, &skopts))
+	if (dump_socket_opts(lfd, AF_NETLINK, &skopts))
 		goto err;
 
 	fe.type = FD_TYPES__NETLINKSK;

--- a/criu/sk-packet.c
+++ b/criu/sk-packet.c
@@ -173,7 +173,7 @@ static int dump_one_packet_fd(int lfd, u32 id, const struct fd_parms *p)
 	psk.fown = (FownEntry *)&p->fown;
 	psk.opts = &skopts;
 
-	if (dump_socket_opts(lfd, &skopts))
+	if (dump_socket_opts(lfd, AF_PACKET, &skopts))
 		return -1;
 
 	psk.protocol = sd->proto;

--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -527,7 +527,7 @@ static int dump_one_unix_fd(int lfd, uint32_t id, const struct fd_parms *p)
 			}
 	}
 dump:
-	if (dump_socket_opts(lfd, skopts))
+	if (dump_socket_opts(lfd, AF_UNIX, skopts))
 		goto err;
 
 	pr_info("Dumping unix socket at %d\n", p->fd);

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -649,7 +649,7 @@ int do_dump_opt(int sk, int level, int name, void *val, int len)
 	return 0;
 }
 
-int dump_socket_opts(int sk, SkOptsEntry *soe)
+int dump_socket_opts(int sk, int family, SkOptsEntry *soe)
 {
 	int ret = 0, val;
 	struct timeval tv;
@@ -688,13 +688,15 @@ int dump_socket_opts(int sk, SkOptsEntry *soe)
 	soe->so_reuseport = val ? true : false;
 	soe->has_so_reuseport = true;
 
-	ret |= dump_opt(sk, SOL_SOCKET, SO_PASSCRED, &val);
-	soe->has_so_passcred = true;
-	soe->so_passcred = val ? true : false;
+	if (family == AF_UNIX || family == AF_NETLINK) {
+		ret |= dump_opt(sk, SOL_SOCKET, SO_PASSCRED, &val);
+		soe->has_so_passcred = true;
+		soe->so_passcred = val ? true : false;
 
-	ret |= dump_opt(sk, SOL_SOCKET, SO_PASSSEC, &val);
-	soe->has_so_passsec = true;
-	soe->so_passsec = val ? true : false;
+		ret |= dump_opt(sk, SOL_SOCKET, SO_PASSSEC, &val);
+		soe->has_so_passsec = true;
+		soe->so_passsec = val ? true : false;
+	}
 
 	ret |= dump_opt(sk, SOL_SOCKET, SO_DONTROUTE, &val);
 	soe->has_so_dontroute = true;


### PR DESCRIPTION
This is to follow mainstream kernel change from commit [1]. Else we have all our socket related zdtm tests failing.

7d8d93fdde50b ("net: Restrict SO_PASS{CRED,PIDFD,SEC} to AF_{UNIX,NETLINK,BLUETOOTH}.") [1]

Fixes: #2718
Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>