### PR TITLE
ci: install junit-xml in rawhide via pip

### DIFF
--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -26,7 +26,6 @@ dnf install -y \
 	protobuf-devel \
 	python3-PyYAML \
 	python3-protobuf \
-	python3-junit_xml \
 	python3-pip \
 	python3-importlib-metadata \
 	python-unversioned-command \
@@ -39,6 +38,8 @@ dnf install -y \
 	libdrm-devel \
 	libuuid-devel \
 	kmod
+
+python3 -m pip install junit-xml
 
 # /tmp is no longer 755 in the rawhide container image and breaks CI - fix it
 chmod 1777 /tmp

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -44,8 +44,10 @@ setup() {
 	ssh default sudo dnf upgrade -y
 	ssh default sudo dnf install -y gcc git gnutls-devel nftables-devel libaio-devel \
 		libasan libcap-devel libnet-devel libnl3-devel libbsd-devel make protobuf-c-devel \
-		protobuf-devel python3-protobuf python3-importlib-metadata python3-junit_xml \
+		protobuf-devel python3-pip python3-protobuf python3-importlib-metadata \
 		rubygem-asciidoctor iptables libselinux-devel libbpf-devel python3-yaml libuuid-devel
+
+	ssh default sudo python3 -m pip install junit-xml
 
 	# Disable sssd to avoid zdtm test failures in pty04 due to sssd socket
 	ssh default sudo systemctl mask sssd


### PR DESCRIPTION
The `python3-junit_xml` package [has been orphaned](https://src.fedoraproject.org/rpms/python-junit_xml/c/9d1e464e70d9e1086de7621070884a253cff7eaa?branch=rawhide) and no longer exists in Fedora Rawhide. This patch updates the CI scripts to install this dependency via `pip`.



<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
