### PR TITLE
lsm: use attr/apparmor/current to get apparmor label

### DIFF
--- a/criu/lsm.c
+++ b/criu/lsm.c
@@ -29,7 +29,9 @@ static int apparmor_get_label(pid_t pid, char **profile_name)
 	FILE *f;
 	char *space;
 
-	f = fopen_proc(pid, "attr/current");
+	f = fopen_proc(pid, "attr/apparmor/current");
+	if (!f)
+		f = fopen_proc(pid, "attr/current");
 	if (!f)
 		return -1;
 


### PR DESCRIPTION
On some kernels, attr/current can be intercepted by BPF LSM, causing errors (#2033). Using attr/apparmor/current is preferable, because it is guaranteed to return the apparmor label. attr/current will still be used as a fallback for older kernels.

Fixes: #2033

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
