### PR TITLE
files: fork helpers without CLONE_FILES | CLONE_FS

### DIFF
--- a/criu/files.c
+++ b/criu/files.c
@@ -1329,7 +1329,6 @@ int prepare_fds(struct pstree_item *me)
 		}
 	}
 
-	BUG_ON(current->pid->state == TASK_HELPER);
 	ret = open_fdinfos(me);
 
 	if (rsti(me)->fdt)

--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -237,9 +237,8 @@ int init_pstree_helper(struct pstree_item *ret)
 {
 	BUG_ON(!ret->parent);
 	ret->pid->state = TASK_HELPER;
-	rsti(ret)->clone_flags = CLONE_FILES | CLONE_FS;
-	if (shared_fdt_prepare(ret) < 0)
-		return -1;
+	rsti(ret)->clone_flags = 0;
+	INIT_LIST_HEAD(&rsti(ret)->fds);
 	task_entries->nr_helpers++;
 	return 0;
 }


### PR DESCRIPTION
On restore, CRIU needs to change mount namespaces to properly restore files and unix sockets. However, the kernel prevents this if a process is sharing its file system information (fs) with other processes.

Fixes #2687

