### PR TITLE
zdtm: stop importing junit_xml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,7 +34,7 @@ task:
   setup_script: |
     dnf config-manager --set-enabled crb # Same as CentOS 8 powertools
     dnf -y install epel-release epel-next-release
-    dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python-junit_xml python3-importlib-metadata xmlto libdrm-devel libuuid-devel
+    dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python3-importlib-metadata xmlto libdrm-devel libuuid-devel
     # The image has a too old version of nettle which does not work with gnutls.
     # Just upgrade to the latest to make the error go away.
     dnf -y upgrade nettle nettle-devel

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -48,6 +48,4 @@ RUN apk add \
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 -D test
 
-RUN pip3 install junit_xml --break-system-packages
-
 RUN make -C test/zdtm

--- a/scripts/build/Dockerfile.archlinux
+++ b/scripts/build/Dockerfile.archlinux
@@ -32,7 +32,6 @@ RUN pacman -Syu --noconfirm \
 	go \
 	python-yaml \
 	asciidoctor \
-	python-junit-xml \
 	python-importlib-metadata \
 	libdrm \
 	util-linux-libs \

--- a/scripts/build/Dockerfile.centos8
+++ b/scripts/build/Dockerfile.centos8
@@ -45,6 +45,4 @@ RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 test
 
-RUN pip3 install junit_xml
-
 RUN make -C test/zdtm -j $(nproc)

--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -26,7 +26,6 @@ dnf install -y \
 	protobuf-devel \
 	python3-PyYAML \
 	python3-protobuf \
-	python3-junit_xml \
 	python3-pip \
 	python3-importlib-metadata \
 	python-unversioned-command \

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -6,7 +6,7 @@ CI_PKGS=(protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
 		libnl-3-dev gdb bash libnet-dev util-linux asciidoctor
 		libnl-route-3-dev time libbsd-dev python3-yaml uuid-dev
 		libperl-dev pkg-config python3-protobuf python3-pip
-		python3-importlib-metadata python3-junit.xml libdrm-dev)
+		python3-importlib-metadata libdrm-dev)
 
 X86_64_PKGS=(gcc-multilib)
 

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -44,7 +44,7 @@ setup() {
 	ssh default sudo dnf upgrade -y
 	ssh default sudo dnf install -y gcc git gnutls-devel nftables-devel libaio-devel \
 		libasan libcap-devel libnet-devel libnl3-devel libbsd-devel make protobuf-c-devel \
-		protobuf-devel python3-protobuf python3-importlib-metadata python3-junit_xml \
+		protobuf-devel python3-protobuf python3-importlib-metadata \
 		rubygem-asciidoctor iptables libselinux-devel libbpf-devel python3-yaml libuuid-devel
 
 	# Disable sssd to avoid zdtm test failures in pty04 due to sssd socket

--- a/test/jenkins/criu-lazy-migration.pipeline
+++ b/test/jenkins/criu-lazy-migration.pipeline
@@ -21,7 +21,6 @@ pipeline {
 		stage('Test'){
 			steps {
 				sh './test/jenkins/run_ct sh -c "mount --make-rprivate / && mount --rbind . /mnt && cd /mnt && ./test/jenkins/criu-lazy-migration.sh"'
-				junit 'test/report/criu-testreport*.xml'
 			}
 		}
 	}


### PR DESCRIPTION
We are dropping support for generating JUnit XML reports in zdtm.py as we've migrated testing infrastructure entirely to `GitHub Actions` and other third-party test runners.

This package has been removed from some distribution repositories (e.g., Fedora), making it simpler to remove the dependency than to force installation via pip.

