### PR TITLE
Easier CI Package Addition

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,8 +34,13 @@ task:
   setup_script: |
     dnf config-manager --set-enabled crb # Same as CentOS 8 powertools
     dnf -y install epel-release epel-next-release
-    dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python3-importlib-metadata xmlto libdrm-devel libuuid-devel
-    dnf install -y  $(sed 's/\#.*$//' contrib/dependencies/dnf-packages.txt)
+    dnf install -y --allowerasing \
+      asciidoc \
+      libasan \
+      libselinux-devel \
+      python-devel \
+      xmlto \
+      $(sed 's/\#.*$//' contrib/dependencies/dnf-packages.txt)
     # The image has a too old version of nettle which does not work with gnutls.
     # Just upgrade to the latest to make the error go away.
     dnf -y upgrade nettle nettle-devel

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,6 +35,7 @@ task:
     dnf config-manager --set-enabled crb # Same as CentOS 8 powertools
     dnf -y install epel-release epel-next-release
     dnf -y install --allowerasing asciidoc gcc git gnutls-devel libaio-devel libasan libcap-devel libnet-devel libnl3-devel libbsd-devel libselinux-devel make protobuf-c-devel protobuf-devel python-devel python-PyYAML python-protobuf python3-importlib-metadata xmlto libdrm-devel libuuid-devel
+    dnf install -y  $(sed 's/\#.*$//' contrib/dependencies/dnf-packages.txt)
     # The image has a too old version of nettle which does not work with gnutls.
     # Just upgrade to the latest to make the error go away.
     dnf -y upgrade nettle nettle-devel

--- a/contrib/dependencies/apk-packages.txt
+++ b/contrib/dependencies/apk-packages.txt
@@ -1,0 +1,28 @@
+# Equivalents of packages mentioned in https://criu.org/Installation
+build-base
+gnutls-dev
+iproute2
+libaio-dev
+libbsd-dev
+libcap-dev
+libdrm-dev
+libnet-dev
+libnl3-dev
+nftables-dev
+pkgconfig
+protobuf-c-compiler
+protobuf-c-dev
+protobuf-dev
+protobuf-dev
+py3-protobuf
+py3-yaml
+util-linux-dev
+
+# Other packages
+bash
+coreutils
+git
+ip6tables
+iptables
+python3
+sudo

--- a/contrib/dependencies/apt-packages.txt
+++ b/contrib/dependencies/apt-packages.txt
@@ -1,0 +1,22 @@
+# From https://criu.org/Installation
+build-essential
+iproute2
+libaio-dev
+libbsd-dev
+libcap-dev
+libdrm-dev
+libgnutls28-dev
+libnet-dev
+libnftables-dev
+libnl-3-dev
+libprotobuf-c-dev
+libprotobuf-dev
+pkg-config
+protobuf-c-compiler
+protobuf-compiler
+python3-protobuf
+python3-yaml
+uuid-dev
+
+# Other packages
+libnl-route-3-dev

--- a/contrib/dependencies/dnf-packages.txt
+++ b/contrib/dependencies/dnf-packages.txt
@@ -1,0 +1,31 @@
+# Packages mentioned in https://criu.org/Installation
+binutils
+gcc
+git
+glibc-devel
+gnutls-devel
+iproute
+libaio-devel
+libbsd-devel
+libcap-devel
+libdrm-devel
+libnet-devel
+libnl3-devel
+libuuid-devel
+make
+nftables
+pkg-config
+protobuf
+protobuf-c
+protobuf-c-devel
+protobuf-compiler
+protobuf-compiler
+protobuf-devel
+python3-protobuf
+python3-pyyaml
+
+# Other packages
+iptables
+libasan
+python3-importlib-metadata
+rubygem-asciidoctor

--- a/contrib/dependencies/pacman-packages.txt
+++ b/contrib/dependencies/pacman-packages.txt
@@ -1,0 +1,31 @@
+# Equivalents of packages mentioned in https://criu.org/Installation
+base-devel
+gnutls
+iproute2
+libaio
+libbsd
+libcap
+libdrm
+libnet
+libnl
+nftables
+pkg-config
+protobuf
+protobuf-c
+python-protobuf
+python-yaml
+util-linux
+
+# Other packages
+asciidoctor
+bash
+coreutils
+diffutils
+git
+go
+iptables
+python-importlib-metadata
+python-pip
+sudo
+tar
+util-linux-libs

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -1,7 +1,9 @@
 FROM alpine
 ARG CC=gcc
 
-RUN apk update && apk add \
+COPY contrib/dependencies/apk-packages.txt /tmp/apk-packages.txt
+
+RUN apk add --no-cache \
 	$CC \
 	bash \
 	build-base \
@@ -25,7 +27,10 @@ RUN apk update && apk add \
 	libcap-utils \
 	libdrm-dev \
 	util-linux \
-	util-linux-dev
+	util-linux-dev \
+	$(sed 's/\#.*$//' /tmp/apk-packages.txt) \
+	&& \
+	rm /tmp/apk-packages.txt
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -5,29 +5,18 @@ COPY contrib/dependencies/apk-packages.txt /tmp/apk-packages.txt
 
 RUN apk add --no-cache \
 	$CC \
+	asciidoctor \
 	bash \
-	build-base \
-	coreutils \
-	procps \
-	git \
-	gnutls-dev \
-	libaio-dev \
-	libcap-dev \
-	libnet-dev \
-	libnl3-dev \
-	nftables \
-	nftables-dev \
-	pkgconfig \
-	protobuf-c-dev \
-	protobuf-dev \
-	py3-pip \
-	py3-protobuf \
-	python3 \
-	sudo \
+	e2fsprogs \
+	go \
+	iptables-legacy \
 	libcap-utils \
-	libdrm-dev \
+	nftables \
+	procps \
+	py3-importlib-metadata \
+	py3-pip \
+	tar \
 	util-linux \
-	util-linux-dev \
 	$(sed 's/\#.*$//' /tmp/apk-packages.txt) \
 	&& \
 	rm /tmp/apk-packages.txt
@@ -35,20 +24,6 @@ RUN apk add --no-cache \
 COPY . /criu
 WORKDIR /criu
 RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
-
-RUN apk add \
-	ip6tables \
-	iptables \
-	iptables-legacy \
-	nftables \
-	iproute2 \
-	tar \
-	bash \
-	go \
-	e2fsprogs \
-	py-yaml \
-	py3-importlib-metadata \
-	asciidoctor
 
 # The rpc test cases are running as user #1000, let's add the user
 RUN adduser -u 1000 -D test

--- a/scripts/build/Dockerfile.amd-rocm
+++ b/scripts/build/Dockerfile.amd-rocm
@@ -12,64 +12,46 @@ ENV BRANCH=$BRANCH \
 #
 # Package installation
 #
-
 COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 RUN apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-install-recommends \
 	--no-upgrade -yq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-	apt-utils \
-	apt-transport-https\
-	gnupg \
-	gnupg2 \
-	gettext \
-	locales \
-	iproute2 \
-	iputils-ping \
-	moreutils \
-	net-tools \
-	psmisc\
-	supervisor \
-	cifs-utils \
-	nfs-common \
-	systemd \
-	fuse \
-	xmlto \
-	autossh \
-	netbase \
-	libnet-dev \
-	libnl-route-3-dev \
 	$CC \
+	apt-transport-https\
+	apt-utils \
+	asciidoc \
+	autossh \
 	bsdmainutils \
 	ca-certificates \
-	build-essential \
+	cifs-utils \
+	curl \
+	fuse \
+	gettext \
 	git-core \
+	gnupg \
+	gnupg2 \
 	iptables \
-	libaio-dev \
-	libbsd-dev \
-	libcap-dev \
-	libgnutls28-dev \
+	iputils-ping \
+	libdrm-amdgpu1 \
 	libgnutls30 \
-	libnl-3-dev \
-	libprotobuf-c-dev \
-	libprotobuf-dev \
+	libnuma1 \
 	libselinux-dev \
-	pkg-config \
-	protobuf-c-compiler \
-	protobuf-compiler \
-	python-protobuf \
+	locales \
+	moreutils \
+	netbase \
+	net-tools \
+	nfs-common \
+	openssh-server \
+	openssl \
+	psmisc\
+	python \
 	python3-minimal \
 	python-ipaddress \
-	uuid-dev \
-	curl \
-	wget \
-	vim \
-	openssl \
-	openssh-server \
-	python \
 	sudo \
-	libnuma1 \
-	libdrm-dev \
-	libdrm-amdgpu1 \
-	asciidoc \
+	supervisor \
+	systemd \
+	vim \
+	wget \
+	xmlto \
 	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
 	&& \
 	rm /tmp/apt-packages.txt && \

--- a/scripts/build/Dockerfile.amd-rocm
+++ b/scripts/build/Dockerfile.amd-rocm
@@ -12,6 +12,8 @@ ENV BRANCH=$BRANCH \
 #
 # Package installation
 #
+
+COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 RUN apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-install-recommends \
 	--no-upgrade -yq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
 	apt-utils \
@@ -68,7 +70,9 @@ RUN apt-get clean -qqy && apt-get update -qqy && apt-get install -qqy --no-insta
 	libdrm-dev \
 	libdrm-amdgpu1 \
 	asciidoc \
+	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
 	&& \
+	rm /tmp/apt-packages.txt && \
 	rm -rf /var/lib/apt/lists/* && \
 	apt-get purge --auto-remove && \
 	apt-get clean

--- a/scripts/build/Dockerfile.archlinux
+++ b/scripts/build/Dockerfile.archlinux
@@ -5,6 +5,8 @@ ARG CC=gcc
 # Initialize machine ID
 RUN systemd-machine-id-setup
 
+COPY contrib/dependencies/pacman-packages.txt /tmp/pacman-packages.txt
+
 RUN pacman -Syu --noconfirm \
 	$CC \
 	bash \
@@ -35,7 +37,10 @@ RUN pacman -Syu --noconfirm \
 	python-importlib-metadata \
 	libdrm \
 	util-linux-libs \
-	diffutils
+	diffutils \
+	$(sed 's/\#.*$//' /tmp/pacman-packages.txt) \
+	&& \
+	rm /tmp/pacman-packages.txt
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/build/Dockerfile.archlinux
+++ b/scripts/build/Dockerfile.archlinux
@@ -9,35 +9,6 @@ COPY contrib/dependencies/pacman-packages.txt /tmp/pacman-packages.txt
 
 RUN pacman -Syu --noconfirm \
 	$CC \
-	bash \
-	make \
-	coreutils \
-	git \
-	gnutls \
-	libaio \
-	libcap \
-	libnet \
-	libnl \
-	nftables \
-	pkgconfig \
-	protobuf-c \
-	protobuf \
-	python-pip \
-	python-protobuf \
-	which \
-	sudo \
-	iptables \
-	nftables \
-	iproute2 \
-	tar \
-	bash \
-	go \
-	python-yaml \
-	asciidoctor \
-	python-importlib-metadata \
-	libdrm \
-	util-linux-libs \
-	diffutils \
 	$(sed 's/\#.*$//' /tmp/pacman-packages.txt) \
 	&& \
 	rm /tmp/pacman-packages.txt

--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -1,7 +1,9 @@
 ARG CC=gcc
 
 COPY scripts/ci/prepare-for-fedora-rawhide.sh /bin/prepare-for-fedora-rawhide.sh
-RUN /bin/prepare-for-fedora-rawhide.sh
+COPY contrib/dependencies/dnf-packages.txt /tmp/dnf-packages.txt
+RUN /bin/prepare-for-fedora-rawhide.sh /tmp/dnf-packages.txt && \
+	rm /tmp/dnf-packages.txt
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/build/Dockerfile.hotspot-alpine
+++ b/scripts/build/Dockerfile.hotspot-alpine
@@ -3,28 +3,7 @@ ARG CC=gcc
 
 COPY contrib/dependencies/apk-packages.txt /tmp/apk-packages.txt
 
-RUN apk add --no-cache \
-	bash \
-	build-base \
-	coreutils \
-	git \
-	gnutls-dev \
-	libaio-dev \
-	libcap-dev \
-	libnet-dev \
-	libnl3-dev \
-	pkgconfig \
-	protobuf-c-dev \
-	protobuf-dev \
-	python3 \
-	sudo \
-	maven \
-	ip6tables \
-	iptables \
-	util-linux-dev \
-	bash \
-	$(sed 's/\#.*$//' /tmp/apk-packages.txt) \
-	&& \
+RUN apk add --no-cache $(sed 's/\#.*$//' /tmp/apk-packages.txt) && \
 	rm /tmp/apk-packages.txt
 
 COPY . /criu

--- a/scripts/build/Dockerfile.hotspot-alpine
+++ b/scripts/build/Dockerfile.hotspot-alpine
@@ -1,7 +1,9 @@
 FROM docker.io/library/eclipse-temurin:11-alpine
 ARG CC=gcc
 
-RUN apk update && apk add \
+COPY contrib/dependencies/apk-packages.txt /tmp/apk-packages.txt
+
+RUN apk add --no-cache \
 	bash \
 	build-base \
 	coreutils \
@@ -20,7 +22,10 @@ RUN apk update && apk add \
 	ip6tables \
 	iptables \
 	util-linux-dev \
-	bash
+	bash \
+	$(sed 's/\#.*$//' /tmp/apk-packages.txt) \
+	&& \
+	rm /tmp/apk-packages.txt
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/build/Dockerfile.hotspot-ubuntu
+++ b/scripts/build/Dockerfile.hotspot-ubuntu
@@ -4,26 +4,11 @@ ARG CC=gcc
 COPY scripts/ci/apt-install /bin/apt-install
 COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 
-RUN apt-install protobuf-c-compiler \
-	libprotobuf-c-dev \
-	libaio-dev \
-	libprotobuf-dev \
-	protobuf-compiler \
-	libcap-dev \
-	libnl-3-dev \
-	gdb \
+RUN apt-install \
 	bash \
-	python3-protobuf \
-	python3-yaml \
-	libnet-dev \
-	libnl-route-3-dev \
-	libbsd-dev \
-	make \
+	gdb \
 	git \
-	pkg-config \
 	iptables \
-	gcc \
-	uuid-dev \
 	maven \
 	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
 	&& \

--- a/scripts/build/Dockerfile.hotspot-ubuntu
+++ b/scripts/build/Dockerfile.hotspot-ubuntu
@@ -2,6 +2,7 @@ FROM docker.io/library/eclipse-temurin:11-focal
 ARG CC=gcc
 
 COPY scripts/ci/apt-install /bin/apt-install
+COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 
 RUN apt-install protobuf-c-compiler \
 	libprotobuf-c-dev \
@@ -23,7 +24,10 @@ RUN apt-install protobuf-c-compiler \
 	iptables \
 	gcc \
 	uuid-dev \
-	maven
+	maven \
+	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
+	&& \
+	rm /tmp/apt-packages.txt
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/build/Dockerfile.linux32.tmpl
+++ b/scripts/build/Dockerfile.linux32.tmpl
@@ -4,25 +4,12 @@ COPY scripts/ci/apt-install /bin/apt-install
 COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 
 RUN apt-install \
-	libnet-dev \
-	libnl-route-3-dev \
 	$CC \
 	bsdmainutils \
-	build-essential \
 	git-core \
 	iptables \
-	libaio-dev \
-	libcap-dev \
-	libgnutls28-dev \
 	libgnutls30 \
-	libnl-3-dev \
-	libprotobuf-c-dev \
-	libprotobuf-dev \
 	libselinux-dev \
-	pkg-config \
-	protobuf-c-compiler \
-	protobuf-compiler \
-	uuid-dev \
 	python3-minimal \
 	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
 	&& \

--- a/scripts/build/Dockerfile.linux32.tmpl
+++ b/scripts/build/Dockerfile.linux32.tmpl
@@ -1,6 +1,7 @@
 ARG CC=gcc
 
 COPY scripts/ci/apt-install /bin/apt-install
+COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 
 RUN apt-install \
 	libnet-dev \
@@ -22,7 +23,10 @@ RUN apt-install \
 	protobuf-c-compiler \
 	protobuf-compiler \
 	uuid-dev \
-	python3-minimal
+	python3-minimal \
+	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
+	&& \
+	rm /tmp/apt-packages.txt
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -2,6 +2,7 @@ FROM docker.io/library/ibm-semeru-runtimes:open-11-jdk-focal
 ARG CC=gcc
 
 COPY scripts/ci/apt-install /bin/apt-install
+COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 
 RUN apt-install protobuf-c-compiler \
 	libprotobuf-c-dev \
@@ -23,7 +24,10 @@ RUN apt-install protobuf-c-compiler \
 	iptables \
 	gcc \
 	uuid-dev \
-	maven
+	maven \
+	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
+	&& \
+	rm /tmp/apt-packages.txt
 
 RUN mkdir -p /etc/criu && echo 'ghost-limit 16777216' > /etc/criu/default.conf
 COPY . /criu

--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -4,26 +4,11 @@ ARG CC=gcc
 COPY scripts/ci/apt-install /bin/apt-install
 COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 
-RUN apt-install protobuf-c-compiler \
-	libprotobuf-c-dev \
-	libaio-dev \
-	libprotobuf-dev \
-	protobuf-compiler \
-	libcap-dev \
-	libnl-3-dev \
-	gdb \
+RUN apt-install \
 	bash \
-	python3-protobuf \
-	python3-yaml \
-	libnet-dev \
-	libnl-route-3-dev \
-	libbsd-dev \
-	make \
+	gdb \
 	git \
-	pkg-config \
 	iptables \
-	gcc \
-	uuid-dev \
 	maven \
 	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
 	&& \

--- a/scripts/build/Dockerfile.riscv64-stable-cross.tmpl
+++ b/scripts/build/Dockerfile.riscv64-stable-cross.tmpl
@@ -17,29 +17,18 @@ RUN dpkg --add-architecture ${DEBIAN_ARCH} && \
 # Install required packages
 RUN apt-get install -y --no-install-recommends \
 	build-essential \
-	pkg-config \
-	git \
 	crossbuild-essential-${DEBIAN_ARCH}	\
-	libc6-dev-${DEBIAN_ARCH}-cross		\
-	libc6-${DEBIAN_ARCH}-cross		\
+	git 					\
 	libbz2-dev:${DEBIAN_ARCH}		\
+	libc6-${DEBIAN_ARCH}-cross		\
+	libc6-dev-${DEBIAN_ARCH}-cross		\
 	libexpat1-dev:${DEBIAN_ARCH}		\
-	ncurses-dev:${DEBIAN_ARCH}		\
 	libssl-dev:${DEBIAN_ARCH}		\
+	ncurses-dev:${DEBIAN_ARCH}		\
+	pkg-config				\
 	protobuf-c-compiler			\
 	protobuf-compiler			\
 	python3-protobuf			\
-	libnl-3-dev:${DEBIAN_ARCH}		\
-	libprotobuf-dev:${DEBIAN_ARCH}		\
-	libnet-dev:${DEBIAN_ARCH}		\
-	libprotobuf-c-dev:${DEBIAN_ARCH}	\
-	libcap-dev:${DEBIAN_ARCH}		\
-	libaio-dev:${DEBIAN_ARCH}		\
-	uuid-dev:${DEBIAN_ARCH}			\
-	libnl-route-3-dev:${DEBIAN_ARCH}	\
-	libnftables-dev:${DEBIAN_ARCH}	\
-	libgnutls28-dev:${DEBIAN_ARCH}	\
-	iproute2:${DEBIAN_ARCH}	\
 	$(awk '!/^#/ && NF {print $0 ":'"${DEBIAN_ARCH}"'"}' /tmp/apt-packages.txt) \
 	&& \
 	rm /tmp/apt-packages.txt

--- a/scripts/build/Dockerfile.riscv64-stable-cross.tmpl
+++ b/scripts/build/Dockerfile.riscv64-stable-cross.tmpl
@@ -9,6 +9,8 @@ COPY scripts/ci/riscv64-cross/amd64-sources.list /etc/apt/sources.list
 
 COPY scripts/ci/riscv64-cross/riscv64-sources.list /etc/apt/sources.list.d/
 
+COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
+
 RUN dpkg --add-architecture ${DEBIAN_ARCH} && \
 	apt-get update -y
 
@@ -37,7 +39,10 @@ RUN apt-get install -y --no-install-recommends \
 	libnl-route-3-dev:${DEBIAN_ARCH}	\
 	libnftables-dev:${DEBIAN_ARCH}	\
 	libgnutls28-dev:${DEBIAN_ARCH}	\
-	iproute2:${DEBIAN_ARCH}
+	iproute2:${DEBIAN_ARCH}	\
+	$(awk '!/^#/ && NF {print $0 ":'"${DEBIAN_ARCH}"'"}' /tmp/apt-packages.txt) \
+	&& \
+	rm /tmp/apt-packages.txt
 
 ENV CROSS_COMPILE=${CROSS_TRIPLET}-				\
 	CROSS_ROOT=/usr/${CROSS_TRIPLET}			\

--- a/scripts/build/Dockerfile.stable-cross.tmpl
+++ b/scripts/build/Dockerfile.stable-cross.tmpl
@@ -7,24 +7,15 @@ RUN echo "deb http://deb.debian.org/debian/ stable main" >> /etc/apt/sources.lis
 
 RUN apt-install \
 	crossbuild-essential-${DEBIAN_ARCH}	\
-	libc6-dev-${DEBIAN_ARCH}-cross		\
-	libc6-${DEBIAN_ARCH}-cross		\
 	libbz2-dev:${DEBIAN_ARCH}		\
+	libc6-${DEBIAN_ARCH}-cross		\
+	libc6-dev-${DEBIAN_ARCH}-cross		\
 	libexpat1-dev:${DEBIAN_ARCH}		\
-	ncurses-dev:${DEBIAN_ARCH}		\
 	libssl-dev:${DEBIAN_ARCH}		\
+	ncurses-dev:${DEBIAN_ARCH}		\
 	protobuf-c-compiler			\
 	protobuf-compiler			\
 	python3-protobuf			\
-	libnl-3-dev:${DEBIAN_ARCH}		\
-	libprotobuf-dev:${DEBIAN_ARCH}		\
-	libnet-dev:${DEBIAN_ARCH}		\
-	uuid-dev:${DEBIAN_ARCH}			\
-	libprotobuf-c-dev:${DEBIAN_ARCH}	\
-	libcap-dev:${DEBIAN_ARCH}		\
-	libaio-dev:${DEBIAN_ARCH}		\
-	libnl-route-3-dev:${DEBIAN_ARCH} \
-	libdrm-dev:${DEBIAN_ARCH}	\
 	$(awk '!/^#/ && NF {print $0 ":'"${DEBIAN_ARCH}"'"}' /tmp/apt-packages.txt) \
 	&& \
 	rm /tmp/apt-packages.txt

--- a/scripts/build/Dockerfile.stable-cross.tmpl
+++ b/scripts/build/Dockerfile.stable-cross.tmpl
@@ -1,4 +1,5 @@
 COPY scripts/ci/apt-install /bin/apt-install
+COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 
 # Add the cross compiler sources
 RUN echo "deb http://deb.debian.org/debian/ stable main" >> /etc/apt/sources.list && \
@@ -23,7 +24,10 @@ RUN apt-install \
 	libcap-dev:${DEBIAN_ARCH}		\
 	libaio-dev:${DEBIAN_ARCH}		\
 	libnl-route-3-dev:${DEBIAN_ARCH} \
-	libdrm-dev:${DEBIAN_ARCH}
+	libdrm-dev:${DEBIAN_ARCH}	\
+	$(awk '!/^#/ && NF {print $0 ":'"${DEBIAN_ARCH}"'"}' /tmp/apt-packages.txt) \
+	&& \
+	rm /tmp/apt-packages.txt
 
 ENV CROSS_COMPILE=${CROSS_TRIPLET}-				\
 	CROSS_ROOT=/usr/${CROSS_TRIPLET}			\

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -6,32 +6,14 @@ COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 # On Ubuntu, kernel modules such as ip_tables and xt_mark may not be loaded by default
 # We need to install kmod to enable iptables to load these modules for us.
 RUN apt-install \
-	libnet-dev \
-	libnl-route-3-dev \
 	$CC \
 	bsdmainutils \
-	build-essential \
 	git-core \
 	iptables \
-	libaio-dev \
-	libbsd-dev \
-	libcap-dev \
-	libgnutls28-dev \
-	libgnutls30 \
-	libnftables-dev \
-	libnl-3-dev \
-	libprotobuf-c-dev \
-	libprotobuf-dev \
-	libselinux-dev \
-	iproute2 \
 	kmod \
-	pkg-config \
-	protobuf-c-compiler \
-	protobuf-compiler \
+	libgnutls30 \
+	libselinux-dev \
 	python3-minimal \
-	python3-protobuf \
-	uuid-dev \
-	python3-yaml \
 	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
 	&& \
 	rm /tmp/apt-packages.txt

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -1,6 +1,7 @@
 ARG CC=gcc
 
 COPY scripts/ci/apt-install /bin/apt-install
+COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 
 # On Ubuntu, kernel modules such as ip_tables and xt_mark may not be loaded by default
 # We need to install kmod to enable iptables to load these modules for us.
@@ -30,7 +31,10 @@ RUN apt-install \
 	python3-minimal \
 	python3-protobuf \
 	uuid-dev \
-	python3-yaml
+	python3-yaml \
+	$(sed 's/\#.*$//' /tmp/apt-packages.txt) \
+	&& \
+	rm /tmp/apt-packages.txt
 
 COPY . /criu
 WORKDIR /criu

--- a/scripts/build/Dockerfile.unstable-cross.tmpl
+++ b/scripts/build/Dockerfile.unstable-cross.tmpl
@@ -1,4 +1,5 @@
 COPY scripts/ci/apt-install /bin/apt-install
+COPY contrib/dependencies/apt-packages.txt /tmp/apt-packages.txt
 
 # Add the cross compiler sources
 RUN echo "deb http://deb.debian.org/debian/ unstable main" >> /etc/apt/sources.list && \
@@ -22,7 +23,10 @@ RUN apt-install \
 	libprotobuf-c-dev:${DEBIAN_ARCH}	\
 	libcap-dev:${DEBIAN_ARCH}		\
 	libaio-dev:${DEBIAN_ARCH}		\
-	libnl-route-3-dev:${DEBIAN_ARCH}
+	libnl-route-3-dev:${DEBIAN_ARCH}	\
+	$(awk '!/^#/ && NF {print $0 ":'"${DEBIAN_ARCH}"'"}' /tmp/apt-packages.txt) \
+	&& \
+	rm /tmp/apt-packages.txt
 
 ENV CROSS_COMPILE=${CROSS_TRIPLET}-				\
 	CROSS_ROOT=/usr/${CROSS_TRIPLET}			\

--- a/scripts/build/Dockerfile.unstable-cross.tmpl
+++ b/scripts/build/Dockerfile.unstable-cross.tmpl
@@ -7,23 +7,15 @@ RUN echo "deb http://deb.debian.org/debian/ unstable main" >> /etc/apt/sources.l
 
 RUN apt-install \
 	crossbuild-essential-${DEBIAN_ARCH}	\
-	libc6-dev-${DEBIAN_ARCH}-cross		\
-	libc6-${DEBIAN_ARCH}-cross		\
 	libbz2-dev:${DEBIAN_ARCH}		\
+	libc6-${DEBIAN_ARCH}-cross		\
+	libc6-dev-${DEBIAN_ARCH}-cross		\
 	libexpat1-dev:${DEBIAN_ARCH}		\
-	ncurses-dev:${DEBIAN_ARCH}		\
 	libssl-dev:${DEBIAN_ARCH}		\
+	ncurses-dev:${DEBIAN_ARCH}		\
 	protobuf-c-compiler			\
 	protobuf-compiler			\
 	python3-protobuf			\
-	libnl-3-dev:${DEBIAN_ARCH}		\
-	libprotobuf-dev:${DEBIAN_ARCH}		\
-	uuid-dev:${DEBIAN_ARCH}			\
-	libnet-dev:${DEBIAN_ARCH}		\
-	libprotobuf-c-dev:${DEBIAN_ARCH}	\
-	libcap-dev:${DEBIAN_ARCH}		\
-	libaio-dev:${DEBIAN_ARCH}		\
-	libnl-route-3-dev:${DEBIAN_ARCH}	\
 	$(awk '!/^#/ && NF {print $0 ":'"${DEBIAN_ARCH}"'"}' /tmp/apt-packages.txt) \
 	&& \
 	rm /tmp/apt-packages.txt

--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e -x
 
+COMMON_PACKAGES_LIST_FILE="${1:-contrib/dependencies/dnf-packages.txt}"
+
+# SC2046 is "Quote this to prevent word splitting". We do want word splitting
+# so that each line is passed as a separate argument
+# shellcheck disable=SC2046
 dnf install -y \
 	diffutils \
 	findutils \
@@ -37,7 +42,8 @@ dnf install -y \
 	rubygem-asciidoctor \
 	libdrm-devel \
 	libuuid-devel \
-	kmod
+	kmod \
+	$(sed 's/\#.*$//' "${COMMON_PACKAGES_LIST_FILE}")
 
 # /tmp is no longer 755 in the rawhide container image and breaks CI - fix it
 chmod 1777 /tmp

--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -8,41 +8,19 @@ COMMON_PACKAGES_LIST_FILE="${1:-contrib/dependencies/dnf-packages.txt}"
 # shellcheck disable=SC2046
 dnf install -y \
 	diffutils \
+	e2fsprogs \
 	findutils \
 	gawk \
-	gcc \
-	git \
-	gnutls-devel \
 	gzip \
-	iproute \
-	iptables \
-	nftables \
-	nftables-devel \
-	libaio-devel \
-	libasan \
-	libcap-devel \
-	libnet-devel \
-	libnl3-devel \
-	libbsd-devel \
+	kmod \
 	libselinux-utils \
-	make \
 	procps-ng \
-	protobuf-c-devel \
-	protobuf-devel \
-	python3-PyYAML \
-	python3-protobuf \
 	python3-pip \
-	python3-importlib-metadata \
 	python-unversioned-command \
 	redhat-rpm-config \
 	sudo \
 	tar \
 	which \
-	e2fsprogs \
-	rubygem-asciidoctor \
-	libdrm-devel \
-	libuuid-devel \
-	kmod \
 	$(sed 's/\#.*$//' "${COMMON_PACKAGES_LIST_FILE}")
 
 # /tmp is no longer 755 in the rawhide container image and breaks CI - fix it

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -8,6 +8,10 @@ CI_PKGS=(protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
 		libperl-dev pkg-config python3-protobuf python3-pip
 		python3-importlib-metadata libdrm-dev)
 
+while IFS='' read -r line; do
+	CI_PKGS+=("$line");
+done < <(sed 's/\#.*$//' ../../contrib/dependencies/apt-packages.txt)
+
 X86_64_PKGS=(gcc-multilib)
 
 # Convert from string to array.

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 set -x -e
 
-CI_PKGS=(protobuf-c-compiler libprotobuf-c-dev libaio-dev libgnutls28-dev
-		libgnutls30 libprotobuf-dev protobuf-compiler libcap-dev
-		libnl-3-dev gdb bash libnet-dev util-linux asciidoctor
-		libnl-route-3-dev time libbsd-dev python3-yaml uuid-dev
-		libperl-dev pkg-config python3-protobuf python3-pip
-		python3-importlib-metadata libdrm-dev)
+CI_PKGS=( \
+	asciidoctor \
+	bash \
+	gdb \
+	libgnutls30 \
+	libperl-dev \
+	python3-importlib-metadata \
+	python3-pip \
+	time \
+	util-linux \
+	)
 
 while IFS='' read -r line; do
 	CI_PKGS+=("$line");

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -47,6 +47,12 @@ setup() {
 		protobuf-devel python3-protobuf python3-importlib-metadata \
 		rubygem-asciidoctor iptables libselinux-devel libbpf-devel python3-yaml libuuid-devel
 
+	# SC2046 is "Quote this to prevent word splitting". We do want word splitting
+	# so that each line is passed as a separate argument
+	# shellcheck disable=SC2046
+	ssh default sudo dnf install -y \
+		$(sed 's/\#.*$//' ../../contrib/dependencies/dnf-packages.txt)
+
 	# Disable sssd to avoid zdtm test failures in pty04 due to sssd socket
 	ssh default sudo systemctl mask sssd
 

--- a/scripts/ci/vagrant.sh
+++ b/scripts/ci/vagrant.sh
@@ -42,10 +42,7 @@ setup() {
 	mkdir -p /root/.ssh
 	vagrant ssh-config >> /root/.ssh/config
 	ssh default sudo dnf upgrade -y
-	ssh default sudo dnf install -y gcc git gnutls-devel nftables-devel libaio-devel \
-		libasan libcap-devel libnet-devel libnl3-devel libbsd-devel make protobuf-c-devel \
-		protobuf-devel python3-protobuf python3-importlib-metadata \
-		rubygem-asciidoctor iptables libselinux-devel libbpf-devel python3-yaml libuuid-devel
+	ssh default sudo dnf install -y libselinux-devel libbpf-devel
 
 	# SC2046 is "Quote this to prevent word splitting". We do want word splitting
 	# so that each line is passed as a separate argument


### PR DESCRIPTION
To test the `--allow-uprobes` introduces by https://github.com/checkpoint-restore/criu/pull/2717 requires the addition of a few packages to be downloaded in the CI pipeline. The current way of doing this requires adding the package names to multiple Dockerfiles and scripts, which are not exhaustively listed, as far as I can see. This way, some files may end up being missed. As discussed in  https://github.com/checkpoint-restore/criu/pull/2717#discussion_r2357376276, this PR makes the Dockerfiles and scripts pull in common package names from package-manager specific files, making it easier to add new packages.