### PR TITLE
ci: consolidate aarch64 tests on GitHub runners

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,28 +89,6 @@ task:
     make -C scripts/ci vagrant-fedora-non-root
 
 task:
-  name: aarch64 build GCC (native)
-  arm_container:
-    image: docker.io/library/ubuntu:jammy
-    cpu: 4
-    memory: 4G
-  script: uname -a
-  build_script: |
-    contrib/apt-install make
-    make -C scripts/ci local
-
-task:
-  name: aarch64 build CLANG (native)
-  arm_container:
-    image: docker.io/library/ubuntu:jammy
-    cpu: 4
-    memory: 4G
-  script: uname -a
-  build_script: |
-    contrib/apt-install make
-    make -C scripts/ci local CLANG=1
-
-task:
   name: aarch64 Fedora Rawhide
   arm_container:
     image: registry.fedoraproject.org/fedora:rawhide

--- a/.github/workflows/aarch64-test.yaml
+++ b/.github/workflows/aarch64-test.yaml
@@ -9,14 +9,16 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
+        os: [ubuntu-24.04-arm, ubuntu-22.04-arm]
         target: [GCC=1, CLANG=1]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
-    - name: Run Tests ${{ matrix.target }}
+    - name: Run Tests ${{ matrix.target }} on ${{ matrix.os }}
       # Following tests are failing on the VMs:
       #  ./change_mnt_context --pidfile=change_mnt_context.pid --outfile=change_mnt_context.out
       #   45: ERR: change_mnt_context.c:23: mount (errno = 22 (Invalid argument))


### PR DESCRIPTION
Currently we run aarch64 tests on both Cirrus CI and GitHub runners. However, Cirrus CI fails with `"Monthly compute limit exceeded!"`. This change removes the redundant tests to streamline our CI process.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
