### PR TITLE
criu/compel: fix compilation on musl/arm64

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -9,10 +9,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
         target: [GCC=1, CLANG=1]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4

--- a/compel/arch/aarch64/src/lib/include/uapi/asm/sigframe.h
+++ b/compel/arch/aarch64/src/lib/include/uapi/asm/sigframe.h
@@ -1,10 +1,11 @@
 #ifndef UAPI_COMPEL_ASM_SIGFRAME_H__
 #define UAPI_COMPEL_ASM_SIGFRAME_H__
 
-#include <asm/sigcontext.h>
+#include <signal.h>
 #include <sys/ucontext.h>
 
 #include <stdint.h>
+#include <asm/types.h>
 
 /* Copied from the kernel header arch/arm64/include/uapi/asm/sigcontext.h */
 

--- a/contrib/dependencies/apk-packages.sh
+++ b/contrib/dependencies/apk-packages.sh
@@ -22,6 +22,7 @@ apk add --no-cache \
 	libnl3-dev \
 	nftables \
 	nftables-dev \
+	perl \
 	pkgconfig \
 	procps \
 	protobuf-c-compiler \

--- a/criu/arch/aarch64/include/asm/restorer.h
+++ b/criu/arch/aarch64/include/asm/restorer.h
@@ -1,7 +1,7 @@
 #ifndef __CR_ASM_RESTORER_H__
 #define __CR_ASM_RESTORER_H__
 
-#include <asm/sigcontext.h>
+#include <signal.h>
 #include <sys/ucontext.h>
 
 #include "asm/types.h"


### PR DESCRIPTION
Compilation on gentoo/arm64 (llvm+musl) fails with:

```
In file included from compel/include/uapi/compel/asm/sigframe.h:4,
                 from compel/plugins/std/infect.c:14:
/usr/include/asm/sigcontext.h:28:8: error: redefinition of 'struct sigcontext'
   28 | struct sigcontext {
      |        ^~~~~~~~~~

In file included from criu/arch/aarch64/include/asm/restorer.h:4,
                 from criu/arch/aarch64/crtools.c:11:
/usr/include/asm/sigcontext.h:28:8: error: redefinition of 'struct sigcontext'
   28 | struct sigcontext {
      |        ^~~~~~~~~~

```
This is happening because <asm/sigcontext.h> and <signal.h> are mutually incompatible on Linux.
To fix, use  <signal.h> instead of <asm/sigcontext.h> for arm64 (like all others arches do).