### PR TITLE
pycriu: add missing protobuf dependency

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 license = {text = "GPLv2"}
 dynamic = ["version"]
 requires-python = ">=3.6"
+dependencies = ["protobuf"]
 
 [tool.setuptools]
 packages = ["pycriu", "pycriu.images"]

--- a/lib/setup.cfg
+++ b/lib/setup.cfg
@@ -14,3 +14,5 @@ version = attr: pycriu.__version__
 [options]
 packages = find:
 python_requires = >=3.6
+install_requires =
+    protobuf


### PR DESCRIPTION
pycriu depends on protobuf to function correctly. Currently,
it raises an error if protobuf is not installed. Adding
protobuf to the dependencies ensures it is available after
installing pycriu.

Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>