### PR TITLE
pycriu: prevent trailing "Unknown" in error messages

### DIFF
--- a/lib/pycriu/criu.py
+++ b/lib/pycriu/criu.py
@@ -181,15 +181,14 @@ class CRIUExceptionExternal(CRIUException):
         if self.errno == errno.EBADRQC:
             s += "Bad options"
 
-        if self.typ == rpc.DUMP:
-            if self.errno == errno.ESRCH:
-                s += "No process with such pid"
+        elif self.typ == rpc.DUMP and self.errno == errno.ESRCH:
+            s += "No process with such pid"
 
-        if self.typ == rpc.RESTORE:
-            if self.errno == errno.EEXIST:
-                s += "Process with requested pid already exists"
+        elif self.typ == rpc.RESTORE and self.errno == errno.EEXIST:
+            s += "Process with requested pid already exists"
 
-        s += "Unknown"
+        else:
+            s += "Unknown"
 
         return s
 


### PR DESCRIPTION
Regardless of the actual error message, "Unknown" was always appended
to the end of the string, resulting in messages like:
"DUMP failed: Error(3): No process with such pid**Unknown**".

Fixed by changing standalone if statements to else-if blocks so
"Unknown" is only added when no specific error condition matches.

Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>