### PR TITLE
pycriu: adjust licence according to README

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -8,7 +8,7 @@ description = "Python bindings for CRIU"
 authors = [
     {name = "CRIU team", email = "criu@lists.linux.dev"},
 ]
-license = {text = "GPLv2"}
+license = {text = "LGPLv2.1"}
 dynamic = ["version"]
 requires-python = ">=3.6"
 

--- a/lib/setup.cfg
+++ b/lib/setup.cfg
@@ -8,7 +8,7 @@ name = pycriu
 description = Python bindings for CRIU
 author = CRIU team
 author_email = criu@lists.linux.dev
-license = GPLv2
+license = LGPLv2.1
 version = attr: pycriu.__version__
 
 [options]


### PR DESCRIPTION
Updated the project license from GPLv2 to LGPLv2.1 to match the license specified in the README.

Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>