### PR TITLE
fix-tests: prevent pip from installing third-party dependencies 

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -48,7 +48,8 @@ endif
 # Default flags for pip install:
 # --upgrade: Upgrade crit/pycriu packages
 # --ignore-installed: Ignore existing packages and reinstall them
-PIPFLAGS ?= --upgrade --ignore-installed
+# --no-deps: Do not install package dependencies
+PIPFLAGS ?= --upgrade --ignore-installed --no-deps
 
 export SKIP_PIP_INSTALL PIPFLAGS
 


### PR DESCRIPTION
fix-tests: prevent pip from installing third-party dependencies 

Added `--no-deps` to the pip arguments since all required dependencies
(such as `python3-protobuf`) have already been installed system-wide.

Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>