### PR TITLE
lib/pycriu: changing the default behavior to use the system binary

### DIFF
--- a/lib/pycriu/criu.py
+++ b/lib/pycriu/criu.py
@@ -103,7 +103,7 @@ class _criu_comm_bin(_criu_comm):
                 os.close(2)
 
                 css[0].send(struct.pack('i', os.getpid()))
-                os.execv(self.comm,
+                os.execvp(self.comm,
                          [self.comm, 'swrk',
                           "%d" % css[0].fileno()])
                 os._exit(1)


### PR DESCRIPTION
Use system-installed CRIU binary instead of a local file

Thanks to @avagin for suggesting this solution.

Co-authored-by: Andrei Vagin <avagin@gmail.com>
Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>