### PR TITLE
rpc.proto: making `images_dir_fd` optional

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -674,7 +674,7 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 	}
 
 	/*
-	 * open images_dir - images_dir_fd is a required RPC parameter
+	 * open images_dir - images_dir_fd is -1 by default
 	 *
 	 * This assumes that if opts.imgs_dir is set we have a value
 	 * from the configuration file parser. The test to see that

--- a/images/rpc.proto
+++ b/images/rpc.proto
@@ -61,7 +61,7 @@ enum criu_pre_dump_mode {
 };
 
 message criu_opts {
-	required int32			images_dir_fd	= 1 [default = -1];
+	optional int32			images_dir_fd	= 1 [default = -1];
 	optional string			images_dir	= 68; /* used only if images_dir_fd == -1 */
 	optional int32			pid		= 2; /* if not set on dump, will dump requesting process */
 


### PR DESCRIPTION
Currently, using `images_dir` requires explicitly setting `opts.images_dir_fd` to `-1` for **every
request**, because Protobuf treats the field as required, even though its default value is already `-1`.

This makes the field unnecessarily mandatory.

Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>