### PR TITLE
pycriu: making `images_dir_fd` optional

### DIFF
--- a/lib/pycriu/criu.py
+++ b/lib/pycriu/criu.py
@@ -204,6 +204,9 @@ class criu:
     def __init__(self):
         self.use_binary('criu')
         self.opts = rpc.criu_opts()
+        # Since images_dir_fd is a required field in rpc.proto
+        # we need to explicitly pass it into opts
+        self.opts.images_dir_fd = self.opts.images_dir_fd
         self.sk = None
 
     def use_sk(self, sk_name):


### PR DESCRIPTION
Since `images_dir_fd` is a required filed in `rpc.proto` we must
explicitly pass it into `opts` in order to use `images_dir`.

Co-authored-by: Andrei Vagin <avagin@gmail.com>
Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>