### PR TITLE
cr-service: skip dump&restore specific optons when doing check

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -673,6 +673,9 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 		xfree(tmp_work);
 	}
 
+	if (opts.mode == CR_CHECK)
+		goto after_dump_restore_specific;
+
 	/*
 	 * open images_dir - images_dir_fd is a required RPC parameter
 	 *
@@ -732,6 +735,8 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 		pr_perror("Can't chdir to work_dir");
 		goto err;
 	}
+
+after_dump_restore_specific:
 
 	if (req->n_irmap_scan_paths) {
 		for (i = 0; i < req->n_irmap_scan_paths; i++) {

--- a/lib/pycriu/criu.py
+++ b/lib/pycriu/criu.py
@@ -265,6 +265,8 @@ class criu:
         """
         req = rpc.criu_req()
         req.type = rpc.CHECK
+        req.opts.MergeFrom(self.opts)
+        req.opts.images_dir_fd = self.opts.images_dir_fd
 
         resp = self._send_req_and_recv_resp(req)
 


### PR DESCRIPTION
Fixes pycriu check funciton

Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>