### PR TITLE
pycriu: better `socket` error handling

### DIFF
--- a/lib/pycriu/criu.py
+++ b/lib/pycriu/criu.py
@@ -45,7 +45,14 @@ class _criu_comm_sk(_criu_comm):
 
     def connect(self, daemon):
         self.sk = socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET)
-        self.sk.connect(self.comm)
+        try:
+            self.sk.connect(self.comm)
+            
+        except FileNotFoundError:
+            raise FileNotFoundError("Socket file not found.")
+        
+        except ConnectionRefusedError:
+            raise ConnectionRefusedError("Service not running.")
 
         return self.sk
 


### PR DESCRIPTION
[Errno 2] No such file or directory -> Socket file not found.
[Errno 111] Connection refused -> Service not running.

Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>