### PR TITLE
pycriu: better `dump` errors

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -710,7 +710,8 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 	 */
 	if (open_image_dir(images_dir_path, -1) < 0) {
 		pr_perror("Can't open images directory");
-		goto err;
+		set_cr_errno(ENOENT);
+		return -1;
 	}
 
 	/* get full path to images_dir to use in process title */

--- a/lib/pycriu/criu.py
+++ b/lib/pycriu/criu.py
@@ -181,6 +181,9 @@ class CRIUExceptionExternal(CRIUException):
         if self.errno == errno.EBADRQC:
             s += "Bad options"
 
+        elif self.typ == rpc.DUMP and self.errno == errno.ENOENT:
+            s += "Dump folder not found. Please create it first."
+
         elif self.typ == rpc.DUMP and self.errno == errno.ESRCH:
             s += "No process with such pid"
 


### PR DESCRIPTION
Specify the reason for a dump fail (No dumps dir).

Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>