### PR TITLE
Use command -v instead of which

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       image: registry.fedoraproject.org/fedora:latest
     steps:
     - name: Install tools
-      run: sudo dnf -y install git make ruff xz clang-tools-extra which codespell git-clang-format ShellCheck
+      run: sudo dnf -y install git make ruff xz clang-tools-extra codespell git-clang-format ShellCheck
 
     - uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,7 @@ lint: ruff shellcheck codespell
 	! git --no-pager grep -E '\s+$$' \*.c \*.h
 .PHONY: lint ruff shellcheck codespell
 
-codecov: SHELL := $(shell which bash)
+codecov: SHELL := $(shell command -v bash)
 codecov:
 	curl -Os https://uploader.codecov.io/latest/linux/codecov
 	chmod +x codecov

--- a/contrib/dependencies/dnf-packages.sh
+++ b/contrib/dependencies/dnf-packages.sh
@@ -37,5 +37,4 @@ dnf install -y \
 	python3-setuptools \
 	python3-wheel \
 	rubygem-asciidoctor \
-	which \
 	xmlto

--- a/contrib/docker_cr.sh
+++ b/contrib/docker_cr.sh
@@ -418,7 +418,7 @@ resolve_path() {
 	local p
 
 	p="${2}"
-	if which realpath > /dev/null; then
+	if command -v realpath > /dev/null; then
 		p=$(realpath "${p}")
 	fi
 	${ECHO} "${1}: ${p}"
@@ -427,7 +427,7 @@ resolve_path() {
 resolve_cmd() {
 	local cpath
 
-	cpath=$(which "${2}")
+	cpath=$(command -v "${2}")
 	resolve_path "${1}" "${cpath}"
 }
 

--- a/scripts/ci/prepare-for-fedora-rawhide.sh
+++ b/scripts/ci/prepare-for-fedora-rawhide.sh
@@ -15,8 +15,7 @@ dnf install -y \
 	python-unversioned-command \
 	redhat-rpm-config \
 	sudo \
-	tar \
-	which
+	tar
 
 # /tmp is no longer 755 in the rawhide container image and breaks CI - fix it
 chmod 1777 /tmp

--- a/scripts/nmk/scripts/tools.mk
+++ b/scripts/nmk/scripts/tools.mk
@@ -23,7 +23,7 @@ MAKE		:= make
 MKDIR		:= mkdir -p
 AWK		:= awk
 PERL		:= perl
-FULL_PYTHON	:= $(shell which python3 2>/dev/null)
+FULL_PYTHON	:= $(shell command -v python3 2>/dev/null)
 PYTHON		?= $(shell basename $(FULL_PYTHON))
 FIND		:= find
 SH		:= $(shell if [ -x "$$BASH" ]; then echo $$BASH;        \
@@ -36,7 +36,7 @@ CTAGS		:= ctags
 export RM HOSTLD LD HOSTCC CC CPP AS AR STRIP OBJCOPY OBJDUMP
 export NM SH MAKE MKDIR AWK PERL PYTHON SH CSCOPE
 
-export USE_ASCIIDOCTOR ?= $(shell which asciidoctor 2>/dev/null)
+export USE_ASCIIDOCTOR ?= $(shell command -v asciidoctor 2>/dev/null)
 
 #
 # Footer.


### PR DESCRIPTION
Unlike "which", which is a separate executable not always installed by default, "command -v" is a shell built-in available at least for bash, dash, and busybox shell.

Unlike "which", "command -v" is also easier to grep for, and it is already used in a few places here.

Inspired by commit 57251d811.