### PR TITLE
pycriu: making sk_name optional

### DIFF
--- a/lib/pycriu/criu.py
+++ b/lib/pycriu/criu.py
@@ -8,6 +8,7 @@ import struct
 
 import pycriu.rpc_pb2 as rpc
 
+CR_DEFAULT_SERVICE_ADDRESS = "./criu_service.socket"
 
 class _criu_comm:
     """
@@ -213,7 +214,7 @@ class criu:
         self.opts = rpc.criu_opts()
         self.sk = None
 
-    def use_sk(self, sk_name):
+    def use_sk(self, sk_name=CR_DEFAULT_SERVICE_ADDRESS):
         """
         Access criu using unix socket which that belongs to criu service daemon.
         """


### PR DESCRIPTION
so user can just call criu.use_sk() without any parameters to use the default socket

Co-authored-by: Radostin Stoyanov <rstoyanov@fedoraproject.org>
Signed-off-by: Andrii Herheliuk <andrii@herheliuk.com>