### PR TITLE
coredump: use required `compat_nr_pages` as fallback for `nr_pages`

### DIFF
--- a/coredump/criu_coredump/coredump.py
+++ b/coredump/criu_coredump/coredump.py
@@ -794,7 +794,8 @@ class coredump_generator:
         off = 0  # in pages
         for m in pagemap[1:]:
             found = False
-            for i in range(m["nr_pages"]):
+            num_pages = m.get("nr_pages", m.compat_nr_pages)
+            for i in range(num_pages):
                 if m["vaddr"] + i * PAGESIZE == page_no * PAGESIZE:
                     found = True
                     break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->

Noticed that `coredump` was blowing up when constructing a coredump from a checkpoint (arm64).

```
Traceback (most recent call last):
  File "/home/ubuntu_ssm_sudo/checkpoint/checkpoint/../../criu/coredump/coredump", line 55, in <module>
    main()
  File "/home/ubuntu_ssm_sudo/checkpoint/checkpoint/../../criu/coredump/coredump", line 47, in main
    coredump(opts)
  File "/home/ubuntu_ssm_sudo/checkpoint/checkpoint/../../criu/coredump/coredump", line 14, in coredump
    cores = generator(os.path.realpath(opts['in']))
  File "/home/ubuntu_ssm_sudo/criu/coredump/criu_coredump/coredump.py", line 192, in __call__
    self.coredumps[pid] = self._gen_coredump(pid)
  File "/home/ubuntu_ssm_sudo/criu/coredump/criu_coredump/coredump.py", line 214, in _gen_coredump
    cd.vmas = self._gen_vmas(pid)
  File "/home/ubuntu_ssm_sudo/criu/coredump/criu_coredump/coredump.py", line 991, in _gen_vmas
    v.data = self._gen_mem_chunk(pid, vma, v.filesz)
  File "/home/ubuntu_ssm_sudo/criu/coredump/criu_coredump/coredump.py", line 878, in _gen_mem_chunk
    page_mem = self._get_page(pid, page_no)
  File "/home/ubuntu_ssm_sudo/criu/coredump/criu_coredump/coredump.py", line 797, in _get_page
    for i in range(m["nr_pages"]):
KeyError: 'nr_pages'
```

Since the pagemap contained `compat_nr_pages` instead of `nr_pages`, I've added a fallback to use that instead.


E.g., dict contained the below
```
{'vaddr': 281474652319744, 'compat_nr_pages': 2, 'flags': 6}
```


