### PR TITLE
coredump: fix handling of num_pages

### DIFF
--- a/coredump/criu_coredump/coredump.py
+++ b/coredump/criu_coredump/coredump.py
@@ -794,7 +794,11 @@ class coredump_generator:
         off = 0  # in pages
         for m in pagemap[1:]:
             found = False
-            num_pages = m.get("nr_pages", m.compat_nr_pages)
+            num_pages = m.get("nr_pages", m.get("compat_nr_pages"))
+
+            if num_pages is None:
+                raise ValueError("num_pages and compat_nr_pages are missing")
+
             for i in range(num_pages):
                 if m["vaddr"] + i * PAGESIZE == page_no * PAGESIZE:
                     found = True


### PR DESCRIPTION
This patch fixes the following error:

```
$ sudo make -C test/others/criu-coredump run
...
Traceback (most recent call last):
  File "/home/circleci/criu/coredump/coredump", line 55, in <module>
    main()
  File "/home/circleci/criu/coredump/coredump", line 47, in main
    coredump(opts)
  File "/home/circleci/criu/coredump/coredump", line 14, in coredump
    cores = generator(os.path.realpath(opts['in']))
  File "/home/circleci/criu/coredump/criu_coredump/coredump.py", line 192, in __call__
    self.coredumps[pid] = self._gen_coredump(pid)
  File "/home/circleci/criu/coredump/criu_coredump/coredump.py", line 214, in _gen_coredump
    cd.vmas = self._gen_vmas(pid)
  File "/home/circleci/criu/coredump/criu_coredump/coredump.py", line 992, in _gen_vmas
    v.data = self._gen_mem_chunk(pid, vma, v.filesz)
  File "/home/circleci/criu/coredump/criu_coredump/coredump.py", line 879, in _gen_mem_chunk
    page_mem = self._get_page(pid, page_no)
  File "/home/circleci/criu/coredump/criu_coredump/coredump.py", line 797, in _get_page
    num_pages = m.get("nr_pages", m.compat_nr_pages)
AttributeError: 'dict' object has no attribute 'compat_nr_pages'
+ exit 1 make[1]: *** [Makefile:3: run] Error 1
```