### PR TITLE
Util: close_safe must not clear fd on close() failure

### DIFF
--- a/criu/util.c
+++ b/criu/util.c
@@ -354,8 +354,11 @@ int set_proc_fd(int fd)
 		pr_perror("dup() failed");
 		return -1;
 	}
-	if (install_service_fd(PROC_FD_OFF, _fd) < 0)
+	if (install_service_fd(PROC_FD_OFF, _fd) < 0) {
+		/* Avoid leaking the duplicated descriptor on failure. */
+		close(_fd);
 		return -1;
+	}
 	return 0;
 }
 
@@ -371,8 +374,11 @@ static int open_proc_sfd(char *path)
 	}
 
 	ret = install_service_fd(PROC_FD_OFF, fd);
-	if (ret < 0)
+	if (ret < 0) {
+		/* install_service_fd failed; close the fd to prevent a leak. */
+		close(fd);
 		return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This pull request addresses potential file descriptor leaks in the `criu/util.c` file by ensuring that file descriptors are properly closed if `install_service_fd` fails. This improves resource management and prevents leaking system resources.

Resource management improvements:

* In both `set_proc_fd` and `open_proc_sfd`, added logic to close the duplicated or opened file descriptor if `install_service_fd` fails, preventing file descriptor leaks. [[1]](diffhunk://#diff-1120c47e8f3ca1a8b18111630a63190d0930ad39a2c63ff40b899add44872640L357-R361) [[2]](diffhunk://#diff-1120c47e8f3ca1a8b18111630a63190d0930ad39a2c63ff40b899add44872640L374-R381)