### PR TITLE
Fixing two small static code analysis warnings

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -2329,8 +2329,6 @@ int cr_dump_tasks(pid_t pid)
 	}
 
 	ret = write_img_inventory(&he);
-	if (ret)
-		goto err;
 err:
 	if (parent_ie)
 		inventory_entry__free_unpacked(parent_ie, NULL);

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2440,6 +2440,7 @@ static long restorer_get_vma_hint(struct list_head *tgt_vma_list, struct list_he
 
 	end_vma.e = &end_e;
 	end_e.start = end_e.end = kdat.task_size;
+	INIT_LIST_HEAD(&end_vma.list);
 
 	s_vma = list_first_entry(self_vma_list, struct vma_area, list);
 	t_vma = list_first_entry(tgt_vma_list, struct vma_area, list);


### PR DESCRIPTION
I got a static code analysis report and this fixes the warnings.

Both reports do not look like a real problem, but the fixes are simple at the same time. If this is seen as unnecessary I can close it again.