### PR TITLE
tty: fix compiler error

### DIFF
--- a/criu/tty.c
+++ b/criu/tty.c
@@ -259,7 +259,7 @@ static int pts_fd_get_index(int fd, const struct fd_parms *p)
 {
 	int index;
 	const struct fd_link *link = p->link;
-	char *pos = strrchr(link->name, '/');
+	const char *pos = strrchr(link->name, '/');
 
 	if (!pos || pos == (link->name + link->len - 1)) {
 		pr_err("Unexpected format on path %s\n", link->name + 1);


### PR DESCRIPTION
At least on tests running on Fedora rawhide following error could be seen:

```
  criu/tty.c: In function 'pts_fd_get_index':
  criu/tty.c:262:21: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
    262 |         char *pos = strrchr(link->name, '/');
        |
```

This fixes it.