### PR TITLE
ci: also exclude docker version 29

### DIFF
--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -2,7 +2,7 @@
 
 set -x -e -o pipefail
 
-# Workaround: Docker 28.x has a known regression that breaks the checkpoint and
+# Workaround: Docker 28.x and 29.x has a known regression that breaks the checkpoint and
 # restore (C/R) feature. Let's install previous, or next major version. See
 # https://github.com/moby/moby/issues/50750 for details on the bug.
 export DEBIAN_FRONTEND=noninteractive
@@ -17,7 +17,7 @@ echo \
   $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" > /etc/apt/sources.list.d/docker.list
 apt update -y
 apt-cache madison docker-ce | awk '{ print $3 }'
-verstr="$(apt-cache madison docker-ce | awk '{ print $3 }' | sort | grep -v ':28\.'| tail -n 1)"
+verstr="$(apt-cache madison docker-ce | awk '{ print $3 }' | sort | grep -Ev ':(28|29)\.'| tail -n 1)"
 ../../contrib/apt-install -y "docker-ce=$verstr" "docker-ce-cli=$verstr"
 
 # docker checkpoint and restore is an experimental feature


### PR DESCRIPTION
Docker version 28 broke container restore in combination with network namespaces. The workaround in the CI script was excluding Docker version 28. Now that there is also Docker version 29, which is still broken, this also excludes Docker version 29.