### PR TITLE
plugin: add UPDATE_INETSK hook to adjust inet socket IPs on restore

### DIFF
--- a/criu/include/criu-plugin.h
+++ b/criu/include/criu-plugin.h
@@ -66,6 +66,8 @@ enum {
 
 	CR_PLUGIN_HOOK__DUMP_DEVICES_LATE = 14,
 
+	CR_PLUGIN_HOOK__UPDATE_INETSK = 15,
+
 	CR_PLUGIN_HOOK__MAX
 };
 
@@ -87,6 +89,7 @@ DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__CHECKPOINT_DEVICES, int pid);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__POST_FORKING, void);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__RESTORE_INIT, void);
 DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__DUMP_DEVICES_LATE, int id);
+DECLARE_PLUGIN_HOOK_ARGS(CR_PLUGIN_HOOK__UPDATE_INETSK, uint32_t family, uint32_t state, uint32_t *src_ip, uint32_t *dst_ip);
 
 enum {
 	CR_PLUGIN_STAGE__DUMP,
@@ -162,5 +165,6 @@ typedef int(cr_plugin_update_vma_map_t)(const char *path, const uint64_t addr, c
 					uint64_t *new_pgoff, int *plugin_fd);
 typedef int(cr_plugin_resume_devices_late_t)(int pid);
 typedef int(cr_plugin_post_forking_t)(void);
+typedef int(cr_plugin_update_inetsk_t)(uint32_t family, uint32_t state, uint32_t *src_ip, uint32_t *dst_ip);
 
 #endif /* __CRIU_PLUGIN_H__ */

--- a/criu/plugin.c
+++ b/criu/plugin.c
@@ -62,6 +62,7 @@ static cr_plugin_desc_t *cr_gen_plugin_desc(void *h, char *path)
 	__assign_hook(POST_FORKING, "cr_plugin_post_forking");
 	__assign_hook(RESTORE_INIT, "cr_plugin_restore_init");
 	__assign_hook(DUMP_DEVICES_LATE, "cr_plugin_dump_devices_late");
+	__assign_hook(UPDATE_INETSK, "cr_plugin_update_inetsk");
 
 #undef __assign_hook
 

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -35,6 +35,7 @@
 #include "protobuf.h"
 #include "util.h"
 #include "namespaces.h"
+#include "plugin.h"
 
 #include "images/inventory.pb-c.h"
 
@@ -707,8 +708,14 @@ static inline int tcp_connection(InetSkEntry *ie)
 static int collect_one_inetsk(void *o, ProtobufCMessage *base, struct cr_img *i)
 {
 	struct inet_sk_info *ii = o;
+	int ret;
 
 	ii->ie = pb_msg(base, InetSkEntry);
+	
+	ret = run_plugins(UPDATE_INETSK, ii->ie->family, ii->ie->state, ii->ie->src_addr, ii->ie->dst_addr);
+	if (ret < 0 && ret != -ENOTSUP)
+		return -1;
+
 	if (tcp_connection(ii->ie))
 		tcp_locked_conn_add(ii);
 


### PR DESCRIPTION
We need to migrate processes across nodes/subnets, and after restore the saved socket IPs may no longer make sense. This PR introduces a new plugin hook CR_PLUGIN_HOOK__UPDATE_INETSK.

The idea is to let a plugin update IPv4/IPv6 addresses in InetSkEntry during restore. The hook runs in collect_one_inetsk() before we do port reservation / bind / connect, so the plugin can adjust the addresses in-place. The old descriptor autogen is also updated so existing plugins keep working.

Usage is simple: the plugin rewrites src_ip / dst_ip (network byte order) and returns 0. -ENOTSUP means “not for me”—we try the next plugin. Any other error aborts restore for that socket. Only the IPs are allowed to change; we still enforce family, ports, ifname, and length constraints.

A note regarding TCP: for established connections you still need external coordination or some mechanism to preserve the original 4-tuple (NAT/overlay/etc.). This hook only changes addresses, it doesn’t touch TCP state. UDP and listen sockets work fine; connected TCP success depends on the network setup.