### PR TITLE
cr-dump: fix error handling

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -2138,8 +2138,8 @@ int cr_dump_tasks(pid_t pid)
 	InventoryEntry he = INVENTORY_ENTRY__INIT;
 	InventoryEntry *parent_ie = NULL;
 	struct pstree_item *item;
-	int pre_dump_ret = 0;
-	int ret = -1;
+	int ret;
+	int exit_code = -1;
 
 	kerndat_warn_about_madv_guards();
 
@@ -2159,9 +2159,9 @@ int cr_dump_tasks(pid_t pid)
 		goto err;
 	root_item->pid->real = pid;
 
-	pre_dump_ret = run_scripts(ACT_PRE_DUMP);
-	if (pre_dump_ret != 0) {
-		pr_err("Pre dump script failed with %d!\n", pre_dump_ret);
+	ret = run_scripts(ACT_PRE_DUMP);
+	if (ret != 0) {
+		pr_err("Pre dump script failed with %d!\n", ret);
 		goto err;
 	}
 	if (init_stats(DUMP_STATS))
@@ -2287,39 +2287,32 @@ int cr_dump_tasks(pid_t pid)
 	 * ipc shared memory, but an ipc namespace is dumped in a child
 	 * process.
 	 */
-	ret = cr_dump_shmem();
-	if (ret)
+	if (cr_dump_shmem())
 		goto err;
 
 	if (root_ns_mask) {
-		ret = dump_namespaces(root_item, root_ns_mask);
-		if (ret)
+		if (dump_namespaces(root_item, root_ns_mask))
 			goto err;
 	}
 
 	if ((root_ns_mask & CLONE_NEWTIME) == 0) {
-		ret = dump_time_ns(0);
-		if (ret)
+		if (dump_time_ns(0))
 			goto err;
 	}
 
 	if (dump_aa_namespaces() < 0)
 		goto err;
 
-	ret = dump_cgroups();
-	if (ret)
+	if (dump_cgroups())
 		goto err;
 
-	ret = fix_external_unix_sockets();
-	if (ret)
+	if (fix_external_unix_sockets())
 		goto err;
 
-	ret = tty_post_actions();
-	if (ret)
+	if (tty_post_actions())
 		goto err;
 
-	ret = inventory_save_uptime(&he);
-	if (ret)
+	if (inventory_save_uptime(&he))
 		goto err;
 
 	he.has_pre_dump_mode = false;
@@ -2328,10 +2321,10 @@ int cr_dump_tasks(pid_t pid)
 		he.allow_uprobes = true;
 	}
 
-	ret = write_img_inventory(&he);
+	exit_code = write_img_inventory(&he);
 err:
 	if (parent_ie)
 		inventory_entry__free_unpacked(parent_ie, NULL);
 
-	return cr_dump_finish(ret);
+	return cr_dump_finish(exit_code);
 }


### PR DESCRIPTION
Commit ["plugin: Add DUMP_DEVICES_LATE callback"](https://github.com/checkpoint-restore/criu/commit/d43217dadb9764e0342306da84f45f7a85c78bbf) introduced a new plugin callback that is invoked in `cr_dump_tasks()`. The return value of this callback was assigned to the variable `ret`. However, this variable is later
used as the return value when `goto err` is triggered in subsequent conditions. As a result, CRIU exits with `"Dumping finished successfully"` even when some actions have failed and `inventory.img` has not been created:
```
(00.062460) Error (criu/tty.c:1830): tty: Found dangling tty with sid 804742 pgid 818131 (pts) on peer fd 0.
Task attached to shell terminal. Consider using --shell-job option. More details on http://criu.org/Simple_loop
(00.062490) Running post-dump scripts
(00.062494) amdgpu_plugin: finished  amdgpu_plugin (AMDGPU/KFD)
(00.062589) Unfreezing tasks into 2
(00.062593)     Unseizing 818131 into 2
(00.062689) Writing stats
(00.062710) Dumping finished successfully
```

To fix this, we replace `ret` with `exit_code` and use it only when it is actually needed.
