### PR TITLE
Check the return value of sys_rseq and report errors in advance

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1363,13 +1363,19 @@ __visible void __export_unmap(void)
 	sys_munmap(bootstrap_start, bootstrap_len - vdso_rt_size);
 }
 
-static void unregister_libc_rseq(struct rst_rseq_param *rseq)
+static int unregister_libc_rseq(struct rst_rseq_param *rseq)
 {
-	if (!rseq->rseq_abi_pointer)
-		return;
+	long ret;
 
-	/* can't fail if rseq is registered */
-	sys_rseq(decode_pointer(rseq->rseq_abi_pointer), rseq->rseq_abi_size, 1, rseq->signature);
+	if (!rseq->rseq_abi_pointer)
+		return 0;
+
+	ret = sys_rseq(decode_pointer(rseq->rseq_abi_pointer), rseq->rseq_abi_size, 1, rseq->signature);
+	if (ret) {
+		pr_err("Failed to unregister libc rseq %ld\n", ret);
+		return -1;
+	}
+	return 0;
 }
 
 /*
@@ -1803,7 +1809,8 @@ __visible long __export_restore_task(struct task_restore_args *args)
 	 * for instance once the kernel will want to update (struct rseq).cpu_id field:
 	 * https://github.com/torvalds/linux/blob/ce522ba9ef7e/kernel/rseq.c#L89
 	 */
-	unregister_libc_rseq(&args->libc_rseq);
+	if (unregister_libc_rseq(&args->libc_rseq))
+		goto core_restore_end;
 
 	if (unmap_old_vmas((void *)args->premmapped_addr, args->premmapped_len, bootstrap_start, bootstrap_len,
 			   args->task_size))


### PR DESCRIPTION
I encountered a SIGSEGV issue and after debugging for a long time, I found that it was caused by a failure of sys_rseq.  Adding a check on the return value and announcing the error beforehand would greatly facilitate problem detection. Please consider this. :)

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
