### PR TITLE
util: Make close_safe() reset fd to -1 even on close() failure

### DIFF
--- a/criu/util.c
+++ b/criu/util.c
@@ -222,10 +222,9 @@ int close_safe(int *fd)
 
 	if (*fd > -1) {
 		ret = close(*fd);
-		if (!ret)
-			*fd = -1;
-		else
-			pr_perror("Unable to close fd %d", *fd);
+		if (ret)
+			pr_perror("Failed closing fd %d", *fd);
+		*fd = -1;
 	}
 
 	return ret;


### PR DESCRIPTION
The "man 2 close":"Dealing with error returns from close()" says:

  "Retrying the close() after a failure return is the wrong thing to do"

We should not leave the fd there, attempting to close it again on next close()/close_safe() may lead to accidentally closing something else.

It confirms with the kernel code where sys_close() removes fd from fdtable in this stack:

```
  +-> sys_close
    +-> file_close_fd
      +-> file_close_fd_locked
        +-> rcu_assign_pointer(fdt->fd[fd], NULL)
```

If there was an fd this stack is always reached and fd is always removed.

Let's replace the fd with -1 after close no matter what.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
