### PR TITLE
ci: fix build errors on Alpine Linux

### DIFF
--- a/compel/arch/aarch64/src/lib/include/uapi/asm/infect-types.h
+++ b/compel/arch/aarch64/src/lib/include/uapi/asm/infect-types.h
@@ -20,8 +20,11 @@ typedef struct user_pt_regs user_regs_struct_t;
 
 /*
  * GCS (Guarded Control Stack)
+ *
+ * This mirrors the kernel definition but renamed to cr_user_gcs
+ * to avoid conflict with kernel headers (/usr/include/asm/ptrace.h).
  */
-struct user_gcs {
+struct cr_user_gcs {
 	__u64 features_enabled;
 	__u64 features_locked;
 	__u64 gcspr_el0;
@@ -29,7 +32,7 @@ struct user_gcs {
 
 struct user_fpregs_struct {
 	struct user_fpsimd_state fpstate;
-	struct user_gcs gcs;
+	struct cr_user_gcs gcs;
 };
 typedef struct user_fpregs_struct user_fpregs_struct_t;
 

--- a/compel/arch/aarch64/src/lib/infect.c
+++ b/compel/arch/aarch64/src/lib/infect.c
@@ -41,7 +41,7 @@ bool __compel_host_supports_gcs(void)
 	return (hwcap & HWCAP_GCS) != 0;
 }
 
-static bool __compel_gcs_enabled(struct user_gcs *gcs)
+static bool __compel_gcs_enabled(struct cr_user_gcs *gcs)
 {
 	if (!compel_host_supports_gcs())
 		return false;
@@ -136,7 +136,7 @@ int compel_set_task_ext_regs(pid_t pid, user_fpregs_struct_t *ext_regs)
 {
 	struct iovec iov;
 
-	struct user_gcs gcs;
+	struct cr_user_gcs gcs;
 	struct iovec gcs_iov = { .iov_base = &gcs, .iov_len = sizeof(gcs) };
 
 	pr_info("Restoring GP/FPU registers for %d\n", pid);
@@ -363,7 +363,7 @@ int ptrace_flush_breakpoints(pid_t pid)
 	return 0;
 }
 
-int inject_gcs_cap_token(struct parasite_ctl *ctl, pid_t pid, struct user_gcs *gcs)
+int inject_gcs_cap_token(struct parasite_ctl *ctl, pid_t pid, struct cr_user_gcs *gcs)
 {
 	struct iovec gcs_iov = { .iov_base = gcs, .iov_len = sizeof(*gcs) };
 
@@ -403,7 +403,7 @@ int inject_gcs_cap_token(struct parasite_ctl *ctl, pid_t pid, struct user_gcs *g
 
 int parasite_setup_shstk(struct parasite_ctl *ctl, user_fpregs_struct_t *ext_regs)
 {
-	struct user_gcs gcs;
+	struct cr_user_gcs gcs;
 	struct iovec gcs_iov = { .iov_base = &gcs, .iov_len = sizeof(gcs) };
 	pid_t pid = ctl->rpid;
 

--- a/compel/arch/arm/plugins/std/syscalls/syscall.def
+++ b/compel/arch/arm/plugins/std/syscalls/syscall.def
@@ -85,7 +85,7 @@ timer_settime			110	258	(kernel_timer_t timer_id, int flags, const struct itimer
 timer_gettime			108	259	(int timer_id, const struct itimerspec *setting)
 timer_getoverrun		109	260	(int timer_id)
 timer_delete			111	261	(kernel_timer_t timer_id)
-clock_gettime			113	263	(const clockid_t which_clock, const struct timespec *tp)
+clock_gettime			113	263	(clockid_t which_clock, struct timespec *tp)
 exit_group			94	248	(int error_code)
 set_robust_list			99	338	(struct robust_list_head *head, size_t len)
 get_robust_list			100	339	(int pid, struct robust_list_head **head_ptr, size_t *len_ptr)

--- a/compel/arch/loongarch64/plugins/std/syscalls/syscall_64.tbl
+++ b/compel/arch/loongarch64/plugins/std/syscalls/syscall_64.tbl
@@ -46,7 +46,7 @@ __NR_sys_timer_gettime		108	sys_timer_gettime	(int timer_id, const struct itimer
 __NR_sys_timer_getoverrun	109	sys_timer_getoverrun	(int timer_id)
 __NR_sys_timer_settime		110	sys_timer_settime	(kernel_timer_t timer_id, int flags, const struct itimerspec *new_setting, struct itimerspec *old_setting)
 __NR_sys_timer_delete		111	sys_timer_delete	(kernel_timer_t timer_id)
-__NR_clock_gettime		113	sys_clock_gettime	(const clockid_t which_clock, const struct timespec *tp)
+__NR_clock_gettime		113	sys_clock_gettime	(clockid_t which_clock, struct timespec *tp)
 __NR_sched_setscheduler		119	sys_sched_setscheduler	(int pid, int policy, struct sched_param *p)
 __NR_restart_syscall		128	sys_restart_syscall	(void)
 __NR_kill			129	sys_kill		(long pid, int sig)

--- a/compel/arch/mips/plugins/std/syscalls/syscall_64.tbl
+++ b/compel/arch/mips/plugins/std/syscalls/syscall_64.tbl
@@ -84,7 +84,7 @@ __NR_sys_timer_settime		5217		sys_timer_settime	(kernel_timer_t timer_id, int fl
 __NR_sys_timer_gettime		5218		sys_timer_gettime	(int timer_id, const struct itimerspec *setting)
 __NR_sys_timer_getoverrun	5219		sys_timer_getoverrun	(int timer_id)
 __NR_sys_timer_delete		5220		sys_timer_delete	(kernel_timer_t timer_id)
-__NR_clock_gettime		5222		sys_clock_gettime	(const clockid_t which_clock, const struct timespec *tp)
+__NR_clock_gettime		5222		sys_clock_gettime	(clockid_t which_clock, struct timespec *tp)
 __NR_exit_group			5205		sys_exit_group		(int error_code)
 __NR_set_thread_area		5242		sys_set_thread_area	(unsigned long *addr)
 __NR_openat			5247		sys_openat		(int dfd, const char *filename, int flags, int mode)

--- a/compel/arch/ppc64/plugins/std/syscalls/syscall-ppc64.tbl
+++ b/compel/arch/ppc64/plugins/std/syscalls/syscall-ppc64.tbl
@@ -82,7 +82,7 @@ __NR_sys_timer_settime	241		sys_timer_settime	(kernel_timer_t timer_id, int flag
 __NR_sys_timer_gettime	242		sys_timer_gettime	(int timer_id, const struct itimerspec *setting)
 __NR_sys_timer_getoverrun	243		sys_timer_getoverrun	(int timer_id)
 __NR_sys_timer_delete	244		sys_timer_delete	(kernel_timer_t timer_id)
-__NR_clock_gettime	246		sys_clock_gettime	(const clockid_t which_clock, const struct timespec *tp)
+__NR_clock_gettime	246		sys_clock_gettime	(clockid_t which_clock, struct timespec *tp)
 __NR_exit_group		234		sys_exit_group		(int error_code)
 __NR_waitid		272		sys_waitid		(int which, pid_t pid, struct siginfo *infop, int options, struct rusage *ru)
 __NR_set_robust_list	300		sys_set_robust_list	(struct robust_list_head *head, size_t len)

--- a/compel/arch/riscv64/plugins/std/syscalls/syscall.def
+++ b/compel/arch/riscv64/plugins/std/syscalls/syscall.def
@@ -85,7 +85,7 @@ timer_settime			110	258	(kernel_timer_t timer_id, int flags, const struct itimer
 timer_gettime			108	259	(int timer_id, const struct itimerspec *setting)
 timer_getoverrun		109	260	(int timer_id)
 timer_delete			111	261	(kernel_timer_t timer_id)
-clock_gettime			113	263	(const clockid_t which_clock, const struct timespec *tp)
+clock_gettime			113	263	(clockid_t which_clock, struct timespec *tp)
 exit_group			94	248	(int error_code)
 set_robust_list			99	338	(struct robust_list_head *head, size_t len)
 get_robust_list			100	339	(int pid, struct robust_list_head **head_ptr, size_t *len_ptr)

--- a/compel/arch/s390/plugins/std/syscalls/syscall-s390.tbl
+++ b/compel/arch/s390/plugins/std/syscalls/syscall-s390.tbl
@@ -82,7 +82,7 @@ __NR_sys_timer_settime	255		sys_timer_settime	(kernel_timer_t timer_id, int flag
 __NR_sys_timer_gettime	256		sys_timer_gettime	(int timer_id, const struct itimerspec *setting)
 __NR_sys_timer_getoverrun	257		sys_timer_getoverrun	(int timer_id)
 __NR_sys_timer_delete	258		sys_timer_delete	(kernel_timer_t timer_id)
-__NR_clock_gettime	260		sys_clock_gettime	(const clockid_t which_clock, const struct timespec *tp)
+__NR_clock_gettime	260		sys_clock_gettime	(clockid_t which_clock, struct timespec *tp)
 __NR_exit_group		248		sys_exit_group		(int error_code)
 __NR_waitid		281		sys_waitid		(int which, pid_t pid, struct siginfo *infop, int options, struct rusage *ru)
 __NR_set_robust_list	304		sys_set_robust_list	(struct robust_list_head *head, size_t len)

--- a/compel/arch/x86/plugins/std/syscalls/syscall_64.tbl
+++ b/compel/arch/x86/plugins/std/syscalls/syscall_64.tbl
@@ -85,7 +85,7 @@ __NR_sys_timer_settime		223		sys_timer_settime	(kernel_timer_t timer_id, int fla
 __NR_sys_timer_gettime		224		sys_timer_gettime	(int timer_id, const struct itimerspec *setting)
 __NR_sys_timer_getoverrun	225		sys_timer_getoverrun	(int timer_id)
 __NR_sys_timer_delete		226		sys_timer_delete	(kernel_timer_t timer_id)
-__NR_clock_gettime		228		sys_clock_gettime	(const clockid_t which_clock, const struct timespec *tp)
+__NR_clock_gettime		228		sys_clock_gettime	(clockid_t which_clock, struct timespec *tp)
 __NR_exit_group			231		sys_exit_group		(int error_code)
 __NR_openat			257		sys_openat		(int dfd, const char *filename, int flags, int mode)
 __NR_waitid			247		sys_waitid		(int which, pid_t pid, struct siginfo *infop, int options, struct rusage *ru)

--- a/criu/arch/aarch64/crtools.c
+++ b/criu/arch/aarch64/crtools.c
@@ -148,7 +148,7 @@ static int save_pac_keys(int pid, CoreEntry *core)
 int save_task_regs(pid_t pid, void *x, user_regs_struct_t *regs, user_fpregs_struct_t *fpsimd)
 {
 	int i;
-	struct user_gcs gcs_live;
+	struct cr_user_gcs gcs_live;
 	struct iovec gcs_iov = {
 		.iov_base = &gcs_live,
 		.iov_len = sizeof(gcs_live),

--- a/plugins/amdgpu/Makefile
+++ b/plugins/amdgpu/Makefile
@@ -28,7 +28,7 @@ criu-amdgpu.pb-c.c: criu-amdgpu.proto
 		protoc --proto_path=. --c_out=. criu-amdgpu.proto
 
 amdgpu_plugin.so: amdgpu_plugin.c amdgpu_plugin_drm.c amdgpu_plugin_dmabuf.c amdgpu_plugin_topology.c amdgpu_plugin_util.c criu-amdgpu.pb-c.c amdgpu_socket_utils.c
-	$(CC) $(PLUGIN_CFLAGS) $(shell $(COMPEL) includes) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS) $(LIBDRM_INC)
+	$(CC) $(PLUGIN_CFLAGS) $(DEFINES) $(shell $(COMPEL) includes) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS) $(LIBDRM_INC)
 
 amdgpu_plugin_clean:
 	$(call msg-clean, $@)

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -2283,7 +2283,7 @@ void *parallel_restore_bo_contents(void *_thread_data)
 			continue;
 
 		entry = &restore_cmd->entries[i];
-		fseeko64(bo_contents_fp, entry->read_offset + offset, SEEK_SET);
+		fseeko(bo_contents_fp, entry->read_offset + offset, SEEK_SET);
 		ret = sdma_copy_bo(restore_cmd->fds_write[entry->write_id], entry->size, bo_contents_fp,
 				   buffer, buffer_size, h_dev,
 				   max_copy_size, SDMA_OP_VRAM_WRITE, false);

--- a/plugins/cuda/Makefile
+++ b/plugins/cuda/Makefile
@@ -19,7 +19,7 @@ all: $(DEPS_CUDA)
 
 cuda_plugin.so: cuda_plugin.c
 	$(call msg-gen, $@)
-	$(Q) $(CC) $(PLUGIN_CFLAGS) $(shell $(COMPEL) includes) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS)
+	$(Q) $(CC) $(PLUGIN_CFLAGS) $(DEFINES) $(shell $(COMPEL) includes) $^ -o $@ $(PLUGIN_INCLUDE) $(PLUGIN_LDFLAGS)
 
 clean:
 	$(call msg-clean, $@)

--- a/test/zdtm/static/cgroup_stray.c
+++ b/test/zdtm/static/cgroup_stray.c
@@ -135,7 +135,7 @@ out:
 int main(int argc, char **argv)
 {
 	int ret = -1, sk_pair[2], sk, status;
-	char path[PATH_MAX], c;
+	char path[PATH_MAX], c = 0;
 	pid_t pid = 0;
 
 	test_init(argc, argv);

--- a/test/zdtm/static/tempfs_subns.c
+++ b/test/zdtm/static/tempfs_subns.c
@@ -20,7 +20,7 @@ int main(int argc, char **argv)
 {
 	int fds[2], i;
 	pid_t pid;
-	int fd, status;
+	int status, fd = -1;
 
 	test_init(argc, argv);
 


### PR DESCRIPTION
The  arm64 linux-headers package in Alpine provides a version of `/usr/include/asm/ptrace.h` that includes a definition for `struct user_gcs`. This causes the build to fail as mentioned in https://github.com/checkpoint-restore/criu/pull/2725#issuecomment-3664519298. In addition, the latest Alpine linux container provides gcc version 15.2.0, which reports an error when uninitialized variable is passed as a pointer argument.