### PR TITLE
test/libcriu: fix include paths for CRIU headers

### DIFF
--- a/test/others/libcriu/Makefile
+++ b/test/others/libcriu/Makefile
@@ -1,4 +1,4 @@
-include ../../../../criu/Makefile.versions
+include ../../../Makefile.versions
 
 TESTS += test_sub
 TESTS += test_self
@@ -20,13 +20,13 @@ run: all
 
 define genb
 $(1): $(1).o lib.o
-	gcc $$^ -L ../../../../criu/lib/c/ -L ../../../../criu/images/ -lcriu -o $$@
+	gcc $$^ -L ../../../lib/c/ -L ../../../images/ -lcriu -o $$@
 endef
 
 $(foreach t, $(TESTS), $(eval $(call genb, $(t))))
 
 %.o: %.c
-	gcc -c $^ -iquote ../../../../criu/criu/include -I../../../../criu/lib/c/ -I../../../../criu/images/ -o $@ -Werror
+	gcc -c $^ -iquote ../../../criu/include -I../../../lib/c/ -I../../../images/ -o $@ -Werror
 
 clean: libcriu_clean
 	rm -rf $(TESTS) $(TESTS:%=%.o) lib.o
@@ -37,5 +37,5 @@ libcriu_clean:
 .PHONY: libcriu_clean
 
 libcriu:
-	ln -s ../../../../criu/lib/c/libcriu.so libcriu.so.${CRIU_SO_VERSION_MAJOR}
+	ln -s ../../../lib/c/libcriu.so libcriu.so.${CRIU_SO_VERSION_MAJOR}
 .PHONY: libcriu

--- a/test/others/libcriu/Makefile
+++ b/test/others/libcriu/Makefile
@@ -26,7 +26,7 @@ endef
 $(foreach t, $(TESTS), $(eval $(call genb, $(t))))
 
 %.o: %.c
-	gcc -c $^ -iquote ../../../criu/include -I../../../lib/c/ -I../../../images/ -o $@ -Werror
+	gcc -c $^ -iquote../../../criu/include -I../../../include -I../../../lib/c/ -I../../../images/ -o $@ -Werror
 
 clean: libcriu_clean
 	rm -rf $(TESTS) $(TESTS:%=%.o) lib.o


### PR DESCRIPTION
The libcriu tests include CRIU headers that are split across "criu/include" and "criu/criu/include". Using only "criu/criu/include" causes CRIU's "linux/openat2.h" to fail to find "common/config.h":
    
      gcc -c test_join_ns.c -iquote ../../../criu -iquote ../../../criu/include -I../../../lib/c/ -I../../../images/ -o test_join_ns.o -Werror
      In file included from /usr/include/bits/fcntl-linux.h:468,
                       from /usr/include/bits/fcntl.h:61,
                       from /usr/include/fcntl.h:35,
                       from test_join_ns.c:3:
      ../../../criu/include/linux/openat2.h:6:10: fatal error: common/config.h: No such file or directory
          6 | #include "common/config.h"
            |          ^~~~~~~~~~~~~~~~~
      compilation terminated.
    
Fixes: f8125b8bef7bf5a7bbaea5e6e1d29578c45bf53d ("Couple of fixes to build and run libcriu tests")
