### PR TITLE
ci: add iproute2 to the list of packages in apt-packages.sh

### DIFF
--- a/contrib/dependencies/apt-packages.sh
+++ b/contrib/dependencies/apt-packages.sh
@@ -13,6 +13,7 @@ fi
 	build-essential \
 	gdb \
 	git-core \
+	iproute2 \
 	iptables \
 	kmod \
 	libaio-dev \


### PR DESCRIPTION
When running the command 'make docker-test', almost all zdtm tests fail, logging 'ip: not found'. 'ip' command of the iproute2 package was missing. So added the package to the list of dependencies in 'apt-packages.sh'. Now tests run