### PR TITLE
test: fix GCC 16 compile error

### DIFF
--- a/test/zdtm/static/uprobes.c
+++ b/test/zdtm/static/uprobes.c
@@ -31,7 +31,7 @@ const char *test_author = "Shashank Balaji <shashank.mahadasyam@sony.com>";
  * compiler optimization) and use it (to prevent "unused variable" warning)
  */
 void UPROBED_FUNCTION(void) {
-	volatile int dummy = 0;
+	volatile int dummy __maybe_unused = 0;
 	dummy += 1;
 }
 /* Calling via volatile function pointer ensures noinline at callsite */


### PR DESCRIPTION
Fedora rawhide ships a pre-release of GCC 16 which produces following error:
```
  uprobes.c:34:22: error: variable ‘dummy’ set but not used [-Werror=unused-but-set-variable=]
  34 |         volatile int dummy = 0;
     |                      ^~~~~
```
Marking this variable as "__maybe_unused" to fix the error.