### PR TITLE
crit: fix incorrect task state decoding

### DIFF
--- a/lib/pycriu/images/pb2dict.py
+++ b/lib/pycriu/images/pb2dict.py
@@ -154,6 +154,7 @@ flags_maps = {
 gen_maps = {
     'task_state': {
         1: 'Alive',
+        2: 'Dead',
         3: 'Stopped',
         6: 'Zombie',
     },

--- a/lib/pycriu/images/pb2dict.py
+++ b/lib/pycriu/images/pb2dict.py
@@ -154,8 +154,8 @@ flags_maps = {
 gen_maps = {
     'task_state': {
         1: 'Alive',
-        3: 'Zombie',
-        6: 'Stopped'
+        3: 'Stopped',
+        6: 'Zombie',
     },
 }
 


### PR DESCRIPTION
CRIU defines the following constants for task state in [`compel/include/uapi/task-state.h`](https://github.com/checkpoint-restore/criu/blob/criu-dev/compel/include/uapi/task-state.h):

```
COMPEL_TASK_ALIVE = 0x01
COMPEL_TASK_STOPPED = 0x03
COMPEL_TASK_ZOMBIE = 0x06
```

Thus, we need to swap the values for "zombie" and "stopped" used in CRIT.