### PR TITLE
pycriu: Fix self-dump failure with explicit PID (os.getpid()) setting

### DIFF
--- a/lib/pycriu/criu.py
+++ b/lib/pycriu/criu.py
@@ -242,7 +242,7 @@ class criu:
         # process resources from its own if criu is located in a same
         # process tree it is trying to dump.
         daemon = False
-        if req.type == rpc.DUMP and not req.opts.HasField('pid'):
+        if req.type == rpc.DUMP and (not req.opts.HasField('pid') or req.opts.pid == os.getpid()):
             daemon = True
 
         try:


### PR DESCRIPTION
When opts.pid is not explicitly `pycriu` properly detects a self-dump and detaches the criu process not causing an error with `infect.c`. But, if `opts.pid` somehow get set to `os.getpid()`, `pycriu` fails to daemonize the `criu` process. This causes `criu` to run as a child of the dumped process, leading to the error "The criu itself is within dumped tree".

Fixed this by appending to the condition statement which sets `daemon=True` in `_send_req_and_recv_resp` to also check `req.opts.pid == os.getpid()`. So if the PID matches the current process id, daemon will still be set to True unlike earlier.

Fixes #2807 
