### PR TITLE
criu: Support binfmt_misc sandboxing

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1810,6 +1810,16 @@ static int check_external_net_ns(void)
 	return 0;
 }
 
+static int check_binfmt_misc_sandboxing(void)
+{
+	if (!kdat.has_binfmt_misc_sandboxing) {
+		pr_info("binfmt_misc sandboxing isn't supported\n");
+		return -1;
+	}
+
+	return 0;
+}
+
 struct feature_list {
 	char *name;
 	int (*func)(void);
@@ -1861,6 +1871,7 @@ static struct feature_list feature_list[] = {
 	{ "overlayfs_maps", check_overlayfs_maps },
 	{ "breakpoints", check_breakpoints },
 	{ "pagemap_scan_guard_pages", check_pagemap_scan_guard_pages },
+	{ "binfmt_misc_sandboxing", check_binfmt_misc_sandboxing },
 	{ NULL, NULL },
 };
 

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -2114,7 +2114,7 @@ static int cr_dump_finish(int ret)
 	free_file_locks();
 	free_link_remaps();
 	free_aufs_branches();
-	free_userns_maps();
+	free_userns_data();
 
 	close_service_fd(CR_PROC_FD_OFF);
 	close_image_dir();

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -2097,7 +2097,6 @@ static int cr_dump_finish(int ret)
 		unsuspend_lsm();
 		network_unlock();
 		delete_link_remaps();
-		clean_cr_time_mounts();
 	}
 
 	if (!ret && opts.lazy_pages)

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -250,9 +250,6 @@ static int crtools_prepare_shared(void)
 	if (!files_collected() && collect_image(&inet_sk_cinfo))
 		return -1;
 
-	if (collect_binfmt_misc())
-		return -1;
-
 	if (tty_prep_fds())
 		return -1;
 

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1667,6 +1667,11 @@ static int __restore_task_with_children(void *_arg)
 	restore_pgid();
 
 	if (current->parent == NULL) {
+		if (root_ns_mask & CLONE_NEWUSER)
+			/* Do this after user ns and mnt ns have been set up */
+			if (restore_userns_binfmt_misc(current))
+				goto err;
+
 		/*
 		 * Wait when all tasks passed the CR_STATE_FORKING stage.
 		 * The stage was started by criu, but now it waits for

--- a/criu/filesystems.c
+++ b/criu/filesystems.c
@@ -79,9 +79,8 @@ static int parse_binfmt_misc_entry(struct bfd *f, BinfmtMiscEntry *bme)
 	return 0;
 }
 
-static int __maybe_unused dump_binfmt_misc_entry(int dfd, char *name, struct cr_img *img)
+static int dump_binfmt_misc_entry(int dfd, char *name, BinfmtMiscEntry *bme)
 {
-	BinfmtMiscEntry bme = BINFMT_MISC_ENTRY__INIT;
 	struct bfd f;
 	int ret = -1;
 
@@ -94,62 +93,232 @@ static int __maybe_unused dump_binfmt_misc_entry(int dfd, char *name, struct cr_
 	if (bfdopenr(&f))
 		return -1;
 
-	if (parse_binfmt_misc_entry(&f, &bme))
+	if (parse_binfmt_misc_entry(&f, bme))
 		goto err;
 
-	bme.name = name;
-
-	if (pb_write_one(img, &bme, PB_BINFMT_MISC))
+	bme->name = xstrdup(name);
+	if (!bme->name)
 		goto err;
+
 	ret = 0;
 err:
-	free(bme.interpreter);
-	free(bme.flags);
-	free(bme.extension);
-	free(bme.magic);
-	free(bme.mask);
 	bclose(&f);
 	return ret;
 }
 
-static int write_binfmt_misc_entry(char *mp, char *buf, BinfmtMiscEntry *bme)
+static void free_bme_fields(BinfmtMiscEntry *bme)
+{
+	xfree(bme->name);
+	xfree(bme->interpreter);
+	xfree(bme->flags);
+	xfree(bme->extension);
+	xfree(bme->magic);
+	xfree(bme->mask);
+}
+
+void free_pb_binfmt_misc_entries(BinfmtMiscEntry **bmes, int n)
+{
+	int i;
+
+	if (!bmes || n == 0)
+		return;
+
+	for (i = 0; i < n; i++)
+		free_bme_fields(bmes[i]);
+
+	xfree(bmes[0]);
+	xfree(bmes);
+}
+
+static int do_binfmt_misc_dump(int fd, BinfmtMiscEntry ***pb_bmes)
+{
+	BinfmtMiscEntry *bmes = NULL;
+	struct dirent *de;
+	DIR *fdir = NULL;
+	int i, ret = 0, len = 0, size = 0;
+
+	*pb_bmes = NULL;
+
+	fdir = fdopendir(fd);
+	if (fdir == NULL) {
+		pr_perror("Failed to open mount directory");
+		close(fd);
+		return -1;
+	}
+
+	while ((de = readdir(fdir))) {
+		BinfmtMiscEntry *bme;
+
+		if (dir_dots(de))
+			continue;
+		if (!strcmp(de->d_name, "register"))
+			continue;
+		if (!strcmp(de->d_name, "status"))
+			continue;
+
+		if (len == size) {
+			BinfmtMiscEntry *e;
+
+			size = size * 2 + 1;
+			e = xrealloc(bmes, size * sizeof(BinfmtMiscEntry));
+			if (e == NULL) {
+				pr_perror("Failed to allocate memory for BinfmtMiscEntry");
+				ret = -1;
+				goto close_dir;
+			}
+			bmes = e;
+		}
+
+		bme = &bmes[len];
+		binfmt_misc_entry__init(bme);
+		/*
+		 * Increase len now as dump_binfmt_misc_entry() might fail with
+		 * partially allocated BinfmtMiscEntry fields.
+		 */
+		len++;
+		ret = dump_binfmt_misc_entry(fd, de->d_name, bme);
+		if (ret < 0)
+			goto close_dir;
+	}
+
+	if (len == 0)
+		goto close_dir;
+
+	*pb_bmes = xmalloc(sizeof(BinfmtMiscEntry *) * len);
+	if (*pb_bmes == NULL) {
+		pr_perror("Failed to allocate memory for BinfmtMiscEntry pointers");
+		ret = -1;
+		goto close_dir;
+	}
+
+	for (i = 0; i < len; i++)
+		(*pb_bmes)[i] = &bmes[i];
+
+close_dir:
+	closedir(fdir);
+
+	if (ret >= 0)
+		return len;
+
+	for (i = 0; i < len; i++)
+		free_bme_fields(&bmes[i]);
+	xfree(bmes);
+
+	return -1;
+}
+
+struct binfmt_misc_dump_arg {
+	pid_t pid;
+	BinfmtMiscEntry ***bmes;
+	int n;
+};
+
+static int binfmt_misc_dump_from_child(void *arg)
+{
+	int exit_code = 1, fd, mnt_fd, n;
+	struct binfmt_misc_dump_arg *dump_arg = (struct binfmt_misc_dump_arg *)arg;
+	BinfmtMiscEntry ***bmes = dump_arg->bmes;
+
+	if (switch_mnt_ns(dump_arg->pid, NULL, NULL) < 0) {
+		pr_err("Failed to switch mount namespace\n");
+		return 1;
+	}
+
+	if (switch_ns(dump_arg->pid, &user_ns_desc, NULL) < 0) {
+		pr_err("Failed to switch user namespace\n");
+		return 1;
+	}
+
+	mnt_fd = mount_detached_fs("binfmt_misc");
+	if (mnt_fd < 0)
+		return 1;
+
+	fd = openat(mnt_fd, ".", O_DIRECTORY | O_RDONLY);
+	if (fd < 0) {
+		pr_perror("Failed to open mountpoint");
+		goto close_mnt_fd;
+	}
+
+	n = do_binfmt_misc_dump(fd, bmes);
+	if (n < 0) {
+		pr_err("Failed to dump binfmt_misc contents\n");
+		goto close_mnt_fd;
+	}
+
+	dump_arg->n = n;
+	exit_code = 0;
+
+close_mnt_fd:
+	close(mnt_fd);
+
+	return exit_code;
+}
+
+/*
+ * The function allocates memory for pb_bmes. It's up to the caller to free it.
+ *
+ * Returns the number of dumped entries or -1 on error.
+ */
+int binfmt_misc_dump_sandboxed(pid_t pid, BinfmtMiscEntry ***pb_bmes)
+{
+	struct binfmt_misc_dump_arg dump_arg;
+	BinfmtMiscEntry **bmes = NULL;
+
+	if (!kdat.has_binfmt_misc_sandboxing)
+		return 0;
+
+	if (!(root_ns_mask & CLONE_NEWUSER)) {
+		pr_err("PID %i is not in a sandbox\n", pid);
+		return -1;
+	}
+
+	dump_arg.pid = pid;
+	dump_arg.bmes = &bmes;
+
+	if (call_in_child_process(binfmt_misc_dump_from_child, (void *)&dump_arg) < 0) {
+		pr_err("Failed to dump binfmt_misc contents from child process\n");
+		return -1;
+	}
+
+	*pb_bmes = bmes;
+	return dump_arg.n;
+}
+
+static int write_binfmt_misc_entry(int mnt_fd, char *buf, BinfmtMiscEntry *bme)
 {
 	int fd, len, ret = -1;
-	char path[PATH_MAX + 1];
 
-	snprintf(path, PATH_MAX, "%s/register", mp);
-
-	fd = open(path, O_WRONLY);
+	fd = openat(mnt_fd, "register", O_WRONLY);
 	if (fd < 0) {
-		pr_perror("binfmt_misc: can't open %s", path);
+		pr_perror("binfmt_misc: can't open 'register'");
 		return -1;
 	}
 
 	len = strlen(buf);
 
 	if (write(fd, buf, len) != len) {
-		pr_perror("binfmt_misc: can't write to %s", path);
+		pr_perror("binfmt_misc: can't write to 'register");
 		goto close;
 	}
 
 	if (!bme->enabled) {
 		close(fd);
-		snprintf(path, PATH_MAX, "%s/%s", mp, bme->name);
 
-		fd = open(path, O_WRONLY);
+		fd = openat(mnt_fd, bme->name, O_WRONLY);
 		if (fd < 0) {
-			pr_perror("binfmt_misc: can't open %s", path);
+			pr_perror("binfmt_misc: can't open %s", bme->name);
 			goto out;
 		}
 		if (write(fd, "0", 1) != 1) {
-			pr_perror("binfmt_misc: can't write to %s", path);
+			pr_perror("binfmt_misc: can't write to %s", bme->name);
 			goto close;
 		}
 	}
 
-	ret = 0;
 close:
 	close(fd);
+
+	ret = 0;
 out:
 	return ret;
 }
@@ -192,7 +361,7 @@ static int make_bfmtm_magic_str(char *buf, BinfmtMiscEntry *bme)
 	return 1;
 }
 
-static int __maybe_unused binfmt_misc_restore_bme(struct mount_info *mi, BinfmtMiscEntry *bme, char *buf)
+static int binfmt_misc_restore_bme(int mnt_fd, BinfmtMiscEntry *bme, char *buf)
 {
 	int ret;
 
@@ -215,13 +384,60 @@ static int __maybe_unused binfmt_misc_restore_bme(struct mount_info *mi, BinfmtM
 		goto bad_dump;
 
 	pr_debug("binfmt_misc_pattern=%s\n", buf);
-	ret = write_binfmt_misc_entry(service_mountpoint(mi), buf, bme);
+	ret = write_binfmt_misc_entry(mnt_fd, buf, bme);
 
 	return ret;
 
 bad_dump:
 	pr_perror("binfmt_misc: bad dump");
 	return -1;
+}
+
+/*
+ * The function is expected to be called from the 'pid' context with namespaces
+ * already set up so no namespace switching is required here.
+ */
+int binfmt_misc_restore_sandboxed(pid_t pid, BinfmtMiscEntry **bmes, size_t n)
+{
+	int ret, mnt_fd;
+	size_t i;
+	char *buf;
+
+	if (!(root_ns_mask & CLONE_NEWUSER)) {
+		pr_err("PID %i is not in a sandbox\n", pid);
+		return -1;
+	}
+
+	if (n == 0)
+		return 0;
+
+	if (!kdat.has_binfmt_misc_sandboxing) {
+		pr_err("binfmt_misc sandboxing is not supported\n");
+		return -1;
+	}
+
+	mnt_fd = mount_detached_fs("binfmt_misc");
+	if (mnt_fd < 0)
+		return -1;
+
+	buf = xmalloc(BINFMT_MISC_STR);
+	if (!buf) {
+		ret = -1;
+		goto close_mnt_fd;
+	}
+
+	for (i = 0; i < n; i++) {
+		ret = binfmt_misc_restore_bme(mnt_fd, bmes[i], buf);
+		if (ret < 0)
+			break;
+	}
+
+	xfree(buf);
+
+close_mnt_fd:
+	close(mnt_fd);
+
+	return ret;
 }
 
 static int tmpfs_dump(struct mount_info *pm)

--- a/criu/filesystems.c
+++ b/criu/filesystems.c
@@ -32,25 +32,6 @@ static int attach_option(struct mount_info *pm, char *opt)
 	return pm->options ? 0 : -1;
 }
 
-#ifdef CONFIG_BINFMT_MISC_VIRTUALIZED
-struct binfmt_misc_info {
-	BinfmtMiscEntry *bme;
-	struct list_head list;
-};
-
-LIST_HEAD(binfmt_misc_list);
-
-static int binfmt_misc_parse_or_collect(struct mount_info *pm)
-{
-	opts.has_binfmt_misc = true;
-	return 0;
-}
-
-static int binfmt_misc_virtual(struct mount_info *pm)
-{
-	return kerndat_fs_virtualized(KERNDAT_FS_STAT_BINFMT_MISC, pm->s_dev);
-}
-
 static int parse_binfmt_misc_entry(struct bfd *f, BinfmtMiscEntry *bme)
 {
 	while (1) {
@@ -98,7 +79,7 @@ static int parse_binfmt_misc_entry(struct bfd *f, BinfmtMiscEntry *bme)
 	return 0;
 }
 
-static int dump_binfmt_misc_entry(int dfd, char *name, struct cr_img *img)
+static int __maybe_unused dump_binfmt_misc_entry(int dfd, char *name, struct cr_img *img)
 {
 	BinfmtMiscEntry bme = BINFMT_MISC_ENTRY__INIT;
 	struct bfd f;
@@ -128,62 +109,6 @@ err:
 	free(bme.magic);
 	free(bme.mask);
 	bclose(&f);
-	return ret;
-}
-
-static int binfmt_misc_dump(struct mount_info *pm)
-{
-	static bool dumped = false;
-	struct cr_img *img = NULL;
-	struct dirent *de;
-	DIR *fdir = NULL;
-	int fd, ret;
-
-	ret = binfmt_misc_virtual(pm);
-	if (ret <= 0)
-		return ret;
-
-	if (dumped) {
-		pr_err("Second binfmt_misc superblock\n");
-		return -1;
-	}
-	dumped = true;
-
-	fd = open_mountpoint(pm);
-	if (fd < 0)
-		return fd;
-
-	fdir = fdopendir(fd);
-	if (fdir == NULL) {
-		close(fd);
-		return -1;
-	}
-
-	ret = -1;
-	while ((de = readdir(fdir))) {
-		if (dir_dots(de))
-			continue;
-		if (!strcmp(de->d_name, "register"))
-			continue;
-		if (!strcmp(de->d_name, "status"))
-			continue;
-
-		if (!img) {
-			/* Create image only if an entry exists, i.e. here */
-			img = open_image(CR_FD_BINFMT_MISC, O_DUMP);
-			if (!img)
-				goto out;
-		}
-
-		if (dump_binfmt_misc_entry(fd, de->d_name, img))
-			goto out;
-	}
-
-	ret = 0;
-out:
-	if (img)
-		close_image(img);
-	closedir(fdir);
 	return ret;
 }
 
@@ -267,7 +192,7 @@ static int make_bfmtm_magic_str(char *buf, BinfmtMiscEntry *bme)
 	return 1;
 }
 
-static int binfmt_misc_restore_bme(struct mount_info *mi, BinfmtMiscEntry *bme, char *buf)
+static int __maybe_unused binfmt_misc_restore_bme(struct mount_info *mi, BinfmtMiscEntry *bme, char *buf)
 {
 	int ret;
 
@@ -298,83 +223,6 @@ bad_dump:
 	pr_perror("binfmt_misc: bad dump");
 	return -1;
 }
-
-static int binfmt_misc_restore(struct mount_info *mi)
-{
-	struct cr_img *img;
-	char *buf;
-	int ret = -1;
-
-	buf = xmalloc(BINFMT_MISC_STR);
-	if (!buf)
-		return -1;
-
-	if (!list_empty(&binfmt_misc_list)) {
-		struct binfmt_misc_info *bmi;
-
-		list_for_each_entry(bmi, &binfmt_misc_list, list) {
-			ret = binfmt_misc_restore_bme(mi, bmi->bme, buf);
-			if (ret)
-				break;
-		}
-		goto free_buf;
-	}
-
-	img = open_image(CR_FD_BINFMT_MISC_OLD, O_RSTR, mi->s_dev);
-	if (!img) {
-		pr_err("Can't open binfmt_misc_old image\n");
-		goto free_buf;
-	} else if (empty_image(img)) {
-		close_image(img);
-		ret = 0;
-		goto free_buf;
-	}
-
-	ret = 0;
-	while (ret == 0) {
-		BinfmtMiscEntry *bme;
-
-		ret = pb_read_one_eof(img, &bme, PB_BINFMT_MISC);
-		if (ret <= 0)
-			break;
-
-		ret = binfmt_misc_restore_bme(mi, bme, buf);
-
-		binfmt_misc_entry__free_unpacked(bme, NULL);
-	}
-
-	close_image(img);
-free_buf:
-	free(buf);
-	return ret;
-}
-
-static int collect_one_binfmt_misc_entry(void *o, ProtobufCMessage *msg, struct cr_img *img)
-{
-	struct binfmt_misc_info *bmi = o;
-
-	bmi->bme = pb_msg(msg, BinfmtMiscEntry);
-	list_add_tail(&bmi->list, &binfmt_misc_list);
-
-	return 0;
-}
-
-struct collect_image_info binfmt_misc_cinfo = {
-	.fd_type = CR_FD_BINFMT_MISC,
-	.pb_type = PB_BINFMT_MISC,
-	.priv_size = sizeof(struct binfmt_misc_info),
-	.collect = collect_one_binfmt_misc_entry,
-};
-
-int collect_binfmt_misc(void)
-{
-	return collect_image(&binfmt_misc_cinfo);
-}
-#else
-#define binfmt_misc_dump	     NULL
-#define binfmt_misc_restore	     NULL
-#define binfmt_misc_parse_or_collect NULL
-#endif
 
 static int tmpfs_dump(struct mount_info *pm)
 {
@@ -689,11 +537,7 @@ static struct fstype fstypes[] = {
 	},
 	{
 		.name = "binfmt_misc",
-		.parse = binfmt_misc_parse_or_collect,
-		.collect = binfmt_misc_parse_or_collect,
 		.code = FSTYPE__BINFMT_MISC,
-		.dump = binfmt_misc_dump,
-		.restore = binfmt_misc_restore,
 	},
 	{
 		.name = "tmpfs",

--- a/criu/image-desc.c
+++ b/criu/image-desc.c
@@ -81,8 +81,6 @@ struct cr_fd_desc_tmpl imgset_template[CR_FD_MAX] = {
 	FD_ENTRY_F(TMPFS_IMG,	"tmpfs-%u.tar.gz", O_NOBUF),
 	FD_ENTRY_F(TMPFS_DEV,	"tmpfs-dev-%u.tar.gz", O_NOBUF),
 	FD_ENTRY_F(AUTOFS,	"autofs-%u", O_NOBUF),
-	FD_ENTRY(BINFMT_MISC_OLD, "binfmt-misc-%u"),
-	FD_ENTRY(BINFMT_MISC,	"binfmt-misc"),
 	FD_ENTRY(TTY_FILES,	"tty"),
 	FD_ENTRY(TTY_INFO,	"tty-info"),
 	FD_ENTRY_F(TTY_DATA,	"tty-data", O_NOBUF),

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -181,9 +181,6 @@ struct cr_options {
 	bool aufs; /* auto-detected, not via cli */
 	bool overlayfs;
 	int ghost_fiemap;
-#ifdef CONFIG_BINFMT_MISC_VIRTUALIZED
-	bool has_binfmt_misc; /* auto-detected */
-#endif
 	size_t ghost_limit;
 	struct list_head irmap_scan_paths;
 	bool lsm_supplied;

--- a/criu/include/filesystems.h
+++ b/criu/include/filesystems.h
@@ -27,6 +27,4 @@ extern int aufs_parse(struct mount_info *mi);
 /* callback for OverlayFS support */
 extern int overlayfs_parse(struct mount_info *mi);
 
-/* FIXME -- remove */
-extern struct list_head binfmt_misc_list;
 #endif

--- a/criu/include/filesystems.h
+++ b/criu/include/filesystems.h
@@ -1,11 +1,18 @@
 #ifndef __CR_FILESYSTEMS_H__
 #define __CR_FILESYSTEMS_H__
+
+#include "images/userns.pb-c.h"
+
 extern struct fstype *find_fstype_by_name(char *fst);
 extern struct fstype *decode_fstype(u32 fst);
 extern bool add_fsname_auto(const char *names);
 
 struct mount_info;
 typedef int (*mount_fn_t)(struct mount_info *mi, const char *src, const char *fstype, unsigned long mountflags);
+
+int binfmt_misc_dump_sandboxed(pid_t pid, BinfmtMiscEntry ***pb_bmes);
+int binfmt_misc_restore_sandboxed(pid_t pid, BinfmtMiscEntry **bmes, size_t n);
+void free_pb_binfmt_misc_entries(BinfmtMiscEntry **bmes, int n);
 
 struct fstype {
 	char *name;

--- a/criu/include/kerndat.h
+++ b/criu/include/kerndat.h
@@ -93,6 +93,7 @@ struct kerndat_s {
 	bool has_breakpoints;
 	bool has_madv_guard;
 	bool has_pagemap_scan_guard_pages;
+	bool has_binfmt_misc_sandboxing;
 };
 
 extern struct kerndat_s kdat;

--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -145,14 +145,6 @@ static inline bool mnt_is_nodev_external(struct mount_info *mi)
 }
 
 extern struct ns_desc mnt_ns_desc;
-#ifdef CONFIG_BINFMT_MISC_VIRTUALIZED
-extern int collect_binfmt_misc(void);
-#else
-static inline int collect_binfmt_misc(void)
-{
-	return 0;
-}
-#endif
 
 extern struct mount_info *mnt_entry_alloc(bool rst);
 extern void mnt_entry_free(struct mount_info *mi);
@@ -191,7 +183,6 @@ extern int ext_mount_parse_auto(char *key);
 extern int mntns_maybe_create_roots(void);
 extern int read_mnt_ns_img(void);
 extern void cleanup_mnt_ns(void);
-extern void clean_cr_time_mounts(void);
 
 extern char *get_plain_mountpoint(int mnt_id, char *name);
 
@@ -221,8 +212,6 @@ extern int mnt_tree_for_each(struct mount_info *start, int (*fn)(struct mount_in
 extern char *service_mountpoint(const struct mount_info *mi);
 
 extern int validate_mounts(struct mount_info *info, bool for_dump);
-extern __maybe_unused struct mount_info *add_cr_time_mount(struct mount_info *root, char *fsname, const char *path,
-							   unsigned int s_dev, bool rst);
 extern char *resolve_source(struct mount_info *mi);
 extern int fetch_rt_stat(struct mount_info *m, const char *where);
 extern int do_simple_mount(struct mount_info *mi, const char *src, const char *fstype, unsigned long mountflags);

--- a/criu/include/namespaces.h
+++ b/criu/include/namespaces.h
@@ -179,13 +179,14 @@ extern struct ns_id *lookup_ns_by_id(unsigned int id, struct ns_desc *nd);
 
 extern int collect_user_namespaces(bool for_dump);
 extern int prepare_userns(struct pstree_item *item);
+extern int restore_userns_binfmt_misc(struct pstree_item *item);
 extern int stop_usernsd(void);
 
 extern uid_t userns_uid(uid_t uid);
 extern gid_t userns_gid(gid_t gid);
 
 extern int dump_user_ns(pid_t pid, int ns_id);
-extern void free_userns_maps(void);
+extern void free_userns_data(void);
 extern int join_ns_add(const char *type, char *ns_file, char *extra_opts);
 extern int check_namespace_opts(void);
 extern int join_namespaces(void);

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1848,6 +1848,92 @@ void kerndat_warn_about_madv_guards(void)
 			"Please, consider updating your kernel.\n");
 }
 
+/* Keep the fd open so that it can be closed by the caller (required by the parent process) */
+static int __mount_and_stat_detached_binfmt_misc(struct stat *st, int *mnt_fd)
+{
+	int fd;
+
+	fd = mount_detached_fs("binfmt_misc");
+	if (fd < 0) {
+		/* Most likely a permission error, so we can't use binfmt_misc */
+		return 1;
+	}
+
+	if (fstat(fd, st) < 0) {
+		pr_perror("Failed to stat a binfmt_misc mountpoint");
+		close(fd);
+		return -1;
+	}
+
+	*mnt_fd = fd;
+
+	return 0;
+}
+
+struct has_binfmt_misc_arg {
+	dev_t st_dev;
+	bool has;
+};
+
+static int __has_binfmt_misc_sandboxing(void *arg)
+{
+	struct has_binfmt_misc_arg *has_arg = (struct has_binfmt_misc_arg *)arg;
+	struct stat st;
+	int ret, mnt_fd;
+
+	if (unshare(CLONE_NEWNS | CLONE_NEWUSER)) {
+		pr_perror("Failed to unshare namespaces");
+		return 1;
+	}
+
+	ret = __mount_and_stat_detached_binfmt_misc(&st, &mnt_fd);
+	if (ret < 0) {
+		return 1;
+	} else if (ret == 1) {
+		has_arg->has = false;
+		return 0;
+	}
+
+	if (has_arg->st_dev != st.st_dev)
+		has_arg->has = true;
+	else
+		has_arg->has = false;
+
+	close(mnt_fd);
+
+	return 0;
+}
+
+static int kerndat_has_binfmt_misc_sandboxing(void)
+{
+	int ret, mnt_fd;
+	struct stat st;
+	struct has_binfmt_misc_arg arg;
+
+	ret = __mount_and_stat_detached_binfmt_misc(&st, &mnt_fd);
+	if (ret < 0) {
+		return -1;
+	} else if (ret == 1) {
+		arg.has = false;
+		goto out;
+	}
+
+	arg.st_dev = st.st_dev;
+
+	ret = call_in_child_process(__has_binfmt_misc_sandboxing, (void *)&arg);
+	close(mnt_fd);
+	if (ret < 0) {
+		pr_err("Failed to check binfmt_misc sandboxing support in child process\n");
+		return -1;
+	}
+
+out:
+	pr_info("binfmt_misc sandboxing is %s supported\n", arg.has ? "" : "not");
+	kdat.has_binfmt_misc_sandboxing = arg.has;
+
+	return 0;
+}
+
 /*
  * Some features depend on resource that can be dynamically changed
  * at the OS runtime. There are cases that we cannot determine the
@@ -2119,6 +2205,10 @@ int kerndat_init(void)
 	}
 	if (!ret && kerndat_has_madv_guard()) {
 		pr_err("kerndat_has_madv_guard has failed when initializing kerndat.\n");
+		ret = -1;
+	}
+	if (!ret && kerndat_has_binfmt_misc_sandboxing()) {
+		pr_err("kerndat_has_binfmt_misc_sandboxing has failed when initializing kerndat.\n");
 		ret = -1;
 	}
 

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -360,11 +360,6 @@ static dev_t get_host_dev(unsigned int which)
 			.path	= "/dev",
 			.magic	= TMPFS_MAGIC,
 		},
-		[KERNDAT_FS_STAT_BINFMT_MISC] = {
-			.name	= "binfmt_misc",
-			.path	= "/proc/sys/fs/binfmt_misc",
-			.magic	= BINFMTFS_MAGIC,
-		},
 	};
 
 	if (which >= KERNDAT_FS_STAT_MAX) {

--- a/criu/mount-v2.c
+++ b/criu/mount-v2.c
@@ -1289,19 +1289,6 @@ int prepare_mnt_ns_v2(void)
 	if (!(root_ns_mask & CLONE_NEWNS))
 		return 0;
 
-#ifdef CONFIG_BINFMT_MISC_VIRTUALIZED
-	if (!opts.has_binfmt_misc && !list_empty(&binfmt_misc_list)) {
-		/*
-		 * Add to root yard along with other plain mounts and mntns
-		 * directories. This mount would be created and restored by
-		 * generic mount creation code, but it would never be moved to
-		 * any restored mount namespaces.
-		 */
-		if (!add_cr_time_mount(root_yard_mp, "binfmt_misc", "binfmt_misc", 0, true))
-			return -1;
-	}
-#endif
-
 	if (validate_mounts(mntinfo, false))
 		return -1;
 

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -1659,123 +1659,6 @@ char *get_plain_mountpoint(int mnt_id, char *name)
 	return xstrdup(tmp);
 }
 
-struct mount_info __maybe_unused *add_cr_time_mount(struct mount_info *root, char *fsname, const char *path,
-						    unsigned int s_dev, bool rst)
-{
-	struct mount_info *mi, *t, *parent;
-	bool add_slash = false;
-	int len;
-
-	mi = mnt_entry_alloc(rst);
-	if (!mi)
-		return NULL;
-
-	len = strlen(root->mountpoint);
-	/* It may be "./" or "./path/to/dir" */
-	if (root->mountpoint[len - 1] != '/') {
-		add_slash = true;
-		len++;
-	}
-
-	mi->mountpoint = xmalloc(len + strlen(path) + 1);
-	if (!mi->mountpoint)
-		goto err;
-	if (!rst)
-		mi->ns_mountpoint = mi->mountpoint;
-	if (!add_slash)
-		sprintf(mi->mountpoint, "%s%s", root->mountpoint, path);
-	else
-		sprintf(mi->mountpoint, "%s/%s", root->mountpoint, path);
-	if (rst) {
-		mi->plain_mountpoint = get_plain_mountpoint(-1, "crtime");
-		if (!mi->plain_mountpoint)
-			goto err;
-	}
-	mi->mnt_id = HELPER_MNT_ID;
-	mi->is_dir = true;
-	mi->flags = mi->sb_flags = 0;
-	mi->root = xstrdup("/");
-	mi->fsname = xstrdup(fsname);
-	mi->source = xstrdup(fsname);
-	mi->options = xstrdup("");
-	if (!mi->root || !mi->fsname || !mi->source || !mi->options)
-		goto err;
-	mi->fstype = find_fstype_by_name(fsname);
-
-	mi->s_dev = mi->s_dev_rt = s_dev;
-
-	parent = root;
-	while (1) {
-		list_for_each_entry(t, &parent->children, siblings) {
-			if (strstartswith(service_mountpoint(mi), service_mountpoint(t))) {
-				parent = t;
-				break;
-			}
-		}
-		if (&t->siblings == &parent->children)
-			break;
-	}
-
-	mi->mnt_bind_is_populated = true;
-	mi->is_overmounted = false;
-	mi->nsid = parent->nsid;
-	mi->parent = parent;
-	mi->parent_mnt_id = parent->mnt_id;
-	list_add(&mi->siblings, &parent->children);
-	pr_info("Add cr-time mountpoint %s with parent %s(%u)\n", service_mountpoint(mi), service_mountpoint(parent),
-		parent->mnt_id);
-	return mi;
-
-err:
-	mnt_entry_free(mi);
-	return NULL;
-}
-
-/*
- * Returns:
- *  0 - success
- * -1 - error
- *  1 - skip
- */
-static __maybe_unused int mount_cr_time_mount(struct ns_id *ns, unsigned int *s_dev, const char *source,
-					      const char *target, const char *type)
-{
-	int mnt_fd, cwd_fd, exit_code = -1;
-	struct stat st;
-
-	if (switch_mnt_ns(ns->ns_pid, &mnt_fd, &cwd_fd)) {
-		pr_err("Can't switch mnt_ns\n");
-		return -1;
-	}
-
-	if (mount(source, target, type, 0, NULL)) {
-		switch (errno) {
-		case EPERM:
-		case EBUSY:
-		case ENODEV:
-		case ENOENT:
-			pr_debug("Skipping %s as was unable to mount it: %s\n", type, strerror(errno));
-			exit_code = 1;
-			break;
-		default:
-			pr_perror("Unable to mount %s %s %s", type, source, target);
-		}
-		goto restore_ns;
-	}
-
-	if (stat(target, &st)) {
-		pr_perror("Can't stat %s", target);
-		goto restore_ns;
-	}
-
-	*s_dev = MKKDEV(major(st.st_dev), minor(st.st_dev));
-	exit_code = 0;
-restore_ns:
-	if (restore_mnt_ns(mnt_fd, &cwd_fd))
-		exit_code = -1;
-	return exit_code;
-}
-
 static int dump_one_fs(struct mount_info *mi)
 {
 	struct mount_info *pm = mi;
@@ -3517,7 +3400,7 @@ void fini_restore_mntns(void)
 /*
  * All nested mount namespaces are restore as sub-trees of the root namespace.
  */
-static int populate_roots_yard(struct mount_info *cr_time)
+static int populate_roots_yard(void)
 {
 	struct mnt_remap_entry *r;
 	char path[PATH_MAX];
@@ -3548,27 +3431,12 @@ static int populate_roots_yard(struct mount_info *cr_time)
 		}
 	}
 
-	if (cr_time && mkdirpat(AT_FDCWD, service_mountpoint(cr_time), 0755)) {
-		pr_perror("Unable to create %s", service_mountpoint(cr_time));
-		return -1;
-	}
-
 	return 0;
 }
 
 static int populate_mnt_ns(void)
 {
-	struct mount_info *cr_time = NULL;
 	int ret;
-
-#ifdef CONFIG_BINFMT_MISC_VIRTUALIZED
-	if (!opts.has_binfmt_misc && !list_empty(&binfmt_misc_list)) {
-		/* Add to mount tree. Generic code will mount it later */
-		cr_time = add_cr_time_mount(root_yard_mp, "binfmt_misc", "binfmt_misc", 0, true);
-		if (!cr_time)
-			return -1;
-	}
-#endif
 
 	if (resolve_shared_mounts(mntinfo))
 		return -1;
@@ -3579,7 +3447,7 @@ static int populate_mnt_ns(void)
 	if (find_remap_mounts(root_yard_mp))
 		return -1;
 
-	if (populate_roots_yard(cr_time))
+	if (populate_roots_yard())
 		return -1;
 
 	if (mount_clean_path())
@@ -3992,29 +3860,6 @@ int collect_mnt_namespaces(bool for_dump)
 
 	search_bindmounts();
 
-#ifdef CONFIG_BINFMT_MISC_VIRTUALIZED
-	if (for_dump && !opts.has_binfmt_misc) {
-		unsigned int s_dev = 0;
-		struct ns_id *ns;
-
-		for (ns = ns_ids; ns != NULL; ns = ns->next) {
-			if (ns->type == NS_ROOT && ns->nd == &mnt_ns_desc)
-				break;
-		}
-
-		if (ns) {
-			ret = mount_cr_time_mount(ns, &s_dev, "binfmt_misc", "/" BINFMT_MISC_HOME, "binfmt_misc");
-			if (ret == -1) {
-				goto err;
-			} else if (ret == 0 && !add_cr_time_mount(ns->mnt.mntinfo_tree, "binfmt_misc", BINFMT_MISC_HOME,
-								  s_dev, false)) {
-				ret = -1;
-				goto err;
-			}
-		}
-	}
-#endif
-
 	ret = resolve_external_mounts(mntinfo);
 	if (ret)
 		goto err;
@@ -4055,32 +3900,6 @@ int dump_mnt_namespaces(void)
 	}
 
 	return 0;
-}
-
-void clean_cr_time_mounts(void)
-{
-	struct mount_info *mi;
-	int ns_old, ret;
-
-	for (mi = mntinfo; mi; mi = mi->next) {
-		int cwd_fd;
-
-		if (mi->mnt_id != HELPER_MNT_ID)
-			continue;
-		ret = switch_mnt_ns(mi->nsid->ns_pid, &ns_old, &cwd_fd);
-		if (ret) {
-			pr_err("Can't switch to pid's %u mnt_ns\n", mi->nsid->ns_pid);
-			continue;
-		}
-
-		if (umount(mi->ns_mountpoint) < 0)
-			pr_perror("Can't umount forced mount %s", mi->ns_mountpoint);
-
-		if (restore_mnt_ns(ns_old, &cwd_fd)) {
-			pr_err("cleanup_forced_mounts exiting with wrong mnt_ns\n");
-			return;
-		}
-	}
 }
 
 struct ns_desc mnt_ns_desc = NS_DESC_ENTRY(CLONE_NEWNS, "mnt");

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -9,6 +9,7 @@
 #include <signal.h>
 #include <sched.h>
 #include <sys/capability.h>
+#include <sys/mount.h>
 #include <sys/stat.h>
 #include <limits.h>
 #include <errno.h>
@@ -28,6 +29,7 @@
 #include "fdstore.h"
 #include "kerndat.h"
 #include "util-caps.h"
+#include "filesystems.h"
 
 #include "protobuf.h"
 #include "util.h"
@@ -1010,8 +1012,9 @@ int dump_user_ns(pid_t pid, int ns_id)
 	ret = parse_id_map(pid, "uid_map", &e->uid_map);
 	if (ret < 0)
 		/*
-		 * The uid_map and gid_map is clean up in free_userns_maps
-		 * later, so we don't need to clean these up in error cases.
+		 * The uid_map, gid_map and binfmt_misc are cleaned up in
+		 * free_userns_data later, so we don't need to clean these up in error
+		 * cases.
 		 */
 		return -1;
 
@@ -1025,6 +1028,11 @@ int dump_user_ns(pid_t pid, int ns_id)
 	if (check_user_ns(pid))
 		return -1;
 
+	ret = binfmt_misc_dump_sandboxed(pid, &e->binfmt_misc);
+	if (ret < 0)
+		return -1;
+	e->n_binfmt_misc = ret;
+
 	img = open_image(CR_FD_USERNS, O_DUMP, ns_id);
 	if (!img)
 		return -1;
@@ -1036,7 +1044,7 @@ int dump_user_ns(pid_t pid, int ns_id)
 	return 0;
 }
 
-void free_userns_maps(void)
+void free_userns_data(void)
 {
 	if (userns_entry.n_uid_map > 0) {
 		xfree(userns_entry.uid_map[0]);
@@ -1046,6 +1054,8 @@ void free_userns_maps(void)
 		xfree(userns_entry.gid_map[0]);
 		xfree(userns_entry.gid_map);
 	}
+	if (userns_entry.n_binfmt_misc > 0)
+		free_pb_binfmt_misc_entries(userns_entry.binfmt_misc, userns_entry.n_binfmt_misc);
 }
 
 static int do_dump_namespaces(struct ns_id *ns)
@@ -1592,6 +1602,28 @@ int prepare_userns(struct pstree_item *item)
 		return -1;
 
 	return 0;
+}
+
+int restore_userns_binfmt_misc(struct pstree_item *item)
+{
+	struct cr_img *img;
+	UsernsEntry *e;
+	int ret = 0;
+
+	img = open_image(CR_FD_USERNS, O_RSTR, item->ids->user_ns_id);
+	if (!img)
+		return -1;
+	ret = pb_read_one(img, &e, PB_USERNS);
+	close_image(img);
+	if (ret < 0)
+		return -1;
+
+	if (binfmt_misc_restore_sandboxed(item->pid->real, e->binfmt_misc, e->n_binfmt_misc))
+		ret = -1;
+
+	userns_entry__free_unpacked(e, NULL);
+
+	return ret < 0 ? -1 : 0;
 }
 
 int collect_namespaces(bool for_dump)

--- a/images/userns.proto
+++ b/images/userns.proto
@@ -2,6 +2,8 @@
 
 syntax = "proto2";
 
+import "binfmt-misc.proto";
+
 message uid_gid_extent {
 	required uint32 first		= 1;
 	required uint32 lower_first	= 2;
@@ -11,4 +13,5 @@ message uid_gid_extent {
 message userns_entry {
 	repeated uid_gid_extent uid_map	= 1;
 	repeated uid_gid_extent gid_map = 2;
+	repeated binfmt_misc_entry binfmt_misc = 3;
 }

--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -18,7 +18,7 @@ export UNAME
 CONTAINER_RUNTIME := docker
 export CONTAINER_RUNTIME
 
-alpine: ZDTM_OPTS=-x zdtm/static/binfmt_misc -x zdtm/static/sched_policy00
+alpine: ZDTM_OPTS=-x zdtm/static/sched_policy00
 
 ifeq ($(GITHUB_ACTIONS),true)
 	# GitHub Actions does not give us a real TTY and errors out with

--- a/scripts/ci/docker.env
+++ b/scripts/ci/docker.env
@@ -1,4 +1,4 @@
 SKIP_CI_PREP=1
-ZDTM_OPTS=-x zdtm/static/binfmt_misc -x zdtm/static/sched_policy00
+ZDTM_OPTS=-x zdtm/static/sched_policy00
 CC=gcc
 SKIP_EXT_DEV_TEST=1

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -239,6 +239,12 @@ LAZY_OPTS=(-p 2 -T "$LAZY_TESTS" "${LAZY_EXCLUDE[@]}" "${ZDTM_OPTS[@]}")
 ./test/zdtm.py run "${LAZY_OPTS[@]}" --remote-lazy-pages
 ./test/zdtm.py run "${LAZY_OPTS[@]}" --remote-lazy-pages --tls
 
+# This test is expected o fail as without uesrns binfmt misc is not c/r-ed
+if ./test/zdtm.py run -t zdtm/static/binfmt_misc_ns; then
+	echo "Unexpected pass of zdtm/static/binfmt_misc_ns"
+	exit 1
+fi
+
 bash -x ./test/jenkins/criu-fault.sh
 if [ "$UNAME_M" == "x86_64" ]; then
 	# This fails on aarch64 (aws-graviton2) with:

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -656,7 +656,7 @@ class zdtm_test:
         for postfix in ['.out', '.out.inprogress']:
             if os.access(self.__name + postfix, os.R_OK):
                 print("Test output: " + "=" * 32)
-                with open(self.__name + postfix) as output:
+                with open(self.__name + postfix, errors='ignore') as output:
                     print(output.read())
                 print(" <<< " + "=" * 32)
 

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -480,6 +480,7 @@ TST_DIR_FILE	=				\
 		chroot				\
 		chroot-file			\
 		binfmt_misc			\
+		binfmt_misc_ns			\
 
 TST		=				\
 		$(TST_NOFILE)			\

--- a/test/zdtm/static/binfmt_misc.c
+++ b/test/zdtm/static/binfmt_misc.c
@@ -2,6 +2,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mount.h>
@@ -30,7 +31,7 @@ void create_magic_pattern(char *buf, const char *name)
 {
 	int i, magic, mask, offset;
 
-	magic = rand() % (MAX_MAGIC + 1);
+	magic = rand() % MAX_MAGIC + 1;
 	mask = (rand() % 2) ? magic : 0;
 	offset = MAX_MAGIC_OFFSET - magic;
 	offset = rand() % (offset + 1);
@@ -52,11 +53,11 @@ void create_extension_pattern(char *buf, const char *name)
 {
 	int i, extension;
 
-	extension = rand() % (MAX_EXTENSION + 1);
+	extension = rand() % MAX_EXTENSION + 1;
 	buf += sprintf(buf, ":%s:E::", name);
 
 	for (i = 0; i < extension; i++) {
-		int c = rand();
+		int c = rand() % 256;
 
 		if (c == '\0' || c == ':' || c == '\n' || c == '/')
 			c = '1';
@@ -101,6 +102,8 @@ int main(int argc, char **argv)
 	char path[PATH_MAX * 2 + 1];
 	char *dump[2];
 	int i, fd, len;
+
+	srand(time(NULL));
 
 	test_init(argc, argv);
 

--- a/test/zdtm/static/binfmt_misc.desc
+++ b/test/zdtm/static/binfmt_misc.desc
@@ -1,1 +1,1 @@
-{'flavor': 'ns', 'flags': 'noauto excl suid'}
+{'flavor': 'uns', 'flags': 'excl suid', 'feature': 'binfmt_misc_sandboxing'}

--- a/test/zdtm/static/binfmt_misc.desc
+++ b/test/zdtm/static/binfmt_misc.desc
@@ -1,1 +1,1 @@
-{'flavor': 'ns', 'flags': 'excl suid'}
+{'flavor': 'ns', 'flags': 'noauto excl suid'}

--- a/test/zdtm/static/binfmt_misc.hook
+++ b/test/zdtm/static/binfmt_misc.hook
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[ "$1" == "--clean" ] || exit 0
+[ "$1" == "--clean" ] || [ "$1" == "--pre-restore" ] || exit 0
 
 name=$(basename -s .hook $0).test
 

--- a/test/zdtm/static/binfmt_misc_ns.c
+++ b/test/zdtm/static/binfmt_misc_ns.c
@@ -1,0 +1,1 @@
+binfmt_misc.c

--- a/test/zdtm/static/binfmt_misc_ns.desc
+++ b/test/zdtm/static/binfmt_misc_ns.desc
@@ -1,0 +1,1 @@
+{'flavor': 'ns', 'flags': 'excl suid noauto'}

--- a/test/zdtm/static/binfmt_misc_ns.hook
+++ b/test/zdtm/static/binfmt_misc_ns.hook
@@ -1,0 +1,1 @@
+binfmt_misc.hook


### PR DESCRIPTION
The Linux kernel already supports per user namespace sandboxed mounts: 21ca59b365c0 ("binfmt_misc: enable sandboxed mounts")

Add support for this functionality to criu:
 - Drop the BINFMT_MISC_VIRTUALIZED config option
 - Store the binfmt_misc data to the userns image.

The overall dump/restore logic is based on the fact that a binfmt_misc superblock is static and is allocated once per a binfmt_misc mount withing a given user namespace. So the code makes a temporary mount to read/write the entries and then removes it.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
