### PR TITLE
plugin/amdgpu: Allow dump with victim unable to see all gpus

### DIFF
--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -181,7 +181,7 @@ static int allocate_bo_entries(CriuKfd *e, int num_bos, struct kfd_criu_bo_bucke
 int topology_to_devinfo(struct tp_system *sys, struct device_maps *maps, KfdDeviceEntry **deviceEntries)
 {
 	uint32_t devinfo_index = 0;
-	struct tp_node *node;
+	struct tp_node *node, *node2;
 
 	list_for_each_entry(node, &sys->nodes, listm_system) {
 		KfdDeviceEntry *devinfo = deviceEntries[devinfo_index++];
@@ -191,7 +191,7 @@ int topology_to_devinfo(struct tp_system *sys, struct device_maps *maps, KfdDevi
 		if (NODE_IS_GPU(node)) {
 			devinfo->gpu_id = maps_get_dest_gpu(maps, node->gpu_id);
 			if (!devinfo->gpu_id)
-				return -EINVAL;
+				continue;
 
 			devinfo->simd_count = node->simd_count;
 			devinfo->mem_banks_count = node->mem_banks_count;
@@ -233,7 +233,16 @@ int topology_to_devinfo(struct tp_system *sys, struct device_maps *maps, KfdDevi
 				return -ENOMEM;
 
 			list_for_each_entry(iolink, &node->iolinks, listm) {
+				bool link_to_present_node = false;
+
 				if (!iolink->valid)
+					continue;
+
+				list_for_each_entry(node2, &sys->nodes, listm_system)
+					if (node2->id == iolink->node_to_id && maps_get_dest_gpu(maps, node2->gpu_id) != 0)
+						link_to_present_node = true;
+
+				if (!link_to_present_node)
 					continue;
 
 				devinfo->iolinks[iolink_index] = xmalloc(sizeof(DevIolink));


### PR DESCRIPTION
In container setups, particularly k8s, cgroup may be used to restrict what GPUs a process has access to. CRIU may then be used to checkpoint that process while CRIU itself has full access to all GPUs.

In this case, the kfd CRIU ioctl will return only a subset of the ioctls visible through sysfs.

Don't write these devices or any links connected to them to the topology dump files.

Aiming to fix https://github.com/checkpoint-restore/criu/issues/2723

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
