### PR TITLE
fsnotify: Fix memory leaks in pre_dump error paths

### DIFF
--- a/criu/fsnotify.c
+++ b/criu/fsnotify.c
@@ -364,7 +364,7 @@ free:
 static int pre_dump_one_inotify(int pid, int lfd)
 {
 	InotifyFileEntry ie = INOTIFY_FILE_ENTRY__INIT;
-	int i;
+	int i, ret = -1;
 
 	if (parse_fdinfo_pid(pid, lfd, FD_TYPES__INOTIFY, &ie)) {
 		pr_err("Failed to parse fdinfo for inotify (pid %d lfd %d)\n", pid, lfd);
@@ -377,13 +377,18 @@ static int pre_dump_one_inotify(int pid, int lfd)
 		if (irmap_queue_cache(we->s_dev, we->i_ino, we->f_handle)) {
 			pr_err("Failed to queue irmap cache for inotify wd %#x (dev %#x ino %#" PRIx64 ")\n",
 			       we->wd, we->s_dev, we->i_ino);
-			return -1;
+			goto err;
 		}
 
 		xfree(we);
 	}
 
-	return 0;
+	ret = 0;
+err:
+	for (; i < ie.n_wd; i++)
+		xfree(ie.wd[i]);
+	xfree(ie.wd);
+	return ret;
 }
 
 const struct fdtype_ops inotify_dump_ops = {

--- a/criu/fsnotify.c
+++ b/criu/fsnotify.c
@@ -476,7 +476,7 @@ free:
 static int pre_dump_one_fanotify(int pid, int lfd)
 {
 	FanotifyFileEntry fe = FANOTIFY_FILE_ENTRY__INIT;
-	int i;
+	int i, ret = -1;
 
 	if (parse_fdinfo_pid(pid, lfd, FD_TYPES__FANOTIFY, &fe)) {
 		pr_err("Failed to parse fdinfo for fanotify (pid %d lfd %d)\n", pid, lfd);
@@ -489,13 +489,18 @@ static int pre_dump_one_fanotify(int pid, int lfd)
 		if (me->type == MARK_TYPE__INODE && irmap_queue_cache(me->s_dev, me->ie->i_ino, me->ie->f_handle)) {
 			pr_err("Failed to queue irmap cache for fanotify mark (dev %#x ino %#" PRIx64 " mask %#x)\n",
 			       me->s_dev, me->ie->i_ino, me->mask);
-			return -1;
+			goto err;
 		}
 
 		xfree(me);
 	}
 
-	return 0;
+	ret = 0;
+err:
+	for (; i < fe.n_mark; i++)
+		xfree(fe.mark[i]);
+	xfree(fe.mark);
+	return ret;
 }
 
 const struct fdtype_ops fanotify_dump_ops = {


### PR DESCRIPTION
## What

Fix memory leaks in `pre_dump_one_inotify` and `pre_dump_one_fanotify` error paths.

## How

- Add cleanup labels to ensure proper deallocation on error
- Free remaining entries and arrays when `irmap_queue_cache` fails

## Why

When `irmap_queue_cache` fails during pre-dump, the remaining watch descriptors/mark entries and their arrays are not freed, causing memory leaks.

## Testing

- [x]   inotify00 - Basic inotify test
- [x]   fanotify00 - Basic fanotify test  
- [x]   inotify_irmap - Tests irmap_queue_cache error path
