### PR TITLE
sk-unix: fix mutex_ghost deadlock on connect() failure

### DIFF
--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -1404,6 +1404,7 @@ static int post_open_standalone(struct file_desc *d, int fd)
 	mutex_lock(mutex_ghost);
 	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr.sun_family) + len) < 0) {
 		pr_perror("Can't connect %d socket", ui->ue->ino);
+		mutex_unlock(mutex_ghost);
 		goto err_revert_and_exit;
 	}
 	mutex_unlock(mutex_ghost);


### PR DESCRIPTION
# Fix: Prevent cross-process deadlock during Unix socket restore

## Description

This PR fixes a critical deadlock in CRIU’s Unix socket restore path.

In `post_open_standalone()` (`sk-unix.c`), the shared-memory mutex `mutex_ghost` is acquired before calling `connect()`. When `connect()` fails, execution jumps to a common error label without releasing the mutex. Because `mutex_ghost` is allocated via `shmalloc()` and shared across all restoring processes, this leaves the mutex permanently locked and causes the entire restore to hang silently.

This failure blocks all subsequent Unix socket bind/connect operations across all restore tasks and cannot recover without terminating the restore.

---

## What Was Fixed

- Added a missing `mutex_unlock(mutex_ghost)` on the `connect()` failure path in `post_open_standalone()`
- The unlock is placed **before** the `goto err_revert_and_exit`, ensuring it executes only when the mutex is held
- The shared error label remains unchanged to preserve correctness for other failure paths that do not hold the mutex

This is a single-line, behavior-preserving fix.

---

## Impact

- Prevents permanent cross-process deadlocks during Unix socket restore
- Allows CRIU restore to fail or retry correctly instead of hanging indefinitely
- Improves reliability for containers and workloads using Unix domain sockets (systemd, dbus, databases, service meshes)
- Eliminates a silent failure mode during production restores and live migration

---

## Code Changes

- **Area:** Unix socket restore
- **File:** `sk-unix.c`
- **Function:** `post_open_standalone()`

The change is strictly limited to the error path following a failed `connect()` call.

---

## Test / Verification

- **No new tests added**

**Reason:**  
This bug is a cross-process deadlock involving a shared-memory futex-backed mutex and requires a specific Unix socket restore race (ghost socket with `connect()` failure) to trigger. CRIU’s current test infrastructure does not directly exercise this mutex lifecycle, and creating a reliable automated test would require intrusive timing control.

The fix is minimal, isolated to an error path, and follows the same lock/unlock pattern already used in `bind_unix_sk()` in the same file.

---

## Risk Assessment

- Low risk
- Success paths are unchanged
- No control-flow restructuring
- No behavior changes outside the failing error path
