### PR TITLE
Fix lease type corruption in restore_breaking_file_lease() due to fd_types misuse

### DIFF
--- a/criu/file-lock.c
+++ b/criu/file-lock.c
@@ -495,9 +495,9 @@ static int break_lease(int lease_type, struct file_desc *desc)
 	return open_path(desc, open_break_cb, (void *)&break_flags);
 }
 
-static int set_file_lease(int fd, int type)
+static int set_file_lease(int fd, int type, bool can_fail)
 {
-	int old_fsuid, ret;
+	int saved_errno, old_fsuid, ret;
 	struct stat st;
 
 	if (fstat(fd, &st)) {
@@ -512,19 +512,31 @@ static int set_file_lease(int fd, int type)
 	old_fsuid = setfsuid(st.st_uid);
 
 	ret = fcntl(fd, F_SETLEASE, type);
-	if (ret < 0)
-		pr_perror("Can't set lease");
+	saved_errno = errno;
+	if (ret < 0) {
+		if (!can_fail || errno != EWOULDBLOCK)
+			pr_perror("Can't set lease");
+		else
+			pr_debug("The requested lease isn't available");
+	}
 
 	setfsuid(old_fsuid);
+	errno = saved_errno;
 	return ret;
 }
 
-static int restore_lease_prebreaking_state(int fd, int fd_type)
+static int restore_lease_prebreaking_state(int fd, int target_lease_type)
 {
-	int access_flags = fd_type & O_ACCMODE;
-	int lease_type = (access_flags == O_RDONLY) ? F_RDLCK : F_WRLCK;
+	int lease_type = (target_lease_type == F_UNLCK) ? F_RDLCK : F_WRLCK;
 
-	return set_file_lease(fd, lease_type);
+	/*
+	 * The origin lease type is unknown. Let's try the read one
+	 * then the write one.
+	 */
+	if (set_file_lease(fd, lease_type, /* can_fail = */ true)) {
+		return set_file_lease(fd, F_WRLCK, false);
+	}
+	return 0;
 }
 
 static struct fdinfo_list_entry *find_fd_unordered(struct pstree_item *task, int fd)
@@ -550,7 +562,7 @@ static int restore_breaking_file_lease(FileLockEntry *fle)
 		return -1;
 	}
 
-	ret = restore_lease_prebreaking_state(fle->fd, fdle->desc->ops->type);
+	ret = restore_lease_prebreaking_state(fle->fd, fle->type  & (~LEASE_BREAKING));
 	if (ret)
 		return ret;
 
@@ -594,7 +606,7 @@ static int restore_file_lease(FileLockEntry *fle)
 		}
 		return ret;
 	} else {
-		ret = set_file_lease(fle->fd, fle->type);
+		ret = set_file_lease(fle->fd, fle->type, /* can_fail = */ false);
 		if (ret < 0)
 			pr_perror("Can't restore non breaking lease");
 		return ret;

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -366,6 +366,7 @@ TST_FILE	=				\
 		file_lease02			\
 		file_lease03			\
 		file_lease04			\
+		file_lease05			\
 		file_locks00			\
 		file_locks00_fail		\
 		file_locks01			\

--- a/test/zdtm/static/file_lease05.c
+++ b/test/zdtm/static/file_lease05.c
@@ -1,0 +1,89 @@
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <sys/wait.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check broken read-lease is restored with correct type";
+const char *test_author = "CRIU";
+
+char *filename;
+TEST_OPTION(filename, string, "file name", 1);
+
+static void break_sigaction(int signo, siginfo_t *info, void *ctx)
+{
+}
+
+int main(int argc, char **argv)
+{
+	struct sigaction act = {};
+	int fd;
+
+	test_init(argc, argv);
+
+	act.sa_sigaction = break_sigaction;
+	act.sa_flags = SA_SIGINFO | SA_RESTART;
+	if (sigaction(SIGIO, &act, NULL)) {
+		pr_perror("Can't set signal action");
+		return 1;
+	}
+
+	fd = open(filename, O_RDONLY | O_CREAT, 0666);
+	if (fd < 0) {
+		pr_perror("Can't open file");
+		return 1;
+	}
+
+	if (fcntl(fd, F_SETLEASE, F_RDLCK) < 0) {
+		pr_perror("Can't set read lease");
+		return 1;
+	}
+
+	if (fcntl(fd, F_SETSIG, SIGIO) < 0) {
+		pr_perror("Can't set lease signal");
+		return 1;
+	}
+
+	{
+		int fd_break = open(filename, O_WRONLY | O_NONBLOCK);
+		if (fd_break >= 0) {
+			close(fd_break);
+			pr_err("Conflicting lease not found\n");
+			return 1;
+		} else if (errno != EWOULDBLOCK) {
+			pr_perror("Can't break lease");
+			return 1;
+		}
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	{
+		int fd_check = open(filename, O_RDONLY | O_NONBLOCK);
+		if (fd_check >= 0) {
+			close(fd_check);
+		} else if (errno == EWOULDBLOCK) {
+			fail("Unexpected lease has been found");
+			return 1;
+		} else {
+			pr_perror("unexpected error");
+			return 1;
+		}
+	}
+	{
+		int fd_break = open(filename, O_WRONLY | O_NONBLOCK);
+		if (fd_break >= 0) {
+			close(fd_break);
+			fail("Conflicting lease not found\n");
+			return 1;
+		} else if (errno != EWOULDBLOCK) {
+			pr_perror("unexpected error");
+			return 1;
+		}
+	}
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/file_lease05.desc
+++ b/test/zdtm/static/file_lease05.desc
@@ -1,0 +1,1 @@
+{'feature': 'fdinfo_lock', 'opts': '--file-locks'}


### PR DESCRIPTION
# Fix: Incorrect Lease Type Restoration in `restore_breaking_file_lease()`

## Overview

This PR fixes a critical lease restoration bug in CRIU that could cause:

- Restore failures
- Silent state corruption
- Incorrect kernel I/O blocking behavior

The issue was caused by passing a `fd_types` enum value where file open flags were expected during lease restoration.

---

## Problem

In `criu/file-lock.c`, the function:

