### PR TITLE
page-xfer: Fix page_read resource leak in page_pipe_from_pagemap()

### DIFF
--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -1357,6 +1357,7 @@ static int page_pipe_from_pagemap(struct page_pipe **pp, int pid)
 {
 	struct page_read pr;
 	unsigned long nr_pages = 0;
+	int ret = -1;
 
 	if (open_page_read(pid, &pr, PR_TASK) <= 0) {
 		pr_err("Failed to open page read for %d\n", pid);
@@ -1370,13 +1371,20 @@ static int page_pipe_from_pagemap(struct page_pipe **pp, int pid)
 	*pp = create_page_pipe(nr_pages, NULL, 0);
 	if (!*pp) {
 		pr_err("Cannot create page pipe for %d\n", pid);
-		return -1;
+		goto err;
 	}
 
 	if (fill_page_pipe(&pr, *pp))
-		return -1;
+		goto err_pp;
 
-	return 0;
+	ret = 0;
+err:
+	pr.close(&pr);
+	return ret;
+err_pp:
+	destroy_page_pipe(*pp);
+	*pp = NULL;
+	goto err;
 }
 
 static int page_server_init_send(void)


### PR DESCRIPTION
`page_pipe_from_pagemap()` opens a `page_read` via `open_page_read()` but never calls `pr.close()` on error or success paths. This leaks the pagemap and pages image file descriptors, and any parent `page_read` chain.

Add proper cleanup using `goto err` pattern to ensure `pr.close()` is always called before returning. Also destroy the `page_pipe` on `fill_page_pipe()` failure to avoid leaking its memory and pipe FDs.