### PR TITLE
dump: Fix uninitialized thread leader vtid breaking posix timer dump

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1671,6 +1671,7 @@ static int dump_one_task(struct pstree_item *item, InventoryEntry *parent_ie)
 	}
 
 	item->pid->ns[0].virt = misc.pid;
+	item->threads[0].ns[0].virt = misc.pid;
 	pstree_insert_pid(item->pid);
 	item->sid = misc.sid;
 	item->pgid = misc.pgid;

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -73,6 +73,7 @@ TST_NOFILE	:=				\
 		pthread02			\
 		pthread_timers			\
 		pthread_timers_h		\
+		leader_posix_timer		\
 		rseq00				\
 		membarrier			\
 		vdso00				\
@@ -612,6 +613,7 @@ pthread01:		LDLIBS += -pthread
 pthread02:		LDLIBS += -pthread
 pthread_timers:		LDLIBS += -lrt -pthread
 pthread_timers_h:	LDLIBS += -lrt -pthread
+leader_posix_timer:	LDLIBS += -lrt -pthread
 different_creds:	LDLIBS += -pthread
 sigpending:		LDLIBS += -pthread
 sigaltstack:		LDLIBS += -pthread

--- a/test/zdtm/static/leader_posix_timer.c
+++ b/test/zdtm/static/leader_posix_timer.c
@@ -1,0 +1,122 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <time.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#include "zdtmtst.h"
+
+#ifndef SIGEV_THREAD_ID
+#define SIGEV_THREAD_ID 4
+#endif
+
+const char *test_doc = "Check SIGEV_THREAD_ID timer on the thread leader";
+const char *test_author = "CRIU developers";
+
+static volatile int sigcnt;
+
+static void timer_handler(int sig, siginfo_t *si, void *uc)
+{
+	sigcnt++;
+}
+
+static void *worker(void *arg)
+{
+	volatile int *stop = (volatile int *)arg;
+
+	while (!*stop)
+		usleep(100000);
+
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	struct sigevent evp = {};
+	struct itimerspec its = {};
+	struct sigaction sa = {};
+	timer_t timerid;
+	pthread_t thr;
+	int stop = 0;
+	pid_t tid;
+
+	test_init(argc, argv);
+
+	/*
+	 * Spawn a worker thread so the process is multithreaded.
+	 * The bug only manifests when collect_threads() runs and
+	 * skips vtid initialization for threads[0] (the leader).
+	 */
+	if (pthread_create(&thr, NULL, worker, &stop)) {
+		pr_perror("pthread_create");
+		return 1;
+	}
+
+	sa.sa_sigaction = timer_handler;
+	sa.sa_flags = SA_SIGINFO;
+	sigemptyset(&sa.sa_mask);
+	if (sigaction(SIGRTMIN, &sa, NULL)) {
+		pr_perror("sigaction");
+		return 1;
+	}
+
+	tid = syscall(SYS_gettid);
+
+	evp.sigev_notify = SIGEV_THREAD_ID;
+#ifdef __GLIBC__
+	evp._sigev_un._tid = tid;
+#else
+	evp.sigev_notify_thread_id = tid;
+#endif
+	evp.sigev_signo = SIGRTMIN;
+
+	if (timer_create(CLOCK_MONOTONIC, &evp, &timerid)) {
+		pr_perror("timer_create");
+		return 1;
+	}
+
+	its.it_interval.tv_nsec = 10000000; /* 10 ms */
+	its.it_value.tv_nsec = 10000000;
+
+	if (timer_settime(timerid, 0, &its, NULL)) {
+		pr_perror("timer_settime");
+		return 1;
+	}
+
+	/* Let at least one signal arrive */
+	while (!sigcnt)
+		usleep(1000);
+
+	test_daemon();
+	test_waitsig();
+
+	/* Verify the timer is still running after restore */
+	sigcnt = 0;
+	usleep(100000); /* 100 ms – should get ~10 signals */
+
+	if (sigcnt == 0) {
+		fail("No timer signals received after restore");
+		goto out;
+	}
+
+	if (timer_gettime(timerid, &its)) {
+		pr_perror("timer_gettime");
+		goto out;
+	}
+
+	if (its.it_interval.tv_nsec != 10000000 || its.it_interval.tv_sec) {
+		fail("Wrong timer interval after restore");
+		goto out;
+	}
+
+	pass();
+
+out:
+	stop = 1;
+	pthread_join(thr, NULL);
+	timer_delete(timerid);
+	return 0;
+}

--- a/test/zdtm/static/leader_posix_timer.desc
+++ b/test/zdtm/static/leader_posix_timer.desc
@@ -1,0 +1,1 @@
+{'feature': 'ns_pid'}


### PR DESCRIPTION
Fixes #2887

## Problem

When a multithreaded process has a POSIX timer created with SIGEV_THREAD_ID notification targeting the thread leader, CRIU dump fails with:

```
Error (criu/timer.c:329): Unable to convert the notify thread id <pid>
Can't dump posix timers (pid: <pid>)
Dumping FAILED.
```

If the dump somehow completed (e.g. in older versions where the vtid happened to be zero and didn't match), the garbage notify_thread_id value (e.g. -282857328) gets written into the image and timer_create() fails with -EINVAL on restore.

## Root Cause

There is a vtid initialization gap for the thread leader in the dump path:

1. collect_threads() in seize.c initializes threads[0] for the thread leader but only sets .real and .item — it never sets .ns[0].virt:

```c
if (item->nr_threads == 0) {
    item->threads[0].real = item->pid->real;
    item->nr_threads = 1;
    item->threads[0].item = NULL;
    /* .ns[0].virt left uninitialized! */
}
```

Non-leader threads correctly get their vtid set:

```c
item->threads[item->nr_threads].ns[0].virt = t_creds.s.vpid;
```

2. dump_one_task() sets item->pid->ns[0].virt = misc.pid but does not propagate this to threads[0].ns[0].virt.

3. parasite_dump_posix_timers_seized() is called next, which calls encode_notify_thread_id(). This function iterates item->threads[] looking for a matching .real pid and reads its .ns[0].virt. For the thread leader, it finds threads[0] but reads garbage because the vtid was never initialized.

4. dump_task_threads() finally sets threads[0].ns[0].virt = vpid(item) — but this runs after the timer dump, so it is too late.

## Fix

Initialize threads[0].ns[0].virt immediately after item->pid->ns[0].virt is set, before the posix timer dump:

```diff
 item->pid->ns[0].virt = misc.pid;
+item->threads[0].ns[0].virt = misc.pid;
 pstree_insert_pid(item->pid);
```

## New Test

Added zdtm/static/leader_posix_timer — creates a multithreaded process where the thread leader sets up a SIGEV_THREAD_ID timer targeting itself. After C/R, verifies the timer still fires and has the correct interval.

## Test Output — Before Fix (FAIL)

```
=== Run 1/1 ================ zdtm/static/leader_posix_timer
=================== Run zdtm/static/leader_posix_timer in ns ===================
Start test
./leader_posix_timer --pidfile=leader_posix_timer.pid --outfile=leader_posix_timer.out
Run criu dump
=[log]=> dump/zdtm/static/leader_posix_timer/77/1/dump.log
------------------------ grep Error ------------------------
b'(00.037771) Error (criu/timer.c:329): Unable to convert the notify thread id 80'
b"(00.037801) Error (criu/cr-dump.c:1731): Can't dump posix timers (pid: 80)"
b'(00.093711) Error (criu/cr-dump.c:2128): Dumping FAILED.'
------------------------ ERROR OVER ------------------------
############ Test zdtm/static/leader_posix_timer FAIL at CRIU dump #############
##################################### FAIL #####################################
```

## Test Output — After Fix (PASS)

```
=== Run 1/1 ================ zdtm/static/leader_posix_timer
================== Run zdtm/static/leader_posix_timer in uns ===================
Start test
./leader_posix_timer --pidfile=leader_posix_timer.pid --outfile=leader_posix_timer.out
Run criu dump
Run criu restore
=================== Test zdtm/static/leader_posix_timer PASS ===================
=================== Run zdtm/static/leader_posix_timer in ns ===================
Start test
./leader_posix_timer --pidfile=leader_posix_timer.pid --outfile=leader_posix_timer.out
Run criu dump
Run criu restore
=================== Test zdtm/static/leader_posix_timer PASS ===================
=================== Run zdtm/static/leader_posix_timer in h ====================
Start test
./leader_posix_timer --pidfile=leader_posix_timer.pid --outfile=leader_posix_timer.out
Run criu dump
Run criu restore
=================== Test zdtm/static/leader_posix_timer PASS ===================
```

## Full Timer Regression Suite — All Pass

| Test              | uns  | ns   | h    |
|-------------------|------|------|------|
| posix_timers      | PASS | PASS | PASS |
| pthread_timers    | PASS | PASS | PASS |
| pthread_timers_h  | —    | —    | PASS |
| timers            | PASS | PASS | PASS |
| timers01          | PASS | PASS | PASS |
| leader_posix_timer| PASS | PASS | PASS |
