### PR TITLE
MAINTAINERS: Update maintainer roles

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,8 +1,9 @@
-Pavel Emelyanov <ovzxemul@gmail.com> (chief)
-Andrey Vagin <avagin@gmail.com>
+Andrey Vagin <avagin@gmail.com> (chief)
 Mike Rapoport <rppt@kernel.org>
 Dmitry Safonov <0x7f454c46@gmail.com>
 Adrian Reber <areber@redhat.com>
 Pavel Tikhomirov <ptikhomirov@virtuozzo.com>
 Radostin Stoyanov <rstoyanov@fedoraproject.org>
 Alexander Mikhalitsyn <alexander@mihalicyn.com>
+
+Pavel Emelyanov <ovzxemul@gmail.com> (retired)


### PR DESCRIPTION
Pavel Emelyanov, the founder and long-time leader of the CRIU project, is moving to a retired role. As the project's inventor, Pavel's vision and leadership over many years were fundamental in bringing CRIU to its current status as a production-ready solution.

Andrey Vagin is appointed as the chief maintainer.