### PR TITLE
Handle truncated pages on restore

### DIFF
--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -559,6 +559,12 @@ static int process_async_reads(struct page_read *pr)
 			return -1;
 		}
 
+		if (ret == 0 && piov->end != piov->from) {
+			pr_err("Unexpected EOF reading pages: expected %ju more bytes at offset %ju\n",
+			       piov->end - piov->from, piov->from);
+			return -1;
+		}
+
 		if (opts.auto_dedup && punch_hole(pr, piov->from, ret, false))
 			return -1;
 

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1915,6 +1915,12 @@ __visible long __export_restore_task(struct task_restore_args *args)
 				goto core_restore_end;
 			}
 
+			if (r == 0) {
+				pr_err("Unexpected EOF reading pages data at offset %ld (%d iovs remaining)\n",
+				       (long)rio->off, nr);
+				goto core_restore_end;
+			}
+
 			pr_debug("`- returned %ld\n", (long)r);
 			/* If the file is open for writing, then it means we should punch holes
 			 * in it. */

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -262,6 +262,8 @@ if [ -n "$CIRCLECI" ]; then
 fi
 make -C test/others/criu-ns/ run
 make -C test/others/skip-file-rwx-check/ run
+make -C test/others/truncated-pages/ run
+make -C test/others/truncated-pages/ run-cow
 make -C test/others/rpc/ run
 
 ./test/zdtm.py run -t zdtm/static/env00 --sibling

--- a/test/others/truncated-pages/.gitignore
+++ b/test/others/truncated-pages/.gitignore
@@ -1,0 +1,4 @@
+memalloc
+memalloc_fork
+dump/
+*.log

--- a/test/others/truncated-pages/Makefile
+++ b/test/others/truncated-pages/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all run run-cow clean
+
+all: memalloc memalloc_fork
+
+run: all
+	./run.sh
+
+run-cow: all
+	./run-cow.sh
+
+clean:
+	rm -f memalloc memalloc_fork
+	rm -rf dump/

--- a/test/others/truncated-pages/memalloc.c
+++ b/test/others/truncated-pages/memalloc.c
@@ -1,0 +1,27 @@
+/*
+ * Minimal test program that allocates and fills anonymous memory.
+ * Used by truncated-pages tests to produce a large pages file.
+ */
+#include <sys/mman.h>
+#include <unistd.h>
+
+#define MEM_SIZE (5 * 1024 * 1024)
+
+int main(void)
+{
+	char *p;
+	int i;
+
+	p = mmap(NULL, MEM_SIZE, PROT_READ | PROT_WRITE,
+		 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (p == MAP_FAILED)
+		return 1;
+
+	for (i = 0; i < MEM_SIZE; i += 4096)
+		p[i] = 'X';
+
+	while (1)
+		pause();
+
+	return 0;
+}

--- a/test/others/truncated-pages/memalloc_fork.c
+++ b/test/others/truncated-pages/memalloc_fork.c
@@ -1,0 +1,46 @@
+/*
+ * Test program that allocates anonymous memory, then forks.
+ * The parent and child share COW pages, which forces CRIU to
+ * premap private VMAs during restore (exercising process_async_reads()).
+ */
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <signal.h>
+
+#define MEM_SIZE (5 * 1024 * 1024)
+
+int main(void)
+{
+	char *p;
+	int i;
+	pid_t child;
+
+	p = mmap(NULL, MEM_SIZE, PROT_READ | PROT_WRITE,
+		 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (p == MAP_FAILED)
+		return 1;
+
+	/* Touch every page so they get dumped */
+	for (i = 0; i < MEM_SIZE; i += 4096)
+		p[i] = 'X';
+
+	child = fork();
+	if (child < 0)
+		return 1;
+
+	if (child == 0) {
+		/* Child: touch a few pages to create COW divergence */
+		for (i = 0; i < MEM_SIZE / 2; i += 4096)
+			p[i] = 'Y';
+		while (1)
+			pause();
+		return 0;
+	}
+
+	/* Parent: wait forever */
+	while (1)
+		pause();
+
+	return 0;
+}

--- a/test/others/truncated-pages/run-cow.sh
+++ b/test/others/truncated-pages/run-cow.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Test that truncated pages files are detected during restore of
+# premapped VMAs (the process_async_reads() path in pagemap.c).
+#
+# Uses a parent+child process pair so that COW VMAs get premapped
+# during restore, routing page reads through process_async_reads().
+#
+
+source ../env.sh || exit 1
+
+function fail {
+	echo "$@"
+	exit 1
+}
+set -x
+
+IMGDIR="dump"
+
+rm -rf "$IMGDIR"
+mkdir "$IMGDIR"
+
+setsid ./memalloc_fork < /dev/null &> /dev/null &
+PID=$!
+sleep 1
+kill -0 $PID || fail "Test didn't start"
+
+echo "Dumping process tree"
+${CRIU} dump -D "$IMGDIR" -o dump.log -t $PID -v4 --shell-job \
+	|| fail "Fail to dump"
+
+# In a COW process tree, prepare_cow_vmas() marks the root's matching
+# VMAs with VMA_COW_ROOT. These VMAs are then premapped and their page
+# data is read via process_async_reads() in pagemap.c (using PR_ASYNC).
+#
+# The root process always gets the lowest-numbered pages file
+# (pages-1.img). Truncating it forces process_async_reads() to hit EOF,
+# which — without the fix — causes an infinite loop.
+PAGES_FILES=($(find "$IMGDIR" -name "pages-*.img" -type f | sort))
+if [ ${#PAGES_FILES[@]} -lt 2 ]; then
+	fail "Expected multiple pages files for parent+child dump, got ${#PAGES_FILES[@]}"
+fi
+# Pick the root's file (first) — its premapped COW VMAs use process_async_reads().
+PAGES_FILE="${PAGES_FILES[0]}"
+
+ORIGINAL_SIZE=$(stat -c%s "$PAGES_FILE")
+if [ "$ORIGINAL_SIZE" -lt 4096 ]; then
+	fail "Root pages file too small to truncate ($ORIGINAL_SIZE bytes)"
+fi
+TRUNCATE_SIZE=$((ORIGINAL_SIZE / 4))
+echo "Truncating $PAGES_FILE from $ORIGINAL_SIZE to $TRUNCATE_SIZE bytes"
+truncate -s "$TRUNCATE_SIZE" "$PAGES_FILE"
+
+echo "Restoring"
+set +e
+timeout -k 5 30 ${CRIU} restore -D "$IMGDIR" -o restore.log -v4 --shell-job
+RESTORE_EXIT=$?
+set -e
+
+# Clean up any restored processes
+kill -9 $PID 2>/dev/null || true
+wait $PID 2>/dev/null || true
+
+if [ $RESTORE_EXIT -eq 124 ] || [ $RESTORE_EXIT -eq 137 ]; then
+	fail "Restore timed out (infinite loop — missing EOF check?)"
+fi
+
+if [ $RESTORE_EXIT -eq 0 ]; then
+	fail "Restore succeeded unexpectedly"
+fi
+
+echo PASS

--- a/test/others/truncated-pages/run.sh
+++ b/test/others/truncated-pages/run.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+source ../env.sh || exit 1
+
+function fail {
+	echo "$@"
+	exit 1
+}
+set -x
+
+IMGDIR="dump"
+
+rm -rf "$IMGDIR"
+mkdir "$IMGDIR"
+
+setsid ./memalloc < /dev/null &> /dev/null &
+PID=$!
+sleep 1
+kill -0 $PID || fail "Test didn't start"
+
+echo "Dumping"
+${CRIU} dump -D "$IMGDIR" -o dump.log -t $PID -v4 --shell-job || fail "Fail to dump"
+
+PAGES_FILE=$(find "$IMGDIR" -name "pages-*.img" -type f | head -1)
+if [ -z "$PAGES_FILE" ]; then
+	fail "No pages file found"
+fi
+
+ORIGINAL_SIZE=$(stat -c%s "$PAGES_FILE")
+if [ "$ORIGINAL_SIZE" -lt 8192 ]; then
+	fail "Pages file too small ($ORIGINAL_SIZE bytes)"
+fi
+
+TRUNCATE_SIZE=$((ORIGINAL_SIZE / 4))
+echo "Truncating $PAGES_FILE from $ORIGINAL_SIZE to $TRUNCATE_SIZE bytes"
+truncate -s "$TRUNCATE_SIZE" "$PAGES_FILE"
+
+echo "Restoring"
+set +e
+timeout -k 5 30 ${CRIU} restore -D "$IMGDIR" -o restore.log -v4 --shell-job
+RESTORE_EXIT=$?
+set -e
+
+if [ $RESTORE_EXIT -eq 124 ] || [ $RESTORE_EXIT -eq 137 ]; then
+	fail "Restore timed out (infinite loop — missing EOF check?)"
+fi
+
+if [ $RESTORE_EXIT -eq 0 ]; then
+	fail "Restore succeeded unexpectedly"
+fi
+
+echo PASS


### PR DESCRIPTION
I noticed that when restoring a dump containing a pages file that was truncated (likely caused by a filesystem error) the restore process got stuck while performing `preadv` on the pages file because of the unexpected EOF it would get.

Also this bug is present in two different cases:

- when pages are read directly during a restore
- when restoring premapped VMAs (either because of a predump or because of things like memory COW in a fork like the test here). I decided to do the test with COW because it was simpler.

