### PR TITLE
restore: move cgroup restore after creds are prepared

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1572,7 +1572,12 @@ static int __restore_task_with_children(void *_arg)
 		/* Wait prepare_userns */
 		if (restore_finish_ns_stage(CR_STATE_ROOT_TASK, CR_STATE_PREPARE_NAMESPACES) < 0)
 			goto err;
+	}
 
+	if (needs_prep_creds(current) && (prepare_userns_creds()))
+		goto err;
+
+	if (current->parent == NULL) {
 		/*
 		 * Since we don't support nesting of cgroup namespaces, let's
 		 * only set up the cgns (if it exists) in the init task.
@@ -1580,9 +1585,6 @@ static int __restore_task_with_children(void *_arg)
 		if (prepare_cgroup_namespace(current) < 0)
 			goto err;
 	}
-
-	if (needs_prep_creds(current) && (prepare_userns_creds()))
-		goto err;
 
 	/*
 	 * Call this _before_ forking to optimize cgroups


### PR DESCRIPTION
This PR moves cgroup restore after creds are prepared because prepare_cgns uses usernsd call to move root that's why uid / gid should be right to send msg. Otherwise, the Kernel will return Invalid Argument error.

Fixes https://github.com/checkpoint-restore/criu/issues/2902
