### PR TITLE
zdtm: fix incorrect open() syscall use for file creation without mode

### DIFF
--- a/test/zdtm/static/fanotify00.c
+++ b/test/zdtm/static/fanotify00.c
@@ -223,7 +223,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	del_after = open(fanotify_path, O_CREAT | O_TRUNC);
+	del_after = open(fanotify_path, O_CREAT | O_TRUNC, 0777);
 	if (del_after < 0) {
 		pr_perror("open failed");
 		exit(1);

--- a/test/zdtm/static/mountpoints.c
+++ b/test/zdtm/static/mountpoints.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
 		fail("Can't mount tmpfs");
 		return 1;
 	}
-	tmpfs_fd = open(MPTS_ROOT "/dev/test", O_WRONLY | O_CREAT);
+	tmpfs_fd = open(MPTS_ROOT "/dev/test", O_WRONLY | O_CREAT, 0777);
 	if (write(tmpfs_fd, "hello", 5) <= 0) {
 		pr_perror("write() failed");
 		return 1;
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 
 	/* Check that over-mounted files are restored on tmpfs */
 	mkdir(MPTS_ROOT "/dev/overmount", 0600);
-	fd = open(MPTS_ROOT "/dev/overmount/test.over", O_WRONLY | O_CREAT);
+	fd = open(MPTS_ROOT "/dev/overmount/test.over", O_WRONLY | O_CREAT, 0777);
 	if (fd == -1) {
 		pr_perror("Unable to open " MPTS_ROOT "/dev/overmount");
 		return -1;
@@ -190,14 +190,14 @@ int main(int argc, char **argv)
 	}
 	mkdir(MPTS_ROOT "/dev/slave/test.mnt.slave/test.slave", 0600);
 
-	fd = open(MPTS_ROOT "/dev/bmfile", O_CREAT | O_WRONLY);
+	fd = open(MPTS_ROOT "/dev/bmfile", O_CREAT | O_WRONLY, 0777);
 	if (fd < 0) {
 		pr_perror("Can't create " MPTS_ROOT "/dev/share-1/bmfile");
 		return 1;
 	}
 	close(fd);
 
-	fd = open(MPTS_ROOT "/dev/bmfile-mount", O_CREAT | O_WRONLY);
+	fd = open(MPTS_ROOT "/dev/bmfile-mount", O_CREAT | O_WRONLY, 0777);
 	if (fd < 0) {
 		pr_perror("Can't create " MPTS_ROOT "/dev/share-1/bmfile");
 		return 1;


### PR DESCRIPTION
We saw compilation errors like:

  error: call to ‘__open_missing_mode’ declared with attribute error:
  open with O_CREAT or O_TMPFILE in second argument needs 3 arguments

Let's fix them by adding mode 0777 everywhere.

Before this change the mode was taken randomly from stack (according to man 2 open) and that is likely not what we want.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
