### PR TITLE
plugin/amdgpu: Catch error for failure to open drm device

### DIFF
--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -1555,7 +1555,7 @@ CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__DUMP_EXT_FILE, amdgpu_plugin_dump_file)
 static int restore_devices(struct kfd_ioctl_criu_args *args, CriuKfd *e)
 {
 	struct kfd_criu_device_bucket *device_buckets;
-	int ret = 0, bucket_index = 0;
+	int ret = 0, bucket_index = 0, drm_fd;
 
 	pr_debug("Restoring %d devices\n", e->num_of_gpus);
 	args->num_devices = e->num_of_gpus;
@@ -1588,12 +1588,13 @@ static int restore_devices(struct kfd_ioctl_criu_args *args, CriuKfd *e)
 			goto exit;
 		}
 
-		device_bucket->drm_fd = node_get_drm_render_device(tp_node);
-		if (device_bucket->drm_fd < 0) {
-			pr_perror("Can't pass NULL drm render fd to driver");
+		drm_fd = node_get_drm_render_device(tp_node);
+		if (drm_fd < 0) {
+			pr_perror("Can't open drm render fd %d\n", tp_node->drm_render_minor);
 			goto exit;
 		} else {
-			pr_info("passing drm render fd = %d to driver\n", device_bucket->drm_fd);
+			pr_info("passing drm render fd = %d to driver\n", drm_fd);
+			device_bucket->drm_fd = drm_fd;
 		}
 	}
 


### PR DESCRIPTION
kfd_criu_device_bucket.drm_fd is an unsigned int, so the comparison device_bucket->drm_fd < 0
was always false.

Fix that, and also make the error message a bit more descriptive.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
