### PR TITLE
config: expose --orphan-pts-master as a CLI option

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -403,6 +403,11 @@ mount -t cgroup -o devices,freezer none devices,freezer
     to migrate applications like *top*. If used with *dump* command,
     it must be specified with *restore* as well.
 
+*--orphan-pts-master*::
+    Allow dumping and restoring PTY slave devices whose master is
+    outside the dumped process tree (for example, masters held by
+    container monitors such as LXC/LXD).
+
 *--cpu-cap* ['cap'[,'cap'...]]::
     Specify CPU capabilities to write to an image file. The argument is a
     comma-separated list of:

--- a/criu/config.c
+++ b/criu/config.c
@@ -705,6 +705,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		BOOL_OPT("unprivileged", &opts.unprivileged),
 		BOOL_OPT("ghost-fiemap", &opts.ghost_fiemap),
 		BOOL_OPT(OPT_ALLOW_UPROBES, &opts.allow_uprobes),
+		BOOL_OPT("orphan-pts-master", &opts.orphan_pts_master),
 		{},
 	};
 

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -457,6 +457,8 @@ usage:
 	       "  --ghost-fiemap        enable dumping of deleted files using fiemap\n"
 	       "  --action-script FILE  add an external action script\n"
 	       "  -j|--" OPT_SHELL_JOB "        allow one to dump and restore shell jobs\n"
+	       "  --orphan-pts-master   allow dumping/restoring PTY devices whose master\n"
+	       "                        is outside the dumped process tree\n"
 	       "  -l|--" OPT_FILE_LOCKS "       handle file locks, for safety, only used for container\n"
 	       "  -L|--libdir           path to a plugin directory (by default " CR_PLUGIN_DEFAULT ")\n"
 	       "  --timeout NUM         a timeout (in seconds) on collecting tasks during dump\n"

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -205,7 +205,7 @@ struct cr_options {
 	int display_stats;
 	int weak_sysctls;
 	int status_fd;
-	bool orphan_pts_master;
+	int orphan_pts_master;
 	int stream;
 	pid_t tree_id;
 	int log_level;


### PR DESCRIPTION
## Description

The orphan-pts-master option allows dumping and restoring PTY slave devices whose master lives outside the dumped process tree (e.g. held by the LXC monitor process).

This option was already wired up for the RPC/libcriu interface and fully implemented in tty.c, but was never exposed as a command-line flag.

Add BOOL_OPT("orphan-pts-master") to the getopt_long table in config.c and corresponding help text in crtools.c. Change the field type in cr_options from bool to int, matching the convention used by every other BOOL_OPT field.

related to #1295 

## Relevant logs while reproducing the issue

Scenario 1: without `--orphan-pts-master` (reproduce the bug)
```
$ sudo criu dump -t $PID -D /tmp/lxc-dump -o dump.log -v4 \
    --tcp-established --file-locks --link-remap \
    --manage-cgroups=full --ext-mount-map auto \
    --enable-external-sharing --enable-external-masters \
    --enable-fs hugetlbfs --enable-fs tracefs

...
(00.068066) Obtaining task auvx ...
(00.068123) Dumping path for -3 fd via self 16 [/]
(00.068143) Dumping path for -3 fd via self 16 [/]
(00.068146) Dumping task cwd id 0xf root id 0x10
(00.068172) mnt: Dumping mountpoints
(00.068174) mnt:        828: 62:/.lxc-boot-id @ ./proc/sys/kernel/random/boot_id
(00.068176) mnt: Mount is not fully visible ./dev(1094)
(00.068199) mnt:        mount has children ./dev(1094)
tar: ./log: socket ignored
(00.073833) mnt:        1115: b8:/4 @ ./dev/tty5
(00.073843) Error (criu/tty.c:2399): tty: Unable to find a master for /4
(00.073958) net: Unlock network
(00.073962) Running network-unlock scripts
(00.143606) Unfreezing tasks into 1
(00.143618)     Unseizing 94035 into 1
(00.143627)     Unseizing 94044 into 1
(00.143633)     Unseizing 94048 into 1
(00.143638)     Unseizing 94046 into 1
(00.143676) Error (criu/cr-dump.c:2128): Dumping FAILED.

```


Scenario 2: with `--orphan-pts-master` (only errors realted to iptables exist in my systm)
```
$ sudo criu dump -t $PID -D /tmp/lxc-dump-fix -o dump.log -v4 \
    --tcp-established --file-locks --link-remap \
    --manage-cgroups=full --ext-mount-map auto \
    --enable-external-sharing --enable-external-masters \
    --enable-fs hugetlbfs --enable-fs tracefs \
    --orphan-pts-master
    
...
(00.097840) net: Dumping netns links
(00.106142) net: Dumping netns links
(00.115252) Namespaces dump complete
(00.115368) cg: Dumping 4 sets
(00.115381) cg:    `- Dumping  of /lxc.payload.minictr
(00.115388) cg:    `- Dumping  of /lxc.payload.minictr
(00.115392) cg:    `- Dumping  of /lxc.payload.minictr
(00.115395) cg:    `- Dumping  of /lxc.payload.minictr
(00.115411) cg: Writing CG image
(00.115451) unix: Dumping external sockets
(00.115457) Writing image inventory (version 1)
(00.115629) Running post-dump scripts
(00.115634) Unfreezing tasks into 2
(00.115639)     Unseizing 94476 into 2
(00.115651)     Unseizing 94482 into 2
(00.115659)     Unseizing 94486 into 2
(00.115666)     Unseizing 94484 into 2
(00.132296) Writing stats
(00.132357) Dumping finished successfully
 ```

