### PR TITLE
criu: save and restore timer_slack_ns per thread

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -754,6 +754,8 @@ int dump_thread_core(int pid, CoreEntry *core, const struct parasite_dump_thread
 			tc->has_pdeath_sig = true;
 			tc->pdeath_sig = ti->pdeath_sig;
 		}
+		tc->has_timerslack_ns = true;
+		tc->timerslack_ns = ti->timerslack_ns;
 		tc->comm = xstrdup(ti->comm);
 		if (tc->comm == NULL)
 			return -1;

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -3435,6 +3435,11 @@ static int sigreturn_restore(pid_t pid, struct task_restore_args *task_args, uns
 			goto err;
 		}
 
+		if (tcore->thread_core->has_timerslack_ns) {
+			thread_args[i].has_timerslack_ns = true;
+			thread_args[i].timerslack_ns = tcore->thread_core->timerslack_ns;
+		}
+
 		ret = prep_sched_info(&thread_args[i].sp, tcore->thread_core);
 		if (ret)
 			goto err;

--- a/criu/include/parasite.h
+++ b/criu/include/parasite.h
@@ -184,6 +184,7 @@ struct parasite_dump_thread {
 	struct parasite_check_rseq rseq;
 	stack_t sas;
 	int pdeath_sig;
+	unsigned long timerslack_ns;
 	char comm[TASK_COMM_LEN];
 	struct parasite_dump_creds creds[0];
 };

--- a/criu/include/restorer.h
+++ b/criu/include/restorer.h
@@ -114,6 +114,8 @@ struct thread_restore_args {
 	unsigned int siginfo_n;
 
 	int pdeath_sig;
+	bool has_timerslack_ns;
+	unsigned long timerslack_ns;
 
 	struct thread_creds_args *creds_args;
 

--- a/criu/pie/parasite.c
+++ b/criu/pie/parasite.c
@@ -41,6 +41,10 @@ static struct parasite_dump_pages_args *mprotect_args = NULL;
 #define PR_GET_PDEATHSIG 2
 #endif
 
+#ifndef PR_GET_TIMERSLACK
+#define PR_GET_TIMERSLACK 30
+#endif
+
 #ifndef PR_GET_CHILD_SUBREAPER
 #define PR_GET_CHILD_SUBREAPER 37
 #endif
@@ -192,6 +196,16 @@ static int dump_thread_common(struct parasite_dump_thread *ti)
 	if (ret) {
 		pr_err("Unable to get the parent death signal: %d\n", ret);
 		goto out;
+	}
+
+	{
+		long slack = sys_prctl(PR_GET_TIMERSLACK, 0, 0, 0, 0);
+		if (slack < 0) {
+			pr_err("Unable to get timer slack: %ld\n", slack);
+			ret = (int)slack;
+			goto out;
+		}
+		ti->timerslack_ns = (unsigned long)slack;
 	}
 
 	ret = sys_prctl(PR_GET_NAME, (unsigned long)&ti->comm, 0, 0, 0);

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -66,6 +66,10 @@
 #define PR_SET_PDEATHSIG 1
 #endif
 
+#ifndef PR_SET_TIMERSLACK
+#define PR_SET_TIMERSLACK 29
+#endif
+
 #ifndef PR_SET_CHILD_SUBREAPER
 #define PR_SET_CHILD_SUBREAPER 36
 #endif
@@ -406,6 +410,22 @@ static inline int restore_pdeath_sig(struct thread_restore_args *ta)
 	ret = sys_prctl(PR_SET_PDEATHSIG, ta->pdeath_sig, 0, 0, 0);
 	if (ret) {
 		pr_err("Unable to set PR_SET_PDEATHSIG(%d): %d\n", ta->pdeath_sig, ret);
+		return -1;
+	}
+
+	return 0;
+}
+
+static inline int restore_timerslack(struct thread_restore_args *ta)
+{
+	int ret;
+
+	if (!ta->has_timerslack_ns)
+		return 0;
+
+	ret = sys_prctl(PR_SET_TIMERSLACK, ta->timerslack_ns, 0, 0, 0);
+	if (ret) {
+		pr_err("Unable to set PR_SET_TIMERSLACK(%lu): %d\n", ta->timerslack_ns, ret);
 		return -1;
 	}
 
@@ -816,6 +836,7 @@ __visible long __export_restore_thread(struct thread_restore_args *args)
 	ret = restore_creds(args->creds_args, args->ta->proc_fd, args->ta->lsm_type, args->ta->uid);
 	ret = ret || restore_dumpable_flag(&args->ta->mm);
 	ret = ret || restore_pdeath_sig(args);
+	ret = ret || restore_timerslack(args);
 	if (ret)
 		BUG();
 
@@ -2290,6 +2311,7 @@ __visible long __export_restore_task(struct task_restore_args *args)
 	ret = restore_creds(args->t->creds_args, args->proc_fd, args->lsm_type, args->uid);
 	ret = ret || restore_dumpable_flag(&args->mm);
 	ret = ret || restore_pdeath_sig(args->t);
+	ret = ret || restore_timerslack(args->t);
 	ret = ret || restore_child_subreaper(args->child_subreaper);
 
 	futex_set_and_wake(&thread_inprogress, args->nr_threads);

--- a/images/core.proto
+++ b/images/core.proto
@@ -111,6 +111,7 @@ message thread_core_entry {
 	optional uint64			blk_sigset_extended	= 14;
 	optional rseq_entry		rseq_entry	= 15;
 	optional uint32			cg_set		= 16;
+	optional uint64			timerslack_ns	= 17;
 }
 
 message task_rlimits_entry {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -26,6 +26,7 @@ TST_NOFILE	:=				\
 		timers				\
 		timers01			\
 		timerfd				\
+		timerslack_ns			\
 		unbound_sock			\
 		sched_prio00			\
 		sched_policy00			\
@@ -619,6 +620,7 @@ sigpending:		LDLIBS += -pthread
 sigaltstack:		LDLIBS += -pthread
 seccomp_filter_tsync:	LDLIBS += -pthread
 seccomp_filter_threads:	LDLIBS += -pthread
+timerslack_ns:		LDLIBS += -pthread
 shm:			CFLAGS += -DNEW_IPC_NS
 msgque:			CFLAGS += -DNEW_IPC_NS
 sem:			CFLAGS += -DNEW_IPC_NS

--- a/test/zdtm/static/timerslack_ns.c
+++ b/test/zdtm/static/timerslack_ns.c
@@ -1,0 +1,90 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <pthread.h>
+#include <sys/prctl.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check that timer_slack_ns is preserved across C/R for multiple threads";
+const char *test_author = "Ahmed Elaidy <elaidya225@gmail.com>";
+
+#define MAIN_SLACK_NS	 123456UL
+#define THREAD_SLACK_NS	 654321UL
+
+static void *thread_fn(void *arg)
+{
+	long slack;
+
+	(void)arg;
+
+	if (prctl(PR_SET_TIMERSLACK, THREAD_SLACK_NS, 0, 0, 0)) {
+		pr_perror("thread: can't set timer_slack_ns");
+		return (void *)(uintptr_t)1;
+	}
+
+	test_waitsig();
+
+	slack = prctl(PR_GET_TIMERSLACK, 0, 0, 0, 0);
+	if (slack < 0) {
+		pr_perror("thread: can't get timer_slack_ns");
+		return (void *)(uintptr_t)1;
+	}
+
+	if (slack != THREAD_SLACK_NS) {
+		pr_err("thread: timer_slack_ns changed: expected %lu, got %ld\n",
+		       THREAD_SLACK_NS, slack);
+		return (void *)(uintptr_t)1;
+	}
+
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	pthread_t thread;
+	void *thread_ret;
+	long slack;
+	int ret;
+
+	test_init(argc, argv);
+
+	if (prctl(PR_SET_TIMERSLACK, MAIN_SLACK_NS, 0, 0, 0)) {
+		pr_perror("can't set timer_slack_ns");
+		return 1;
+	}
+
+	ret = pthread_create(&thread, NULL, thread_fn, NULL);
+	if (ret) {
+		pr_err("pthread_create: %d\n", ret);
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	slack = prctl(PR_GET_TIMERSLACK, 0, 0, 0, 0);
+	if (slack < 0) {
+		pr_perror("can't get timer_slack_ns");
+		return 1;
+	}
+
+	if (slack != MAIN_SLACK_NS) {
+		fail("main: timer_slack_ns changed: expected %lu, got %ld",
+		     MAIN_SLACK_NS, slack);
+		return 1;
+	}
+
+	ret = pthread_join(thread, &thread_ret);
+	if (ret) {
+		pr_err("pthread_join: %d\n", ret);
+		return 1;
+	}
+
+	if (thread_ret) {
+		fail("thread timer_slack_ns was not preserved");
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
## Problem

Linux has a per-thread `timer_slack_ns` value that controls wakeup
coalescing for `select()`, `poll()`, `nanosleep()`, and similar calls.
It defaults to 50000 ns and is set via `prctl(PR_SET_TIMERSLACK)`.

CRIU does not save or restore this value, so any process that
customises its timer slack (e.g. latency-sensitive applications that
set it to 0, or battery-saving daemons that increase it) silently
reverts to the default after checkpoint/restore.

## Solution

Collect and restore `timer_slack_ns` per thread, following the same
pattern used for `pdeath_sig`:

1. **Image schema** — add `optional uint64 timerslack_ns = 17` to
   `thread_core_entry` in `images/core.proto`.

2. **Dump** — read the value via `prctl(PR_GET_TIMERSLACK)` inside
   the parasite and write it into the protobuf image during dump.

3. **Restore** — read the value from the image, pass it via
   `struct thread_restore_args`, and call `prctl(PR_SET_TIMERSLACK)`
   in the restorer for each thread.

4. **Test** — add a ZDTM test (`zdtm/static/timerslack_ns`) that sets
   a non-default value, checkpoints, and verifies it is preserved.

## Before (criu-dev)

```
$ sudo ./test/zdtm.py run -t zdtm/static/timerslack_ns --ignore-taint
zdtm/static/timerslack_ns                       FAIL
```

Test binary does not exist; `timer_slack_ns` is silently lost on C/R.

## After (this PR)

```
$ sudo ./test/zdtm.py run -t zdtm/static/timerslack_ns --ignore-taint
Test zdtm/static/timerslack_ns PASS (h)
Test zdtm/static/timerslack_ns PASS (ns)
Test zdtm/static/timerslack_ns PASS (uns)
```

All three flavours pass — `timer_slack_ns` is correctly preserved.

## Commits

Each commit builds and runs independently (bisect-safe):

1. `images:` add schema field
2. `criu:` dump — parasite collection + `cr-dump.c` wiring
3. `criu:` restore — restorer function + `cr-restore.c` wiring
4. `zdtm:` test
