### PR TITLE
pycriu: force protobuf python backend on Python 3.14+

### DIFF
--- a/lib/pycriu/__init__.py
+++ b/lib/pycriu/__init__.py
@@ -1,3 +1,16 @@
+import os
+import sys
+
+# Python 3.14 introduced changes that break some older protobuf C-extension
+# builds shipped by certain distributions. If the user has not explicitly
+# selected an implementation, default to the pure-Python backend to avoid
+# import failures (e.g. "Metaclasses with custom tp_new are not supported").
+#
+# This is a temporary compatibility workaround and should be removed once
+# protobuf packages fully support Python 3.14+.
+if sys.version_info >= (3, 14):
+    os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
+
 from . import rpc_pb2 as rpc
 from . import images
 from .criu import criu, CRIUExceptionExternal, CRIUException


### PR DESCRIPTION
 Problem

  - pycriu can fail on Python 3.14+ when protobuf uses C extensions.

  Context

  - Distributions currently mitigate this by forcing the pure-python protobuf implementation for affected environments.

  Change

  - In pycriu init, set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python when Python >= 3.14.
  - Do this only if the variable is not already set, so explicit user/distribution configuration is preserved.

  Impact

  - No behavior change for Python < 3.14.
  - Keeps override path available via environment.

  Fixes: #2848