### PR TITLE
rseq: use kernel rseq.h when glibc detects it

### DIFF
--- a/criu/include/linux/rseq.h
+++ b/criu/include/linux/rseq.h
@@ -14,6 +14,16 @@
 
 #include "common/config.h"
 
+/*
+ * If glibc detected that the kernel rseq.h header exists, include
+ * it directly using angle brackets (which bypasses -iquote and finds
+ * the real kernel header).  Otherwise fall back to our own copy of
+ * the definitions.
+ */
+#ifdef __GLIBC_HAVE_KERNEL_RSEQ
+#include <linux/rseq.h>
+#else /* !__GLIBC_HAVE_KERNEL_RSEQ */
+
 #ifdef CONFIG_HAS_NO_LIBC_RSEQ_DEFS
 /*
  * linux/rseq.h
@@ -44,6 +54,8 @@ enum rseq_cs_flags {
 	RSEQ_CS_FLAG_NO_RESTART_ON_MIGRATE = (1U << RSEQ_CS_FLAG_NO_RESTART_ON_MIGRATE_BIT),
 };
 #endif /* CONFIG_HAS_NO_LIBC_RSEQ_DEFS */
+
+#endif /* !__GLIBC_HAVE_KERNEL_RSEQ */
 
 /*
  * Let's use our own definition of struct rseq_cs because some distros


### PR DESCRIPTION
Compilation fails with the latest glibc-devel in Fedora rawhide. Recent glibc conditionally includes the kernel's linux/rseq.h when __GLIBC_HAVE_KERNEL_RSEQ is defined, but CRIU's own copy of the rseq definitions does not account for this and conflicts with the kernel header which has additional information.

Check if __GLIBC_HAVE_KERNEL_RSEQ is defined and if so include the kernel header directly using angle brackets (which bypasses -iquote and finds the real kernel header instead of CRIU's copy).  Otherwise fall back to CRIU's own definitions.

Generated with Claude Code (https://claude.ai/code)