### PR TITLE
openat2: fix build failure when included without config.h

### DIFF
--- a/criu/include/linux/openat2.h
+++ b/criu/include/linux/openat2.h
@@ -3,10 +3,21 @@
 
 #include <linux/types.h>
 
+#ifdef __has_include
+#if __has_include("common/config.h")
 #include "common/config.h"
+#endif
+#endif
 
-#ifdef CONFIG_HAS_OPENAT2
+/*
+ * If CONFIG_HAS_OPENAT2 is set (from config.h) or the system header
+ * has already been included (e.g. via glibc's fcntl.h), use the real
+ * definitions.  Otherwise provide a fallback.
+ */
+#if defined(CONFIG_HAS_OPENAT2) || defined(_LINUX_OPENAT2_H)
+#ifndef _LINUX_OPENAT2_H
 #include <linux/openat2.h>
+#endif
 #else
 struct open_how {
 	__u64 flags;


### PR DESCRIPTION
On Fedora Rawhide, glibc commit 0f0a5cd33899 ("linux: Add openat2 (BZ 31664)") [1] added `#include <linux/openat2.h>` in `bits/fcntl-linux.h`. When building the libcriu tests, the compiler flag `-iquote criu/include` causes GCC to pick up CRIU's own `criu/include/linux/openat2.h` instead of the system header. CRIU's version unconditionally includes "common/config.h", which is a build-generated file that does not exist outside the main CRIU build tree, resulting in a fatal error:
```
  ../../../../criu/criu/include/linux/openat2.h:6:10: fatal error: common/config.h: No such file or directory
```
Fix this by guarding the `common/config.h` include with `__has_include` so the header is simply skipped when unavailable. Additionally, check for _LINUX_OPENAT2_H (the system header's include guard) so that when glibc has already pulled in the real `<linux/openat2.h>`, we use those definitions instead of emitting a duplicate fallback struct.

This follows the same pattern established in commit 95531dcc3 ("rseq: use kernel rseq.h when glibc detects it").

[1] https://sourceware.org/git/?p=glibc.git;a=commit;h=0f0a5cd338998f4b603f52f3ce2163df0db7b814

Generated with Claude Code (https://claude.ai/code)