### PR TITLE
scripts: rseq: fix detection of rseq_cpu_id_state

### DIFF
--- a/scripts/feature-tests.mak
+++ b/scripts/feature-tests.mak
@@ -165,8 +165,7 @@ define FEATURE_TEST_NO_LIBC_RSEQ_DEFS
 #endif
 
 enum rseq_cpu_id_state {
-	RSEQ_CPU_ID_UNINITIALIZED = -1,
-	RSEQ_CPU_ID_REGISTRATION_FAILED = -2,
+	RSEQ_CPU_CRIU_TEST = -1,
 };
 
 int main(void)


### PR DESCRIPTION
gcc doesn't report any warnings if there are two identical enums with the same name. Actually, we wanted to detect if a specific enum is already exists. By using a different member name in the test, we ensure that a conflict occurs if the enum is already defined in the system headers.

