### PR TITLE
test: libcriu: stop using CRIU-internal headers

### DIFF
--- a/test/others/libcriu/Makefile
+++ b/test/others/libcriu/Makefile
@@ -11,6 +11,16 @@ TESTS += test_pre_dump
 TESTS += test_check
 TESTS += test_feature_check
 
+# Install libcriu (headers and library) into a local staging directory so
+# that nothing from the non-test part of the repo is referenced directly
+# during the build or at runtime.
+INSTALL_DIR:= $(CURDIR)/.install
+CRIU_INCLUDE:= $(INSTALL_DIR)/include/criu
+CRIU_LIB:= $(INSTALL_DIR)/lib
+
+CFLAGS:= -I$(CRIU_INCLUDE)
+LDFLAGS:= -L$(CRIU_LIB) -lcriu
+
 all: $(TESTS)
 .PHONY: all
 
@@ -18,24 +28,24 @@ run: all
 	./run.sh
 .PHONY: run
 
+$(CRIU_LIB)/libcriu.so:
+	$(MAKE) -C ../../../../criu install-lib \
+		DESTDIR=$(INSTALL_DIR) PREFIX=/ LIBDIR=/lib \
+		SKIP_PIP_INSTALL=1
+
+$(CRIU_INCLUDE): $(CRIU_LIB)/libcriu.so
+	@:
+
 define genb
 $(1): $(1).o lib.o
-	gcc $$^ -L ../../../../criu/lib/c/ -L ../../../../criu/images/ -lcriu -o $$@
+	gcc $$^ $(LDFLAGS) -o $$@
 endef
 
 $(foreach t, $(TESTS), $(eval $(call genb, $(t))))
 
-%.o: %.c
-	gcc -c $^ -iquote ../../../../criu/criu/include -I../../../../criu/lib/c/ -I../../../../criu/images/ -o $@ -Werror
+%.o: %.c | $(CRIU_INCLUDE)
+	gcc -c $< $(CFLAGS) -o $@ -Werror
 
-clean: libcriu_clean
-	rm -rf $(TESTS) $(TESTS:%=%.o) lib.o
+clean:
+	rm -rf $(TESTS) $(TESTS:%=%.o) lib.o $(INSTALL_DIR)
 .PHONY: clean
-
-libcriu_clean:
-	rm -f libcriu.so.${CRIU_SO_VERSION_MAJOR}
-.PHONY: libcriu_clean
-
-libcriu:
-	ln -s ../../../../criu/lib/c/libcriu.so libcriu.so.${CRIU_SO_VERSION_MAJOR}
-.PHONY: libcriu

--- a/test/others/libcriu/run.sh
+++ b/test/others/libcriu/run.sh
@@ -14,12 +14,11 @@ source "${MAIN_DIR}/../env.sh" || exit 1
 
 echo "== Clean"
 make clean
-make libcriu
 
 rm -rf "${OUTPUT_DIR}"
 
 echo "== Run tests"
-export LD_LIBRARY_PATH=.
+export LD_LIBRARY_PATH=${MAIN_DIR}/.install/lib
 export PATH="${MAIN_DIR}/../../../criu:${PATH}"
 
 RESULT=0
@@ -76,6 +75,5 @@ fi
 run_test test_feature_check
 
 echo "== Tests done"
-make libcriu_clean
 [ "${RESULT}" -eq 0 ] && echo "Success" || echo "FAIL"
 exit "${RESULT}"


### PR DESCRIPTION
test: libcriu: stop using CRIU-internal headers

Fixes: #2927

**Problem**

The compile rule for `test/others/libcriu` included CRIU's internal header
directory via `-iquote ../../../../criu/criu/include`. This path was added so
that `lib/c/criu.h`'s transitive include of `version.h` could be resolved,
but it also exposed all of `criu/include/` to the compiler's search path.

On some distros, the system `<fcntl.h>` contains:

    #include "linux/openat2.h"

With the `-iquote` path in place the compiler resolves that quoted include to
CRIU's internal `criu/include/linux/openat2.h`, which in turn requires
`common/config.h` — a file that is entirely internal and not findable from
the test directory. The build fails.

Additionally, the compile pattern rule was using `$^` (all prerequisites)
instead of `$<` (the source file) for `gcc -c`, which was technically
incorrect.

**Fix**

Install libcriu's public UAPI headers into a local staging directory
(`.install/include/criu/`) using the existing `make install-lib` target
before compiling. The installed set is exactly:

    $ ls test/others/libcriu/.install/include/criu/
    criu.h  rpc.pb-c.h  rpc.proto  version.h

All four land flat in the same directory, so `-I.install/include/criu/` is
sufficient and no internal CRIU path is needed or present. The `.install/`
directory is added to `clean`.

The library itself continues to be used directly from the build tree via the
`libcriu` symlink and `LD_LIBRARY_PATH=.` set by `run.sh`.

**Testing**

    $ sudo ./test/others/libcriu/run.sh
    ...
    == Tests done
    Success
