### PR TITLE
Contrib/void linux dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,18 @@ First, you need to install the required build dependencies. We provide scripts t
 ./contrib/dependencies/dnf-packages.sh
 ```
 
+##### On Arch Linux:
+
+```
+./contrib/dependencies/pacman-packages.sh
+```
+
+##### On Void Linux:
+
+```
+./contrib/dependencies/xbps-packages.sh
+```
+
 ##### Using Nix:
 
 ```

--- a/contrib/dependencies/xbps-packages.sh
+++ b/contrib/dependencies/xbps-packages.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+sudo xbps-install -Sy \
+
+    gcc \
+    make \
+    git \
+    pkg-config \
+    binutils \
+    protobuf \
+    protobuf-devel \
+    protobuf-c-devel \
+    python3 \
+    python3-protobuf \
+    python3-setuptools \
+    python3-pip \
+    python3-yaml \
+    libnet-devel \
+    libnl3-devel \
+    libcap-devel \
+    libaio-devel \
+    gnutls-devel \
+    libbsd-devel \
+    libuuid-devel \
+    elfutils-devel \
+    libbpf-devel \
+    libdrm-devel \
+    libnftables-devel \
+    libselinux-devel \
+    iproute2 \
+    libtraceevent-devel \
+    libtracefs-devel \
+    xmlto \
+    asciidoc

--- a/contrib/dependencies/xbps-packages.sh
+++ b/contrib/dependencies/xbps-packages.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 sudo xbps-install -Sy \
-
     gcc \
     make \
     git \


### PR DESCRIPTION
[x] I have read and understood the contributing guidelines.
[x] Describe.

- CRIU's `contrib/dependencies/` directory provides distro-specific scripts to install build dependencies for Ubuntu/Debian (`apt-packages.sh`), Arch, and Fedora/CentOS (`dnf-packages.sh`), but Void Linux was not covered. This PR adds `contrib/dependencies/xbps-packages.sh` following the same structure as the existing scripts, and updates `CONTRIBUTING.md` to reference it.
- Because Arch is similar to Void, I tried to run and install all packages, but many failed because the xbps repos do not have them all with the same name, so I did some research and added the appropriate ones. I also updated the `CONTRIBUTING` file to make it easier for developers.

**Notes on Void Linux package naming:**
- Development headers are in separate `-devel` packages
- `util-linux` is split on Void — only `libuuid-devel` is needed
- `nftables` is split on Void — only `libnftables-devel` is needed
- `protobuf` must be installed alongside `protobuf-devel` to get the `protoc` compiler binary

Void Linux required special attention due to package splitting:
- `libuuid-devel` instead of `util-linux-devel`
- `libnftables-devel` instead of `nftables-devel`
- `protobuf` must be installed alongside `protobuf-devel` to get the `protoc` compiler binary

**Testing:** Tested on my current Void machine and in a Docker container.
- All packages installed successfully
- All libraries verified via `pkg-config`
- `./criu/criu check` reports `Looks good.`
- 
<img width="714" height="375" alt="image" src="https://github.com/user-attachments/assets/cf04edc6-c305-4f08-9c6e-22a85f5bc88e" />
<img width="972" height="575" alt="image" src="https://github.com/user-attachments/assets/204b8aed-08ed-4b62-b7dc-5960dbfb23f3" />
<img width="725" height="99" alt="image" src="https://github.com/user-attachments/assets/b76fe743-2a6c-41c8-8e13-c856036d436e" />


Signed-off-by: Abdullah Badawy <[abdullahalbadawy1@gmail.com](mailto:abdullahalbadawy1@gmail.com)>