### PR TITLE
scripts: improve layer caching of container builds

### DIFF
--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine
+FROM docker.io/library/alpine:latest
 ARG CC=gcc
 
 COPY contrib/dependencies/apk-packages.sh /criu/contrib/dependencies/apk-packages.sh

--- a/scripts/build/Dockerfile.alpine
+++ b/scripts/build/Dockerfile.alpine
@@ -1,10 +1,11 @@
 FROM alpine
 ARG CC=gcc
 
+COPY contrib/dependencies/apk-packages.sh /criu/contrib/dependencies/apk-packages.sh
+RUN apk add --no-cache "$CC" && /criu/contrib/dependencies/apk-packages.sh
+
 COPY . /criu
 WORKDIR /criu
-
-RUN apk add --no-cache "$CC" && /criu/contrib/dependencies/apk-packages.sh
 
 RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 

--- a/scripts/build/Dockerfile.amd-rocm
+++ b/scripts/build/Dockerfile.amd-rocm
@@ -1,4 +1,4 @@
-FROM rocm/pytorch:latest
+FROM docker.io/rocm/pytorch:latest
 
 ARG CC=gcc
 

--- a/scripts/build/Dockerfile.archlinux
+++ b/scripts/build/Dockerfile.archlinux
@@ -5,10 +5,11 @@ ARG CC=gcc
 # Initialize machine ID
 RUN systemd-machine-id-setup
 
-COPY . /criu
+COPY contrib/dependencies/pacman-packages.sh /criu/contrib/dependencies/pacman-packages.sh
 WORKDIR /criu
+RUN pacman -Syu --noconfirm "$CC" && /criu/contrib/dependencies/pacman-packages.sh
 
-RUN pacman -Syu --noconfirm "$CC" && contrib/dependencies/pacman-packages.sh
+COPY . /criu
 
 RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 

--- a/scripts/build/Dockerfile.armv7hf.hdr
+++ b/scripts/build/Dockerfile.armv7hf.hdr
@@ -1,1 +1,1 @@
-FROM arm32v7/ubuntu:bionic
+FROM docker.io/arm32v7/ubuntu:bionic

--- a/scripts/build/Dockerfile.fedora.tmpl
+++ b/scripts/build/Dockerfile.fedora.tmpl
@@ -1,9 +1,12 @@
 ARG CC=gcc
 
-COPY . /criu
+COPY contrib/dependencies/dnf-packages.sh /criu/contrib/dependencies/dnf-packages.sh
+COPY scripts/ci/prepare-for-fedora-rawhide.sh /criu/scripts/ci/prepare-for-fedora-rawhide.sh
+# prepare-for-fedora-rawhide.sh assumes we are in the criu directory
 WORKDIR /criu
+RUN dnf install -y "$CC" && /criu/scripts/ci/prepare-for-fedora-rawhide.sh
 
-RUN dnf install -y "$CC" && scripts/ci/prepare-for-fedora-rawhide.sh
+COPY . /criu
 
 RUN make mrproper && date && make -j $(nproc) CC="$CC" && date
 

--- a/scripts/build/Dockerfile.hotspot-alpine
+++ b/scripts/build/Dockerfile.hotspot-alpine
@@ -1,10 +1,11 @@
 FROM docker.io/library/eclipse-temurin:11-alpine
 ARG CC=gcc
 
-COPY . /criu
+COPY contrib/dependencies/apk-packages.sh /criu/contrib/dependencies/apk-packages.sh
 WORKDIR /criu
+RUN apk add --no-cache maven "$CC" && /criu/contrib/dependencies/apk-packages.sh
 
-RUN apk add --no-cache maven "$CC" && contrib/dependencies/apk-packages.sh
+COPY . /criu
 
 RUN make mrproper && make -j $(nproc) CC="$CC"
 

--- a/scripts/build/Dockerfile.hotspot-ubuntu
+++ b/scripts/build/Dockerfile.hotspot-ubuntu
@@ -1,10 +1,12 @@
 FROM docker.io/library/eclipse-temurin:11-jammy
 ARG CC=gcc
 
-COPY . /criu
+COPY contrib/dependencies/apt-packages.sh /criu/contrib/dependencies/apt-packages.sh
+COPY contrib/apt-install /criu/contrib/apt-install
 WORKDIR /criu
+RUN /criu/contrib/apt-install maven "$CC" && contrib/dependencies/apt-packages.sh
 
-RUN contrib/apt-install maven "$CC" && contrib/dependencies/apt-packages.sh
+COPY . /criu
 
 RUN make mrproper && make -j $(nproc) CC="$CC"
 

--- a/scripts/build/Dockerfile.linux32.tmpl
+++ b/scripts/build/Dockerfile.linux32.tmpl
@@ -1,9 +1,11 @@
 ARG CC=gcc
 
-COPY . /criu
+COPY contrib/dependencies/apt-cross-packages.sh /criu/contrib/dependencies/apt-cross-packages.sh
+COPY contrib/apt-install /criu/contrib/apt-install
 WORKDIR /criu
+RUN /criu/contrib/apt-install "$CC" && /criu/contrib/dependencies/apt-packages.sh
 
-RUN contrib/apt-install "$CC" && contrib/dependencies/apt-packages.sh
+COPY . /criu
 
 RUN uname -m && setarch linux32 uname -m && setarch --list
 

--- a/scripts/build/Dockerfile.mips64el-stable-cross.hdr
+++ b/scripts/build/Dockerfile.mips64el-stable-cross.hdr
@@ -1,4 +1,4 @@
-FROM dockcross/base:latest
+FROM docker.io/dockcross/base:latest
 
 ENV ARCH=mips
 ENV SUBARCH=mips

--- a/scripts/build/Dockerfile.mips64el-unstable-cross.hdr
+++ b/scripts/build/Dockerfile.mips64el-unstable-cross.hdr
@@ -1,4 +1,4 @@
-FROM dockcross/base:latest
+FROM docker.io/dockcross/base:latest
 
 ENV ARCH=mips
 ENV SUBARCH=mips

--- a/scripts/build/Dockerfile.openj9-ubuntu
+++ b/scripts/build/Dockerfile.openj9-ubuntu
@@ -1,11 +1,13 @@
 FROM docker.io/library/ibm-semeru-runtimes:open-11-jdk-jammy
 ARG CC=gcc
 
+COPY contrib/dependencies/apt-packages.sh /criu/contrib/dependencies/apt-packages.sh
+COPY contrib/apt-install /criu/contrib/apt-install
+WORKDIR /criu
+RUN /criu/contrib/apt-install maven "$CC" && /criu/contrib/dependencies/apt-packages.sh
+
 RUN mkdir -p /etc/criu && echo 'ghost-limit 16777216' > /etc/criu/default.conf
 COPY . /criu
-WORKDIR /criu
-
-RUN contrib/apt-install maven "$CC" && contrib/dependencies/apt-packages.sh
 
 RUN make mrproper && make -j $(nproc) CC="$CC"
 

--- a/scripts/build/Dockerfile.ppc64-stable-cross.hdr
+++ b/scripts/build/Dockerfile.ppc64-stable-cross.hdr
@@ -1,4 +1,4 @@
-FROM dockcross/base:latest
+FROM docker.io/dockcross/base:latest
 
 ENV ARCH=ppc64
 ENV DEBIAN_ARCH=ppc64el

--- a/scripts/build/Dockerfile.ppc64-unstable-cross.hdr
+++ b/scripts/build/Dockerfile.ppc64-unstable-cross.hdr
@@ -1,4 +1,4 @@
-FROM dockcross/base:latest
+FROM docker.io/dockcross/base:latest
 
 ENV ARCH=ppc64
 ENV DEBIAN_ARCH=ppc64el

--- a/scripts/build/Dockerfile.riscv64-stable-cross.hdr
+++ b/scripts/build/Dockerfile.riscv64-stable-cross.hdr
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM docker.io/library/ubuntu:jammy
 
 ENV ARCH=riscv64
 ENV DEBIAN_ARCH=riscv64

--- a/scripts/build/Dockerfile.riscv64-stable-cross.tmpl
+++ b/scripts/build/Dockerfile.riscv64-stable-cross.tmpl
@@ -23,9 +23,11 @@ ENV CROSS_COMPILE=${CROSS_TRIPLET}-				\
 ENV PATH="${PATH}:${CROSS_ROOT}/bin"				\
 	PKG_CONFIG_PATH=/usr/lib/${CROSS_TRIPLET}/pkgconfig
 
-COPY . /criu
+COPY contrib/dependencies/apt-cross-packages.sh /criu/contrib/dependencies/apt-cross-packages.sh
+COPY contrib/apt-install /criu/contrib/apt-install
 WORKDIR /criu
+RUN /criu/contrib/dependencies/apt-cross-packages.sh
 
-RUN contrib/dependencies/apt-cross-packages.sh
+COPY . /criu
 
 RUN make mrproper && date && make -j $(nproc) zdtm && date

--- a/scripts/build/Dockerfile.stable-cross.tmpl
+++ b/scripts/build/Dockerfile.stable-cross.tmpl
@@ -15,10 +15,12 @@ ENV CROSS_COMPILE=${CROSS_TRIPLET}-				\
 ENV PATH="${PATH}:${CROSS_ROOT}/bin"				\
 	PKG_CONFIG_PATH=/usr/lib/${CROSS_TRIPLET}/pkgconfig
 
-COPY . /criu
+COPY contrib/dependencies/apt-cross-packages.sh /criu/contrib/dependencies/apt-cross-packages.sh
+COPY contrib/apt-install /criu/contrib/apt-install
 WORKDIR /criu
+RUN /criu/contrib/dependencies/apt-cross-packages.sh
 
-RUN contrib/dependencies/apt-cross-packages.sh
+COPY . /criu
 
 # amdgpu_plugin with armv7 is not supported
 RUN	make mrproper && date && \

--- a/scripts/build/Dockerfile.tmpl
+++ b/scripts/build/Dockerfile.tmpl
@@ -1,11 +1,13 @@
 ARG CC=gcc
 
-COPY . /criu
-WORKDIR /criu
-
 # On Ubuntu, kernel modules such as ip_tables and xt_mark may not be loaded by default
 # We need to install kmod to enable iptables to load these modules for us.
-RUN contrib/apt-install "$CC" && contrib/dependencies/apt-packages.sh
+COPY contrib/dependencies/apt-packages.sh /criu/contrib/dependencies/apt-packages.sh
+COPY contrib/apt-install /criu/contrib/apt-install
+WORKDIR /criu
+RUN /criu/contrib/apt-install "$CC" && /criu/contrib/dependencies/apt-packages.sh
+
+COPY . /criu
 
 RUN git clean -dfx && date && \
 # Check single object build

--- a/scripts/build/Dockerfile.unstable-cross.tmpl
+++ b/scripts/build/Dockerfile.unstable-cross.tmpl
@@ -15,9 +15,11 @@ ENV CROSS_COMPILE=${CROSS_TRIPLET}-				\
 ENV PATH="${PATH}:${CROSS_ROOT}/bin"				\
 	PKG_CONFIG_PATH=/usr/lib/${CROSS_TRIPLET}/pkgconfig
 
-COPY . /criu
+COPY contrib/dependencies/apt-cross-packages.sh /criu/contrib/dependencies/apt-cross-packages.sh
+COPY contrib/apt-install /criu/contrib/apt-install
 WORKDIR /criu
+RUN /criu/contrib/dependencies/apt-cross-packages.sh
 
-RUN contrib/dependencies/apt-cross-packages.sh
+COPY . /criu
 
 RUN make mrproper && date && make -j $(nproc) zdtm && date

--- a/scripts/build/Dockerfile.x86_64.hdr
+++ b/scripts/build/Dockerfile.x86_64.hdr
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM docker.io/library/ubuntu:24.04
 
 COPY contrib/apt-install /bin/apt-install
 


### PR DESCRIPTION
The scripts installing dependencies are now copied and executed before copying the full source tree. This allows to cache the dependency installation layers as long as these scripts remain unchanged. Previously, copying the entire repository invalidated the cache on every source change. While our CI intentionally doesn't preserve cached layers across independent runs, the changes in this patch help with local testing when investigating issues.

Fixes: #2926