### PR TITLE
files-reg: handle deleted /dev/shm files

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -36,6 +36,7 @@
 #define BUILD_ID_MAP_SIZE 1048576
 #define ST_UNIT		  512
 #define EXTENT_MAX_COUNT  512
+#define SHM_DIR		  "/dev/shm/"
 
 #include "cr_options.h"
 #include "imgset.h"
@@ -1293,6 +1294,53 @@ static inline bool nfs_silly_rename(char *rpath, const struct fd_parms *parms)
 	return (parms->fs_type == NFS_SUPER_MAGIC) && is_sillyrename_name(rpath);
 }
 
+static int shm_recover_new_link(
+	const struct stat *ost,
+	struct stat *pst,
+	char *path_buf,
+	size_t nbuf,
+	int mntns_root,
+	int flags
+) {
+	int ret;
+	DIR *dir;
+	struct dirent *entry;
+	char entry_rpath[PATH_MAX];
+
+	ret = openat(mntns_root, "." SHM_DIR, O_RDONLY | O_DIRECTORY);
+	if (ret < 0) {
+		pr_warn("failed to openat %s", SHM_DIR);
+		return -1;
+	}
+
+	dir = fdopendir(ret);
+	if (!dir) {
+		close(ret);
+		pr_warn("failed to fdopendir %s", SHM_DIR);
+		return -1;
+	}
+
+	while ((entry = readdir(dir)) != NULL) {
+		ret = snprintf(entry_rpath, sizeof(entry_rpath), ".%s%s", SHM_DIR, entry->d_name);
+		if (ret < 0)
+			continue;
+
+		ret = fstatat(mntns_root, entry_rpath, pst, flags);
+		if (ret < 0)
+			continue;
+
+		if (pst->st_dev != ost->st_dev || pst->st_ino != ost->st_ino)
+			continue;
+
+		strncpy(path_buf, entry_rpath, nbuf);
+		closedir(dir);
+		return 0;
+	}
+
+	closedir(dir);
+	return -1;
+}
+
 static int check_path_remap(struct fd_link *link, const struct fd_parms *parms, int lfd, u32 id, struct ns_id *nsid)
 {
 	char *rpath = link->name;
@@ -1411,20 +1459,29 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms, 
 		 */
 
 		if (errno == ENOENT) {
-			link_strip_deleted(link);
-			ret = dump_linked_remap(rpath + 1, plen - 1, parms, lfd, id, nsid, &fallback);
-			if (ret < 0 && fallback) {
-				/* fallback is true only if following conditions are true:
-				 * 1. linkat() inside dump_linked_remap() failed with ENOENT
-				 * 2. parms->fs_type == overlayFS
-				 */
-				return dump_ghost_remap(rpath + 1, ost, lfd, id, nsid);
+			/*
+			 * libc's sem_open() creates a temporary file in /dev/shm with mktemp,
+			 * link() it to the final name "sem.<name>" in the same /dev/shm directory,
+			 * then unlink() the temporary name. the object is put into a "deleted" state
+			 * hence there's a good chance the new link is in /dev/shm with a diffrent name
+			 */
+			if (strncmp(rpath + 1, SHM_DIR, sizeof(SHM_DIR) - 1) ||
+			    shm_recover_new_link(ost, &pst, link->name, sizeof(link->name), mntns_root, flags) < 0) {
+				link_strip_deleted(link);
+				ret = dump_linked_remap(rpath + 1, plen - 1, parms, lfd, id, nsid, &fallback);
+				if (ret < 0 && fallback) {
+					/* fallback is true only if following conditions are true:
+					 * 1. linkat() inside dump_linked_remap() failed with ENOENT
+					 * 2. parms->fs_type == overlayFS
+					 */
+					return dump_ghost_remap(rpath + 1, ost, lfd, id, nsid);
+				}
+				return ret;
 			}
-			return ret;
+		} else {
+			pr_perror("Can't stat path");
+			return -1;
 		}
-
-		pr_perror("Can't stat path");
-		return -1;
 	}
 
 	if ((pst.st_ino != ost->st_ino) || (pst.st_dev != ost->st_dev)) {

--- a/test/zdtm/lib/groups.c
+++ b/test/zdtm/lib/groups.c
@@ -25,7 +25,11 @@ int main(int argc, char **argv)
 
 		test_msg("List: [%s]\n", env);
 		sprintf(sh, "sh /%s.start", env);
-		system(sh);
+
+		sret = system(sh);
+		if (sret != 0) {
+			pr_perror("system() failed");
+		}
 	}
 
 	test_daemon();

--- a/test/zdtm/lib/msg.c
+++ b/test/zdtm/lib/msg.c
@@ -64,6 +64,6 @@ skip:
 	off += vsnprintf(buf + off, sizeof(buf) - off, format, arg);
 	va_end(arg);
 
-	write(2, buf, off);
+	if(write(STDERR_FILENO, buf, off)){};
 	errno = _errno;
 }

--- a/test/zdtm/lib/ns.c
+++ b/test/zdtm/lib/ns.c
@@ -175,12 +175,18 @@ static int prepare_mntns(void)
 
 static int prepare_namespaces(void)
 {
+	int ret;
+
 	if (setuid(0) || setgid(0) || setgroups(0, NULL)) {
 		fprintf(stderr, "set*id failed: %m\n");
 		return -1;
 	}
 
-	system("ip link set up dev lo");
+	ret = system("ip link set up dev lo");
+	if (ret != 0) {
+		fprintf(stderr, "system() failed: %m\n");
+		return -1;
+	}
 
 	if (prepare_mntns())
 		return -1;
@@ -233,7 +239,7 @@ static void ns_sig_hand(int signo)
 	return;
 write_out:
 	/* fprintf can't be used in a sighandler due to glibc locks */
-	write(STDERR_FILENO, buf, MIN(len, sizeof(buf)));
+	if(write(STDERR_FILENO, buf, MIN(len, sizeof(buf)))){};
 }
 
 #ifndef CLONE_NEWTIME
@@ -287,7 +293,11 @@ static int ns_exec(void *_arg)
 		return -1;
 	}
 	close(args->status_pipe[1]);
-	read(STATUS_FD, buf, sizeof(buf));
+	ret = read(STATUS_FD, buf, sizeof(buf));
+	if (ret < 0) {
+		fprintf(stderr, "read() failed: %m\n");
+		return -1;
+	}
 	shutdown(STATUS_FD, SHUT_RD);
 
 	if (prepare_namespaces())
@@ -334,7 +344,7 @@ int ns_init(int argc, char **argv)
 		.sa_handler = ns_sig_hand,
 		.sa_flags = SA_RESTART,
 	};
-	int ret, fd, status_pipe = STATUS_FD;
+	int ret, fd, wstatus, status_pipe = STATUS_FD;
 	char buf[128], *x;
 	pid_t pid;
 	bool reap;
@@ -380,11 +390,11 @@ int ns_init(int argc, char **argv)
 		return 0; /* Continue normal test startup */
 	}
 
-	ret = -1;
-	if (waitpid(pid, &ret, 0) < 0)
+	wstatus = -1;
+	if (waitpid(pid, &wstatus, 0) < 0)
 		fprintf(stderr, "waitpid() failed: %m\n");
-	else if (ret)
-		fprintf(stderr, "The test returned non-zero code %d\n", ret);
+	else if (wstatus)
+		fprintf(stderr, "The test returned non-zero code %d\n", wstatus);
 
 	if (reap && sigaction(SIGCHLD, &sa, NULL)) {
 		fprintf(stderr, "Can't set SIGCHLD handler: %m\n");
@@ -406,10 +416,14 @@ int ns_init(int argc, char **argv)
 	}
 
 	/* Daemonize */
-	write(status_pipe, &ret, sizeof(ret));
+	ret = write(status_pipe, &wstatus, sizeof(wstatus));
 	close(status_pipe);
-	if (ret)
-		exit(ret);
+	if (ret < 0) {
+		fprintf(stderr, "write() failed: %m\n");
+		exit(1);
+	}
+	if (wstatus)
+		exit(wstatus);
 
 	/* suspend/resume */
 	test_waitsig();

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -6,6 +6,7 @@ CPPFLAGS += -I$(LIBDIR)
 TST_NOFILE	:=				\
 		busyloop00			\
 		sleeping00			\
+		posix_sem			\
 		pid00				\
 		caps00				\
 		caps01				\

--- a/test/zdtm/static/criu-rtc.c
+++ b/test/zdtm/static/criu-rtc.c
@@ -48,7 +48,7 @@ int cr_plugin_dump_file(int fd, int id)
 	e.irqp = irqp;
 
 	snprintf(img_path, sizeof(img_path), "rtc.%x", id);
-	img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT);
+	img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT, 0600);
 	if (img_fd < 0) {
 		pr_perror("Can't open %s", img_path);
 		return -1;

--- a/test/zdtm/static/posix_sem.c
+++ b/test/zdtm/static/posix_sem.c
@@ -1,0 +1,77 @@
+#include <errno.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <semaphore.h>
+#include <fcntl.h>
+
+#include "zdtmtst.h"
+
+#define SEM_NAME "/criu-sem-test"
+#define SEM_VAL_EXPECTED 2
+
+const char *test_doc = "Check for POSIX semaphores";
+const char *test_author = "Sinan Mohd <sinan@sinanmohd.com>";
+
+int main(int argc, char **argv)
+{
+	sem_t *sem;
+	int ret, semval;
+
+	test_init(argc, argv);
+
+	sem = sem_open(SEM_NAME, O_CREAT | O_EXCL, 0600, SEM_VAL_EXPECTED);
+	if (sem == SEM_FAILED) {
+		pr_perror("sem_open");
+		return 1;
+	}
+
+	ret = sem_post(sem);
+	if (ret == -1) {
+		pr_perror("sem_post");
+		return 1;
+	}
+	ret = sem_trywait(sem);
+	if (ret == -1) {
+		fail("sem_trywait");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	ret = sem_post(sem);
+	if (ret == -1) {
+		fail("sem_post");
+		return 1;
+	}
+	ret = sem_trywait(sem);
+	if (ret == -1) {
+		fail("sem_trywait");
+		return 1;
+	}
+
+	ret = sem_getvalue(sem, &semval);
+	if (ret == -1) {
+		fail("sem_getvalue");
+		return 1;
+	}
+	if (semval != SEM_VAL_EXPECTED) {
+		fail("Expected semvalue to be %d, got %d", SEM_VAL_EXPECTED, semval);
+		return 1;
+	}
+	ret = sem_close(sem);
+	if (ret == -1) {
+		fail("sem_close");
+		return 1;
+	}
+	ret = sem_unlink(SEM_NAME);
+	if (ret == -1) {
+		fail("sem_unlink");
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->

## named POSIX semaphore sharing after CRIU restore, node migration

## Problem

The current CRIU behavior breaks the functionality of POSIX named semaphores after process migration, or reboot. A newly started process cannot open and share an existing named semaphore using the same name (via `sem_open()`), even when the corresponding --link-remap `/dev/shm` file is manually copied from the source node.

## Solution

This PR addresses the issue by

- When CRIU encounters a semaphore-related file in `/dev/shm` marked deleted,
- it verifies whether another active hard link to the same inode already exists in `/dev/shm`.
- If such a link is found, CRIU reuses that existing link instead of re creating the mktemp() link.

This ensures that restored processes and any newly started ones on the target node can correctly share the same named semaphore via its original name.

## Additional notes

- No changes are required on the restore side.
- Added zdtm tests

Related PR #2683 