### PR TITLE
Contrib/void linux dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,14 @@ First, you need to install the required build dependencies. We provide scripts t
 nix develop
 ```
 
+##### Using Arch:
+
+```
+./contrib/dependencies/pacman-packages.sh
+```
+```
+
+
 #### Compiling CRIU
 
 Once the dependencies are installed, you can compile CRIU by running the `make` command from the root of the source directory:

--- a/contrib/dependencies/xbps-packages.sh
+++ b/contrib/dependencies/xbps-packages.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+sudo xbps-install -Sy \
+    gcc \
+    make \
+    git \
+    pkg-config \
+    binutils \
+    protobuf \
+    protobuf-devel \
+    protobuf-c-devel \
+    python3 \
+    python3-protobuf \
+    python3-setuptools \
+    python3-pip \
+    python3-yaml \
+    libnet-devel \
+    libnl3-devel \
+    libcap-devel \
+    libaio-devel \
+    gnutls-devel \
+    libbsd-devel \
+    libuuid-devel \
+    elfutils-devel \
+    libbpf-devel \
+    libdrm-devel \
+    libnftables-devel \
+    libselinux-devel \
+    iproute2 \
+    libtraceevent-devel \
+    libtracefs-devel \
+    xmlto \
+    asciidoc


### PR DESCRIPTION


- Void Linux was not covered in `contrib/dependencies/`. This PR adds `contrib/dependencies/xbps-packages.sh` following the same structure as the existing scripts, and updates `CONTRIBUTING.md` to reference to existing Arch script because it widely used by programmers, adding void installations makes the CONTRIBUTING file too long.
- Because Arch is similar to Void, I tried to run and install all packages, but many failed because the xbps repos do not have them all with the same name, so I did some research and added the appropriate ones.

**Notes on Void Linux package naming:**
- Development headers are in separate `-devel` packages
- `util-linux` is split on Void — only `libuuid-devel` is needed
- `nftables` is split on Void — only `libnftables-devel` is needed
- `protobuf` must be installed alongside `protobuf-devel` to get the `protoc` compiler binary

Void Linux required special attention due to package splitting:
- `libuuid-devel` instead of `util-linux-devel`
- `libnftables-devel` instead of `nftables-devel`
- `protobuf` must be installed alongside `protobuf-devel` to get the `protoc` compiler binary

**Testing:** Tested on my current Void machine and in a Docker container.
- All packages installed successfully
- All libraries verified via `pkg-config`
- `./criu/criu check` reports `Looks good.`
<img width="725" height="99" alt="image" src="https://github.com/user-attachments/assets/b20331bc-08ca-4fcc-bf20-f920e62938a9" />
<img width="714" height="375" alt="image" src="https://github.com/user-attachments/assets/f38b027d-5a8a-47e8-91d7-d32b76656a9f" />
<img width="972" height="575" alt="image" src="https://github.com/user-attachments/assets/233508af-f92f-4529-b1e6-eb88b88faf8e" />

Signed-off-by: Abdullah Albadawy <abdullahalbadawy1@gmail.com>
