### PR TITLE
pagemap-cache: stop filling cache on VMA_AREA_GUARD

### DIFF
--- a/criu/pagemap-cache.c
+++ b/criu/pagemap-cache.c
@@ -137,6 +137,9 @@ static int pmc_fill_cache(pmc_t *pmc, const struct vma_area *vma)
 			 nr_vmas, size_cov);
 
 		list_for_each_entry_continue(vma, pmc->vma_head, list) {
+			if (vma_area_is(vma, VMA_AREA_GUARD))
+				break;
+
 			if (vma->e->start > high || vma->e->end > high)
 				break;
 


### PR DESCRIPTION
VMA_AREA_GUARD areas are added to the end of the vma_area_list and are not necessarily sorted by address. pmc_fill_cache() expects VMAs to be sorted and triggers BUG_ON() if it meets a VMA with a lower address than the current cache window.

Since guard VMAs don't have pagemap entries and are skipped during dump, just stop the lookahead loop when we encounter one.

