### PR TITLE
restore: read user ns from pstree ids image

### DIFF
--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -540,6 +540,10 @@ static int read_pstree_ids(struct pstree_item *pi)
 		if (rst_add_ns_id(pi->ids->pid_ns_id, pi, &pid_ns_desc))
 			return -1;
 	}
+	if (pi->ids->has_user_ns_id) {
+		if (rst_add_ns_id(pi->ids->user_ns_id, pi, &user_ns_desc))
+			return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Commit 6b29103 adds the function read_user_ns_img to read user namespace image. It looks up the user namespace by id.
However, user namespace can not be found because only mnt, net and pid namespaces are added to the nsid list.
The user namespace is not read from pstree ids.

This commit adds user namespace to the nsid list from the pstree ids image.

Fixes: 6b29103 ("criu: fix double-open of userns image in --stream mode")
Fixes: #2938
