### PR TITLE
pstree: restore all namespace types during pstree image reading

### DIFF
--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -15,6 +15,10 @@
 #include "dump.h"
 #include "util.h"
 #include "net.h"
+#include "uts_ns.h"
+#include "ipc_ns.h"
+#include "cgroup.h"
+#include "timens.h"
 
 #include "protobuf.h"
 #include "images/pstree.pb-c.h"
@@ -542,6 +546,22 @@ static int read_pstree_ids(struct pstree_item *pi)
 	}
 	if (pi->ids->has_user_ns_id) {
 		if (rst_add_ns_id(pi->ids->user_ns_id, pi, &user_ns_desc))
+			return -1;
+	}
+	if (pi->ids->has_uts_ns_id) {
+		if (rst_add_ns_id(pi->ids->uts_ns_id, pi, &uts_ns_desc))
+			return -1;
+	}
+	if (pi->ids->has_ipc_ns_id) {
+		if (rst_add_ns_id(pi->ids->ipc_ns_id, pi, &ipc_ns_desc))
+			return -1;
+	}
+	if (pi->ids->has_cgroup_ns_id) {
+		if (rst_add_ns_id(pi->ids->cgroup_ns_id, pi, &cgroup_ns_desc))
+			return -1;
+	}
+	if (pi->ids->has_time_ns_id) {
+		if (rst_add_ns_id(pi->ids->time_ns_id, pi, &time_ns_desc))
 			return -1;
 	}
 


### PR DESCRIPTION
While exploring issue #2938 which was later solved by https://github.com/checkpoint-restore/criu/commit/09134c8ca8ea1889e7d45f8fc439a9c6812687f4, I found out that while dumping, CRIU saves a total of 8 namespace IDs (ref: https://github.com/checkpoint-restore/criu/blob/09134c8ca8ea1889e7d45f8fc439a9c6812687f4/criu/namespaces.c#L694)  while during restore, CRIU only reads 4 (after the fix) out of these 8 namespace IDs.

This PR adds handling for the 4 missing namespaces types in `read_pstree_ids()`:
- `uts_ns_id`: UTS namespace
- `ipc_ns_id`: IPC namespace
- `cgroup_ns_id`: Cgroup namespace
- `time_ns_id`: Time namespace

This creates symmetry between dump and restore paths, ensuring all namespace IDs saved during checkpoint are properly restored.


