### PR TITLE
feat: specify ourselves as Nix flake source

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
         devShells.default = devShell;
 
         # Build CRIU package as well
-        packages.default = pkgs.criu;
+        packages.default = pkgs.criu.overrideAttrs { src = ./.; };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,10 @@
         devShells.default = devShell;
 
         # Build CRIU package as well
-        packages.default = pkgs.criu.overrideAttrs { src = ./.; };
+        packages.default = pkgs.criu.overrideAttrs {
+          src = ./.;
+          postPatch = "";
+        };
       }
     );
 }


### PR DESCRIPTION
This allows users to directly use the criu package declared in the flake as a bleeding-edge substitute to the one found in Nixpkgs, and leverage the existing NixOS testing infrastructure with their development version.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
