### PR TITLE
cr-service: generate uuid only once

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -1358,14 +1358,6 @@ int cr_service_work(int sk)
 	int ret = -1;
 	CriuReq *msg = 0;
 
-	/*
-	 * util_init initializes criu_run_id and compel_run_id so that sockets
-	 * are generated with an unique name identifying the specific process
-	 * even in cases where multiple processes with the same pid in
-	 * different pid namespaces are sharing the same network namespace.
-	 */
-	util_init();
-
 more:
 	opts.mode = CR_SWRK;
 


### PR DESCRIPTION
When checkpointing containers, the function `util_init()` appears to be called twice, once in `crtools.c` then again in `cr-service.c`:

```
(00.000000) Parsing config file /etc/criu/default.conf
(00.000000) Unable to get $HOME directory, local configuration file will not be used.
(00.000000) CRIU run id = 1c9f31c3-aa70-4e8b-9b0c-19410efd92fe
(00.000000) CRIU run id = f19c528e-593c-4f29-b8e5-a2ff9c6b4d73
(00.000000) Would overwrite RPC settings with values from /etc/criu/runc.conf
(00.000000) Parsing config file /etc/criu/runc.conf
(00.000082) Version: 4.2 (gitid v4.2-93-gd691ed685)
```

This appears to be unnecessary as `cr_service()` is always called in `crtools.c` after `util_init()`. Here, `util_init()` is used to initialize global state (`criu_run_id`, `compel_run_id`) and not intended to be called multiple times in the same CRIU process.

Fixes: 622b433 ("criu: Initialize util before service worker starts")

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
