### PR TITLE
ci: use clean state before self-contained check

### DIFF
--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -78,6 +78,7 @@ vagrant-fedora-non-root: setup-vagrant
 .PHONY: setup-vagrant vagrant-fedora-no-vdso vagrant-fedora-rawhide vagrant-fedora-non-root
 
 check-commit:
+	(cd ../.. && git clean -dfx)
 	($(MAKE) -j $$(nproc) -C ../.. && \
 		echo "Commit $$(git rev-parse --short HEAD) built successfully") || \
 		(echo "Build failed for $$(git rev-list -n 1 --pretty HEAD)" && \


### PR DESCRIPTION
The check-commit target verifies that each commit builds successfully on its own. However, without cleaning previously generated build artifacts (e.g. auto-generated `*.o` files) this can cause the check to fail:
    
    make[2]: *** No rule to make target 'compel/include/uapi/compel/asm/breakpoints.h', needed by 'compel/arch/x86/src/lib/infect.o'.  Stop.
    make[1]: *** [Makefile.compel:35: compel/libcompel.a] Error 2
    
To fix this, we add 'git clean -dfx' to remove all untracked and ignored files before attempting the build.
