### PR TITLE
ci: mark archlinux-test as continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
 
   archlinux-test:
     needs: [alpine-test]
+    # archlinux:latest + pacman -Syu is a rolling-release build; failures
+    # caused by upstream package churn are outside CRIU's control.
+    continue-on-error: true
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes: #2911

archlinux:latest is a rolling-release image and pacman -Syu pulls
the latest packages on every build. Failures caused by upstream
package churn or mirror outages are beyond CRIU's control and
should not block merges.

The cross-compile job already uses continue-on-error: true for
its experimental targets; apply the same treatment to archlinux-test.
