### PR TITLE
plugin/amdgpu: Don't print error when restoring drm file

### DIFF
--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -1141,6 +1141,9 @@ int amdgpu_restore_init(void)
 			while ((dir = readdir(d)) != NULL) {
 				if (strncmp("amdgpu-kfd-", dir->d_name, strlen("amdgpu-kfd-")) == 0) {
 					img_fp = open_img_file(dir->d_name, false, &img_size);
+					if (!img_fp)
+						return -EINVAL;
+
 					buf = xmalloc(img_size);
 					if (!buf) {
 						fclose(img_fp);
@@ -1163,6 +1166,9 @@ int amdgpu_restore_init(void)
 				}
 				if (strncmp("amdgpu-renderD-", dir->d_name, strlen("amdgpu-renderD-")) == 0) {
 					img_fp = open_img_file(dir->d_name, false, &img_size);
+					if (!img_fp)
+						return -EINVAL;
+
 					buf = xmalloc(img_size);
 					if (!buf) {
 						fclose(img_fp);

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -849,7 +849,7 @@ void *dump_bo_contents(void *_thread_data)
 	}
 
 	snprintf(img_path, sizeof(img_path), IMG_KFD_PAGES_FILE, thread_data->id, thread_data->gpu_id);
-	bo_contents_fp = open_img_file(img_path, true, &image_size);
+	bo_contents_fp = open_img_file(img_path, true, &image_size, true);
 	if (!bo_contents_fp) {
 		pr_perror("Cannot fopen %s", img_path);
 		ret = -EIO;
@@ -923,7 +923,7 @@ void *restore_bo_contents(void *_thread_data)
 								   SDMA_LINEAR_COPY_MAX_SIZE - 1;
 
 	snprintf(img_path, sizeof(img_path), IMG_KFD_PAGES_FILE, thread_data->id, thread_data->gpu_id);
-	bo_contents_fp = open_img_file(img_path, false, &image_size);
+	bo_contents_fp = open_img_file(img_path, false, &image_size, true);
 	if (!bo_contents_fp) {
 		pr_perror("Cannot fopen %s", img_path);
 		ret = -errno;
@@ -1140,7 +1140,7 @@ int amdgpu_restore_init(void)
 		if (d) {
 			while ((dir = readdir(d)) != NULL) {
 				if (strncmp("amdgpu-kfd-", dir->d_name, strlen("amdgpu-kfd-")) == 0) {
-					img_fp = open_img_file(dir->d_name, false, &img_size);
+					img_fp = open_img_file(dir->d_name, false, &img_size, true);
 					if (!img_fp)
 						return -EINVAL;
 
@@ -1165,7 +1165,7 @@ int amdgpu_restore_init(void)
 					xfree(buf);
 				}
 				if (strncmp("amdgpu-renderD-", dir->d_name, strlen("amdgpu-renderD-")) == 0) {
-					img_fp = open_img_file(dir->d_name, false, &img_size);
+					img_fp = open_img_file(dir->d_name, false, &img_size, true);
 					if (!img_fp)
 						return -EINVAL;
 
@@ -1837,7 +1837,7 @@ int amdgpu_plugin_restore_file(int id, bool *retry_needed)
 
 	snprintf(img_path, sizeof(img_path), IMG_KFD_FILE, id);
 
-	img_fp = open_img_file(img_path, false, &img_size);
+	img_fp = open_img_file(img_path, false, &img_size, false);
 	if (!img_fp) {
 		struct tp_node *tp_node;
 		uint32_t target_gpu_id;
@@ -1849,7 +1849,7 @@ int amdgpu_plugin_restore_file(int id, bool *retry_needed)
 		 */
 		snprintf(img_path, sizeof(img_path), IMG_DRM_FILE, id);
 
-		img_fp = open_img_file(img_path, false, &img_size);
+		img_fp = open_img_file(img_path, false, &img_size, true);
 		if (!img_fp) {
 			ret = amdgpu_plugin_dmabuf_restore(id);
 			if (ret == 1) {
@@ -2231,7 +2231,7 @@ FILE *get_bo_contents_fp(int id, int gpu_id, size_t tot_size)
 	FILE *bo_contents_fp = NULL;
 
 	snprintf(img_path, sizeof(img_path), IMG_KFD_PAGES_FILE, id, gpu_id);
-	bo_contents_fp = open_img_file(img_path, false, &image_size);
+	bo_contents_fp = open_img_file(img_path, false, &image_size, true);
 	if (!bo_contents_fp) {
 		pr_perror("Cannot fopen %s", img_path);
 		return NULL;

--- a/plugins/amdgpu/amdgpu_plugin_dmabuf.c
+++ b/plugins/amdgpu/amdgpu_plugin_dmabuf.c
@@ -106,7 +106,7 @@ int amdgpu_plugin_dmabuf_restore(int id)
 	snprintf(path, sizeof(path), IMG_DMABUF_FILE, id);
 
 	/* Read serialized metadata */
-	img_fp = open_img_file(path, false, &img_size);
+	img_fp = open_img_file(path, false, &img_size, true);
 	if (!img_fp) {
 		pr_err("Failed to open dmabuf metadata file: %s\n", path);
 		return -EINVAL;

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -209,7 +209,7 @@ static int restore_bo_contents_drm(int drm_render_minor, CriuRenderNode *rd, int
 
 		snprintf(img_path, sizeof(img_path), IMG_DRM_PAGES_FILE, rd->id, drm_render_minor, i);
 
-		bo_contents_fp = open_img_file(img_path, false, &image_size);
+		bo_contents_fp = open_img_file(img_path, false, &image_size, true);
 		if (!bo_contents_fp) {
 			ret = -EINVAL;
 			break;
@@ -382,7 +382,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		drmPrimeHandleToFD(device_fd, boinfo->handle, 0, &dmabuf_fd);
 
 		snprintf(img_path, sizeof(img_path), IMG_DRM_PAGES_FILE, rd->id, rd->drm_render_minor, i);
-		bo_contents_fp = open_img_file(img_path, true, &image_size);
+		bo_contents_fp = open_img_file(img_path, true, &image_size, true);
 
 		posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), handle_entry.size);
 

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -210,6 +210,10 @@ static int restore_bo_contents_drm(int drm_render_minor, CriuRenderNode *rd, int
 		snprintf(img_path, sizeof(img_path), IMG_DRM_PAGES_FILE, rd->id, drm_render_minor, i);
 
 		bo_contents_fp = open_img_file(img_path, false, &image_size);
+		if (!bo_contents_fp) {
+			ret = -EINVAL;
+			break;
+		}
 
 		ret = sdma_copy_bo(dmabufs[i], rd->bo_entries[i]->size, bo_contents_fp, buffer, buffer_size, h_dev, max_copy_size,
 				   SDMA_OP_VRAM_WRITE, true);

--- a/plugins/amdgpu/amdgpu_plugin_util.c
+++ b/plugins/amdgpu/amdgpu_plugin_util.c
@@ -228,9 +228,10 @@ int write_fp(FILE *fp, const void *buf, const size_t buf_len)
  * @param path The file path
  * @param write False for read, true for write
  * @param size Size of actual contents
+ * @param expect_present If true, the file not existing is an error
  * @return FILE *if successful, NULL if failed
  */
-FILE *open_img_file(char *path, bool write, size_t *size)
+FILE *open_img_file(char *path, bool write, size_t *size, bool expect_present)
 {
 	FILE *fp = NULL;
 	int fd, ret;
@@ -241,7 +242,8 @@ FILE *open_img_file(char *path, bool write, size_t *size)
 		fd = openat(criu_get_image_dir(), path, write ? (O_WRONLY | O_CREAT) : O_RDONLY, 0600);
 
 	if (fd < 0) {
-		pr_err("%s: Failed to open for %s\n", path, write ? "write" : "read");
+		if (expect_present)
+			pr_err("%s: Failed to open for %s\n", path, write ? "write" : "read");
 		return NULL;
 	}
 
@@ -300,7 +302,7 @@ int write_img_file(char *path, const void *buf, const size_t buf_len)
 	FILE *fp;
 	size_t len = buf_len;
 
-	fp = open_img_file(path, true, &len);
+	fp = open_img_file(path, true, &len, true);
 	if (!fp)
 		return -errno;
 

--- a/plugins/amdgpu/amdgpu_plugin_util.h
+++ b/plugins/amdgpu/amdgpu_plugin_util.h
@@ -119,7 +119,7 @@ int read_fp(FILE *fp, void *buf, const size_t buf_len);
 int write_fp(FILE *fp, const void *buf, const size_t buf_len);
 int read_file(const char *file_path, void *buf, const size_t buf_len);
 int write_img_file(char *path, const void *buf, const size_t buf_len);
-FILE *open_img_file(char *path, bool write, size_t *size);
+FILE *open_img_file(char *path, bool write, size_t *size, bool expect_present);
 
 int record_dumped_fd(int fd, bool is_drm);
 struct list_head *get_dumped_fds();


### PR DESCRIPTION
When the amdgpu plugin is called for restore of a file img, we don't initially know if it's a kfd or drm file. So we first try to open a kfd file, and if that fails, we assume it's a drm file. That failure leads to a lot of error messages like

Error amdgpu_plugin: amdgpu-kfd-141.img: Failed to open for read

For this normal behaviour.

Add an option on open_img_file to suppress this error when we aren't sure if the file we're trying to open exists.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
