### PR TITLE
ci: remove mips64el-stable-cross and mips64el-unstable-cross

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
           armv7-stable-cross,
           aarch64-stable-cross,
           ppc64-stable-cross,
-          mips64el-stable-cross,
           riscv64-stable-cross,
         ]
         include:
@@ -95,8 +94,6 @@ jobs:
             target: aarch64-unstable-cross
           - experimental: true
             target: ppc64-unstable-cross
-          - experimental: true
-            target: mips64el-unstable-cross
     steps:
     - uses: actions/checkout@v4
     - name: Run Cross Compilation Targets

--- a/scripts/build/Dockerfile.mips64el-stable-cross.hdr
+++ b/scripts/build/Dockerfile.mips64el-stable-cross.hdr
@@ -1,6 +1,0 @@
-FROM docker.io/dockcross/base:latest
-
-ENV ARCH=mips
-ENV SUBARCH=mips
-ENV DEBIAN_ARCH=mips64el
-ENV CROSS_TRIPLET=mips64el-linux-gnuabi64

--- a/scripts/build/Dockerfile.mips64el-stable-cross.tmpl
+++ b/scripts/build/Dockerfile.mips64el-stable-cross.tmpl
@@ -1,1 +1,0 @@
-Dockerfile.stable-cross.tmpl

--- a/scripts/build/Dockerfile.mips64el-unstable-cross.hdr
+++ b/scripts/build/Dockerfile.mips64el-unstable-cross.hdr
@@ -1,6 +1,0 @@
-FROM docker.io/dockcross/base:latest
-
-ENV ARCH=mips
-ENV SUBARCH=mips
-ENV DEBIAN_ARCH=mips64el
-ENV CROSS_TRIPLET=mips64el-linux-gnuabi64

--- a/scripts/build/Dockerfile.mips64el-unstable-cross.tmpl
+++ b/scripts/build/Dockerfile.mips64el-unstable-cross.tmpl
@@ -1,1 +1,0 @@
-Dockerfile.unstable-cross.tmpl

--- a/scripts/build/Makefile
+++ b/scripts/build/Makefile
@@ -1,6 +1,6 @@
 ARCHES := x86_64 fedora-asan fedora-rawhide armv7hf
-STABLE_CROSS_ARCHES := armv7-stable-cross aarch64-stable-cross ppc64-stable-cross mips64el-stable-cross riscv64-stable-cross
-UNSTABLE_CROSS_ARCHES := armv7-unstable-cross aarch64-unstable-cross ppc64-unstable-cross mips64el-unstable-cross
+STABLE_CROSS_ARCHES := armv7-stable-cross aarch64-stable-cross ppc64-stable-cross riscv64-stable-cross
+UNSTABLE_CROSS_ARCHES := armv7-unstable-cross aarch64-unstable-cross ppc64-unstable-cross
 NON_CLANG := $(UNSTABLE_CROSS_ARCHES) $(STABLE_CROSS_ARCHES)
 CREATE_DOCKERFILES := $(ARCHES) $(NON_CLANG)
 TARGETS := $(ARCHES) alpine archlinux


### PR DESCRIPTION
These jobs are failing for a long time. Debian is in the process of removing mips64el:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1105972.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
