### PR TITLE
criu: fs-magic: add MQUEUE_MAGIC

### DIFF
--- a/criu/include/fs-magic.h
+++ b/criu/include/fs-magic.h
@@ -61,4 +61,8 @@
 #define PID_FS_MAGIC 0x50494446
 #endif
 
+#ifndef MQUEUE_MAGIC
+#define MQUEUE_MAGIC 0x19800202
+#endif
+
 #endif /* __CR_FS_MAGIC_H__ */


### PR DESCRIPTION
MQUEUE_MAGIC (0x19800202) is missing from fs-magic.h while
every other filesystem handles is listed there. The value
is defined in ipc/mqueue.c in the kernel source [1]  and is not
exposed in uapi/linux/magic.h, which is why distro headers are
missing it. It is needed to identify mqueue file descriptors
via fstatfs() when implementing POSIX mqueue.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/ipc/mqueue.c#n50
Link: https://github.com/checkpoint-restore/criu/issues/2285

Signed-off-by: Abdullah Albadawy <abdullahalbadawy1@gmail.com>

