### PR TITLE
plugin/amdgpu: fix missing error checks and resource leaks

### DIFF
--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -841,10 +841,11 @@ void *dump_bo_contents(void *_thread_data)
 
 	buffer_size = kfd_max_buffer_size > 0 ? min(kfd_max_buffer_size, max_bo_size) : max_bo_size;
 
-	posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), buffer_size);
-	if (!buffer) {
+	ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), buffer_size);
+	if (ret) {
+		errno = ret;
 		pr_perror("Failed to alloc aligned memory. Consider setting KFD_MAX_BUFFER_SIZE.");
-		ret = -ENOMEM;
+		ret = -ret;
 		goto exit;
 	}
 
@@ -949,10 +950,11 @@ void *restore_bo_contents(void *_thread_data)
 
 	buffer_size = kfd_max_buffer_size > 0 ? min(kfd_max_buffer_size, max_bo_size) : max_bo_size;
 
-	posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), buffer_size);
-	if (!buffer) {
+	ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), buffer_size);
+	if (ret) {
+		errno = ret;
 		pr_perror("Failed to alloc aligned memory. Consider setting KFD_MAX_BUFFER_SIZE.");
-		ret = -ENOMEM;
+		ret = -ret;
 		goto exit;
 	}
 
@@ -2287,10 +2289,11 @@ void *parallel_restore_bo_contents(void *_thread_data)
 	}
 	offset = ftell(bo_contents_fp);
 
-	posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), buffer_size);
-	if (!buffer) {
+	ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), buffer_size);
+	if (ret) {
+		errno = ret;
 		pr_perror("Failed to alloc aligned memory. Consider setting KFD_MAX_BUFFER_SIZE.");
-		ret = -ENOMEM;
+		ret = -ret;
 		goto err_sdma;
 	}
 

--- a/plugins/amdgpu/amdgpu_plugin_dmabuf.c
+++ b/plugins/amdgpu/amdgpu_plugin_dmabuf.c
@@ -139,12 +139,16 @@ int amdgpu_plugin_dmabuf_restore(int id)
 	fd_id = amdgpu_id_for_handle(rd->gem_handle);
 	if (fd_id == -1) {
 		pr_err("Failed to find dmabuf_fd for GEM handle = %d\n", rd->gem_handle);
+		criu_dmabuf_node__free_unpacked(rd, NULL);
+		xfree(buf);
 		return 1;
 	}
 
 	int dmabuf_fd = fdstore_get(fd_id);
 	if (dmabuf_fd == -1) {
 		pr_err("Failed to find dmabuf_fd for GEM handle = %d\n", rd->gem_handle);
+		criu_dmabuf_node__free_unpacked(rd, NULL);
+		xfree(buf);
 		return 1; /* Retry needed */
 	}
 

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -538,6 +538,10 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 		}
 
 		if (boinfo->is_import) {
+			if (dmabuf_fd == -1) {
+				retry_needed = true;
+				continue;
+			}
 			ret = drmPrimeFDToHandle(device_fd, dmabuf_fd, &handle);
 			if (ret) {
 				pr_perror("Failed to get handle from dmabuf fd");
@@ -618,6 +622,9 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 		pr_info("Error in deinit amdgpu device\n");
 		goto exit;
 	}
+
+	if (retry_needed)
+		goto exit;
 
 	ret = record_completed_work(-1, rd->drm_render_minor);
 	if (ret)

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -193,10 +193,11 @@ static int restore_bo_contents_drm(int drm_render_minor, CriuRenderNode *rd, int
 
 	buffer_size = max_bo_size;
 
-	posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), buffer_size);
-	if (!buffer) {
+	ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), buffer_size);
+	if (ret) {
+		errno = ret;
 		pr_perror("Failed to alloc aligned memory. Consider setting KFD_MAX_BUFFER_SIZE.");
-		ret = -ENOMEM;
+		ret = -ret;
 		goto exit;
 	}
 
@@ -394,9 +395,14 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 		ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), handle_entry.size);
 		if (ret) {
+			errno = ret;
 			pr_perror("Failed to allocate buffer");
+			ret = -ret;
 			fclose(bo_contents_fp);
-			break;
+			close(dmabuf_fd);
+			amdgpu_device_deinitialize(h_dev);
+			xfree(vm_info_entries);
+			goto exit;
 		}
 
 		ret = sdma_copy_bo(dmabuf_fd, handle_entry.size, bo_contents_fp, buffer, handle_entry.size, h_dev, 0x1000,

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -211,7 +211,7 @@ static int restore_bo_contents_drm(int drm_render_minor, CriuRenderNode *rd, int
 
 		bo_contents_fp = open_img_file(img_path, false, &image_size, true);
 		if (!bo_contents_fp) {
-			ret = -EINVAL;
+			ret = -errno;
 			break;
 		}
 
@@ -379,12 +379,25 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 		device_fd = amdgpu_device_get_fd(h_dev);
 
-		drmPrimeHandleToFD(device_fd, boinfo->handle, 0, &dmabuf_fd);
+		ret = drmPrimeHandleToFD(device_fd, boinfo->handle, 0, &dmabuf_fd);
+		if (ret) {
+			pr_perror("Failed to get dmabuf fd from handle");
+			break;
+		}
 
 		snprintf(img_path, sizeof(img_path), IMG_DRM_PAGES_FILE, rd->id, rd->drm_render_minor, i);
 		bo_contents_fp = open_img_file(img_path, true, &image_size, true);
+		if (!bo_contents_fp) {
+			ret = -errno;
+			break;
+		}
 
-		posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), handle_entry.size);
+		ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), handle_entry.size);
+		if (ret) {
+			pr_perror("Failed to allocate buffer");
+			fclose(bo_contents_fp);
+			break;
+		}
 
 		ret = sdma_copy_bo(dmabuf_fd, handle_entry.size, bo_contents_fp, buffer, handle_entry.size, h_dev, 0x1000,
 				   SDMA_OP_VRAM_READ, false);
@@ -480,7 +493,11 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 		}
 
 		if (boinfo->is_import) {
-			drmPrimeFDToHandle(device_fd, dmabuf_fd, &handle);
+			ret = drmPrimeFDToHandle(device_fd, dmabuf_fd, &handle);
+			if (ret) {
+				pr_perror("Failed to get handle from dmabuf fd");
+				goto exit;
+			}
 		} else {
 			union drm_amdgpu_gem_create create_args = { 0 };
 
@@ -496,7 +513,11 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 			}
 			handle = create_args.out.handle;
 
-			drmPrimeHandleToFD(device_fd, handle, 0, &dmabuf_fd);
+			ret = drmPrimeHandleToFD(device_fd, handle, 0, &dmabuf_fd);
+			if (ret) {
+				pr_perror("Failed to get dmabuf fd from handle");
+				goto exit;
+			}
 		}
 
 		change_args.handle = handle;

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -268,6 +268,10 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 	num_bos = 8;
 	list_handles_entries = xzalloc(sizeof(struct drm_amdgpu_gem_list_handles_entry) * num_bos);
+	if (!list_handles_entries) {
+		ret = -ENOMEM;
+		goto exit;
+	}
 	list_handles_args.num_entries = num_bos;
 	list_handles_args.entries = (uintptr_t)list_handles_entries;
 
@@ -284,6 +288,10 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		num_bos = list_handles_args.num_entries;
 		xfree(list_handles_entries);
 		list_handles_entries = xzalloc(sizeof(struct drm_amdgpu_gem_list_handles_entry) * num_bos);
+		if (!list_handles_entries) {
+			ret = -ENOMEM;
+			goto exit;
+		}
 		list_handles_args.num_entries = num_bos;
 		list_handles_args.entries = (uintptr_t)list_handles_entries;
 		ret = drmIoctl(fd, DRM_IOCTL_AMDGPU_GEM_LIST_HANDLES, &list_handles_args);
@@ -334,6 +342,10 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		boinfo->offset = mmap_args.out.addr_ptr;
 
 		vm_info_entries = xzalloc(sizeof(struct drm_amdgpu_gem_vm_entry) * num_vm_entries);
+		if (!vm_info_entries) {
+			ret = -ENOMEM;
+			goto exit;
+		}
 		vm_info_args.handle = handle_entry.gem_handle;
 		vm_info_args.num_entries = num_vm_entries;
 		vm_info_args.value = (uintptr_t)vm_info_entries;
@@ -348,6 +360,10 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			num_vm_entries = vm_info_args.num_entries;
 			xfree(vm_info_entries);
 			vm_info_entries = xzalloc(sizeof(struct drm_amdgpu_gem_vm_entry) * num_vm_entries);
+			if (!vm_info_entries) {
+				ret = -ENOMEM;
+				goto exit;
+			}
 			vm_info_args.handle = handle_entry.gem_handle;
 			vm_info_args.num_entries = num_vm_entries;
 			vm_info_args.value = (uintptr_t)vm_info_entries;
@@ -467,6 +483,8 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 	amdgpu_device_handle h_dev;
 	int device_fd;
 	int *dmabufs = xzalloc(sizeof(int) * rd->num_of_bos);
+	if (!dmabufs)
+		return -ENOMEM;
 
 	ret = amdgpu_device_initialize(fd, &major, &minor, &h_dev);
 	if (ret) {

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -251,7 +251,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 	size_t image_size;
 	struct tp_node *tp_node;
 	struct drm_amdgpu_gem_list_handles list_handles_args = { 0 };
-	struct drm_amdgpu_gem_list_handles_entry *list_handles_entries;
+	struct drm_amdgpu_gem_list_handles_entry *list_handles_entries = NULL;
 	int num_bos;
 
 	rd = xmalloc(sizeof(*rd));
@@ -353,6 +353,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		ret = drmIoctl(fd, DRM_IOCTL_AMDGPU_GEM_OP, &vm_info_args);
 		if (ret) {
 			pr_perror("Failed to call vm info ioctl");
+			xfree(vm_info_entries);
 			goto exit;
 		}
 
@@ -371,6 +372,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			ret = drmIoctl(fd, DRM_IOCTL_AMDGPU_GEM_OP, &vm_info_args);
 			if (ret) {
 				pr_perror("Failed to call vm info ioctl");
+				xfree(vm_info_entries);
 				goto exit;
 			}
 		} else {
@@ -379,8 +381,10 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 		boinfo->num_of_vms = num_vm_entries;
 		ret = allocate_vm_entries(boinfo, num_vm_entries);
-		if (ret)
+		if (ret) {
+			xfree(vm_info_entries);
 			goto exit;
+		}
 
 		for (int j = 0; j < num_vm_entries; j++) {
 			DrmVmEntry *vminfo = boinfo->vm_entries[j];
@@ -393,20 +397,30 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		}
 
 		ret = amdgpu_device_initialize(fd, &major, &minor, &h_dev);
+		if (ret) {
+			pr_perror("Failed to initialize amdgpu device");
+			xfree(vm_info_entries);
+			goto exit;
+		}
 
 		device_fd = amdgpu_device_get_fd(h_dev);
 
 		ret = drmPrimeHandleToFD(device_fd, boinfo->handle, 0, &dmabuf_fd);
 		if (ret) {
 			pr_perror("Failed to get dmabuf fd from handle");
-			break;
+			amdgpu_device_deinitialize(h_dev);
+			xfree(vm_info_entries);
+			goto exit;
 		}
 
 		snprintf(img_path, sizeof(img_path), IMG_DRM_PAGES_FILE, rd->id, rd->drm_render_minor, i);
 		bo_contents_fp = open_img_file(img_path, true, &image_size, true);
 		if (!bo_contents_fp) {
 			ret = -errno;
-			break;
+			close(dmabuf_fd);
+			amdgpu_device_deinitialize(h_dev);
+			xfree(vm_info_entries);
+			goto exit;
 		}
 
 		ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), handle_entry.size);
@@ -424,6 +438,8 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		ret = sdma_copy_bo(dmabuf_fd, handle_entry.size, bo_contents_fp, buffer, handle_entry.size, h_dev, 0x1000,
 				   SDMA_OP_VRAM_READ, false);
 
+		xfree(buffer);
+
 		if (dmabuf_fd != KFD_INVALID_FD)
 			close(dmabuf_fd);
 
@@ -436,7 +452,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 		xfree(vm_info_entries);
 	}
-	xfree(list_handles_entries);
 
 	for (int i = 0; i < num_bos; i++) {
 		DrmBoEntry *boinfo = rd->bo_entries[i];
@@ -471,7 +486,9 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 	xfree(buf);
 exit:
-	free_e(rd);
+	xfree(list_handles_entries);
+	if (rd)
+		free_e(rd);
 	return ret;
 }
 

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -479,18 +479,22 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 {
 	int ret = 0;
 	bool retry_needed = false;
+	bool dev_initialized = false;
+	bool bo_restore_called = false;
 	uint32_t major, minor;
 	amdgpu_device_handle h_dev;
 	int device_fd;
-	int *dmabufs = xzalloc(sizeof(int) * rd->num_of_bos);
+	int *dmabufs = xmalloc(sizeof(int) * rd->num_of_bos);
 	if (!dmabufs)
 		return -ENOMEM;
+	memset(dmabufs, 0xff, sizeof(int) * rd->num_of_bos);
 
 	ret = amdgpu_device_initialize(fd, &major, &minor, &h_dev);
 	if (ret) {
 		pr_info("Error in init amdgpu device\n");
 		goto exit;
 	}
+	dev_initialized = true;
 
 	device_fd = amdgpu_device_get_fd(h_dev);
 
@@ -520,6 +524,7 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 			ret = drmPrimeFDToHandle(device_fd, dmabuf_fd, &handle);
 			if (ret) {
 				pr_perror("Failed to get handle from dmabuf fd");
+				close(dmabuf_fd);
 				goto exit;
 			}
 		} else {
@@ -601,18 +606,26 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 	if (ret)
 		goto exit;
 
-	ret = amdgpu_device_deinitialize(h_dev);
-
 	if (rd->num_of_bos > 0) {
+		bo_restore_called = true;
 		ret = restore_bo_contents_drm(rd->drm_render_minor, rd, fd, dmabufs);
 		if (ret)
 			goto exit;
 	}
 
 exit:
+	if (dev_initialized)
+		amdgpu_device_deinitialize(h_dev);
+	if (ret < 0 && !bo_restore_called) {
+		for (int i = 0; i < rd->num_of_bos; i++) {
+			if (dmabufs[i] != KFD_INVALID_FD)
+				close(dmabufs[i]);
+		}
+	}
+	xfree(dmabufs);
+
 	if (ret < 0)
 		return ret;
-	xfree(dmabufs);
 
 	return retry_needed;
 }

--- a/plugins/amdgpu/amdgpu_plugin_util.c
+++ b/plugins/amdgpu/amdgpu_plugin_util.c
@@ -250,6 +250,7 @@ FILE *open_img_file(char *path, bool write, size_t *size, bool expect_present)
 	fp = fdopen(fd, write ? "w" : "r");
 	if (!fp) {
 		pr_err("%s: Failed get pointer for %s\n", path, write ? "write" : "read");
+		close(fd);
 		return NULL;
 	}
 

--- a/plugins/amdgpu/amdgpu_plugin_util.c
+++ b/plugins/amdgpu/amdgpu_plugin_util.c
@@ -262,6 +262,7 @@ FILE *open_img_file(char *path, bool write, size_t *size, bool expect_present)
 	if (ret) {
 		pr_err("%s:Failed to access file size\n", path);
 		fclose(fp);
+		errno = EIO;
 		return NULL;
 	}
 

--- a/plugins/amdgpu/amdgpu_plugin_util.c
+++ b/plugins/amdgpu/amdgpu_plugin_util.c
@@ -132,12 +132,16 @@ int handle_for_shared_bo_fd(int fd)
 		}
 
 		trial_handle = get_gem_handle(h_dev, fd);
-		if (trial_handle < 0)
+		if (trial_handle < 0) {
+			amdgpu_device_deinitialize(h_dev);
 			continue;
+		}
 
 		list_for_each_entry(bo, &shared_bos, l) {
-			if (bo->handle == trial_handle)
+			if (bo->handle == trial_handle) {
+				amdgpu_device_deinitialize(h_dev);
 				return trial_handle;
+			}
 		}
 
 		amdgpu_device_deinitialize(h_dev);

--- a/plugins/amdgpu/amdgpu_socket_utils.c
+++ b/plugins/amdgpu/amdgpu_socket_utils.c
@@ -162,6 +162,9 @@ int init_parallel_restore_cmd(int num, int id, int gpu_num, parallel_restore_cmd
 	restore_cmd->cmd_head.fd_write_num = 0;
 	restore_cmd->cmd_head.entry_num = 0;
 	restore_cmd->cmd_head.gpu_num = 0;
+	restore_cmd->gpu_ids = NULL;
+	restore_cmd->fds_write = NULL;
+	restore_cmd->entries = NULL;
 
 	restore_cmd->gpu_ids = xzalloc(gpu_num * sizeof(parallel_gpu_info));
 	if (!restore_cmd->gpu_ids)
@@ -187,6 +190,10 @@ void free_parallel_restore_cmd(parallel_restore_cmd *restore_cmd)
 
 static int init_parallel_restore_cmd_by_head(parallel_restore_cmd *restore_cmd)
 {
+	restore_cmd->gpu_ids = NULL;
+	restore_cmd->fds_write = NULL;
+	restore_cmd->entries = NULL;
+
 	restore_cmd->gpu_ids = xzalloc(restore_cmd->cmd_head.gpu_num * sizeof(parallel_gpu_info));
 	if (!restore_cmd->gpu_ids)
 		return -ENOMEM;


### PR DESCRIPTION
While reviewing https://github.com/checkpoint-restore/criu/pull/2952, I noticed a few more places in the amdgpu plugin with missing error handling. This pull request aims to fix the remaining cases. I've tested these changes with a PyTorch GPT-2 fine-tuning job on an MI300X GPU with AMDGPU DKMS driver 6.16.13 (ROCm 7.2) and kernel 6.8.0-106-generic  ([dump.log](https://github.com/user-attachments/files/25997381/dump-log.txt), [restore.log](https://github.com/user-attachments/files/25997380/restore-log.txt)).
