### PR TITLE
coredump: enable coredump generation on riscv64

### DIFF
--- a/coredump/coredump
+++ b/coredump/coredump
@@ -6,7 +6,7 @@ import sys
 
 import criu_coredump
 
-PLATFORMS = ["aarch64", "armv7l", "x86_64"]
+PLATFORMS = ["aarch64", "armv7l", "riscv64", "x86_64"]
 
 
 def coredump(opts):

--- a/coredump/criu_coredump/coredump.py
+++ b/coredump/criu_coredump/coredump.py
@@ -141,6 +141,7 @@ class coredump_generator:
     thread_info_key = {
         "aarch64": "ti_aarch64",
         "armv7l": "ti_arm",
+        "riscv64": "ti_riscv64",
         "x86_64": "thread_info",
     }
 
@@ -259,6 +260,7 @@ class coredump_generator:
         e_machine_dict = {
             "aarch64": elf.EM_AARCH64,
             "armv7l": elf.EM_ARM,
+            "riscv64": elf.EM_RISCV,
             "x86_64": elf.EM_X86_64,
         }
         return e_machine_dict[self.machine]
@@ -463,6 +465,39 @@ class coredump_generator:
             pr_reg.es = regs["es"]
             pr_reg.fs = regs["fs"]
             pr_reg.gs = regs["gs"]
+        elif self.machine == "riscv64":
+            pr_reg.pc = regs["pc"]
+            pr_reg.ra = regs["ra"]
+            pr_reg.sp = regs["sp"]
+            pr_reg.gp = regs["gp"]
+            pr_reg.tp = regs["tp"]
+            pr_reg.t0 = regs["t0"]
+            pr_reg.t1 = regs["t1"]
+            pr_reg.t2 = regs["t2"]
+            pr_reg.s0 = regs["s0"]
+            pr_reg.s1 = regs["s1"]
+            pr_reg.a0 = regs["a0"]
+            pr_reg.a1 = regs["a1"]
+            pr_reg.a2 = regs["a2"]
+            pr_reg.a3 = regs["a3"]
+            pr_reg.a4 = regs["a4"]
+            pr_reg.a5 = regs["a5"]
+            pr_reg.a6 = regs["a6"]
+            pr_reg.a7 = regs["a7"]
+            pr_reg.s2 = regs["s2"]
+            pr_reg.s3 = regs["s3"]
+            pr_reg.s4 = regs["s4"]
+            pr_reg.s5 = regs["s5"]
+            pr_reg.s6 = regs["s6"]
+            pr_reg.s7 = regs["s7"]
+            pr_reg.s8 = regs["s8"]
+            pr_reg.s9 = regs["s9"]
+            pr_reg.s10 = regs["s10"]
+            pr_reg.s11 = regs["s11"]
+            pr_reg.t3 = regs["t3"]
+            pr_reg.t4 = regs["t4"]
+            pr_reg.t5 = regs["t5"]
+            pr_reg.t6 = regs["t6"]
 
     def _gen_fpregset(self, pid, tid):
         """
@@ -492,7 +527,7 @@ class coredump_generator:
         """
         Get the floating point register dictionary based on the current architecture.
         """
-        fpregs_key_dict = {"aarch64": "fpsimd", "x86_64": "fpregs"}
+        fpregs_key_dict = {"aarch64": "fpsimd", "riscv64": "fpsimd", "x86_64": "fpregs"}
         fpregs_key = fpregs_key_dict[self.machine]
 
         thread_info_key = self.thread_info_key[self.machine]
@@ -507,6 +542,9 @@ class coredump_generator:
             fpregset.vregs = (ctypes.c_ulonglong * len(regs["vregs"]))(*regs["vregs"])
             fpregset.fpsr = regs["fpsr"]
             fpregset.fpcr = regs["fpcr"]
+        elif self.machine == "riscv64":
+            fpregset.f = (ctypes.c_ulonglong * len(regs["f"]))(*regs["f"])
+            fpregset.fcsr = regs["fcsr"]
         elif self.machine == "x86_64":
             fpregset.cwd = regs["cwd"]
             fpregset.swd = regs["swd"]

--- a/coredump/criu_coredump/elf.py
+++ b/coredump/criu_coredump/elf.py
@@ -53,6 +53,7 @@ ET_CORE = 4  # #define ET_CORE         4               /* Core file */
 EM_ARM = 40  # #define EM_ARM		40	/* ARM */
 EM_X86_64 = 62  # #define EM_X86_64       62              /* AMD x86-64 architecture */
 EM_AARCH64 = 183  # #define EM_AARCH64	183	/* ARM AARCH64 */
+EM_RISCV = 243  # #define EM_RISCV        243             /* RISC-V */
 
 # Legal values for e_version (version).
 EV_CURRENT = 1  # #define EV_CURRENT      1               /* Current version */
@@ -461,12 +462,50 @@ class arm_user_regs_struct(ctypes.Structure):  # struct arm_user_regs_struct
     ]
 
 
+class riscv64_user_regs_struct(ctypes.Structure):  # struct user_regs_struct
+    _fields_ = [
+        ("pc", ctypes.c_ulonglong),
+        ("ra", ctypes.c_ulonglong),
+        ("sp", ctypes.c_ulonglong),
+        ("gp", ctypes.c_ulonglong),
+        ("tp", ctypes.c_ulonglong),
+        ("t0", ctypes.c_ulonglong),
+        ("t1", ctypes.c_ulonglong),
+        ("t2", ctypes.c_ulonglong),
+        ("s0", ctypes.c_ulonglong),
+        ("s1", ctypes.c_ulonglong),
+        ("a0", ctypes.c_ulonglong),
+        ("a1", ctypes.c_ulonglong),
+        ("a2", ctypes.c_ulonglong),
+        ("a3", ctypes.c_ulonglong),
+        ("a4", ctypes.c_ulonglong),
+        ("a5", ctypes.c_ulonglong),
+        ("a6", ctypes.c_ulonglong),
+        ("a7", ctypes.c_ulonglong),
+        ("s2", ctypes.c_ulonglong),
+        ("s3", ctypes.c_ulonglong),
+        ("s4", ctypes.c_ulonglong),
+        ("s5", ctypes.c_ulonglong),
+        ("s6", ctypes.c_ulonglong),
+        ("s7", ctypes.c_ulonglong),
+        ("s8", ctypes.c_ulonglong),
+        ("s9", ctypes.c_ulonglong),
+        ("s10", ctypes.c_ulonglong),
+        ("s11", ctypes.c_ulonglong),
+        ("t3", ctypes.c_ulonglong),
+        ("t4", ctypes.c_ulonglong),
+        ("t5", ctypes.c_ulonglong),
+        ("t6", ctypes.c_ulonglong),
+    ]
+
+
 # elf_greg_t    = ctypes.c_ulonglong
 # ELF_NGREG = ctypes.sizeof(user_regs_struct)/ctypes.sizeof(elf_greg_t)
 # elf_gregset_t = elf_greg_t*ELF_NGREG
 user_regs_dict = {
         "aarch64": aarch64_user_regs_struct,
         "armv7l": arm_user_regs_struct,
+        "riscv64": riscv64_user_regs_struct,
         "x86_64": x86_64_user_regs_struct,
 }
 
@@ -653,9 +692,17 @@ class aarch64_user_fpregs_struct(ctypes.Structure):  # struct aarch64_user_fpreg
     ]
 
 
+class riscv64_user_fpregs_struct(ctypes.Structure):  # struct __riscv_d_ext_state
+    _fields_ = [
+        ("f", ctypes.c_ulonglong * 32),
+        ("fcsr", ctypes.c_uint),
+    ]
+
+
 user_fpregs_dict = {
         "aarch64": aarch64_user_fpregs_struct,
         "armv7l": None,
+        "riscv64": riscv64_user_fpregs_struct,
         "x86_64": x86_64_user_fpregs_struct,
 }
 

--- a/test/others/criu-coredump/test.sh
+++ b/test/others/criu-coredump/test.sh
@@ -45,8 +45,8 @@ function run_test {
 
 UNAME_M=$(uname -m)
 
-if [[ "$UNAME_M" != "aarch64" && "$UNAME_M" != "armv7l" &&"$UNAME_M" != "x86_64" ]]; then
-	echo "criu-coredump only supports aarch64 armv7l, and x86_64. skipping."
+if [[ "$UNAME_M" != "aarch64" && "$UNAME_M" != "armv7l" && "$UNAME_M" != "riscv64" && "$UNAME_M" != "x86_64" ]]; then
+	echo "criu-coredump only supports aarch64, armv7l, riscv64, and x86_64. skipping."
 	exit 0
 fi
 


### PR DESCRIPTION
Enable criu-coredump on riscv64.

This wires riscv64 CRIU core image data into the Python coredump generator so it can emit ELF core files with the correct RISC-V machine type and register layout.

The change adds:
- riscv64 support to the launcher
- EM_RISCV in the ELF header
- GP register mapping for NT_PRSTATUS
- FP register mapping for NT_FPREGSET
- riscv64 coverage in the existing criu-coredump smoke test

The register layout follows the current CRIU riscv64 core image format and Linux RISC-V user ABI.

Partially addresses #2433.