### PR TITLE
contributing: document AI-assisted contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,6 +304,38 @@ Signed-off-by: Random J Developer <random at developer.example.org>
 Patch body here
 ```
 
+## AI-assisted contributions
+
+Use this tag when AI tools meaningfully contribute to the code,
+design, or commit message. Trivial use (e.g. basic autocomplete)
+does not require attribution. Following the
+[Linux kernel guidance on coding assistants](https://docs.kernel.org/process/coding-assistants.html),
+the tag format is:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+```
+
+Where `AGENT_NAME` identifies the AI tool or framework, `MODEL_VERSION`
+specifies which model was used, and the optional `[TOOL1] [TOOL2]`
+fields list any specialized analysis tools (e.g. coccinelle, sparse,
+smatch, clang-tidy) that were used alongside the AI assistant. Basic
+development tools (git, gcc, make, editors) should not be listed.
+
+For example:
+
+```
+Assisted-by: Claude:claude-3-opus coccinelle sparse
+```
+
+The `Assisted-by` tag should be placed after the commit message body
+and before the `Signed-off-by` line.
+
+Note that AI agents should not add `Signed-off-by` tags. Only human
+developers can certify the Developer's Certificate of Origin. The
+submitter is responsible for reviewing all AI-generated code and
+ensuring its correctness and license compliance.
+
 ## Submit your work upstream
 
 We accept GitHub pull requests and this is the preferred way to contribute to CRIU.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -134,3 +134,14 @@ Each ZDTM test has three stages: preparation, C/R, and results checks. During
 the test, a process calls `test_daemon()` to signal it is ready for C/R, then
 calls `test_waitsig()` to wait for the C/R stage to complete. After being
 restored, the test checks that all its resources are still in a valid state.
+
+## AI-assisted contributions
+
+Add an `Assisted-by` tag to each commit message, placed after the
+commit message body and before the `Signed-off-by` line:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION
+```
+
+Do not add `Signed-off-by` tags on behalf of the user.


### PR DESCRIPTION
Add an "AI-assisted contributions" section to CONTRIBUTING.md describing the Assisted-by tag format for commits that involve AI coding assistants, following the Linux kernel guidance at docs.kernel.org/process/coding-assistants.html.

Also add matching instructions to GEMINI.md (symlinked to CLAUDE.md) so that AI agents use the Assisted-by tag instead of free-form attribution lines.

@avagin This is a result of your comment in #2971. I tried to document what you mentioned there.