### PR TITLE
files-reg: warn when external file has no inherit-fd mapping on restore

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -2216,6 +2216,7 @@ int open_path(struct file_desc *d, int (*open_cb)(int mntns_root, struct reg_fil
 			rfi->path = path;
 			goto ext;
 		}
+		pr_warn("External file %s has no --inherit-fd mapping on restore\n", rfi->rfe->name);
 	}
 
 	if (rfi->remap) {


### PR DESCRIPTION
In open_path(), when inherit_fd_lookup_id() returns negative for an external file, execution silently falls through to the normal open path causing an incorrect size mismatch error. Added a pr_warn() to make the failure explicit.

Fixes:  #2951

Note: unable to fully reproduce in CRIU 4.2 as should_check_size() appears to mask this path for O_APPEND|O_WRONLY files, but the code path exists.
