### PR TITLE
sk-queue: increase CMSG_MAX_SIZE to handle all SCM types

### DIFF
--- a/criu/sk-queue.c
+++ b/criu/sk-queue.c
@@ -120,8 +120,17 @@ static int dump_scm_rights(struct cmsghdr *ch, SkPacketEntry *pe)
 /*
  * Maximum size of the control messages. XXX -- is there any
  * way to get this value out of the kernel?
- * */
-#define CMSG_MAX_SIZE 1024
+ *
+ * The kernel limits SCM_RIGHTS to SCM_MAX_FD (253) file descriptors,
+ * defined in include/net/scm.h. A single packet can carry multiple
+ * SCM types simultaneously:
+ *   - SCM_RIGHTS:      CMSG_SPACE(253 * sizeof(int)) = 1032 bytes
+ *   - SCM_CREDENTIALS: CMSG_SPACE(sizeof(struct ucred)) = 32 bytes
+ *   - SCM_PIDFD:       CMSG_SPACE(sizeof(int)) = 24 bytes
+ *
+ * Total worst case: ~1088 bytes. Round up to 2048 for safety.
+ */
+#define CMSG_MAX_SIZE 2048
 
 static int dump_packet_cmsg(struct msghdr *mh, SkPacketEntry *pe)
 {


### PR DESCRIPTION
## Summary
The control message buffer in `dump_sk_queue()` was hardcoded to 1024 bytes, which is insufficient for the kernel's maximum allowed file descriptor count and cannot accommodate multiple SCM types in a single packet.
## Problem
1. **SCM_RIGHTS truncation**: The kernel limits SCM_RIGHTS to `SCM_MAX_FD` (253) file descriptors, requiring `CMSG_SPACE(253 * sizeof(int))` = 1032 bytes. The previous 1024-byte buffer would cause `MSG_CTRUNC` at maximum capacity.
2. **Multi-SCM packets**: A single packet can carry multiple SCM types simultaneously:
   - SCM_RIGHTS: 1032 bytes (max)
   - SCM_CREDENTIALS: 32 bytes
   - SCM_PIDFD: 24 bytes
   - **Total worst case: ~1088 bytes**
## Solution
Increase `CMSG_MAX_SIZE` from 1024 to 2048 bytes.
## Testing
- Build tested: `make -j$(nproc)` passes
- The existing SCM tests (`scm00` through `scm09`) cover this code path