### PR TITLE
[clang] default CC to cc instead of gcc

### DIFF
--- a/scripts/nmk/scripts/tools.mk
+++ b/scripts/nmk/scripts/tools.mk
@@ -7,7 +7,7 @@ HOSTLD		?= ld
 ifeq ($(origin LD), default)
 LD		:= $(CROSS_COMPILE)$(HOSTLD)
 endif
-HOSTCC		?= gcc
+HOSTCC		?= cc
 ifeq ($(origin CC), default)
 CC		:= $(CROSS_COMPILE)$(HOSTCC)
 endif


### PR DESCRIPTION
building on a system without gcc fails with error:
make[1]: gcc: No such file or directory

use system default cc to enhance portability

fixes: #2976