### PR TITLE
Keep ELF metadata for ld.lld

### DIFF
--- a/compel/arch/aarch64/scripts/compel-pack.lds.S
+++ b/compel/arch/aarch64/scripts/compel-pack.lds.S
@@ -19,7 +19,11 @@ SECTIONS
 		. = ALIGN(32);
 		*(.toc*)
 		. = ALIGN(32);
-	} =0x00000000,
+	} =0x00000000
+
+	.shstrtab : { *(.shstrtab) }
+	.strtab   : { *(.strtab) }
+	.symtab   : { *(.symtab) }
 
 	/DISCARD/ : {
 		*(.debug*)


### PR DESCRIPTION
Linking on arm64 using lld fails with:
  LINK     criu/pie/parasite.built-in.o
ld: error: discarding .shstrtab section is not allowed

keep the missing sections to enhance portability

Fixes: #2978