### PR TITLE
pie/restorer: normalize tv_nsec when re-anchoring absolute timerfd expiry

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1258,9 +1258,9 @@ static int timerfd_arm(struct task_restore_args *args)
 
 			/*
 			 * We might need to adjust value because the checkpoint
-			 * and restore procedure takes some time itself. Note
-			 * we don't adjust nanoseconds, since the result may
-			 * overflow the limit NSEC_PER_SEC FIXME
+			 * and restore procedure takes some time itself. We also
+			 * accumulate tv_nsec and propagate any carry into tv_sec
+			 * to keep the itimerspec value normalized.
 			 */
 			if (sys_clock_gettime(t->clockid, &ts)) {
 				pr_err("Can't get current time\n");
@@ -1268,6 +1268,11 @@ static int timerfd_arm(struct task_restore_args *args)
 			}
 
 			t->val.it_value.tv_sec += (time_t)ts.tv_sec;
+			t->val.it_value.tv_nsec += ts.tv_nsec;
+			if (t->val.it_value.tv_nsec >= NSEC_PER_SEC) {
+				t->val.it_value.tv_nsec -= NSEC_PER_SEC;
+				t->val.it_value.tv_sec++;
+			}
 
 			pr_debug("Adjust id %x it_value(%llu, %llu) -> it_value(%llu, %llu)\n", t->id,
 				 (unsigned long long)ts.tv_sec, (unsigned long long)ts.tv_nsec,


### PR DESCRIPTION
When accumulating ts.tv_nsec into t->val.it_value.tv_nsec, the result
can exceed NSEC_PER_SEC (999999999). Without normalization, the restored
timer carries an invalid tv_nsec value, causing incorrect timer behavior
after restore.

Add a single carry-propagation step: if tv_nsec >= NSEC_PER_SEC, subtract
one full second and increment tv_sec. A single if-check suffices because
ts.tv_nsec is always < NSEC_PER_SEC on entry, so overflow is at most 1s.