### PR TITLE
pipes: restore pipe ownership to fix /proc/self/fd access

### DIFF
--- a/criu/pipes.c
+++ b/criu/pipes.c
@@ -305,6 +305,13 @@ int open_pipe(struct file_desc *d, int *new_fd)
 		return -1;
 	}
 
+	if (pi->pe->has_uid && pi->pe->has_gid) {
+		if (cr_fchown(pfd[0], pi->pe->uid, pi->pe->gid) < 0) {
+			pr_perror("Can't change pipe ownership");
+			return -1;
+		}
+	}
+
 	ret = restore_pipe_data(CR_FD_PIPES_DATA, pfd[1], pi->pe->pipe_id, pd_hash_pipes);
 	if (ret)
 		return -1;
@@ -495,6 +502,10 @@ static int dump_one_pipe(int lfd, u32 id, const struct fd_parms *p)
 	pe.pipe_id = pipe_id(p);
 	pe.flags = p->flags & ~O_DIRECT;
 	pe.fown = (FownEntry *)&p->fown;
+	pe.uid = userns_uid(p->stat.st_uid);
+	pe.gid = userns_gid(p->stat.st_gid);
+	pe.has_uid = true;
+	pe.has_gid = true;
 
 	fe.type = FD_TYPES__PIPE;
 	fe.id = pe.id;

--- a/images/pipe.proto
+++ b/images/pipe.proto
@@ -10,4 +10,6 @@ message pipe_entry {
 	required uint32		pipe_id		= 2;
 	required uint32		flags		= 3 [(criu).hex = true];
 	required fown_entry	fown		= 4;
+	optional uint32		uid		= 5;
+	optional uint32		gid		= 6;
 }

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -67,6 +67,7 @@ TST_NOFILE	:=				\
 		pipe00				\
 		pipe01				\
 		pipe02				\
+		pipe_owner			\
 		pthread00			\
 		pthread00-pac			\
 		pthread01			\

--- a/test/zdtm/static/pipe_owner.c
+++ b/test/zdtm/static/pipe_owner.c
@@ -1,0 +1,114 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <linux/limits.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check pipe ownership is preserved after C/R";
+const char *test_author = "Ahmed Elaidy <elaidya225@gmail.com>";
+
+#define TEST_STRING "Hello world"
+
+int main(int argc, char **argv)
+{
+	int pfd[2];
+	int ret;
+	char path[PATH_MAX];
+	struct stat st_before, st_after;
+	uid_t expected_uid;
+	gid_t expected_gid;
+	int proc_fd;
+	char buf[sizeof(TEST_STRING)];
+
+	test_init(argc, argv);
+
+	ret = pipe(pfd);
+	if (ret) {
+		pr_perror("pipe() failed");
+		return 1;
+	}
+
+	/*
+	 * If running as root, change pipe ownership to test that uid/gid
+	 * are properly saved and restored across C/R. Otherwise, just
+	 * verify the current ownership is preserved.
+	 */
+	if (getuid() == 0) {
+		expected_uid = 13333;
+		expected_gid = 44444;
+		if (fchown(pfd[0], expected_uid, expected_gid)) {
+			pr_perror("fchown(pfd[0]) failed");
+			return 1;
+		}
+		if (fchown(pfd[1], expected_uid, expected_gid)) {
+			pr_perror("fchown(pfd[1]) failed");
+			return 1;
+		}
+	} else {
+		expected_uid = getuid();
+		expected_gid = getgid();
+	}
+
+	/* Record ownership before C/R */
+	if (fstat(pfd[0], &st_before)) {
+		pr_perror("fstat() failed before C/R");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	/* Verify ownership is preserved after C/R */
+	if (fstat(pfd[0], &st_after)) {
+		pr_perror("fstat() failed after C/R");
+		return 1;
+	}
+
+	if (st_after.st_uid != expected_uid || st_after.st_gid != expected_gid) {
+		fail("UID/GID mismatch (got %d/%d but %d/%d expected)",
+		     (int)st_after.st_uid, (int)st_after.st_gid,
+		     (int)expected_uid, (int)expected_gid);
+		return 1;
+	}
+
+	/*
+	 * Test /proc/self/fd access. This was broken when pipe
+	 * ownership wasn't restored (issue #2984).
+	 */
+	snprintf(path, PATH_MAX, "/proc/self/fd/%d", pfd[1]);
+	proc_fd = open(path, O_WRONLY);
+	if (proc_fd == -1) {
+		fail("open(%s) failed after C/R - ownership not restored?", path);
+		return 1;
+	}
+
+	/* Verify the pipe still works */
+	ret = write(proc_fd, TEST_STRING, sizeof(TEST_STRING));
+	if (ret != sizeof(TEST_STRING)) {
+		pr_perror("write() failed");
+		close(proc_fd);
+		return 1;
+	}
+	close(proc_fd);
+
+	ret = read(pfd[0], buf, sizeof(TEST_STRING));
+	if (ret != sizeof(TEST_STRING)) {
+		pr_perror("read() failed");
+		return 1;
+	}
+
+	if (strcmp(TEST_STRING, buf)) {
+		fail("data corruption");
+		return 1;
+	}
+
+	close(pfd[0]);
+	close(pfd[1]);
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
## Summary

When CRIU runs as root and restores a pipe, the pipe inode is created with root ownership. If the restored process runs as a non-root user and tries to reopen the pipe via `/proc/self/fd/<n>`, the `open()` fails with `EACCES`.

## Solution

- Add `uid` and `gid` fields to `pipe_entry` in `images/pipe.proto`
- Save pipe ownership during dump from `stat()`
- Restore ownership with `fchown()` after `pipe()` creation
- Add a test `pipe_owenr` that verifies pipe ownership (uid/gid) is preserved across
checkpoint/restore.

This matches how memfds and TTYs already handle ownership restoration.

## Test plan

- `zdtm/static/pipe00` passes
- `zdtm/static/pipe01` passes
- `zdtm/static/pipe02` passes
- `zdtm/static/pipe_owner` passes after the fix and fails when we roll it back

Fixes: #2984
