### PR TITLE
pidfd: fix proto definition — remove package declaration, add nspid/i…

### DIFF
--- a/images/pidfd.proto
+++ b/images/pidfd.proto
@@ -5,9 +5,9 @@ syntax = "proto2";
 import "fown.proto";
 
 message pidfd_entry {
-	required uint32		id		= 1;
-	required uint32		ino		= 2;
-	required uint32		flags		= 3;
-	required int32		nspid		= 4;
-	required fown_entry	fown		= 5;
+	required uint32		id	= 1;
+	required uint32		ino	= 2;
+	required uint32		flags	= 3;
+	required int32		nspid	= 4;
+	required fown_entry	fown	= 5;
 }


### PR DESCRIPTION
…no fields

CRIU protos use no package namespace. Adding 'package cr;' broke FdinfoEntry codegen. Removed package declarations from both pidfd.proto and fdinfo.proto.

Also added nspid and ino fields to pidfd_entry for stale pidfd support.

Fixes: https://github.com/checkpoint-restore/criu/issues/2258

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
