### PR TITLE
compel: Fix PTRACE_SEIZE PID reuse validation by checking start_time

### DIFF
--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -32,9 +32,10 @@ struct seize_task_status {
 	int vpid;
 	int ppid;
 	int seccomp_mode;
+	unsigned long long start_time;
 };
 
-extern int __must_check compel_wait_task(int pid, int ppid,
+extern int __must_check compel_wait_task(int pid, int ppid, unsigned long long start_time,
 					 int (*get_status)(int pid, struct seize_task_status *, void *data),
 					 void (*free_status)(int pid, struct seize_task_status *, void *data),
 					 struct seize_task_status *st, void *data);

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -99,6 +99,30 @@ static int parse_pid_status(int pid, struct seize_task_status *ss, void *data)
 	}
 
 	fclose(f);
+
+	sprintf(aux, "/proc/%d/stat", pid);
+	f = fopen(aux, "r");
+	ss->start_time = 0;
+	if (f) {
+		char buf[1024];
+		if (fgets(buf, sizeof(buf), f)) {
+			char *p = strrchr(buf, ')');
+			if (p) {
+				unsigned long long start_time = 0;
+				int i;
+				p++;
+				for (i = 0; i < 19; i++) {
+					while (*p == ' ') p++;
+					while (*p && *p != ' ') p++;
+				}
+				while (*p == ' ') p++;
+				if (sscanf(p, "%llu", &start_time) == 1)
+					ss->start_time = start_time;
+			}
+		}
+		fclose(f);
+	}
+
 	return 0;
 
 err_parse:
@@ -113,7 +137,7 @@ int compel_stop_task(int pid)
 
 	ret = compel_interrupt_task(pid);
 	if (ret == 0)
-		ret = compel_wait_task(pid, -1, parse_pid_status, NULL, &ss, NULL);
+		ret = compel_wait_task(pid, -1, 0, parse_pid_status, NULL, &ss, NULL);
 	return ret;
 }
 
@@ -220,7 +244,7 @@ int compel_parse_stop_signo(int pid)
  * of it so the task would not know if it was saddled
  * up with someone else.
  */
-int compel_wait_task(int pid, int ppid, int (*get_status)(int pid, struct seize_task_status *, void *),
+int compel_wait_task(int pid, int ppid, unsigned long long start_time, int (*get_status)(int pid, struct seize_task_status *, void *),
 		     void (*free_status)(int pid, struct seize_task_status *, void *), struct seize_task_status *ss,
 		     void *data)
 {
@@ -271,6 +295,12 @@ try_again:
 
 	if ((ppid != -1) && (ss->ppid != ppid)) {
 		pr_err("Task pid reused while suspending (%d: %d -> %d)\n", pid, ppid, ss->ppid);
+		goto err;
+	}
+
+	if (start_time != 0 && ss->start_time != start_time) {
+		pr_err("Task pid reused (start_time mismatch) while suspending (%d: %llu -> %llu)\n",
+		       pid, start_time, ss->start_time);
 		goto err;
 	}
 

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -1243,8 +1243,14 @@ int parse_pid_status(pid_t pid, struct seize_task_status *ss, void *data)
 	expected_done = (parsed_seccomp ? 13 : 12);
 	if (kdat.has_nspid)
 		expected_done++;
-	if (done == expected_done)
+	if (done == expected_done) {
+		struct proc_pid_stat stat;
+		if (parse_pid_stat(pid, &stat) == 0)
+			cr->s.start_time = stat.start_time;
+		else
+			cr->s.start_time = 0;
 		ret = 0;
+	}
 
 err_parse:
 	if (ret)

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -718,11 +718,16 @@ static int collect_children(struct pstree_item *item)
 			goto free;
 		}
 
+		struct proc_pid_stat stat;
+		unsigned long long expected_st = 0;
+		if (parse_pid_stat(pid, &stat) == 0)
+			expected_st = stat.start_time;
+
 		if (!opts.freeze_cgroup || compel_interrupt_only_mode)
 			/* fails when meets a zombie */
 			__ignore_value(compel_interrupt_task(pid));
 
-		ret = compel_wait_task(pid, item->pid->real, parse_pid_status, NULL, &creds.s, NULL);
+		ret = compel_wait_task(pid, item->pid->real, expected_st, parse_pid_status, NULL, &creds.s, NULL);
 		if (ret < 0) {
 			/*
 			 * Here is a race window between parse_children() and seize(),
@@ -908,11 +913,16 @@ static int collect_threads(struct pstree_item *item)
 
 		pr_info("\tSeizing %d's %d thread\n", item->pid->real, pid);
 
+		struct proc_pid_stat stat;
+		unsigned long long expected_st = 0;
+		if (parse_pid_stat(pid, &stat) == 0)
+			expected_st = stat.start_time;
+
 		if ((!opts.freeze_cgroup || compel_interrupt_only_mode) &&
 		    compel_interrupt_task(pid))
 			continue;
 
-		ret = compel_wait_task(pid, item_ppid(item), parse_pid_status, NULL, &t_creds.s, NULL);
+		ret = compel_wait_task(pid, item_ppid(item), expected_st, parse_pid_status, NULL, &t_creds.s, NULL);
 		if (ret < 0) {
 			/*
 			 * Here is a race window between parse_threads() and seize(),
@@ -1065,6 +1075,11 @@ int collect_pstree(void)
 
 	pr_debug("Detected cgroup V%d freezer\n", cgroup_v2 ? 2 : 1);
 
+	struct proc_pid_stat stat;
+	unsigned long long expected_st = 0;
+	if (parse_pid_stat(pid, &stat) == 0)
+		expected_st = stat.start_time;
+
 	if (opts.freeze_cgroup && !compel_interrupt_only_mode) {
 		ret = run_plugins(PAUSE_DEVICES, pid);
 		if (ret < 0 && ret != -ENOTSUP) {
@@ -1092,7 +1107,7 @@ int collect_pstree(void)
 		}
 	}
 
-	ret = compel_wait_task(pid, -1, parse_pid_status, NULL, &creds.s, NULL);
+	ret = compel_wait_task(pid, -1, expected_st, parse_pid_status, NULL, &creds.s, NULL);
 	if (ret < 0)
 		goto err;
 

--- a/plugins/cuda/cuda_plugin.c
+++ b/plugins/cuda/cuda_plugin.c
@@ -288,7 +288,7 @@ static int interrupt_restore_thread(int restore_tid, k_rtsigset_t *restore_sigse
 	}
 
 	struct proc_status_creds creds;
-	if (compel_wait_task(restore_tid, -1, parse_pid_status, NULL, &creds.s, NULL) != COMPEL_TASK_ALIVE) {
+	if (compel_wait_task(restore_tid, -1, 0, parse_pid_status, NULL, &creds.s, NULL) != COMPEL_TASK_ALIVE) {
 		pr_err("compel_wait_task failed after interrupt\n");
 		return -1;
 	}


### PR DESCRIPTION
## Bug Fix: Prevent PID Reuse Race in `PTRACE_SEIZE` (CRIU / Compel)

### Problem
CRIU could attach to the wrong process due to a **PID reuse race** in highly concurrent environments (e.g., Kubernetes).

Flow:
1. CRIU collects target `pid`
2. Process exits before `ptrace(PTRACE_SEIZE)`
3. Kernel reuses same PID for a new process (often same `ppid`)
4. `compel_wait_task()` validates only `ppid` 
5. CRIU attaches to the wrong process and injects parasite

**Impact:**
- Memory corruption of unrelated processes
- Silent crashes in containers/host workloads
- Extremely hard-to-debug production failures

---

### Solution
Introduce **strict process identity validation using `start_time`** (`/proc/[pid]/stat`, field 22).

#### Key Changes
- **Compel**
  - Add `start_time` extraction in process parsing
  - Extend `compel_wait_task()` to validate:
    ```c
    if (actual_start_time != expected_start_time)
        return -ESRCH; // PID reused
    ```

- **CRIU**
  - Capture `start_time` during:
    - `collect_children`
    - `collect_threads`
    - `collect_pstree`
  - Pass expected `start_time` into `compel_wait_task()`

---

### Result
Process identity upgraded from:

to:

- Eliminates PID reuse collisions
- Prevents parasite injection into wrong processes
- Ensures deterministic and safe `PTRACE_SEIZE`

---

### Error Handling
On mismatch:

---

### Notes
- `start_time` is monotonic per boot and uniquely identifies a process instance
- No behavioral changes for valid processes
- Only impacts race-condition scenarios

---

### Testing
- Simulated rapid fork/exit PID reuse scenarios
- Verified attach failure on mismatched `start_time`
- Confirmed no regressions in normal dump/restore flows

---

### Fixes
Critical race condition causing potential process corruption during checkpoint