### PR TITLE
compel: fix ptrace_seize wait4 infinite deadlock

### DIFF
--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <linux/seccomp.h>
+#include <time.h>
 
 #include "log.h"
 #include "common/bug.h"
@@ -170,13 +171,26 @@ static int skip_sigstop(int pid, int nr_signals)
 	 * immediately, because we sent PTRACE_INTERRUPT to it.
 	 */
 	for (i = 0; i < nr_signals; i++) {
+		int wait_retries = 1000;
+
 		ret = ptrace(PTRACE_CONT, pid, 0, 0);
 		if (ret) {
 			pr_perror("Unable to start process");
 			return -1;
 		}
 
-		ret = wait4(pid, &status, __WALL, NULL);
+		while (wait_retries-- > 0) {
+			ret = wait4(pid, &status, WNOHANG | __WALL, NULL);
+			if (ret != 0)
+				break;
+			struct timespec ts = { .tv_sec = 0, .tv_nsec = 1000000 };
+			nanosleep(&ts, NULL);
+		}
+		if (ret == 0) {
+			pr_err("SEIZE %d: timeout waiting for task\n", pid);
+			errno = ESRCH;
+			return -1;
+		}
 		if (ret < 0) {
 			pr_perror("SEIZE %d: can't wait task", pid);
 			return -1;
@@ -227,6 +241,7 @@ int compel_wait_task(int pid, int ppid, int (*get_status)(int pid, struct seize_
 	siginfo_t si;
 	int status, nr_stopsig;
 	int ret = 0, ret2, wait_errno = 0;
+	int wait_retries;
 
 	/*
 	 * It's ugly, but the ptrace API doesn't allow to distinguish
@@ -236,8 +251,20 @@ int compel_wait_task(int pid, int ppid, int (*get_status)(int pid, struct seize_
 	 */
 
 try_again:
+	wait_retries = 1000;
+	while (wait_retries-- > 0) {
+		ret = wait4(pid, &status, WNOHANG | __WALL, NULL);
+		if (ret != 0)
+			break;
+		struct timespec ts = { .tv_sec = 0, .tv_nsec = 1000000 };
+		nanosleep(&ts, NULL);
+	}
+	if (ret == 0) {
+		pr_err("SEIZE %d: timeout waiting for task to stop\n", pid);
+		ret = -1;
+		errno = ESRCH;
+	}
 
-	ret = wait4(pid, &status, __WALL, NULL);
 	if (ret < 0) {
 		/*
 		 * wait4() can expectedly fail only in a first time


### PR DESCRIPTION
## Bug Fix: Prevent CRIU Deadlock Caused by ptrace TOCTOU Race

###  Problem Summary

This PR fixes a critical race condition in `compel/src/lib/infect.c`, primarily within:
- `compel_wait_task`
- `skip_sigstop`

#### Root Cause

A **Time-of-Check to Time-of-Use (TOCTOU)** race exists between:
- `ptrace(PTRACE_SEIZE, pid, ...)`
- Subsequent `wait4(pid, &status, __WALL, NULL)`

In highly concurrent environments (e.g., containerized workloads), a target process may **exit (e.g., SIGKILL)** in the narrow window between:
1. Successful `PTRACE_SEIZE`
2. Entry into the blocking `wait4` loop

In such cases, the kernel may **not emit a ptrace stop event** (`PTRACE_EVENT_STOP` or `SIGSTOP`).

#### Impact

- `wait4` (without `WNOHANG`) blocks indefinitely
- No event is ever received for the already-dead task
- Results in **permanent deadlock**
- Breaks CRIU dump operation reliability in production (especially under high PID churn)

---

###  Solution

Replace the blocking wait mechanism with a **bounded, non-blocking polling loop**.

#### Key Changes

1. **Non-blocking wait**
   ```c
   wait4(pid, &status, WNOHANG | __WALL, NULL);

for (i = 0; i < 1000; i++) {
    // attempt wait
}

nanosleep(1ms);