### PR TITLE
Migrate Fedora Rawhide test to GitHub Actions with aarch64 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,14 +68,3 @@ task:
   build_script: |
     make -C scripts/ci vagrant-fedora-non-root
 
-task:
-  name: aarch64 Fedora Rawhide
-  arm_container:
-    image: registry.fedoraproject.org/fedora:rawhide
-    cpu: 4
-    memory: 4G
-  script: uname -a
-  build_script: |
-    scripts/ci/prepare-for-fedora-rawhide.sh
-    make -C scripts/ci/ local CC=gcc SKIP_CI_PREP=1 SKIP_CI_TEST=1 CD_TO_TOP=1
-    make -C test/zdtm -j 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,16 @@ jobs:
       run: sudo -E make -C scripts/ci fedora-asan
 
   fedora-rawhide-test:
+    name: ${{ matrix.name }}
     needs: [alpine-test]
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            name: x86_64 Fedora Rawhide
+          - os: ubuntu-24.04-arm
+            name: aarch64 Fedora Rawhide
     steps:
     - uses: actions/checkout@v4
     - name: Run Fedora Rawhide Test


### PR DESCRIPTION
As Cirrus CI seems to be not working anymore. Bring one more test from Cirrus to GitHub Actions.