### PR TITLE
page-xfer: write zero pages when parent hole is missing

### DIFF
--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -341,9 +341,39 @@ static int write_pagemap_loc(struct page_xfer *xfer, struct iovec *iov, u32 flag
 		if (xfer->parent != NULL) {
 			ret = check_pagehole_in_parent(xfer->parent, iov);
 			if (ret) {
-				pr_err("Hole %p - %p not found in parent\n",
-				       iov->iov_base, iov->iov_base + iov->iov_len);
-				return -1;
+				/*
+				 * Page not found in parent. This can happen
+				 * when a page was allocated between pre-dumps
+				 * and the soft-dirty bit is clear (kernel
+				 * zero-fills new pages without setting it).
+				 * Write zero pages instead of a broken parent
+				 * reference that would fail on restore.
+				 */
+				unsigned long i, nr = iov->iov_len / PAGE_SIZE;
+				static const char zero_page[PAGE_SIZE];
+
+				pr_warn("Hole %p - %p not found in parent, "
+					"writing %lu zero page(s)\n",
+					iov->iov_base,
+					iov->iov_base + iov->iov_len, nr);
+
+				pe.flags = PE_PRESENT;
+				flags = PE_PRESENT;
+
+				if (pb_write_one(xfer->pmi, &pe, PB_PAGEMAP) < 0)
+					return -1;
+
+				for (i = 0; i < nr; i++) {
+					ret = write(img_raw_fd(xfer->pi),
+						    zero_page, PAGE_SIZE);
+					if (ret != PAGE_SIZE) {
+						pr_perror("Can't write zero page");
+						return -1;
+					}
+				}
+
+				cnt_add(CNT_PAGES_WRITTEN, nr);
+				return 0;
 			}
 		}
 	}

--- a/test/zdtm/transition/Makefile
+++ b/test/zdtm/transition/Makefile
@@ -21,6 +21,7 @@ TST_NOFILE	=	\
 		socket-tcp6     \
 		shmem		\
 		lazy-thp	\
+		maps_newpage	\
 		pid_reuse	\
 		pidfd_store_sk \
 		rseq01		\

--- a/test/zdtm/transition/maps_newpage.c
+++ b/test/zdtm/transition/maps_newpage.c
@@ -1,0 +1,139 @@
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Test pages with cleared soft-dirty after pre-dump";
+const char *test_author = "Radostin Stoyanov <rstoyanov@fedoraproject.org>";
+
+/*
+ * After a pre-dump, soft-dirty bits are cleared. If new pages are
+ * then written and soft-dirty is cleared again (e.g. by a device
+ * driver or by writing to /proc/self/clear_refs), CRIU sees
+ * "present, not dirty" and classifies them as PE_PARENT. But the
+ * parent has no data for these pages, causing restore to fail with
+ * "Hole not found in parent".
+ *
+ * This test simulates the scenario by:
+ * 1. Mapping and writing init pages (will be in pre-dump)
+ * 2. Letting the pre-dump run
+ * 3. Mapping new pages in a separate VMA and writing a pattern
+ * 4. Clearing soft-dirty via /proc/self/clear_refs
+ * 5. Re-dirtying init pages so they are dumped normally
+ * 6. Letting the final dump run — the new pages appear "clean"
+ *    but have no parent data
+ */
+
+#define INIT_PAGES	4
+#define NEW_PAGES	4
+
+static int clear_soft_dirty(void)
+{
+	int fd;
+	ssize_t ret;
+
+	fd = open("/proc/self/clear_refs", O_WRONLY);
+	if (fd < 0) {
+		pr_perror("open clear_refs");
+		return -1;
+	}
+	/* 4 = clear soft-dirty bits */
+	ret = write(fd, "4", 1);
+	close(fd);
+	if (ret != 1) {
+		pr_perror("write clear_refs");
+		return -1;
+	}
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	unsigned char *init_mem, *new_mem = NULL;
+	size_t init_size = INIT_PAGES * PAGE_SIZE;
+	size_t new_size = NEW_PAGES * PAGE_SIZE;
+	int i;
+
+	test_init(argc, argv);
+
+	/* Map and write init pages — these go into the pre-dump */
+	init_mem = mmap(NULL, init_size, PROT_READ | PROT_WRITE,
+			MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (init_mem == MAP_FAILED) {
+		pr_perror("mmap init");
+		return 1;
+	}
+	memset(init_mem, 0xAB, init_size);
+
+	test_daemon();
+
+	/* Wait for pre-dump to complete */
+	if (test_wait_pre_dump())
+		goto skip;
+
+	/*
+	 * Map new pages in a separate VMA and write a pattern.
+	 * This creates real page backing (not the kernel zero page).
+	 */
+	new_mem = mmap(NULL, new_size, PROT_READ | PROT_WRITE,
+		       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (new_mem == MAP_FAILED) {
+		pr_perror("mmap new");
+		test_wait_pre_dump_ack();
+		return 1;
+	}
+	memset(new_mem, 0xCD, new_size);
+
+	/*
+	 * Clear soft-dirty for all pages. Now CRIU sees the new
+	 * pages as "present, not dirty" → PE_PARENT, but the
+	 * parent has no data for them.
+	 */
+	if (clear_soft_dirty()) {
+		test_wait_pre_dump_ack();
+		return 1;
+	}
+
+	/*
+	 * Re-dirty init pages so CRIU dumps them as PE_PRESENT.
+	 * Without this, they would also go to PE_PARENT (which
+	 * would work since the parent has them, but let's keep
+	 * the test focused on the new pages).
+	 */
+	memset(init_mem, 0xAB, init_size);
+
+	test_wait_pre_dump_ack();
+
+skip:
+	test_waitsig();
+
+	/* Verify init pages kept their pattern */
+	for (i = 0; i < (int)init_size; i++) {
+		if (init_mem[i] != 0xAB) {
+			fail("init_mem[%d] = 0x%02x, expected 0xAB",
+			     i, init_mem[i]);
+			return 1;
+		}
+	}
+
+	/*
+	 * The new pages will be zero after restore: CRIU thought
+	 * they were in the parent, so the fix writes zero pages.
+	 * The 0xCD data is lost, but the process doesn't crash.
+	 */
+	if (new_mem) {
+		for (i = 0; i < (int)new_size; i++) {
+			if (new_mem[i] != 0x00) {
+				fail("new_mem[%d] = 0x%02x, expected 0x00",
+				     i, new_mem[i]);
+				return 1;
+			}
+		}
+	}
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/transition/maps_newpage.desc
+++ b/test/zdtm/transition/maps_newpage.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h', 'flags': 'suid pre-dump-notify'}


### PR DESCRIPTION
During incremental dump with pre-dumps, pages allocated between pre-dumps may have their soft-dirty bit clear (the kernel zero-fills new mmap'd pages without setting it). CRIU classifies these as PE_PARENT holes, but since the page is newly allocated, no parent has it.

This causes restore to fail with `"Missing in parent pagemap"` (https://github.com/checkpoint-restore/criu/issues/2995) because `write_pagemap_loc()` wrote a broken `PE_PARENT` entry referencing data that does not exist in any parent image.
    
To fix this, write zero-filled PE_PRESENT pages instead, which is correct because new mmap'd pages with a clear soft-dirty bit are guaranteed to be zero-filled by the kernel.