### PR TITLE
criu: optimize mntinfo_add_list to O(1)

### DIFF
--- a/criu/cr-check.c
+++ b/criu/cr-check.c
@@ -1642,7 +1642,7 @@ int cr_check(void)
 	if (ns == NULL)
 		return -1;
 
-	mntinfo = collect_mntinfo(ns, false);
+	mntinfo_set(collect_mntinfo(ns, false));
 	if (mntinfo == NULL)
 		return -1;
 

--- a/criu/include/mount.h
+++ b/criu/include/mount.h
@@ -122,6 +122,7 @@ struct mount_info {
 };
 
 extern struct mount_info *mntinfo;
+extern void mntinfo_set(struct mount_info *new_mntinfo);
 
 extern void mntinfo_add_list_before(struct mount_info **head, struct mount_info *new);
 

--- a/criu/mount.c
+++ b/criu/mount.c
@@ -110,19 +110,38 @@ static char *ext_mount_lookup(char *key)
  * Single linked list of mount points get from proc/images
  */
 struct mount_info *mntinfo;
+static struct mount_info *mntinfo_tail;
+
+void mntinfo_set(struct mount_info *new_mntinfo)
+{
+	mntinfo = new_mntinfo;
+	if (mntinfo) {
+		mntinfo_tail = mntinfo;
+		while (mntinfo_tail->next)
+			mntinfo_tail = mntinfo_tail->next;
+	} else {
+		mntinfo_tail = NULL;
+	}
+}
 
 static void mntinfo_add_list(struct mount_info *new)
 {
+	struct mount_info *tail = new;
+
+	/* nothing to append */
+	if (!new)
+		return;
+
+	/* find the actual end of the appended sequence */
+	while (tail->next)
+		tail = tail->next;
+
 	if (!mntinfo)
 		mntinfo = new;
-	else {
-		struct mount_info *pm;
+	else
+		mntinfo_tail->next = new;
 
-		/* Add to the tail. (FIXME -- make O(1) ) */
-		for (pm = mntinfo; pm->next != NULL; pm = pm->next)
-			;
-		pm->next = new;
-	}
+	mntinfo_tail = tail;
 }
 
 void mntinfo_add_list_before(struct mount_info **head, struct mount_info *new)
@@ -3264,7 +3283,7 @@ int read_mnt_ns_img(void)
 	struct ns_id *nsid;
 
 	if (!(root_ns_mask & CLONE_NEWNS)) {
-		mntinfo = NULL;
+		mntinfo_set(NULL);
 		return 0;
 	}
 
@@ -3288,7 +3307,7 @@ int read_mnt_ns_img(void)
 		pms = head;
 	}
 
-	mntinfo = pms;
+	mntinfo_set(pms);
 
 	search_bindmounts();
 	prepare_is_overmounted();


### PR DESCRIPTION
currently, `mntinfo_add_list()` appends elements to the `mntinfo` linked list using an O(N) iterative loop to find the tail. 

this patch introduces a static `mntinfo_tail` pointer to track the end of the list, making appending an O(1) operation. it also ensures `mntinfo_tail` correctly handles appending entire sub-lists by advancing to the actual end, and keeps the tail synced whenever `mntinfo` is directly reassigned in the codebase.

fixes the `FIXME -- make O(1)` comment in `mntinfo_add_list()`.
