### PR TITLE
Handle UDPLITE removal in kernel 7.1 and add mainline kernel CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,18 @@ jobs:
       run: sudo -E XDG_RUNTIME_DIR= make -C scripts/ci fedora-rawhide CONTAINER_RUNTIME=podman BUILD_OPTIONS="--security-opt seccomp=unconfined"
 
   vagrant-fedora-rawhide-test:
-    name: Vagrant Fedora Rawhide based test
+    name: Vagrant Fedora ${{ matrix.name }} based test
     needs: [alpine-test]
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: fedora-stable
+            name: Stable
+          - variant: fedora-next
+            name: Next
     steps:
     - uses: actions/checkout@v4
     - name: Install Lima
@@ -162,7 +170,7 @@ jobs:
         lima sudo chown "$(lima whoami)" /home/criu
         limactl copy -r . default:/home/criu
     - name: Setup VM
-      run: lima sudo /home/criu/scripts/ci/lima.sh fedora-rawhide-setup
+      run: lima sudo /home/criu/scripts/ci/lima.sh ${{ matrix.variant }}-setup
     - name: Reboot VM to activate new kernel
       run: |
         limactl stop default
@@ -172,7 +180,7 @@ jobs:
         lima uname -a
         lima cat /proc/cmdline
     - name: Run tests
-      run: ssh -tt lima-default sudo -i /home/criu/scripts/ci/lima.sh fedora-rawhide-test
+      run: ssh -tt lima-default sudo -i /home/criu/scripts/ci/lima.sh ${{ matrix.variant }}-test
 
   gcov-test:
     needs: [alpine-test]

--- a/criu/sockets.c
+++ b/criu/sockets.c
@@ -827,16 +827,20 @@ static int collect_err(int err, struct ns_id *ns, void *arg)
 	if (err == -ENOENT) {
 		pr_debug("%s: %d\n", msg, err);
 		/*
-		 * Unlike other modules RAW sockets are
-		 * always optional and not commonly used.
+		 * Unlike other modules RAW and UDPLITE sockets
+		 * are always optional and not commonly used.
 		 * Currently we warn user about lack of
 		 * a particular module support in "check"
 		 * procedure. Thus don't fail on lack of
-		 * RAW diags in a regular dump. If we meet
-		 * a raw socket we will simply fail on dump
+		 * these diags in a regular dump. If we meet
+		 * such a socket we will simply fail on dump
 		 * procedure because it won't be resolved.
+		 *
+		 * Note: IPPROTO_UDPLITE support was removed
+		 * from the kernel starting with v7.1.
 		 */
-		if (gr->protocol == IPPROTO_RAW)
+		if (gr->protocol == IPPROTO_RAW ||
+		    gr->protocol == IPPROTO_UDPLITE)
 			return 0;
 		return -ENOENT;
 	}

--- a/scripts/ci/lima.sh
+++ b/scripts/ci/lima.sh
@@ -4,8 +4,10 @@
 # the Fedora Rawhide based CI tests with a vanilla kernel.
 # It mirrors the logic from vagrant.sh's setup() and fedora-rawhide().
 #
-#   lima.sh fedora-rawhide-setup
-#   lima.sh fedora-rawhide-test
+#   lima.sh fedora-stable-setup
+#   lima.sh fedora-stable-test
+#   lima.sh fedora-next-setup
+#   lima.sh fedora-next-test
 
 
 set -e
@@ -13,18 +15,16 @@ set -x
 
 CRIU_DIR="${CRIU_DIR:-/home/criu}"
 
-fedora-rawhide-setup() {
+_common_setup() {
 	# Disable sssd to avoid zdtm test failures in pty04 due to sssd socket
 	systemctl mask sssd
 
-	# Upgrade the kernel to the latest vanilla one
-	dnf -y copr enable @kernel-vanilla/stable
 	# The shellcheck tool misunderstands the "do" to be from a loop
 	# shellcheck disable=SC1010
 	dnf -y do --action=upgrade \* --action=install make podman
 }
 
-fedora-rawhide-test() {
+_common_test() {
 	# Increase the max thread limit for the thread-bomb test
 	sysctl -w kernel.threads-max=100000
 
@@ -58,6 +58,26 @@ fedora-rawhide-test() {
 		CONTAINER_RUNTIME=podman \
 		BUILD_OPTIONS="--security-opt seccomp=unconfined" \
 		ZDTM_OPTS="-x zdtm/static/socket-tcpbuf-local"
+}
+
+fedora-stable-setup() {
+	# Upgrade the kernel to the latest vanilla stable one
+	dnf -y copr enable @kernel-vanilla/stable
+	_common_setup
+}
+
+fedora-stable-test() {
+	_common_test
+}
+
+fedora-next-setup() {
+	# Upgrade the kernel to the latest vanilla next one
+	dnf -y copr enable @kernel-vanilla/next
+	_common_setup
+}
+
+fedora-next-test() {
+	_common_test
 }
 
 "$@"

--- a/test/zdtm/static/socket_udplite.checkskip
+++ b/test/zdtm/static/socket_udplite.checkskip
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# IPPROTO_UDPLITE was removed in kernel 7.1, skip the test if the
+# protocol is not available.
+import socket
+import errno
+
+try:
+	socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDPLITE).close()
+except OSError as e:
+	if e.errno == errno.EPROTONOSUPPORT:
+		print("UDPLITE is not supported by this kernel.")
+		exit(1)
+	raise
+
+exit(0)


### PR DESCRIPTION
  Kernel 7.1 removed support for IPPROTO_UDPLITE, which causes CRIU to fail during socket collection when the UDPLITE diag module is absent. This PR makes UDPLITE optional in the same way IPPROTO_RAW already is,                                                                                                                                                                      
  and adds a mainline kernel CI variant so we catch these kinds of  pstream kernel changes early.                                                                                                                                                                                                              
                                                                                                                                                                                                                                              
  - Treat UDPLITE as optional in `collect_err()` so that a missing UDPLITE diag module no longer aborts the dump. If a UDPLITE socket is actually encountered it will still fail at dump time, matching the existing RAW socket behavior.                                                                                                                                                                                                         
  - Add a Lima-based CI job that boots the next kernel (`@kernel-vanilla/next` COPR) alongside the existing                                                                                                                                                                             
    vanilla stable variant. This gives us ongoing coverage against the latest upstream kernel where changes like the UDPLITE removal surface first.    

Fixes: #3002 