### PR TITLE
pycriu: Fix FieldDescriptor.label removal in protobuf 7.x

### DIFF
--- a/lib/pycriu/images/pb2dict.py
+++ b/lib/pycriu/images/pb2dict.py
@@ -9,6 +9,13 @@ from google.protobuf.descriptor import FieldDescriptor as FD
 
 import opts_pb2
 
+
+def _is_repeated(field):
+    """Check if a field is repeated, compatible with protobuf 3.x and 7.x."""
+    if hasattr(field, 'label'):
+        return field.label == FD.LABEL_REPEATED
+    return field.is_repeated
+
 if "encodebytes" not in dir(base64):
     base64.encodebytes = base64.encodestring
     base64.decodebytes = base64.decodestring
@@ -342,7 +349,7 @@ def pb2dict(pb, pretty=False, is_hex=False):
     """
     d = collections.OrderedDict() if pretty else {}
     for field, value in pb.ListFields():
-        if field.label == FD.LABEL_REPEATED:
+        if _is_repeated(field):
             d_val = []
             if pretty and _marked_as_ip(field):
                 if len(value) == 1:
@@ -418,7 +425,7 @@ def dict2pb(d, pb):
         if field.name not in d:
             continue
         value = d[field.name]
-        if field.label == FD.LABEL_REPEATED:
+        if _is_repeated(field):
             pb_val = getattr(pb, field.name, None)
             if is_string(value[0]) and _marked_as_ip(field):
                 val = ip_address(value[0])


### PR DESCRIPTION
Protobuf 7.x (shipped in Arch Linux) removed the `label` instance attribute from `FieldDescriptor`.  Accessing `field.label` now raises `AttributeError`, which breaks all CRIU tests at the `check_pages_counts` step when pycriu tries to convert protobuf stats images to dicts:

    File "test/pycriu/images/pb2dict.py", line 345, in pb2dict
        if field.label == FD.LABEL_REPEATED:
    AttributeError: 'FieldDescriptor' object has no attribute 'label'

Protobuf 7.x replaced `field.label` with boolean properties `field.is_repeated` and `field.is_required`.  These properties do not exist in protobuf 3.x/4.x.

Add a `_is_repeated()` compatibility helper that checks for the `label` attribute first (protobuf <= 5.x) and falls back to `is_repeated` (protobuf >= 7.x), keeping pycriu working across both old and new protobuf versions.