### PR TITLE
mem: don't PROT_WRITE on reservation mmaps

### DIFF
--- a/coredump/criu_coredump/coredump.py
+++ b/coredump/criu_coredump/coredump.py
@@ -56,6 +56,7 @@ status = {
     "VMA_AREA_AIORING": 1 << 13,
     "VMA_AREA_MEMFD": 1 << 14,
     "VMA_AREA_UPROBES": 1 << 17,
+    "VMA_AREA_NOT_ACCOUNTABLE": 1 << 18,
     "VMA_AREA_UNSUPP": 1 << 31
 }
 

--- a/criu/include/image.h
+++ b/criu/include/image.h
@@ -101,6 +101,7 @@
 #define VMA_AREA_SHSTK	 (1 << 15)
 #define VMA_AREA_GUARD	 (1 << 16)
 #define VMA_AREA_UPROBES	(1 << 17)
+#define VMA_AREA_NOT_ACCOUNTABLE (1 << 18)
 
 #define VMA_EXT_PLUGIN	  (1 << 27)
 #define VMA_CLOSE	  (1 << 28)

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -951,15 +951,25 @@ static int premap_private_vma(struct pstree_item *t, struct vma_area *vma, void 
 		}
 
 		/*
-		 * All mappings here get PROT_WRITE regardless of whether we
-		 * put any data into it or not, because this area will get
-		 * mremap()-ed (branch below) so we MIGHT need to have WRITE
-		 * bits there. Ideally we'd check for the whole COW-chain
-		 * having any data in.
+		 * For VMAs that have PROT_NONE and are not accountable
+		 * (did not have the "ac" flag in /proc/pid/smaps), we
+		 * can safely mmap them with PROT_NONE because we know
+		 * we will never need to write any bits to them.
 		 */
-		addr = mmap(*tgt_addr, size, vma->e->prot | PROT_WRITE, vma->e->flags | MAP_FIXED | flag, vma->e->fd,
-			    vma->e->pgoff);
-
+		if (vma->e->prot == PROT_NONE && vma_area_is(vma, VMA_AREA_NOT_ACCOUNTABLE)) {
+			addr = mmap(*tgt_addr, size, PROT_NONE, vma->e->flags | MAP_FIXED | flag, vma->e->fd,
+				    vma->e->pgoff);
+		} else {
+			/*
+			 * All mappings here get PROT_WRITE regardless of whether we
+			 * put any data into it or not, because this area will get
+			 * mremap()-ed (branch below) so we MIGHT need to have WRITE
+			 * bits there. Ideally we'd check for the whole COW-chain
+			 * having any data in.
+			 */
+			addr = mmap(*tgt_addr, size, vma->e->prot | PROT_WRITE, vma->e->flags | MAP_FIXED | flag, vma->e->fd,
+				    vma->e->pgoff);
+		}
 		if (addr == MAP_FAILED) {
 			pr_perror("Unable to map ANON_VMA");
 			return -1;

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -123,10 +123,11 @@ bool handle_vma_plugin(int *fd, struct stat *stat)
 }
 
 static void __parse_vmflags(char *buf, u32 *flags, u64 *madv, int *io_pf,
-			    int *shstk)
+			    int *shstk, bool *no_ac)
 {
 	char *tok;
 
+	*no_ac = true;
 	if (!buf[0])
 		return;
 
@@ -174,6 +175,9 @@ static void __parse_vmflags(char *buf, u32 *flags, u64 *madv, int *io_pf,
 		if (_vmflag_match(tok, "ss"))
 			*shstk = 1;
 
+		if (_vmflag_match(tok, "ac"))
+			*no_ac = false;
+
 		/*
 		 * Anything else is just ignored.
 		 */
@@ -185,20 +189,25 @@ static void __parse_vmflags(char *buf, u32 *flags, u64 *madv, int *io_pf,
 void parse_vmflags(char *buf, u32 *flags, u64 *madv, int *io_pf)
 {
 	int shstk = 0;
+	bool no_ac = false;
 
-	__parse_vmflags(buf, flags, madv, io_pf, &shstk);
+	__parse_vmflags(buf, flags, madv, io_pf, &shstk, &no_ac);
 }
 
 static void parse_vma_vmflags(char *buf, struct vma_area *vma_area)
 {
 	int io_pf = 0;
 	int shstk = 0;
+	bool no_ac = false;
 
 	__parse_vmflags(buf, &vma_area->e->flags, &vma_area->e->madv, &io_pf,
-			&shstk);
+			&shstk, &no_ac);
 
 	if (shstk)
 		vma_area->e->status |= VMA_AREA_SHSTK;
+
+	if (no_ac)
+		vma_area->e->status |= VMA_AREA_NOT_ACCOUNTABLE;
 
 	/*
 	 * vmsplice doesn't work for VM_IO and VM_PFNMAP mappings, the

--- a/lib/pycriu/images/pb2dict.py
+++ b/lib/pycriu/images/pb2dict.py
@@ -113,6 +113,7 @@ mmap_status_map = [
     ('VMA_AREA_MEMFD', 1 << 14),
     ('VMA_AREA_SHSTK', 1 << 15),
     ('VMA_AREA_UPROBES', 1 << 17),
+    ('VMA_AREA_NOT_ACCOUNTABLE', 1 << 18),
     ('VMA_UNSUPP', 1 << 31),
 ]
 

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -215,6 +215,7 @@ TST_NOFILE	:=				\
 		dumpable02			\
 		remap_dead_pid			\
 		remap_dead_pid_root			\
+		reservation_mmaps		\
 		scm00				\
 		scm01				\
 		scm02				\
@@ -663,6 +664,7 @@ mntns_root_bind02:	CFLAGS += -DROOT_BIND02
 maps02: get_smaps_bits.o
 mlock_setuid: get_smaps_bits.o
 thp_disable: get_smaps_bits.o
+reservation_mmaps: get_smaps_bits.o
 inotify01:		CFLAGS += -DINOTIFY01
 unlink_fstat01+:	CFLAGS += -DUNLINK_OVER
 unlink_fstat04:		CFLAGS += -DUNLINK_FSTAT04

--- a/test/zdtm/static/get_smaps_bits.c
+++ b/test/zdtm/static/get_smaps_bits.c
@@ -80,7 +80,7 @@ static void parse_vmflags(char *buf, unsigned long *flags, unsigned long *madv)
 
 #define is_hex_digit(c) (((c) >= '0' && (c) <= '9') || ((c) >= 'a' && (c) <= 'f') || ((c) >= 'A' && (c) <= 'F'))
 
-static int is_vma_range_fmt(char *line, unsigned long *start, unsigned long *end)
+int is_vma_range_fmt(char *line, unsigned long *start, unsigned long *end)
 {
 	char *p = line;
 	while (*line && is_hex_digit(*line))

--- a/test/zdtm/static/get_smaps_bits.h
+++ b/test/zdtm/static/get_smaps_bits.h
@@ -2,5 +2,6 @@
 #define ZDTM_GET_SMAPS_BITS_H_
 
 extern int get_smaps_bits(unsigned long where, unsigned long *flags, unsigned long *madv);
+extern int is_vma_range_fmt(char *line, unsigned long *start, unsigned long *end);
 
 #endif /* ZDTM_GET_SMAPS_BITS_H_ */

--- a/test/zdtm/static/reservation_mmaps.c
+++ b/test/zdtm/static/reservation_mmaps.c
@@ -1,0 +1,132 @@
+#include <sys/mman.h>
+
+#include "zdtmtst.h"
+#include "get_smaps_bits.h"
+
+#define SIZE (4UL * (1UL << 20)) /* 4MB */
+
+const char *test_doc = "Check mmaps done for reserving virtual address space, do not have ac flag set in /proc/pid/smaps\n";
+const char *test_author = "Bhavik Sachdev <b.sachdev1904@gmail.com>";
+
+static void check_ac_flag(char *buf, bool *no_ac)
+{
+	char *tok;
+
+	if (!buf[0])
+		return;
+
+	*no_ac = true;
+	tok = strtok(buf, " \n");
+	if (!tok)
+		return;
+
+#define _vmflag_match(_t, _s) (_t[0] == _s[0] && _t[1] == _s[1])
+
+	do {
+		if (_vmflag_match(tok, "ac")) {
+			*no_ac = false;
+			return;
+		}
+		/*
+		 * Anything else is just ignored.
+		 */
+	} while ((tok = strtok(NULL, " \n")));
+
+#undef _vmflag_match
+	return;
+}
+
+static int is_accountable(unsigned long where, bool *no_ac)
+{
+	unsigned long start = 0, end = 0;
+	FILE *smaps = NULL;
+	char buf[1024];
+	int found = 0;
+
+	if (!where)
+		return 0;
+
+	smaps = fopen("/proc/self/smaps", "r");
+	if (!smaps) {
+		pr_perror("Can't open smaps");
+		return -1;
+	}
+
+	while (fgets(buf, sizeof(buf), smaps)) {
+		is_vma_range_fmt(buf, &start, &end);
+
+		if (!strncmp(buf, "VmFlags: ", 9) && start <= where && where < end) {
+			found = 1;
+			check_ac_flag(buf, no_ac);
+			break;
+		}
+	}
+
+	fclose(smaps);
+
+	if (!found) {
+		pr_perror("VmFlags not found for %lx", where);
+		return -1;
+	}
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	uint32_t crc = ~0;
+	uint8_t *data_mmap, *reservation_mmap;
+	bool no_ac;
+
+	test_init(argc, argv);
+	data_mmap = mmap(NULL, SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+	if (data_mmap == MAP_FAILED) {
+		pr_perror("Failed to mmap %lu Mb memory", SIZE >> 20);
+		return 1;
+	}
+
+	reservation_mmap = mmap(NULL, SIZE, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+	if (reservation_mmap == MAP_FAILED) {
+		pr_perror("Failed to mmap %lu Mb memory", SIZE >> 20);
+		return 1;
+	}
+
+	datagen(data_mmap, SIZE, &crc);
+
+	if (mprotect(data_mmap, SIZE, PROT_NONE)) {
+		pr_perror("Failed to set protections on %p", data_mmap);
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	/*
+	 * check that a mmap whose memory protection got changed
+	 * to PROT_NONE still has the data stored in it.
+	 */
+	if (mprotect(data_mmap, SIZE, PROT_READ)) {
+		pr_perror("Failed to set protections on %p", data_mmap);
+		return 1;
+	}
+
+	crc = ~0;
+	if (datachk(data_mmap, SIZE, &crc)) {
+		fail("Data mismatch");
+		return 1;
+	}
+
+	/* reservation_mmap should not have ac flag set in /proc/pid/smaps */
+	if (is_accountable((unsigned long)reservation_mmap, &no_ac)) {
+		fail("could not check for no ac flag on reservation mmap");
+		return 1;
+	}
+
+	if (!no_ac) {
+		fail("reservation mmap has ac flag set");
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
Consider the following program:

```
#include <stdio.h>
#include <stdlib.h>
#include <sys/mman.h>
#include <unistd.h>

#define SIZE (64ULL * 1024 * 1024 * 1024)

int main(void)
{
    void *addr = mmap(NULL, SIZE, PROT_NONE,
                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);

    if (addr == MAP_FAILED) {
        perror("mmap");
        return EXIT_FAILURE;
    }

    printf("Mapped 64 GB at %p\n", addr);

    while (1) {
        sleep(1);
    }

    return 0;
}
```

while doing a restore using criu-image-streamer we get the following error:
```
64334: Error (criu/mem.c:964): Unable to map ANON_VMA: Cannot allocate memory
Error (criu/cr-restore.c:2369): Restoring FAILED.
Error (criu/cr-restore.c:1268): 64334 killed by signal 9: Killed
Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory
```

full restore log here: https://gist.github.com/bsach64/d0eac6c4db420ddb574c5ad8b98d447c

This PR is a potential fix for the problem, although i am not sure if it is the right approach.

This issue does not occur normal checkpoint restore because we can read the pages multiple times and
verify if there are any pages for a vma and remove `PROT_WRITE` which this commit implements:
https://github.com/checkpoint-restore/criu/commit/c9194500b
