### PR TITLE
restorer: unmap vDSO target before ARCH_MAP_VDSO

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1856,8 +1856,30 @@ __visible long __export_restore_task(struct task_restore_args *args)
 		goto core_restore_end;
 
 	/* Map vdso that wasn't parked */
-	if (args->can_map_vdso && (map_vdso(args, args->compatible_mode) < 0))
-		goto core_restore_end;
+	if (args->can_map_vdso) {
+		/*
+		 * The runtime vDSO area is appended to the bootstrap mapping
+		 * so the restorer can either park CRIU's own vDSO there or ask
+		 * the kernel to map a fresh one there. When ARCH_MAP_VDSO is
+		 * available, unmap that tail first. Otherwise the address is
+		 * still occupied and the kernel may place the vDSO elsewhere,
+		 * while map_vdso() still records vdso_rt_parked_at as the
+		 * runtime vDSO location.
+		 */
+		if (args->vdso_rt_size) {
+			ret = sys_munmap((void *)args->vdso_rt_parked_at,
+					 args->vdso_rt_size);
+			if (ret) {
+				pr_err("Failed to unmap vDSO parking area %lx-%lx: %ld\n",
+				       args->vdso_rt_parked_at,
+				       args->vdso_rt_parked_at + args->vdso_rt_size,
+				       ret);
+				goto core_restore_end;
+			}
+		}
+		if (map_vdso(args, args->compatible_mode) < 0)
+			goto core_restore_end;
+	}
 
 	vdso_update_gtod_addr(&args->vdso_maps_rt);
 


### PR DESCRIPTION
## Summary

When the restorer uses `ARCH_MAP_VDSO_*` instead of parking CRIU's own runtime vDSO, unmap the reserved runtime vDSO tail before asking the kernel to map a fresh vDSO there.

CRIU already reserves `vdso_rt_size` bytes at the end of the bootstrap mapping and records that address in `vdso_rt_parked_at`. The non-`ARCH_MAP_VDSO` path moves CRIU's current vDSO/VVAR pair into that reserved range with `vdso_do_park()`. The `ARCH_MAP_VDSO` path skips parking and asks the kernel to create a new vDSO/VVAR pair at `vdso_rt_parked_at` instead.

The problem is that the bootstrap tail is still mapped at that point. If the requested address is occupied, the kernel does not necessarily install the vDSO/VVAR pair at the requested address. On current x86 kernels the syscall can still succeed, but the mapping is placed elsewhere. CRIU then continues with `map_vdso()` recording `vdso_rt_parked_at` as the runtime vDSO location, even though the actual vDSO/VVAR pair is somewhere else.

That leaves `vdso_maps_rt` inconsistent with the restored address space and can break later vDSO handling, including gettimeofday setup and vDSO proxification decisions.

## Root cause

`unmap_old_vmas()` keeps the bootstrap mapping intact and excludes the runtime vDSO tail from the range it unmaps. That is correct for the parking path, because `vdso_do_park()` needs a reserved destination range.

For the `ARCH_MAP_VDSO` path, however, the same reserved range has to be free before calling `arch_map_vdso()`. The kernel treats the supplied address as a requested mapping location; if it is already occupied, the call can succeed while choosing a different address. CRIU does not observe that actual address and instead assumes the requested address was used.

This patch frees the reserved tail immediately before `map_vdso()` when `args->can_map_vdso` is true.

## Reproducer

This reproducer models the CRIU state at the failing point:

1. reserve a mapping to stand in for the bootstrap tail at `vdso_rt_parked_at`
2. remove the process's existing VDSO/VVAR mappings, matching the restorer after old VMAs are unmapped
3. call `arch_prctl(ARCH_MAP_VDSO_64, vdso_rt_parked_at)` while that address is still occupied
4. repeat with the address unmapped first

On an Ubuntu 22.04 x86_64 kernel (`5.19.0-45-generic`) the occupied case succeeds but maps VVAR/VDSO elsewhere:

```text
case: requested address is still mapped before ARCH_MAP_VDSO_64
requested address: 0x7ffff7f99000
arch_prctl(ARCH_MAP_VDSO_64, 0x7ffff7f99000) returned 8192 errno 0
  7ffff7f99000-7ffff7fa9000 rw-p 00000000 00:00 0
  7ffff7fbd000-7ffff7fc1000 r--p 00000000 00:00 0                          [vvar]
  7ffff7fc1000-7ffff7fc3000 r-xp 00000000 00:00 0                          [vdso]
requested address used for vvar/vdso start: no
reproduced: syscall succeeded, but vvar/vdso was mapped elsewhere

case: requested address was unmapped before ARCH_MAP_VDSO_64
requested address: 0x7ffff7f99000
arch_prctl(ARCH_MAP_VDSO_64, 0x7ffff7f99000) returned 8192 errno 0
  7ffff7f99000-7ffff7f9d000 r--p 00000000 00:00 0                          [vvar]
  7ffff7f9d000-7ffff7f9f000 r-xp 00000000 00:00 0                          [vdso]
requested address used for vvar/vdso start: yes
control: unmapping the target first lets ARCH_MAP_VDSO_64 use it

Both cases behaved as expected.
```

A minimal standalone reproducer is:

```c
#define _GNU_SOURCE
#include <errno.h>
#include <stdbool.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/mman.h>
#include <sys/syscall.h>
#include <sys/wait.h>
#include <unistd.h>

#ifndef ARCH_MAP_VDSO_64
#define ARCH_MAP_VDSO_64 0x2003
#endif

static bool is_vdso_line(const char *line)
{
	return strstr(line, "[vdso]") || strstr(line, "[vvar]") || strstr(line, "[vvar_vclock]");
}

static void unmap_current_vdso(void)
{
	FILE *fp = fopen("/proc/self/maps", "r");
	unsigned long start[8], end[8];
	char line[512];
	int nr = 0;

	while (fgets(line, sizeof(line), fp)) {
		if (is_vdso_line(line) && sscanf(line, "%lx-%lx", &start[nr], &end[nr]) == 2)
			nr++;
	}
	fclose(fp);

	while (nr--)
		munmap((void *)start[nr], end[nr] - start[nr]);
}

static void dump_vdso_lines(unsigned long target)
{
	FILE *fp = fopen("/proc/self/maps", "r");
	char line[512];

	while (fgets(line, sizeof(line), fp)) {
		unsigned long start, end;

		if (sscanf(line, "%lx-%lx", &start, &end) != 2)
			continue;
		if (is_vdso_line(line) || (start <= target && target < end))
			printf("  %s", line);
	}
	fclose(fp);
}

static void run_case(bool leave_occupied)
{
	void *tail = mmap(NULL, 64 * 1024, PROT_READ | PROT_WRITE,
			  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
	unsigned long target = (unsigned long)tail;
	long ret;

	printf("\ncase: target %s before ARCH_MAP_VDSO_64\n",
	       leave_occupied ? "occupied" : "unmapped");
	printf("target: %#lx\n", target);

	if (!leave_occupied)
		munmap(tail, 64 * 1024);

	unmap_current_vdso();
	errno = 0;
	ret = syscall(SYS_arch_prctl, ARCH_MAP_VDSO_64, target);
	printf("arch_prctl returned %ld errno %d\n", ret, errno);
	dump_vdso_lines(target);
}

int main(void)
{
	if (!fork()) {
		run_case(true);
		exit(0);
	}
	wait(NULL);

	if (!fork()) {
		run_case(false);
		exit(0);
	}
	wait(NULL);

	return 0;
}
```

## User-visible impact

The bug is only on the restore path where CRIU uses `ARCH_MAP_VDSO_*` instead of parking the runtime vDSO/VVAR mapping. It is architecture and kernel behavior dependent, but when it triggers CRIU's runtime vDSO bookkeeping no longer describes the actual mappings in the restored process.

The fix keeps the existing allocation model and only frees the already-reserved runtime VDSO tail at the point where it must become the destination for `ARCH_MAP_VDSO_*`.

## Validation

- `git diff --check`
- compiled and ran the standalone reproducer above
