### PR TITLE
plugins/amdgpu: Cleanup env variable handling

### DIFF
--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -308,33 +308,36 @@ int devinfo_to_topology(KfdDeviceEntry *devinfos[], uint32_t num_devices, struct
 	return 0;
 }
 
-void getenv_bool(const char *var, bool *value)
+static bool getenv_bool(const char *var, bool defvalue)
 {
 	char *value_str = getenv(var);
+	bool val = defvalue;
 
 	if (value_str) {
 		if (!strcmp(value_str, "0") || !strcasecmp(value_str, "NO"))
-			*value = false;
+			val = false;
 		else if (!strcmp(value_str, "1") || !strcasecmp(value_str, "YES"))
-			*value = true;
+			val = true;
 		else
-			pr_err("Ignoring invalid value for %s=%s, expecting (YES/NO)\n", var, value_str);
+			pr_warn("Ignoring invalid value for %s=%s, expecting (0/1 or YES/NO)\n", var, value_str);
 	}
-	pr_info("param: %s:%s\n", var, *value ? "Y" : "N");
+
+	pr_info("param: %s:%u\n", var, val);
+	return val;
 }
 
-void getenv_size_t(const char *var, size_t *value)
+static size_t getenv_size_t(const char *var, size_t defvalue)
 {
 	char *value_str = getenv(var);
 	char *endp = value_str;
+	size_t val = defvalue;
 	int sh = 0;
-	size_t size;
 
 	if (value_str) {
-		size = (size_t)strtoul(value_str, &endp, 0);
+		val = (size_t)strtoul(value_str, &endp, 0);
 		if (errno || value_str == endp) {
 			pr_err("Ignoring invalid value for %s=%s, expecting a positive integer\n", var, value_str);
-			return;
+			goto out;
 		}
 		switch (*endp) {
 		case 'k':
@@ -351,16 +354,19 @@ void getenv_size_t(const char *var, size_t *value)
 			sh = 0;
 			break;
 		default:
-			pr_err("Ignoring invalid size suffix for %s=%s, expecting 'K'/k', 'M', or 'G'\n", var, value_str);
-			return;
+			pr_warn("Ignoring invalid size suffix for %s=%s, expecting 'K'/k', 'M', or 'G'\n", var, value_str);
+			goto out;
 		}
-		if (SIZE_MAX >> sh < size) {
-			pr_err("Ignoring invalid value for %s=%s, exceeds SIZE_MAX\n", var, value_str);
-			return;
+		if (SIZE_MAX >> sh < val) {
+			pr_warn("Ignoring invalid value for %s=%s, exceeds SIZE_MAX\n", var, value_str);
+			goto out;
 		}
-		*value = size << sh;
+		val <<= sh;
 	}
-	pr_info("param: %s:0x%lx\n", var, *value);
+
+out:
+	pr_info("param: %s:0x%lx\n", var, val);
+	return val;
 }
 
 int amdgpu_plugin_init(int stage)
@@ -389,25 +395,17 @@ int amdgpu_plugin_init(int stage)
 				return -1;
 			}
 		}
-		/* Default Values */
-		kfd_fw_version_check = true;
-		kfd_sdma_fw_version_check = true;
-		kfd_caches_count_check = true;
-		kfd_num_gws_check = true;
-		kfd_vram_size_check = true;
-		kfd_numa_check = true;
-		kfd_capability_check = true;
 
-		getenv_bool("KFD_FW_VER_CHECK", &kfd_fw_version_check);
-		getenv_bool("KFD_SDMA_FW_VER_CHECK", &kfd_sdma_fw_version_check);
-		getenv_bool("KFD_CACHES_COUNT_CHECK", &kfd_caches_count_check);
-		getenv_bool("KFD_NUM_GWS_CHECK", &kfd_num_gws_check);
-		getenv_bool("KFD_VRAM_SIZE_CHECK", &kfd_vram_size_check);
-		getenv_bool("KFD_NUMA_CHECK", &kfd_numa_check);
-		getenv_bool("KFD_CAPABILITY_CHECK", &kfd_capability_check);
+		kfd_fw_version_check = getenv_bool("KFD_FW_VER_CHECK", true);
+		kfd_sdma_fw_version_check = getenv_bool("KFD_SDMA_FW_VER_CHECK", true);
+		kfd_caches_count_check = getenv_bool("KFD_CACHES_COUNT_CHECK", true);
+		kfd_num_gws_check = getenv_bool("KFD_NUM_GWS_CHECK", true);
+		kfd_vram_size_check = getenv_bool("KFD_VRAM_SIZE_CHECK", true);
+		kfd_numa_check = getenv_bool("KFD_NUMA_CHECK", true);
+		kfd_capability_check = getenv_bool("KFD_CAPABILITY_CHECK", true);
 	}
-	kfd_max_buffer_size = 0;
-	getenv_size_t("KFD_MAX_BUFFER_SIZE", &kfd_max_buffer_size);
+
+	kfd_max_buffer_size = getenv_size_t("KFD_MAX_BUFFER_SIZE", 0);
 
 	return 0;
 }


### PR DESCRIPTION
This is not saving a lot of lines, just two, but perhaps the pattern of:

```
  kfd_fw_version_check = getenv_bool("KFD_FW_VER_CHECK", true);
```

Is somewhat cleaner than:

```
  /* Default Values */
  kfd_fw_version_check = true;
...
  getenv_bool("KFD_FW_VER_CHECK", &kfd_fw_version_check); 
```

I also make the helpers static and demote parsing errors to warnings since the execution does continue.

I am locally toying with the idea of adding a new env variable to ignore gpu id hence I spotted this cleanup opportunity.

cc @fdavid-amd 