### PR TITLE
amdgpu rendernode somewhat working but no fork support yet

### DIFF
--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -2210,25 +2210,28 @@ int amdgpu_plugin_update_vmamap(const char *in_path, const uint64_t addr, const 
 	}
 
 	list_for_each_entry(vma_md, &update_vma_info_list, list) {
-		if (addr == vma_md->vma_entry && old_offset == vma_md->old_pgoff) {
-			*new_offset = vma_md->new_pgoff;
+		if (old_offset != vma_md->old_pgoff)
+			continue;
+		if (is_kfd && addr != vma_md->vma_entry)
+			continue;
 
-			*updated_fd = -1;
-			if (is_renderD) {
-				int fd = dup(vma_md->fd);
-				if (fd == -1) {
-					pr_perror("unable to duplicate the render fd");
-					return -1;
-				}
-				*updated_fd = fd;
+		*new_offset = vma_md->new_pgoff;
+		if (is_renderD) {
+			int fd = dup(vma_md->fd);
+
+			if (fd == -1) {
+				pr_perror("unable to duplicate the render fd");
+				return -1;
 			}
-
-			pr_debug("old_pgoff=0x%lx new_pgoff=0x%lx fd=%d\n",
-				 vma_md->old_pgoff, vma_md->new_pgoff,
-				 *updated_fd);
-
-			return 1;
+			*updated_fd = fd;
+		} else {
+			*updated_fd = -1;
 		}
+
+		pr_debug("old_pgoff=0x%lx new_pgoff=0x%lx fd=%d\n",
+			 vma_md->old_pgoff, vma_md->new_pgoff, *updated_fd);
+
+		return 1;
 	}
 	pr_info("No match for addr:0x%lx offset:%lx\n", addr, old_offset);
 	return 0;

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -1872,11 +1872,11 @@ static int amdgpu_plugin_restore_drm_file(int id, bool *retry_needed)
 	size_t img_size;
 	int fd, ret;
 
-	/* This is restorer plugin for renderD nodes. Criu doesn't guarantee that they will
-	 * be called before the plugin is called for kfd file descriptor.
-	 * TODO: Currently, this code will only work if this function is called for /dev/kfd
-	 * first as we assume restore_maps is already filled. Need to fix this later.
+	/* This is restorer plugin for renderD nodes. Criu doesn't guarantee
+	 * that they will be called before the plugin is called for kfd file
+	 * descriptor.
 	 */
+
 	snprintf(img_path, sizeof(img_path), IMG_DRM_FILE, id);
 	ret = load_img(img_path, &buf, &img_size);
 	if (ret < 0) {
@@ -1905,14 +1905,61 @@ static int amdgpu_plugin_restore_drm_file(int id, bool *retry_needed)
 
 	pr_info("render node gpu_id = 0x%04x\n", rd->gpu_id);
 
-	target_gpu_id = maps_get_dest_gpu(&restore_maps, rd->gpu_id);
-	if (!target_gpu_id) {
-		fd = -ENODEV;
-		goto fail;
+	if (fd_next == -1) {
+		ret = find_unused_fd_pid(getpid());
+		if (ret < 0) {
+			pr_err("Failed to find unused fd (fd:%d)\n", ret);
+			fd = ret;
+			goto fail;
+		}
+		fd_next = ret;
+	}
+
+	if (!dest_topology.parsed) {
+		pr_info("Parsing local topology for render node restore\n");
+		ret = topology_parse(&dest_topology, "Local");
+		if (ret) {
+			pr_err("Failed to parse local system topology %d\n",
+			       ret);
+			fd = ret;
+			goto fail;
+		}
+	}
+
+	if (restore_maps.mapped_cnt) {
+		target_gpu_id = maps_get_dest_gpu(&restore_maps, rd->gpu_id);
+		if (!target_gpu_id) {
+			pr_err("Unable to map gpu_id 0x%04x!\n", rd->gpu_id);
+			fd = -ENODEV;
+			goto fail;
+		}
+	} else {
+		unsigned int num_gpus = 0;
+
+		pr_info("Assuming same system with a single gpu_id 0x%04x\n",
+			rd->gpu_id);
+		list_for_each_entry(tp_node, &dest_topology.nodes,
+				    listm_system) {
+			if (NODE_IS_GPU(tp_node)) {
+				num_gpus++;
+				target_gpu_id = tp_node->gpu_id;
+			}
+		}
+		if (num_gpus != 1) {
+			pr_err("Unexpectedly found %u GPUs!\n", num_gpus);
+			fd = -EINVAL;
+			goto fail;
+		} else if (target_gpu_id != rd->gpu_id) {
+			pr_err("Unexpectedly found gpu_id 0x%04x (expected 0x%04x)!\n",
+			       target_gpu_id, rd->gpu_id);
+			fd = -EINVAL;
+			goto fail;
+		}
 	}
 
 	tp_node = sys_get_node_by_gpu_id(&dest_topology, target_gpu_id);
 	if (!tp_node) {
+		pr_err("Unable to find target gpu_id=0x%04x!\n", target_gpu_id);
 		fd = -ENODEV;
 		goto fail;
 	}

--- a/plugins/amdgpu/amdgpu_plugin.c
+++ b/plugins/amdgpu/amdgpu_plugin.c
@@ -62,6 +62,7 @@ struct vma_metadata {
 static LIST_HEAD(update_vma_info_list);
 
 static size_t kfd_max_buffer_size;
+static bool amdgpu_ignore_single_gpuid;
 
 static bool plugin_added_to_inventory = false;
 
@@ -403,6 +404,8 @@ int amdgpu_plugin_init(int stage)
 		kfd_vram_size_check = getenv_bool("KFD_VRAM_SIZE_CHECK", true);
 		kfd_numa_check = getenv_bool("KFD_NUMA_CHECK", true);
 		kfd_capability_check = getenv_bool("KFD_CAPABILITY_CHECK", true);
+
+		amdgpu_ignore_single_gpuid = getenv_bool("AMDGPU_IGNORE_SINGLE_GPUID", false);
 	}
 
 	kfd_max_buffer_size = getenv_size_t("KFD_MAX_BUFFER_SIZE", 0);
@@ -1949,7 +1952,8 @@ static int amdgpu_plugin_restore_drm_file(int id, bool *retry_needed)
 			pr_err("Unexpectedly found %u GPUs!\n", num_gpus);
 			fd = -EINVAL;
 			goto fail;
-		} else if (target_gpu_id != rd->gpu_id) {
+		} else if (target_gpu_id != rd->gpu_id &&
+			   !amdgpu_ignore_single_gpuid) {
 			pr_err("Unexpectedly found gpu_id 0x%04x (expected 0x%04x)!\n",
 			       target_gpu_id, rd->gpu_id);
 			fd = -EINVAL;
@@ -1958,7 +1962,16 @@ static int amdgpu_plugin_restore_drm_file(int id, bool *retry_needed)
 	}
 
 	tp_node = sys_get_node_by_gpu_id(&dest_topology, target_gpu_id);
-	if (!tp_node) {
+	if (!tp_node && amdgpu_ignore_single_gpuid) {
+		tp_node = sys_get_node_by_index(&dest_topology, 0);
+		if (!NODE_IS_GPU(tp_node)) {
+			pr_err("Cannot find the GPU node!\n");
+			fd = -ENODEV;
+			goto fail;
+		}
+		target_gpu_id = tp_node->gpu_id;
+		pr_warn("Forcing restore on gpu_id=0x%04x\n", target_gpu_id);
+	} else if (!tp_node) {
 		pr_err("Unable to find target gpu_id=0x%04x!\n", target_gpu_id);
 		fd = -ENODEV;
 		goto fail;

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -240,15 +240,16 @@ exit:
 
 int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 {
+	struct drm_amdgpu_gem_list_handles_entry *entries = NULL;
+	struct drm_amdgpu_gem_list_handles handles = {
+		.num_entries = 8,
+	};
 	char path[PATH_MAX];
 	CriuRenderNode *rd;
 	unsigned char *buf;
 	int len, ret;
 	size_t image_size;
 	struct tp_node *tp_node;
-	struct drm_amdgpu_gem_list_handles list_handles_args = { 0 };
-	struct drm_amdgpu_gem_list_handles_entry *list_handles_entries = NULL;
-	int num_bos;
 
 	rd = xmalloc(sizeof(*rd));
 	if (!rd)
@@ -260,53 +261,45 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 	rd->drm_render_minor = minor(drm->st_rdev);
 	rd->id = id;
 
-	num_bos = 8;
-	list_handles_entries = xzalloc(sizeof(struct drm_amdgpu_gem_list_handles_entry) * num_bos);
-	if (!list_handles_entries) {
-		ret = -ENOMEM;
-		goto exit;
-	}
-	list_handles_args.num_entries = num_bos;
-	list_handles_args.entries = (uintptr_t)list_handles_entries;
+	do {
+		unsigned int num_entries = handles.num_entries;
 
-	ret = drmIoctl(fd, DRM_IOCTL_AMDGPU_GEM_LIST_HANDLES, &list_handles_args);
-	if (ret && errno == EINVAL) {
-		pr_info("This kernel appears not to have AMDGPU_GEM_LIST_HANDLES ioctl. Consider disabling Dmabuf IPC or updating your kernel.\n");
-		list_handles_args.num_entries = 0;
-	} else if (ret) {
-		pr_perror("Failed to call bo info ioctl");
-		goto exit;
-	}
+		if (entries) {
+			xfree(entries);
+			entries = NULL;
+		}
 
-	if (list_handles_args.num_entries > num_bos) {
-		num_bos = list_handles_args.num_entries;
-		xfree(list_handles_entries);
-		list_handles_entries = xzalloc(sizeof(struct drm_amdgpu_gem_list_handles_entry) * num_bos);
-		if (!list_handles_entries) {
+		entries = xzalloc(sizeof(*entries) * handles.num_entries);
+		if (!entries) {
 			ret = -ENOMEM;
 			goto exit;
 		}
-		list_handles_args.num_entries = num_bos;
-		list_handles_args.entries = (uintptr_t)list_handles_entries;
-		ret = drmIoctl(fd, DRM_IOCTL_AMDGPU_GEM_LIST_HANDLES, &list_handles_args);
+
+		handles.entries = (uintptr_t)entries;
+		ret = drmIoctl(fd, DRM_IOCTL_AMDGPU_GEM_LIST_HANDLES, &handles);
 		if (ret) {
-			pr_perror("Failed to call bo info ioctl");
+			ret = -errno;
+			if (errno == EINVAL)
+				pr_err("This kernel appears not to have AMDGPU_GEM_LIST_HANDLES ioctl. Consider disabling Dmabuf IPC or updating your kernel.\n");
+			else
+				pr_perror("Failed to call bo info ioctl");
 			goto exit;
 		}
-	} else {
-		num_bos = list_handles_args.num_entries;
-	}
 
-	rd->num_of_bos = num_bos;
-	ret = allocate_bo_entries(rd, num_bos);
+		if (handles.num_entries <= num_entries)
+			break;
+	} while (true);
+
+	rd->num_of_bos = handles.num_entries;
+	ret = allocate_bo_entries(rd, handles.num_entries);
 	if (ret)
 		goto exit;
 
-	for (int i = 0; i < num_bos; i++) {
+	for (int i = 0; i < handles.num_entries; i++) {
 		int num_vm_entries = 8;
 		struct drm_amdgpu_gem_vm_entry *vm_info_entries = NULL;
 		DrmBoEntry *boinfo = rd->bo_entries[i];
-		struct drm_amdgpu_gem_list_handles_entry handle_entry = list_handles_entries[i];
+		struct drm_amdgpu_gem_list_handles_entry *entry = &entries[i];
 		union drm_amdgpu_gem_mmap mmap_args = { 0 };
 		int bo_contents_fd;
 		int dmabuf_fd;
@@ -316,13 +309,12 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		char img_path[40];
 		int device_fd;
 
-		boinfo->size = handle_entry.size;
-
-		boinfo->alloc_flags = handle_entry.alloc_flags;
-		boinfo->preferred_domains = handle_entry.preferred_domains;
-		boinfo->alignment = handle_entry.alignment;
-		boinfo->handle = handle_entry.gem_handle;
-		boinfo->is_import = (handle_entry.flags & AMDGPU_GEM_LIST_HANDLES_FLAG_IS_IMPORT) || shared_bo_has_exporter(boinfo->handle);
+		boinfo->size = entry->size;
+		boinfo->alloc_flags = entry->alloc_flags;
+		boinfo->preferred_domains = entry->preferred_domains;
+		boinfo->alignment = entry->alignment;
+		boinfo->handle = entry->gem_handle;
+		boinfo->is_import = (entry->flags & AMDGPU_GEM_LIST_HANDLES_FLAG_IS_IMPORT) || shared_bo_has_exporter(boinfo->handle);
 
 		mmap_args.in.handle = boinfo->handle;
 
@@ -336,7 +328,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 		while (1) {
 			struct drm_amdgpu_gem_op vm_info_args = {
-				.handle = handle_entry.gem_handle,
+				.handle = entry->gem_handle,
 				.num_entries = num_vm_entries,
 				.op = AMDGPU_GEM_OP_GET_MAPPING_INFO,
 			};
@@ -402,7 +394,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		}
 
 		snprintf(img_path, sizeof(img_path), IMG_DRM_PAGES_FILE, rd->id, rd->drm_render_minor, i);
-		image_size = handle_entry.size;
+		image_size = entry->size;
 		bo_contents_fd = open_img_file(img_path, true, &image_size, true);
 		if (bo_contents_fd < 0) {
 			ret = bo_contents_fd;
@@ -412,7 +404,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			goto exit;
 		}
 
-		ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), handle_entry.size);
+		ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), entry->size);
 		if (ret) {
 			errno = ret;
 			pr_perror("Failed to allocate buffer");
@@ -424,8 +416,8 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			goto exit;
 		}
 
-		ret = sdma_copy_bo(dmabuf_fd, handle_entry.size, bo_contents_fd,
-				   buffer, handle_entry.size, h_dev, 0x1000,
+		ret = sdma_copy_bo(dmabuf_fd, entry->size, bo_contents_fd,
+				   buffer, entry->size, h_dev, 0x1000,
 				   SDMA_OP_VRAM_READ, false);
 		close(bo_contents_fd);
 		if (ret)
@@ -443,7 +435,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		xfree(vm_info_entries);
 	}
 
-	for (int i = 0; i < num_bos; i++) {
+	for (int i = 0; i < handles.num_entries; i++) {
 		DrmBoEntry *boinfo = rd->bo_entries[i];
 
 		ret = record_shared_bo(boinfo->handle, boinfo->is_import);
@@ -477,7 +469,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 	xfree(buf);
 exit:
-	xfree(list_handles_entries);
+	xfree(entries);
 	free_e(rd);
 	return ret;
 }

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -244,9 +244,11 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 	struct drm_amdgpu_gem_list_handles handles = {
 		.num_entries = 8,
 	};
+	unsigned long buffer_size = 0;
 	char path[PATH_MAX];
 	CriuRenderNode *rd;
 	unsigned char *buf;
+	void *buffer = NULL;
 	int len, ret;
 	size_t image_size;
 	struct tp_node *tp_node;
@@ -305,7 +307,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		int dmabuf_fd;
 		uint32_t major, minor;
 		amdgpu_device_handle h_dev;
-		void *buffer = NULL;
 		int device_fd;
 
 		boinfo->size = entry->size;
@@ -403,16 +404,26 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			goto exit;
 		}
 
-		ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE), entry->size);
-		if (ret) {
-			errno = ret;
-			pr_perror("Failed to allocate buffer");
-			ret = -ret;
-			close(bo_contents_fd);
-			close(dmabuf_fd);
-			amdgpu_device_deinitialize(h_dev);
-			xfree(vm_info_entries);
-			goto exit;
+		if (buffer_size < entry->size) {
+			if (buffer_size) {
+				free(buffer);
+				buffer = NULL;
+			}
+
+			ret = posix_memalign(&buffer, sysconf(_SC_PAGE_SIZE),
+					     entry->size);
+			if (ret) {
+				errno = ret;
+				pr_perror("Failed to allocate userptr buffer");
+				ret = -ret;
+				close(bo_contents_fd);
+				close(dmabuf_fd);
+				amdgpu_device_deinitialize(h_dev);
+				xfree(vm_info_entries);
+				goto exit;
+			}
+
+			buffer_size = entry->size;
 		}
 
 		ret = sdma_copy_bo(dmabuf_fd, entry->size, bo_contents_fd,
@@ -421,8 +432,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		close(bo_contents_fd);
 		if (ret)
 			goto exit;
-
-		xfree(buffer);
 
 		if (dmabuf_fd != KFD_INVALID_FD)
 			close(dmabuf_fd);
@@ -468,6 +477,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 	xfree(buf);
 exit:
+	free(buffer);
 	xfree(entries);
 	free_e(rd);
 	return ret;

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -244,7 +244,9 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 	struct drm_amdgpu_gem_list_handles handles = {
 		.num_entries = 8,
 	};
+	bool libdrm_initialized = false;
 	unsigned long buffer_size = 0;
+	amdgpu_device_handle h_dev;
 	char path[PATH_MAX];
 	CriuRenderNode *rd;
 	unsigned char *buf;
@@ -305,8 +307,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		union drm_amdgpu_gem_mmap mmap_args = { 0 };
 		int bo_contents_fd;
 		int dmabuf_fd;
-		uint32_t major, minor;
-		amdgpu_device_handle h_dev;
 		int device_fd;
 
 		boinfo->size = entry->size;
@@ -376,11 +376,19 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			vminfo->flags = vm_info_entries[j].flags;
 		}
 
-		ret = amdgpu_device_initialize(fd, &major, &minor, &h_dev);
-		if (ret) {
-			pr_err("Failed to initialize amdgpu device - %s\n", strerror(-ret));
-			xfree(vm_info_entries);
-			goto exit;
+		if (!libdrm_initialized) {
+			uint32_t major, minor;
+
+			ret = amdgpu_device_initialize(fd, &major, &minor,
+						       &h_dev);
+			if (ret) {
+				pr_err("Failed to initialize amdgpu device - %s\n",
+				       strerror(-ret));
+				xfree(vm_info_entries);
+				goto exit;
+			}
+
+			libdrm_initialized = true;
 		}
 
 		device_fd = amdgpu_device_get_fd(h_dev);
@@ -388,7 +396,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		ret = drmPrimeHandleToFD(device_fd, boinfo->handle, 0, &dmabuf_fd);
 		if (ret) {
 			pr_perror("Failed to get dmabuf fd from handle");
-			amdgpu_device_deinitialize(h_dev);
 			xfree(vm_info_entries);
 			goto exit;
 		}
@@ -399,7 +406,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		if (bo_contents_fd < 0) {
 			ret = bo_contents_fd;
 			close(dmabuf_fd);
-			amdgpu_device_deinitialize(h_dev);
 			xfree(vm_info_entries);
 			goto exit;
 		}
@@ -418,7 +424,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 				ret = -ret;
 				close(bo_contents_fd);
 				close(dmabuf_fd);
-				amdgpu_device_deinitialize(h_dev);
 				xfree(vm_info_entries);
 				goto exit;
 			}
@@ -435,10 +440,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 		if (dmabuf_fd != KFD_INVALID_FD)
 			close(dmabuf_fd);
-
-		ret = amdgpu_device_deinitialize(h_dev);
-		if (ret)
-			goto exit;
 
 		xfree(vm_info_entries);
 	}
@@ -480,6 +481,8 @@ exit:
 	free(buffer);
 	xfree(entries);
 	free_e(rd);
+	if (libdrm_initialized)
+		amdgpu_device_deinitialize(h_dev);
 	return ret;
 }
 

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -307,7 +307,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		union drm_amdgpu_gem_mmap mmap_args = { 0 };
 		int bo_contents_fd;
 		int dmabuf_fd;
-		int device_fd;
 
 		boinfo->size = entry->size;
 		boinfo->alloc_flags = entry->alloc_flags;
@@ -391,9 +390,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			libdrm_initialized = true;
 		}
 
-		device_fd = amdgpu_device_get_fd(h_dev);
-
-		ret = drmPrimeHandleToFD(device_fd, boinfo->handle, 0, &dmabuf_fd);
+		ret = drmPrimeHandleToFD(fd, boinfo->handle, 0, &dmabuf_fd);
 		if (ret) {
 			pr_perror("Failed to get dmabuf fd from handle");
 			goto exit;

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -240,8 +240,8 @@ exit:
 
 int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 {
-	CriuRenderNode *rd = NULL;
 	char path[PATH_MAX];
+	CriuRenderNode *rd;
 	unsigned char *buf;
 	int minor;
 	int len;
@@ -253,10 +253,9 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 	int num_bos;
 
 	rd = xmalloc(sizeof(*rd));
-	if (!rd) {
-		ret = -ENOMEM;
-		goto exit;
-	}
+	if (!rd)
+		return -ENOMEM;
+
 	criu_render_node__init(rd);
 
 	/* Get the topology node of the DRM device */
@@ -481,8 +480,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 	xfree(buf);
 exit:
 	xfree(list_handles_entries);
-	if (rd)
-		free_e(rd);
+	free_e(rd);
 	return ret;
 }
 

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -243,9 +243,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 	char path[PATH_MAX];
 	CriuRenderNode *rd;
 	unsigned char *buf;
-	int minor;
-	int len;
-	int ret;
+	int len, ret;
 	size_t image_size;
 	struct tp_node *tp_node;
 	struct drm_amdgpu_gem_list_handles list_handles_args = { 0 };
@@ -259,8 +257,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 	criu_render_node__init(rd);
 
 	/* Get the topology node of the DRM device */
-	minor = minor(drm->st_rdev);
-	rd->drm_render_minor = minor;
+	rd->drm_render_minor = minor(drm->st_rdev);
 	rd->id = id;
 
 	num_bos = 8;
@@ -454,9 +451,10 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			goto exit;
 	}
 
-	tp_node = sys_get_node_by_render_minor(&src_topology, minor);
+	tp_node = sys_get_node_by_render_minor(&src_topology, rd->drm_render_minor);
 	if (!tp_node) {
-		pr_err("Failed to find a device with minor number = %d\n", minor);
+		pr_err("Failed to find a device with minor number = %d\n",
+		       rd->drm_render_minor);
 		return -ENODEV;
 	}
 

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -306,7 +306,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		uint32_t major, minor;
 		amdgpu_device_handle h_dev;
 		void *buffer = NULL;
-		char img_path[40];
 		int device_fd;
 
 		boinfo->size = entry->size;
@@ -393,9 +392,9 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			goto exit;
 		}
 
-		snprintf(img_path, sizeof(img_path), IMG_DRM_PAGES_FILE, rd->id, rd->drm_render_minor, i);
+		snprintf(path, sizeof(path), IMG_DRM_PAGES_FILE, rd->id, rd->drm_render_minor, i);
 		image_size = entry->size;
-		bo_contents_fd = open_img_file(img_path, true, &image_size, true);
+		bo_contents_fd = open_img_file(path, true, &image_size, true);
 		if (bo_contents_fd < 0) {
 			ret = bo_contents_fd;
 			close(dmabuf_fd);

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -375,6 +375,7 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			vminfo->offset = vm_info_entries[j].offset;
 			vminfo->flags = vm_info_entries[j].flags;
 		}
+		xfree(vm_info_entries);
 
 		if (!libdrm_initialized) {
 			uint32_t major, minor;
@@ -384,7 +385,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 			if (ret) {
 				pr_err("Failed to initialize amdgpu device - %s\n",
 				       strerror(-ret));
-				xfree(vm_info_entries);
 				goto exit;
 			}
 
@@ -396,7 +396,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		ret = drmPrimeHandleToFD(device_fd, boinfo->handle, 0, &dmabuf_fd);
 		if (ret) {
 			pr_perror("Failed to get dmabuf fd from handle");
-			xfree(vm_info_entries);
 			goto exit;
 		}
 
@@ -406,7 +405,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 		if (bo_contents_fd < 0) {
 			ret = bo_contents_fd;
 			close(dmabuf_fd);
-			xfree(vm_info_entries);
 			goto exit;
 		}
 
@@ -424,7 +422,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 				ret = -ret;
 				close(bo_contents_fd);
 				close(dmabuf_fd);
-				xfree(vm_info_entries);
 				goto exit;
 			}
 
@@ -440,8 +437,6 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 		if (dmabuf_fd != KFD_INVALID_FD)
 			close(dmabuf_fd);
-
-		xfree(vm_info_entries);
 	}
 
 	for (int i = 0; i < handles.num_entries; i++) {

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -452,7 +452,10 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 	}
 
 	/* Get the GPU_ID of the DRM device */
-	rd->gpu_id = maps_get_dest_gpu(&checkpoint_maps, tp_node->gpu_id);
+	if (checkpoint_maps.mapped_cnt)
+		rd->gpu_id = maps_get_dest_gpu(&checkpoint_maps, tp_node->gpu_id);
+	else
+		rd->gpu_id = tp_node->gpu_id; /* Render node only */
 	if (!rd->gpu_id) {
 		pr_err("Failed to find valid gpu_id for the device = %d\n", tp_node->gpu_id);
 		return -ENODEV;

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -497,7 +497,6 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 		uint32_t handle;
 		struct drm_gem_change_handle change_args = { 0 };
 		union drm_amdgpu_gem_mmap mmap_args = { 0 };
-		struct drm_amdgpu_gem_va va_args = { 0 };
 		int fd_id;
 
 		if (work_already_completed(boinfo->handle, rd->drm_render_minor)) {
@@ -572,23 +571,6 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 			goto exit;
 		}
 
-		for (int j = 0; j < boinfo->num_of_vms; j++) {
-			DrmVmEntry *vminfo = boinfo->vm_entries[j];
-
-			va_args.handle = boinfo->handle;
-			va_args.operation = AMDGPU_VA_OP_MAP;
-			va_args.flags = vminfo->flags;
-			va_args.va_address = vminfo->addr;
-			va_args.offset_in_bo = vminfo->offset;
-			va_args.map_size = vminfo->size;
-
-			if (drmIoctl(fd, DRM_IOCTL_AMDGPU_GEM_VA, &va_args) == -1) {
-				pr_perror("Error Failed to call gem va ioctl");
-				ret = -1;
-				goto exit;
-			}
-		}
-
 		ret = save_vma_updates(boinfo->offset, boinfo->addr,
 				       mmap_args.out.addr_ptr, fd);
 		if (ret < 0)
@@ -612,6 +594,28 @@ int amdgpu_plugin_drm_restore_file(int fd, CriuRenderNode *rd)
 		ret = restore_bo_contents_drm(rd->drm_render_minor, rd, fd, dmabufs);
 		if (ret)
 			goto exit;
+	}
+
+	for (int i = 0; i < rd->num_of_bos; i++) {
+		DrmBoEntry *boinfo = rd->bo_entries[i];
+
+		for (int j = 0; j < boinfo->num_of_vms; j++) {
+			DrmVmEntry *vminfo = boinfo->vm_entries[j];
+			struct drm_amdgpu_gem_va va_args = { };
+
+			va_args.handle = boinfo->handle;
+			va_args.operation = AMDGPU_VA_OP_MAP;
+			va_args.flags = vminfo->flags;
+			va_args.va_address = vminfo->addr;
+			va_args.offset_in_bo = vminfo->offset;
+			va_args.map_size = vminfo->size;
+
+			if (drmIoctl(fd, DRM_IOCTL_AMDGPU_GEM_VA, &va_args) == -1) {
+				ret = -errno;
+				pr_perror("Failed to map bo %u/%u!", i, j);
+				goto exit;
+			}
+		}
 	}
 
 exit:

--- a/plugins/amdgpu/amdgpu_plugin_drm.c
+++ b/plugins/amdgpu/amdgpu_plugin_drm.c
@@ -378,9 +378,21 @@ int amdgpu_plugin_drm_dump_file(int fd, int id, struct stat *drm)
 
 		if (!libdrm_initialized) {
 			uint32_t major, minor;
+			char *drm_path;
+			int drm_fd;
 
-			ret = amdgpu_device_initialize(fd, &major, &minor,
+			/* Re-open device to avoid VA conflicts in sdma_copy_bo. */
+			drm_path = drmGetRenderDeviceNameFromFd(fd);
+			drm_fd = open(drm_path, O_RDWR | O_CLOEXEC);
+			if (drm_fd < 0) {
+				ret = -errno;
+				pr_perror("Failed to re-open %s", drm_path);
+				goto exit;
+			}
+
+			ret = amdgpu_device_initialize(drm_fd, &major, &minor,
 						       &h_dev);
+			close(drm_fd);
 			if (ret) {
 				pr_err("Failed to initialize amdgpu device - %s\n",
 				       strerror(-ret));

--- a/plugins/amdgpu/amdgpu_plugin_topology.c
+++ b/plugins/amdgpu/amdgpu_plugin_topology.c
@@ -306,6 +306,7 @@ void maps_init(struct device_maps *maps)
 	INIT_LIST_HEAD(&maps->gpu_maps);
 	maps->tail_cpu = 0;
 	maps->tail_gpu = 0;
+	maps->mapped_cnt = 0;
 }
 
 void maps_free(struct device_maps *maps)
@@ -1219,6 +1220,7 @@ static bool map_devices(struct tp_system *src_sys, struct tp_system *dest_sys, s
 
 			if (map_devices(src_sys, dest_sys, src_nodes, dest_nodes, maps)) {
 				pr_debug("Matched nodes 0x%04X and after\n", dest_node->gpu_id);
+				maps->mapped_cnt++;
 				return true;
 			} else {
 				/* We could not map remaining nodes in the list. Add dest node back

--- a/plugins/amdgpu/amdgpu_plugin_topology.h
+++ b/plugins/amdgpu/amdgpu_plugin_topology.h
@@ -92,6 +92,8 @@ struct id_map {
 };
 
 struct device_maps {
+	unsigned int mapped_cnt;
+
 	struct list_head cpu_maps; /* CPUs are mapped using node_id */
 	struct list_head gpu_maps;
 


### PR DESCRIPTION
cc @fdavid-amd 

This is a RFC style PR with 5 interesting patches on top of the cleanups I've sent as separate PRs. The interesting patches are these:
```
66ec3c611f82 plugins/amdgpu: Re-open the DRM device when saving buffer object content
80e839f67084 plugins/amdgpu: Move GPU VA map to after content restore
afe8e2b2fd23 plugins/amdgpu: Handle DRM render node mmaps
62cd972b4315 plugins/amdgpu: Allow forcing restore on a single GPU system
5d05115056e6 plugins/amdgpu: Enable restore with only the drm node open
```

With this I can get all but the last the test from https://cgit.freedesktop.org/~tursulin/intel-gpu-tools/commit/?h=amd-criu&id=24487611e08c753e73b3fc650ca85793bf053f4d to pass. The last one includes forking and for that problem I will kick off a separate discussion.

But the most complicated test case from the above:

```
sudo ~/build-holo/tests/amdgpu/amd_criu --r map-and-mmap-one
```

Can be checkpointed and restored:
```
$ sudo /usr/local/sbin/criu dump -t `pgrep amd_criu | head -1` -L /usr/local/lib/criu/ -vvv -o criu.log -j --link-remap --tcp-established --file-locks --ext-unix-sk
$ sudo /usr/local/sbin/criu restore  -L /usr/local/lib/criu/ -vvv -o restore.log --shell-job --link-remap --tcp-established --file-locks --ext-unix-sk

Subtest map-and-mmap-one: SUCCESS (13.989s)
```

It would be good to test this series with some kfd and kfd+amdgpu combined workload to check I created no regressions.
