### PR TITLE
restore: fix restorer VMA hint overlap at the end of VMA lists

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2487,36 +2487,48 @@ static long restorer_get_vma_hint(struct list_head *tgt_vma_list, struct list_he
 	end_e.start = end_e.end = kdat.task_size;
 	INIT_LIST_HEAD(&end_vma.list);
 
+	/* Both lists should not be empty. */
 	s_vma = list_first_entry(self_vma_list, struct vma_area, list);
 	t_vma = list_first_entry(tgt_vma_list, struct vma_area, list);
 
 	while (1) {
 		if (prev_vma_end + vma_len > s_vma->e->start) {
+			if (s_vma == &end_vma)
+				break;
+
+			if (prev_vma_end < s_vma->e->end)
+				prev_vma_end = s_vma->e->end;
+			/*
+			 * VMA_AREA_GUARD entries are synthetic and they are
+			 * always after real vma entries.
+			 */
 			if ((s_vma->list.next == self_vma_list) ||
 			    vma_area_is(vma_next(s_vma), VMA_AREA_GUARD)) {
 				s_vma = &end_vma;
 				continue;
 			}
-			if (s_vma == &end_vma)
-				break;
-			if (prev_vma_end < s_vma->e->end)
-				prev_vma_end = s_vma->e->end;
+
 			s_vma = vma_next(s_vma);
-			continue;
 		}
 
 		if (prev_vma_end + vma_len > t_vma->e->start) {
+			if (t_vma == &end_vma)
+				break;
+
+			if (prev_vma_end < t_vma->e->end)
+				prev_vma_end = t_vma->e->end;
+
+			/*
+			 * VMA_AREA_GUARD entries are synthetic and they are
+			 * always after real vma entries.
+			 */
 			if ((t_vma->list.next == tgt_vma_list) ||
 			    vma_area_is(vma_next(t_vma), VMA_AREA_GUARD)) {
 				t_vma = &end_vma;
 				continue;
 			}
-			if (t_vma == &end_vma)
-				break;
-			if (prev_vma_end < t_vma->e->end)
-				prev_vma_end = t_vma->e->end;
+
 			t_vma = vma_next(t_vma);
-			continue;
 		}
 
 		return prev_vma_end;


### PR DESCRIPTION
When restorer_get_vma_hint searches for a suitable gap to map the restorer blob, it was incorrectly peeking ahead to detect the end of the list or a VMA_AREA_GUARD end-marker without first processing the current VMA.

If the current VMA was the last VMA in the list (either because it was the final element, or because the next element was a synthetic VMA_AREA_GUARD), the loop would immediately set the pointer to the dummy end_vma and continue. This premature skip caused the loop to discard the last real VMA without ever updating prev_vma_end with its end address.

If this last VMA overlapped with the candidate address, the hint returned would incorrectly overlap existing memory.

This fix ensures the current VMA's range is used to update prev_vma_end before checking if we have reached the end of the real VMA list.

