### PR TITLE
restore: add missing continue in restorer_get_vma_hint

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2509,6 +2509,7 @@ static long restorer_get_vma_hint(struct list_head *tgt_vma_list, struct list_he
 			}
 
 			s_vma = vma_next(s_vma);
+			continue;
 		}
 
 		if (prev_vma_end + vma_len > t_vma->e->start) {
@@ -2529,6 +2530,7 @@ static long restorer_get_vma_hint(struct list_head *tgt_vma_list, struct list_he
 			}
 
 			t_vma = vma_next(t_vma);
+			continue;
 		}
 
 		return prev_vma_end;


### PR DESCRIPTION
In restorer_get_vma_hint, if a VMA from self_vma_list or tgt_vma_list overlaps with the current candidate region (prev_vma_end + vma_len), we advance prev_vma_end and move to the next VMA in the list. However, we must then restart the check from the beginning of the while loop to ensure that the updated candidate region doesn't overlap with any other VMAs.

Fixes #3018
Fixes: 2c9ee0abd2f1 ("restore: update prev_vma_end after processing the last vma in a list")

