### PR TITLE
service: fix local privilege escalation via RPC config_file

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -1534,11 +1534,15 @@ int cr_service(bool daemon_mode)
 
 		pr_info("The service socket is bound to %s\n", server_addr.sun_path);
 
-		/* change service socket permissions, so anyone can connect to it */
-		if (chmod(server_addr.sun_path, 0666)) {
+		/* restrict service socket permissions to owner only */
+		if (chmod(server_addr.sun_path, 0600)) {
 			pr_perror("Can't change permissions of the service socket");
 			goto err;
 		}
+
+		pr_msg("Service socket %s has permissions 0600. "
+		       "Use chmod to make it accessible to other users if needed.\n",
+		       server_addr.sun_path);
 
 		if (listen(server_fd, 16) == -1) {
 			pr_perror("Can't listen for socket connections");

--- a/test/others/rpc/Makefile
+++ b/test/others/rpc/Makefile
@@ -32,6 +32,8 @@ run: all
 		-d --pidfile pidfile -o service.log --status-fd 200; \
 		$(PYTHON) read.py build/status"
 	rm -f build/status
+	@# Socket defaults to 0600; transfer ownership to the test user.
+	chown 1000:1000 build/criu_service.socket
 	chmod a+rw build/pidfile
 	sudo -g '#1000' -u '#1000' ./run.sh
 	sudo -g '#1000' -u '#1000' ./version.py


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                              
  When `criu service` runs in standalone mode as root, any local user who can                                                                                                                                                                 
  reach the Unix socket can achieve local privilege escalation through the                                                                                                                                                                    
  following attack chain:                                                                                                                                                                                                                     
                                                                                                                                                                                                                                              
  1. The service socket is created with permissions `0666`, allowing any local                                                                                                                                                                
     user to connect.                                                                                                                                                                                                                         
  2. There is no UID authorization check on RPC clients.                                                                                                                                                                                      
  3. The `config_file` RPC field is accepted without restriction in standalone                                                                                                                                                                
     mode, allowing an attacker to point it at an attacker-controlled file.                                                                                                                                                                   
  4. That file can contain `action-script /path/to/payload`, which executes                                                                                                                                                                   
     with CRIU's (root) privileges via `cr_system()`.                                                                                                                                                                                         
                                                                                                                                                                                                                                              
  This series closes the attack with two measures:                                                                                                                                                                                            
                                                                                                                                                                                                                                              
  ### Reject `config_file` in standalone service mode                                                                                                                                                                                         
                                                                                                                                                                                                                                              
  In `setup_opts_from_req()`, reject the `config_file` RPC field when the                                                                                                                                                                     
  service is running in standalone mode (`!opts.swrk_restore`). This follows                                                                                                                                                                  
  the existing pattern used for `rst_sibling` and `inherit_fd`, which are                                                                                                                                                                     
  similarly restricted to swrk mode only.                                                                                                                                                                                                     
                                                                                                                                                                                                                                              
  In swrk mode (used by libcriu), the caller already has full control over the                                                                                                                                                                
  CRIU process — there is no privilege boundary to cross — so `config_file`                                                                                                                                                                   
  (including `action-script` within it) remains allowed.                                                                                                                                                                                      
                                                                                                                                                                                                                                              
  ### Restrict socket permissions to `0600`                                                                                                                                                                                                   
                                                                                                                                                                                                                                              
  Change the service socket permissions from `0666` (world-accessible) to                                                                                                                                                                     
  `0600` (owner-only). A message is printed at startup informing the                                                                                                                                                                          
  administrator that the socket is restricted and that `chmod` should be used                                                                                                                                                                 
  to widen access if needed. This ensures that even without the `config_file`                                                                                                                                                                 
  restriction, untrusted local users cannot connect to the service socket by                                                                                                                                                                  
  default.                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                              
  ### Adapt RPC test                                                                                                                                                                                                                          
                                                                                                                                                                                                                                              
  The test runs the setuid CRIU binary as a non-root user, so the socket ends                                                                                                                                                                 
  up owned by root. After service startup, `chown` the socket to the test user                                                                                                                                                                
  so it can connect with the new `0600` permissions.   