### PR TITLE
ci: pass CC=clang to container when CLANG=1 is set

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -26,6 +26,11 @@ endif
 
 ifeq ($(call pkg-config-check,libdrm),y)
         export CONFIG_AMDGPU := y
+        LIBDRM_CFLAGS	:= $(shell $(PKG_CONFIG) --cflags libdrm)
+        ifeq ($(call try-cc,$(FEATURE_TEST_DRM_COLOR_CTM_3X4),,$(LIBDRM_CFLAGS)),true)
+                export CONFIG_HAS_DRM_COLOR_CTM_3X4 := y
+                FEATURE_DEFINES	+= -DHAVE_DRM_COLOR_CTM_3X4
+        endif
         $(info Note: Building with amdgpu_plugin.)
 else
         $(info Note: Building without amdgpu_plugin.)

--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -57,6 +57,7 @@ $(TARGETS):
 		$(if $(ZDTM_OPTS),-e ZDTM_OPTS) \
 		$(if $(ZDTM_SHARD_INDEX),-e ZDTM_SHARD_INDEX) \
 		$(if $(ZDTM_SHARD_COUNT),-e ZDTM_SHARD_COUNT) \
+		$(if $(CLANG),-e CC=clang -e HOSTCC=clang) \
 		$(CONTAINER_OPTS) \
 		criu-$@ scripts/ci/run-ci-tests.sh
 

--- a/scripts/feature-tests.mak
+++ b/scripts/feature-tests.mak
@@ -156,6 +156,18 @@ int main(void)
 }
 endef
 
+define FEATURE_TEST_DRM_COLOR_CTM_3X4
+
+#include <drm_mode.h>
+
+int main(void)
+{
+	struct drm_color_ctm_3x4 ctm = {};
+
+	return (int)ctm.matrix[0];
+}
+endef
+
 define FEATURE_TEST_NO_LIBC_RSEQ_DEFS
 
 #ifdef __has_include


### PR DESCRIPTION
The CLANG=1 parameter was only used during the Docker image build but never propagated to the container at runtime. The hardcoded CC=gcc in docker.env always took precedence, causing the test container to rebuild and test with gcc instead of clang.

Override CC and HOSTCC via docker run -e flags when CLANG is set.

Enabling CLANG on alpine also revealed a compilation failure on Alpine. This is now also fixed.
