### PR TITLE
uffd: suggest vm.unprivileged_userfaultfd on EPERM

### DIFF
--- a/criu/uffd.c
+++ b/criu/uffd.c
@@ -299,6 +299,7 @@ close:
 int setup_uffd(int pid, struct task_restore_args *task_args)
 {
 	unsigned long features = kdat.uffd_features & NEED_UFFD_API_FEATURES;
+	int err = 0;
 
 	if (!opts.lazy_pages) {
 		task_args->uffd = -1;
@@ -309,9 +310,14 @@ int setup_uffd(int pid, struct task_restore_args *task_args)
 	 * Open userfaulfd FD which is passed to the restorer blob and
 	 * to a second process handling the userfaultfd page faults.
 	 */
-	task_args->uffd = uffd_open(O_CLOEXEC | O_NONBLOCK, &features, NULL);
+	task_args->uffd = uffd_open(O_CLOEXEC | O_NONBLOCK, &features, &err);
 	if (task_args->uffd < 0) {
-		pr_perror("Unable to open an userfaultfd descriptor");
+		if (err)
+			errno = err;
+		pr_perror("Unable to open a userfaultfd descriptor");
+		if (err == EPERM)
+			pr_err("To use --lazy-pages, run with CAP_SYS_PTRACE in the root "
+			       "user namespace or set 'sysctl -w vm.unprivileged_userfaultfd=1'\n");
 		return -1;
 	}
 


### PR DESCRIPTION
When restoring inside a user namespace on a host where userfaultfd is restricted to privileged callers, `criu restore --lazy-pages` fails to open a userfaultfd descriptor with EPERM. This patch improves the error message with a suggestion on how to fix this.

Example:
```
$ sudo sysctl -w vm.unprivileged_userfaultfd=0
$ sudo ./test/zdtm.py run -t zdtm/static/memfd03 --lazy-pages -f uns --ignore-taint
...
======================== Run zdtm/static/memfd03 in uns ========================
Start test
./memfd03 --pidfile=memfd03.pid --outfile=memfd03.out
Run criu dump
Run criu lazy-pages
Run criu restore
=[log]=> dump/zdtm/static/memfd03/77/1/restore.log
------------------------ grep Error ------------------------
b'(00.002545)      1: No ipcns-sem-11.img image'
b'(00.003135)      1: net: Try to restore a link 10:1:lo'
b'(00.003139)      1: net: Restoring link lo type 1'
b'(00.003452)      1: net: \tRunning ip addr restore'
b'Error: ipv4: Address already assigned.'
b'Error: ipv6: address already assigned.'
b'(00.066952)      4: \t\tCreate fd for 3'
b'(00.066953)      4: Restoring memfd id=12'
b'(00.066967)      1: uffd: Lazy pages are not available: Operation not permitted'
b'(00.066968)      4: No parent images directory provided'
b'(00.066969)      1: Error (criu/uffd.c:317): uffd: Unable to open a userfaultfd descriptor: Operation not permitted'
b"(00.066972)      1: Error (criu/uffd.c:319): uffd: To use --lazy-pages, run with CAP_SYS_PTRACE in the root user namespace or set 'sysctl -w vm.unprivileged_userfaultfd=1'"
b'(00.068032) uns: calling exit_usernsd (-1, 1)'
b'(00.068044) uns: daemon calls 0x45c870 (101, -1, 1)'
b'(00.068050) uns: `- daemon exits w/ 0'
b'(00.068354) uns: daemon stopped'
b'(00.068359) Error (criu/cr-restore.c:2369): Restoring FAILED.'
------------------------ ERROR OVER ------------------------
################ Test zdtm/static/memfd03 FAIL at CRIU restore #################
```