### PR TITLE
mem: keep COW root VMAs writable when premapping

### DIFF
--- a/criu/mem.c
+++ b/criu/mem.c
@@ -958,8 +958,17 @@ static int premap_private_vma(struct pstree_item *t, struct vma_area *vma, void 
 		 * (did not have the "ac" flag in /proc/pid/smaps), we
 		 * can safely mmap them with PROT_NONE because we know
 		 * we will never need to write any bits to them.
+		 *
+		 * This only holds for a standalone VMA (vma->pvma == NULL).
+		 * A COW root (vma->pvma == VMA_COW_ROOT) shares this very
+		 * mapping with inherited children via the mremap() in the
+		 * branch below; those children may have pages to restore,
+		 * and restoring content into a PROT_NONE mapping faults
+		 * (e.g. the memcmp()/copy in restore_priv_vma_content()).
+		 * So a COW root must stay writable even when it is itself
+		 * PROT_NONE and not accountable.
 		 */
-		if (vma->e->prot == PROT_NONE && vma_area_is(vma, VMA_AREA_NOT_ACCOUNTABLE)) {
+		if (vma->e->prot == PROT_NONE && vma->pvma == NULL && vma_area_is(vma, VMA_AREA_NOT_ACCOUNTABLE)) {
 			addr = mmap(*tgt_addr, size, PROT_NONE, vma->e->flags | MAP_FIXED | flag, vma->e->fd,
 				    vma->e->pgoff);
 		} else {

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -192,6 +192,7 @@ TST_NOFILE	:=				\
 		socket-ext			\
 		unhashed_proc			\
 		cow00				\
+		cow02				\
 		child_opened_proc		\
 		posix_timers			\
 		sigpending			\

--- a/test/zdtm/static/cow02.c
+++ b/test/zdtm/static/cow02.c
@@ -1,0 +1,100 @@
+#include <sys/mman.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Restore a COW child whose COW-root VMA is a PROT_NONE reservation";
+const char *test_author = "Radostin Stoyanov <rstoyanov@fedoraproject.org>";
+
+/*
+ * A parent reserves an address range with PROT_NONE and never touches it.
+ * Such a mapping has no "ac" flag in /proc/pid/smaps, so CRIU marks it
+ * VMA_AREA_NOT_ACCOUNTABLE. After fork() the child turns the very same range
+ * into a writable mapping and fills it with data.
+ *
+ * CRIU pairs VMAs that coincide by start/end and flags regardless of their
+ * protection bits (see check_cow_vmas()), so the parent's PROT_NONE,
+ * not-accountable VMA becomes the COW root of the child's data VMA.
+ *
+ * On restore, premap_private_vma() used to map a PROT_NONE & not-accountable
+ * COW root with PROT_NONE. The child then inherits that mapping (mremap) and
+ * restore_priv_vma_content() copies the child's pages into it -- writing to a
+ * PROT_NONE mapping faults and the restored task dies with SIGSEGV.
+ *
+ * The fix keeps a COW root writable; this test crashes at restore without it
+ * and passes with it.
+ */
+
+#define MEM_SIZE (32 * 4096)
+
+int main(int argc, char **argv)
+{
+	task_waiter_t lock;
+	void *mem;
+	pid_t pid;
+	int status;
+	uint32_t crc;
+
+	test_init(argc, argv);
+	task_waiter_init(&lock);
+
+	/* Parent: reserve the range and never write to it. */
+	mem = mmap(NULL, MEM_SIZE, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (mem == MAP_FAILED) {
+		pr_perror("Can't reserve memory");
+		return 1;
+	}
+
+	pid = test_fork();
+	if (pid < 0) {
+		pr_perror("Can't fork");
+		return 1;
+	}
+
+	if (pid == 0) {
+		/* Child: make the reservation writable and fill it. */
+		crc = ~0;
+
+		if (mprotect(mem, MEM_SIZE, PROT_READ | PROT_WRITE)) {
+			pr_perror("Child can't mprotect");
+			return 1;
+		}
+		datagen(mem, MEM_SIZE, &crc);
+
+		/* Ready for C/R. */
+		task_waiter_complete(&lock, 1);
+
+		/* Wait until the parent has been restored. */
+		task_waiter_wait4(&lock, 2);
+
+		crc = ~0;
+		if (datachk(mem, MEM_SIZE, &crc)) {
+			fail("Child data corrupted after restore");
+			return 1;
+		}
+		return 0;
+	}
+
+	/* Parent: wait for the child to populate its copy, stay PROT_NONE. */
+	task_waiter_wait4(&lock, 1);
+
+	test_daemon();
+	test_waitsig();
+
+	/* Restore succeeded -- let the child verify its content. */
+	task_waiter_complete(&lock, 2);
+
+	if (waitpid(pid, &status, 0) != pid) {
+		pr_perror("Can't wait for the child");
+		return 1;
+	}
+
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		fail("Child exited abnormally (status %d)", status);
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
Applications sometimes call mmap with `PROT_NONE` to reserve a large amount of the virtual address space. When CRIU premaps private VMAs during restore, it used to map them with `PROT_WRITE`  so it can fill in their pages. However, the kernel charges the full size of writable private mapping against the overcommit limit, so premapping a large reservation as writable can fail with `ENOMEM`. 

Commit 7daaa11a (`"mem: don't PROT_WRITE on reservation mmaps"`) added an optimization to premap such a VMA as `PROT_NONE` instead of writable when a region has no pages to be restored. However, this assumption does not hold for a COW root.

When CRIU looks for COW-shared VMAs between a parent and child, it matches them by start/end and flags but ignores their protection bits (see `check_cow_vmas()`). So a parent's `PROT_NONE`, not-accountable reservation can be matched as the COW root of a child VMA that does have pages (the child made the same range writable and wrote to it after `fork()`).

On restore:
1. `premap_private_vma()` maps the COW root as `PROT_NONE`.
2. the inherited child re-positions that same mapping with `mremap()`, so the child's premapped area is `PROT_NONE` too.
3. `restore_priv_vma_content()` then restores the child's pages. It `memcmp()`s them against the premapped area and copies them in.

 Because the mapping is PROT_NONE, the memcmp() and copy in the previous step are accessing memory with no read or write permission, which faults and kills the restored task with SIGSEGV:

```
$ sudo ./zdtm.py run -t zdtm/static/cow02 -f h --ignore-taint
userns is supported
The kernel is tainted: '12288'
=== Run 1/1 ================ zdtm/static/cow02
========================== Run zdtm/static/cow02 in h ==========================
Start test
./cow02 --pidfile=cow02.pid --outfile=cow02.out
Run criu dump
Run criu restore
=[log]=> dump/zdtm/static/cow02/70/1/restore.log
------------------------ grep Error ------------------------
b'(00.011907)     71: pr71-2 Read 409000 1 pages'
b'(00.011909)     71: \tpr71-2 Read page from self 409000/2000'
b'(00.011925)     71: pr71-2 Read 7f0dc1762000 1 pages'
b'(00.011927)     71: \tpr71-2 Read page from self 7f0dc1762000/3000'
b'(00.053817)     70: Error (criu/cr-restore.c:1268): 71 killed by signal 11: Segmentation fault'
b'(00.053835) Error (criu/cr-restore.c:2369): Restoring FAILED.'
b'(00.054002) Error (criu/cr-restore.c:1268): 70 killed by signal 9: Killed'
------------------------ ERROR OVER ------------------------
################# Test zdtm/static/cow02 FAIL at CRIU restore ##################
```

Fixes: 7daaa11aa039 ("mem: don't PROT_WRITE on reservation mmaps")