### PR TITLE
ci: disable fail-fast for CI matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   alpine-test:
     name: Alpine Test (${{ matrix.target }}, ${{ matrix.shard_name }})
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04]
         target: [GCC=1, CLANG=1]
@@ -39,6 +40,7 @@ jobs:
     name: Alpine Test ARM64
     needs: [alpine-test]
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04-arm]
         target: [GCC=1, CLANG=1]
@@ -51,6 +53,7 @@ jobs:
   aarch64-test:
     needs: [alpine-test]
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04-arm, ubuntu-22.04-arm]
         target: [GCC=1, CLANG=1]
@@ -73,6 +76,7 @@ jobs:
     # caused by upstream package churn are outside CRIU's control.
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         shard: [0, 1, 2, 3, 4]
         include:
@@ -103,6 +107,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         version: [9, 10]
     steps:
@@ -124,6 +129,7 @@ jobs:
     needs: [alpine-test]
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         target: [GCC, CLANG]
     steps:
@@ -162,6 +168,7 @@ jobs:
     needs: [alpine-test]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04]
     steps:
@@ -182,6 +189,7 @@ jobs:
     needs: [alpine-test]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-22.04


### PR DESCRIPTION
By default GitHub Actions cancels all in-progress and queued matrix legs as soon as one leg fails (`fail-fast: true`). Re-running only the failed job afterwards does not bring back the cancelled siblings, so recovering from a single failure requires re-running the whole job.

Cancelling the siblings also hides information: whether the other shards or environments would have passed or failed is exactly what we want to know from a CI run, not something to discard on the first failure. Set fail-fast: false on the matrix jobs that were still inheriting the default, so every leg runs to completion independently.