### PR TITLE
ci: install gdb on dnf based distributions

### DIFF
--- a/contrib/dependencies/dnf-packages.sh
+++ b/contrib/dependencies/dnf-packages.sh
@@ -5,6 +5,7 @@ dnf install -y \
 	binutils \
 	elfutils-libelf-devel \
 	gcc \
+	gdb \
 	git \
 	glibc-devel \
 	gnutls-devel \

--- a/test/others/libcriu/Makefile
+++ b/test/others/libcriu/Makefile
@@ -18,6 +18,7 @@ INSTALL_DIR:= $(CURDIR)/.install
 CRIU_INCLUDE:= $(INSTALL_DIR)/include/criu
 CRIU_LIB:= $(INSTALL_DIR)/lib
 
+CC ?= gcc
 CFLAGS:= -I$(CRIU_INCLUDE)
 LDFLAGS:= -L$(CRIU_LIB) -lcriu
 
@@ -38,13 +39,13 @@ $(CRIU_INCLUDE): $(CRIU_LIB)/libcriu.so
 
 define genb
 $(1): $(1).o lib.o
-	gcc $$^ $(LDFLAGS) -o $$@
+	$(CC) $$^ $(LDFLAGS) -o $$@
 endef
 
 $(foreach t, $(TESTS), $(eval $(call genb, $(t))))
 
 %.o: %.c | $(CRIU_INCLUDE)
-	gcc -c $< $(CFLAGS) -o $@ -Werror
+	$(CC) -c $< $(CFLAGS) -o $@ -Werror
 
 clean:
 	rm -rf $(TESTS) $(TESTS:%=%.o) lib.o $(INSTALL_DIR)

--- a/test/others/libcriu/lib.c
+++ b/test/others/libcriu/lib.c
@@ -46,7 +46,7 @@ int chk_exit(int status, int want)
 	return 1;
 }
 
-int get_version()
+void get_version(void)
 {
 	printf("Using a CRIU binary with version %d\n", criu_get_version());
 }

--- a/test/others/libcriu/lib.h
+++ b/test/others/libcriu/lib.h
@@ -1,5 +1,5 @@
 void what_err_ret_mean(int ret);
 int chk_exit(int status, int want);
-int get_version(void);
+void get_version(void);
 
 #define SUCC_ECODE 42


### PR DESCRIPTION
The custom core dump handler tries to call gdb which makes it much easier to understand why something crashed especially in CI. For dnf based distribution this currently does not work because gdb is missing. This installs gdb on dnf based CI runs.
