### PR TITLE
test: another clang compilation error fix

### DIFF
--- a/test/others/libcriu/test_iters.c
+++ b/test/others/libcriu/test_iters.c
@@ -18,7 +18,7 @@ static void sh(int sig)
 	stop = 1;
 }
 
-static int open_imgdir(void)
+static void open_imgdir(void)
 {
 	char p[10];
 


### PR DESCRIPTION
```
test_iters.c:29:1: error: non-void function does not return a value [-Werror,-Wreturn-type]
   29 | }
      | ^
1 error generated.
make: *** [Makefile:48: test_iters.o] Error 1
```