### PR TITLE
ci: skip socket-tcpbuf* tests on aarch64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,18 @@ jobs:
         sudo sysctl -w kernel.sched_rt_runtime_us=-1
         # etc/hosts entry is needed for netns_lock_iptables
         echo "127.0.0.1   localhost" | sudo tee -a /etc/hosts
+        # socket-tcpbuf* fill large TCP queues, leaving the receive window
+        # retracted toward zero. Restoring that state hits a Linux 6.17
+        # regression where the kernel drops the peer's in-window data and the
+        # restored task hangs ("FAIL at .. die"). Not a CRIU bug; the 6.17
+        # kernel only ships on the *-arm runners here.
+        #   regression: 9ca48d616ed7 ("tcp: do not accept packets beyond window")
+        #   fixed in v7.1: 0e24d17bd966 ("tcp: implement RFC 7323 window
+        #     retraction receiver requirements")
         sudo -E make -C scripts/ci local ${{ matrix.target }} RUN_TESTS=1 \
-          ZDTM_OPTS="-x zdtm/static/change_mnt_context -x zdtm/static/maps05"
+          ZDTM_OPTS="-x zdtm/static/change_mnt_context -x zdtm/static/maps05 \
+          -x zdtm/static/socket-tcpbuf -x zdtm/static/socket-tcpbuf6 \
+          -x zdtm/static/socket-tcpbuf-local -x zdtm/static/socket-tcpbuf6-local"
 
   archlinux-test:
     name: Arch Linux Test (${{ matrix.shard_name }})


### PR DESCRIPTION
The `socket-tcpbuf*` tests fill large TCP send/recv queues, which leaves the receive window retracted toward zero. Restoring such a connection triggers a Linux 6.17 regression: the kernel drops the peer's data even though it was in-window when sent, and the restored task hangs forever in a blocking read, failing as `"FAIL at ... die"`:
```
====================== Run zdtm/static/socket-tcpbuf in h ======================
Start test
./socket-tcpbuf --pidfile=socket-tcpbuf.pid --outfile=socket-tcpbuf.out
    PID TTY          TIME CMD
     43 ?        00:00:00 socket-tcpbuf
    PID TTY      STAT   TIME COMMAND
      1 ?        S      0:00 python3 zdtm.py
      4 ?        S      0:00 python3 zdtm.py
     65 ?        R      0:00  \_ ps axf 43
     42 ?        S      0:00 ./socket-tcpbuf --pidfile=socket-tcpbuf.pid --outfile=socket-tcpbuf.out
     43 ?        Ss     0:00 ./socket-tcpbuf --pidfile=socket-tcpbuf.pid --outfile=socket-tcpbuf.out
Run criu dump
Run criu restore
Send the 15 signal to  43
Wait for zdtm/static/socket-tcpbuf(43) to die for 0.100000
Wait for zdtm/static/socket-tcpbuf(43) to die for 0.200000
Wait for zdtm/static/socket-tcpbuf(43) to die for 0.400000
Wait for zdtm/static/socket-tcpbuf(43) to die for 0.800000
Wait for zdtm/static/socket-tcpbuf(43) to die for 1.600000
Wait for zdtm/static/socket-tcpbuf(43) to die for 3.200000
Wait for zdtm/static/socket-tcpbuf(43) to die for 6.400000
Wait for zdtm/static/socket-tcpbuf(43) to die for 12.800000
Wait for zdtm/static/socket-tcpbuf(43) to die for 25.600000
##### Test zdtm/static/socket-tcpbuf FAIL at zdtm/static/socket-tcpbuf die #####
```

This is a kernel bug rather than a CRIU one. It was introduced by [9ca48d616ed7](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9ca48d616ed76b284f946667a3cb7961205c8ee3) ("tcp: do not accept packets beyond window") and fixed in v7.1 by [0e24d17bd966](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0e24d17bd9668f9dad78ede6a0e8f13dab176682) ("tcp: implement RFC 7323 window retraction receiver requirements"), which is not present in the 6.17 kernel that ships on the `*-arm` GitHub Actions runners.

Skip these tests on the aarch64 job until the runners pick up a kernel that includes the fix.