### PR TITLE
Fix make -C test clean

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -56,7 +56,7 @@ clean: clean_root
 	$(Q) $(RM) *.log
 	$(Q) $(RM) -r ./dump/
 	$(Q) $(MAKE) -C zdtm cleandep clean cleanout
-	$(Q) $(MAKE) -C libcriu clean
-	$(Q) $(MAKE) -C rpc clean
-	$(Q) $(MAKE) -C crit clean
+	$(Q) $(MAKE) -C others/libcriu clean
+	$(Q) $(MAKE) -C others/rpc clean
+	$(Q) $(MAKE) -C others/crit clean
 .PHONY: clean

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -2962,8 +2962,9 @@ if __name__ == '__main__':
 
     if opts['action'] == run_tests:
         criu.available()
-    for tst in test_classes.values():
-        tst.available()
+    if opts['action'] != clean_stuff:
+        for tst in test_classes.values():
+            tst.available()
 
     orig_hugepages = set_nr_hugepages(20)
     opts['action'](opts)


### PR DESCRIPTION
`make -C test clean` has two problems:                                                                                                                                                                                                        
                                                                                                                                                                                                                                              
  1. It builds umount2, zdtm_ct, the zdtm test library, and other targets before actually deleting them. This happens because zdtm.py calls tst.available() unconditionally for every subcommand, including clean. The build-on-clean behavior looks  like this:                                                                                                                                                                                                                                  

```                                                                                                                                                                                                                                              
  $ make -C test clean                               
  make: Entering directory '/home/criu/test'   
  ./zdtm.py clean nsroot      
  cc -D_GNU_SOURCE    umount2.c   -o umount2  
  cc -D_GNU_SOURCE    zdtm_ct.c   -o zdtm_ct    
  ...
```
                                                                                                                                                                                                                                         
  2. After building and deleting those binaries, clean fails entirely because the Makefile references libcriu, rpc, and crit  directly instead of their actual paths under others/:                                                                                                                                                                                       

```                                                                                                                                                                                                                       
  make -C libcriu clean            
  make[1]: *** libcriu: No such file or directory.  Stop.       
```
                                                                                      
  The first commit moves the tst.available() loop inside the existing if opts['action'] == run_tests guard so builds only happen when  running tests. The second commit fixes the sub-make paths in the clean target to others/libcriu, others/rpc, and others/crit.    