### PR TITLE
test: fix unused variable warnings reported by CodeQL

### DIFF
--- a/test/crit-recode.py
+++ b/test/crit-recode.py
@@ -24,7 +24,6 @@ def recode_and_check(imgf, o_img, pretty):
     try:
         r_img = pycriu.images.dumps(pb)
     except Exception as e:
-        r_img = pycriu.images.dumps(pb)
         print("%s %s encode fails: %s" % (imgf, pretty and 'pretty ' or '', e))
         return False
 

--- a/test/exhaustive/unix.py
+++ b/test/exhaustive/unix.py
@@ -605,7 +605,7 @@ def chk_state(st, opts):
 
     pid = os.fork()
     if pid == 0:
-        msg = signal_sk.recv(64)
+        signal_sk.recv(64)
         ret = chk_real_state(st)
         sys.exit(ret)
 

--- a/test/others/mounts/mounts.py
+++ b/test/others/mounts/mounts.py
@@ -25,7 +25,7 @@ root = tempfile.mkdtemp(prefix="root.mount", dir="/tmp")
 mount(None, root, 1, 0, 0)
 mounts = [root]
 
-for i in range(10):
+for _ in range(10):
     dstdir = random.choice(mounts)
     dst = tempfile.mkdtemp(prefix="mount", dir=dstdir)
     src = random.choice(mounts + [None])

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -2419,7 +2419,7 @@ def grep_errors(fname, err=False):
         print_sep("grep Error (no)", "-", 60)
         first = False
         for i in before:
-            print_next = print_error(i)
+            print_error(i)
 
     if not first:
         print_sep("ERROR OVER", "-", 60)


### PR DESCRIPTION
Fix four "unused local/global variable" alerts reported by CodeQL:

- zdtm.py: drop unused assignment to print_next in the tail-printing loop at the end of grep_errors(). The return value of print_error() is not needed here since no further iterations follow.

- crit-recode.py: remove duplicate pycriu.images.dumps(pb) call inside the except handler. The same call just raised the exception, so re-executing it would raise again and prevent the error message from being printed.

- exhaustive/unix.py: drop unused msg variable. The recv() call is used for its blocking side effect to synchronize with the parent, the received data is not needed.

- others/mounts/mounts.py: rename unused loop variable i to _ in the range(10) iteration.
