### PR TITLE
Replace deprecated tempfile.mktemp with mkstemp and simplify list_tests

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -2606,7 +2606,7 @@ def list_tests(opts):
     tlist = all_tests(opts)
     if opts['info']:
         print(sti_fmt % ('Name', 'Flavors', 'Flags'))
-        tlist = map(lambda x: show_test_info(x), tlist)
+        tlist = map(show_test_info, tlist)
     print('\n'.join(tlist))
 
 

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -223,8 +223,9 @@ class ns_flavor:
             except OSError as e:
                 if e.errno != errno.EEXIST:
                     raise
-            dst = tempfile.mktemp(".tso", "",
-                                  self.root + os.path.dirname(fname))
+            fd, dst = tempfile.mkstemp(".tso", "",
+                                      self.root + os.path.dirname(fname))
+            os.close(fd)
             shutil.copy2(fname, dst)
             os.rename(dst, tfname)
 

--- a/test/zdtm/criu_config.py
+++ b/test/zdtm/criu_config.py
@@ -14,8 +14,8 @@ class criu_config:
             preload=False,
             nowait=False):
 
-        config_path = tempfile.mktemp(".conf", "criu-%s-" % action)
-        with open(config_path, "w") as config_fd:
+        config_fd_raw, config_path = tempfile.mkstemp(".conf", "criu-%s-" % action)
+        with os.fdopen(config_fd_raw, "w") as config_fd:
             for arg in args:
                 if arg.startswith("--"):
                     config_fd.write("\n")


### PR DESCRIPTION
Trying to fix complaints from codeql.

Insecure tempfile.mktemp replaced and an unnecessary use of a lambda removed.