### PR TITLE
Fix elf identity check for big endian

### DIFF
--- a/criu/pie/util-vdso.c
+++ b/criu/pie/util-vdso.c
@@ -122,7 +122,7 @@ static int has_elf_identity(Ehdr_t *ehdr)
 #endif
 
 	/* check ELF data encoding */
-	if (ehdr->e_ident[EI_DATA] != ELFDATA2LSB) {
+	if (ehdr->e_ident[EI_DATA] != BORD) {
 		pr_err("Unsupported ELF data encoding: %d\n", ehdr->e_ident[EI_DATA]);
 		return false;
 	};


### PR DESCRIPTION
2d2168fc9c142a2eaf18f319b0d21825775d5660 broke s390x by checking EI_DATA against ELFDATA2LSB instead of ELFDATA2MSB. Fix by checking against BORD which is defined at build time to be the right symbol.