### PR TITLE
mem: properly check for COW vmas in case of no ac

### DIFF
--- a/criu/mem.c
+++ b/criu/mem.c
@@ -838,6 +838,10 @@ static inline bool check_cow_vmas(struct vma_area *vma, struct vma_area *pvma)
 	/* ... belong to the same file if being filemap */
 	if (!(vma->e->flags & MAP_ANONYMOUS) && vma->e->shmid != pvma->e->shmid)
 		return false;
+	/* ... both be accountable, since COW VMAs may carry restored pages */
+	if (vma_area_is(vma, VMA_AREA_NOT_ACCOUNTABLE) ||
+	    vma_area_is(pvma, VMA_AREA_NOT_ACCOUNTABLE))
+		return false;
 
 	pr_debug("Found two COW VMAs @0x%" PRIx64 "-0x%" PRIx64 "\n", vma->e->start, pvma->e->end);
 	return true;
@@ -958,17 +962,8 @@ static int premap_private_vma(struct pstree_item *t, struct vma_area *vma, void 
 		 * (did not have the "ac" flag in /proc/pid/smaps), we
 		 * can safely mmap them with PROT_NONE because we know
 		 * we will never need to write any bits to them.
-		 *
-		 * This only holds for a standalone VMA (vma->pvma == NULL).
-		 * A COW root (vma->pvma == VMA_COW_ROOT) shares this very
-		 * mapping with inherited children via the mremap() in the
-		 * branch below; those children may have pages to restore,
-		 * and restoring content into a PROT_NONE mapping faults
-		 * (e.g. the memcmp()/copy in restore_priv_vma_content()).
-		 * So a COW root must stay writable even when it is itself
-		 * PROT_NONE and not accountable.
 		 */
-		if (vma->e->prot == PROT_NONE && vma->pvma == NULL && vma_area_is(vma, VMA_AREA_NOT_ACCOUNTABLE)) {
+		if (vma->e->prot == PROT_NONE && vma_area_is(vma, VMA_AREA_NOT_ACCOUNTABLE)) {
 			addr = mmap(*tgt_addr, size, PROT_NONE, vma->e->flags | MAP_FIXED | flag, vma->e->fd,
 				    vma->e->pgoff);
 		} else {

--- a/test/zdtm/static/cow02.c
+++ b/test/zdtm/static/cow02.c
@@ -4,7 +4,7 @@
 
 #include "zdtmtst.h"
 
-const char *test_doc = "Restore a COW child whose COW-root VMA is a PROT_NONE reservation";
+const char *test_doc = "Restore a COW child whose parent VMA is a PROT_NONE reservation";
 const char *test_author = "Radostin Stoyanov <rstoyanov@fedoraproject.org>";
 
 /*
@@ -13,17 +13,9 @@ const char *test_author = "Radostin Stoyanov <rstoyanov@fedoraproject.org>";
  * VMA_AREA_NOT_ACCOUNTABLE. After fork() the child turns the very same range
  * into a writable mapping and fills it with data.
  *
- * CRIU pairs VMAs that coincide by start/end and flags regardless of their
- * protection bits (see check_cow_vmas()), so the parent's PROT_NONE,
- * not-accountable VMA becomes the COW root of the child's data VMA.
- *
- * On restore, premap_private_vma() used to map a PROT_NONE & not-accountable
- * COW root with PROT_NONE. The child then inherits that mapping (mremap) and
- * restore_priv_vma_content() copies the child's pages into it -- writing to a
- * PROT_NONE mapping faults and the restored task dies with SIGSEGV.
- *
- * The fix keeps a COW root writable; this test crashes at restore without it
- * and passes with it.
+ * Ensure the child's mapping is restored separately, not through COW with the
+ * parent's not-accountable PROT_NONE reservation, so CRIU has a writable
+ * premap for the child's pages.
  */
 
 #define MEM_SIZE (32 * 4096)


### PR DESCRIPTION
This pull request ports the suggestion mentioned here: https://github.com/checkpoint-restore/criu/pull/3037#discussion_r3437235630

I honestly should've been more careful providing a review to https://github.com/checkpoint-restore/criu/pull/3037 considering I am not very familiar with that part of the codebase and memory management in general

In any case, have tried to properly understand and document this fix from @avagin.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
