### PR TITLE
Refactor imports to avoid namespace pollution and clean up code

### DIFF
--- a/lib/pycriu/images/__init__.py
+++ b/lib/pycriu/images/__init__.py
@@ -1,5 +1,6 @@
 import sys, os
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 from .magic import *
-from .images import *
+from .images import (load, loads, dump, dumps, info,
+                     handlers, MagicException, entry_handler)
 from .pb import *

--- a/test/others/rpc/setup_swrk.py
+++ b/test/others/rpc/setup_swrk.py
@@ -1,4 +1,3 @@
-import sys
 import socket
 import subprocess
 


### PR DESCRIPTION
This tries to fix two complaints from codeql.