### PR TITLE
criu: add --memory-dump-mode, a generic alias for --pre-dump-mode

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -185,10 +185,13 @@ In addition, *page-server* options may be specified.
     not passed the memory tracker get turned on implicitly.
 
 *--pre-dump-mode*='mode'::
-    There are two 'mode' to operate pre-dump algorithm. The 'splice' mode
-    is parasite based, whereas 'read' mode is based on process_vm_readv
-    syscall. The 'read' mode incurs reduced frozen time and reduced
-    memory pressure as compared to 'splice' mode. Default is 'splice' mode.
+*--memory-dump-mode*='mode'::
+    Alias for *--pre-dump-mode*. Applies to both dump and pre-dump
+    operations. There are two 'mode' to operate memory dumping algorithm.
+    The 'splice' mode is parasite based, whereas 'read' mode is based on
+    process_vm_readv syscall. The 'read' mode incurs reduced frozen
+    time and reduced memory pressure as compared to 'splice' mode.
+    Default is 'splice' mode.
 
 *dump*
 ~~~~~~

--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -184,14 +184,14 @@ In addition, *page-server* options may be specified.
     Turn on memory changes tracker in the kernel. If the option is
     not passed the memory tracker get turned on implicitly.
 
-*--pre-dump-mode*='mode'::
 *--memory-dump-mode*='mode'::
-    Alias for *--pre-dump-mode*. Applies to both dump and pre-dump
-    operations. There are two 'mode' to operate memory dumping algorithm.
-    The 'splice' mode is parasite based, whereas 'read' mode is based on
+*--pre-dump-mode*='mode'::
+    There are two modes to operate the memory dumping algorithm. The
+    'splice' mode is parasite based, whereas 'read' mode is based on
     process_vm_readv syscall. The 'read' mode incurs reduced frozen
     time and reduced memory pressure as compared to 'splice' mode.
-    Default is 'splice' mode.
+    Applies to both dump and pre-dump. *--pre-dump-mode* is an alias
+    for *--memory-dump-mode*. Default is 'splice' mode.
 
 *dump*
 ~~~~~~

--- a/criu/config.c
+++ b/criu/config.c
@@ -751,6 +751,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		{ "tls-no-cn-verify", no_argument, &opts.tls_no_cn_verify, true },
 		{ "cgroup-yard", required_argument, 0, 1096 },
 		{ "pre-dump-mode", required_argument, 0, 1097 },
+		{ "memory-dump-mode", required_argument, 0, 1097 },
 		{ "file-validation", required_argument, 0, 1098 },
 		BOOL_OPT("skip-file-rwx-check", &opts.skip_file_rwx_check),
 		{ "lsm-mount-context", required_argument, 0, 1099 },
@@ -1132,7 +1133,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 			if (!strcmp("read", optarg)) {
 				opts.pre_dump_mode = PRE_DUMP_READ;
 			} else if (strcmp("splice", optarg)) {
-				pr_err("Unable to parse value of --pre-dump-mode\n");
+				pr_err("Unable to parse value of --pre-dump-mode/--memory-dump-mode\n");
 				return 1;
 			}
 			break;

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -554,8 +554,9 @@ usage:
 	       "                        pages images of previous dump\n"
 	       "                        when used on restore, as soon as page is restored, it\n"
 	       "                        will be punched from the image\n"
-	       "  --pre-dump-mode       splice - parasite based pre-dumping (default)\n"
-	       "                        read   - process_vm_readv syscall based pre-dumping\n"
+	       "  --memory-dump-mode    splice - parasite based memory dumping (default)\n"
+	       "                        read   - process_vm_readv syscall based memory dumping\n"
+	       "                        (alias for --pre-dump-mode, applies to dump as well)\n"
 #ifdef CONFIG_LZ4
 	       "  -c|--compress         enable LZ4 per-page compression of memory pages\n"
 	       "  --compress-region size\n"

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -556,7 +556,8 @@ usage:
 	       "                        will be punched from the image\n"
 	       "  --memory-dump-mode    splice - parasite based memory dumping (default)\n"
 	       "                        read   - process_vm_readv syscall based memory dumping\n"
-	       "                        (alias for --pre-dump-mode, applies to dump as well)\n"
+	       "                        (applies to dump as well)\n"
+	       "  --pre-dump-mode       (alias for --memory-dump-mode)\n"
 #ifdef CONFIG_LZ4
 	       "  -c|--compress         enable LZ4 per-page compression of memory pages\n"
 	       "  --compress-region size\n"

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -387,16 +387,23 @@ static int drain_pages(struct page_pipe *pp, struct parasite_ctl *ctl, struct pa
 	return 0;
 }
 
-static int xfer_pages(struct page_pipe *pp, struct page_xfer *xfer)
+static int xfer_pages(struct page_pipe *pp, struct page_xfer *xfer, int pid, bool external_read)
 {
 	int ret;
 
 	/*
 	 * Step 3 -- write pages into image (or delay writing for
 	 *           pre-dump action (see pre_dump_one_task)
+	 *
+	 * In READ mode no parasite vmsplice ever happened, so the pages
+	 * are pulled straight from the target's address space here via
+	 * process_vm_readv() instead of drained from the parasite pipe.
 	 */
 	timing_start(TIME_MEMWRITE);
-	ret = page_xfer_dump_pages(xfer, pp);
+	if (external_read)
+		ret = page_xfer_predump_pages(pid, xfer, pp);
+	else
+		ret = page_xfer_dump_pages(xfer, pp);
 	timing_stop(TIME_MEMWRITE);
 
 	return ret;
@@ -540,9 +547,16 @@ again:
 	if (ret == -EAGAIN) {
 		BUG_ON(!(pp->flags & PP_CHUNK_MODE));
 
-		ret = drain_pages(pp, ctl, args);
+		/*
+		 * PP_CHUNK_MODE is only ever set for a full (non-pre) dump,
+		 * so this is never reached during pre-dump.
+		 */
+		if (opts.pre_dump_mode == PRE_DUMP_READ)
+			ret = 0;
+		else
+			ret = drain_pages(pp, ctl, args);
 		if (!ret)
-			ret = xfer_pages(pp, xfer);
+			ret = xfer_pages(pp, xfer, item->pid->real, opts.pre_dump_mode == PRE_DUMP_READ);
 		if (!ret) {
 			page_pipe_reinit(pp);
 			goto again;
@@ -646,14 +660,18 @@ static int __parasite_dump_pages_seized(struct pstree_item *item, struct parasit
 	 * will happen after task unfreezing in cr_pre_dump_finish(). This is
 	 * actual optimization which reduces time for which process was frozen
 	 * during pre-dump.
+	 *
+	 * For a full (non-pre) dump in READ mode there's no later stage to
+	 * defer to and no parasite vmsplice to drain either -- xfer_pages()
+	 * below reads the pages directly via process_vm_readv().
 	 */
-	if (mdc->pre_dump && opts.pre_dump_mode == PRE_DUMP_READ)
+	if (opts.pre_dump_mode == PRE_DUMP_READ)
 		ret = 0;
 	else
 		ret = drain_pages(pp, ctl, args);
 
 	if (!ret && !mdc->pre_dump)
-		ret = xfer_pages(pp, &xfer);
+		ret = xfer_pages(pp, &xfer, item->pid->real, opts.pre_dump_mode == PRE_DUMP_READ);
 	if (ret)
 		goto out_xfer;
 

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -1406,7 +1406,7 @@ int page_xfer_predump_pages(int pid, struct page_xfer *xfer, struct page_pipe *p
 			if (xfer->write_pagemap(xfer, &iov, flags))
 				goto err;
 
-			if (xfer->write_pages(xfer, ppb->p[0], iov.iov_len))
+			if ((flags & PE_PRESENT) && xfer->write_pages(xfer, ppb->p[0], iov.iov_len))
 				goto err;
 		}
 


### PR DESCRIPTION
--memory-dump-mode shares the same opt code and parser as --pre-dump-mode (splice|read). Remove the mdc->pre_dump guard from PRE_DUMP_READ paths in mem.c so the process_vm_readv-based read mode works for full dumps too, not just pre-dumps.

Suggested by @avagin in https://github.com/checkpoint-restore/criu/pull/3057#discussion_r3501553625
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
