### PR TITLE
ci: pin third-party actions to SHAs

### DIFF
--- a/.github/actions/lima-vm-setup/action.yml
+++ b/.github/actions/lima-vm-setup/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
   - name: Install Lima
-    uses: lima-vm/lima-actions/setup@v1
+    uses: lima-vm/lima-actions/setup@55627e31b78637bf254a8b2a14da8ea7d12564e5 # v1
   - name: Cache Lima images
     uses: actions/cache@v6
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
     - name: Run gcov
       run: sudo -E find . -name '*gcda' -type f -print0 | sudo -E xargs --null --max-args 128 gcov
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -6,7 +6,7 @@ jobs:
     if: github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
     steps:
-      - uses: mondeja/remove-labels-gh-action@v2
+      - uses: mondeja/remove-labels-gh-action@b7118e4ba5dca74acf1059b3cb7660378ff9ab1a # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |


### PR DESCRIPTION
Third-party GitHub Actions referenced by tags can change without a CRIU patch if the upstream action repository moves or compromises a tag. That is especially sensitive for actions that receive CI credentials such as CODECOV_TOKEN or GITHUB_TOKEN.

Pin the remaining non-GitHub actions used by regular workflows to the full commit IDs currently behind their version tags. Keep the version tag in a comment next to each SHA so reviewers can see the intended release and future updates remain explicit.

Leave GitHub-owned actions on version tags to match the existing linux-next workflow policy, which already pins non-GitHub actions while using tags for actions/* refs. This keeps the hardening focused on third-party supply chain risk without forcing the repository-wide SHA policy that would also require pinning GitHub-authored actions.

Fixes: #3068