### PR TITLE
test: filter known harmless errors in grep_errors()

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -2390,6 +2390,15 @@ def print_error(line):
     return False
 
 
+# Patterns of log messages to ignore in grep_errors(). These are
+# matched as regular expressions against each line. Matching lines
+# are silently skipped and will not trigger "ERROR OVER" output.
+grep_errors_ignore = [
+    # Commonly seen with ns/uns flavors; harmless but triggers ERROR OVER
+    r"Error: ipv[46]: [Aa]ddress already assigned\.",  # codespell:ignore ddress
+]
+
+
 def grep_errors(fname, err=False):
     first = True
     print_next = False
@@ -2399,6 +2408,9 @@ def grep_errors(fname, err=False):
             before.append(line)
             if len(before) > 5:
                 before.pop(0)
+            # Skip lines matching known harmless messages
+            if any(re.search(p, line) for p in grep_errors_ignore):
+                continue
             if "Error" in line or "Warn" in line:
                 if first:
                     print_fname(fname, 'log')


### PR DESCRIPTION
Add a regex-based ignore list to grep_errors() so that known harmless log messages do not trigger "ERROR OVER" output. This reduces noise when running tests with ns/uns flavors where "Address already assigned" messages are expected and benign.

This reduces CI output by at least 14400 lines (8*450*2*2): 8 lines per occurrence, ~450 tests, 2 flavors (ns and uns), each running with and without --mntns-compat-mode.