### PR TITLE
pipes: fall back to write() when vmsplice(SPLICE_F_GIFT) is unsupported

### DIFF
--- a/criu/pipes.c
+++ b/criu/pipes.c
@@ -181,8 +181,21 @@ int restore_pipe_data(int img_type, int pfd, u32 id, struct pipe_data_rst **hash
 	while (iov.iov_len > 0) {
 		ret = vmsplice(pfd, &iov, 1, SPLICE_F_GIFT | SPLICE_F_NONBLOCK);
 		if (ret < 0) {
-			pr_perror("%#x: Error splicing data", id);
-			return -1;
+			/*
+			 * Since linux-next (see https://lwn.net/Articles/1075838/)
+			 * vmsplice() with SPLICE_F_GIFT into a pipe can fail with
+			 * EOPNOTSUPP. Fall back to a plain write() in that case.
+			 */
+			if (errno == EOPNOTSUPP) {
+				ret = write(pfd, iov.iov_base, iov.iov_len);
+				if (ret < 0) {
+					pr_perror("%#x: Error writing data", id);
+					return -1;
+				}
+			} else {
+				pr_perror("%#x: Error splicing data", id);
+				return -1;
+			}
 		}
 
 		if (ret == 0 || ret > iov.iov_len /* sanity */) {


### PR DESCRIPTION
Fixes #3056.

On recent kernels (linux-next, see https://lwn.net/Articles/1075838/),
vmsplice() with SPLICE_F_GIFT into a pipe can fail with EOPNOTSUPP. This
breaks restore of pipe/fifo data and causes these zdtm tests to fail:

- zdtm/static/fifo
- zdtm/static/fifo-ghost
- zdtm/static/fifo-rowo-pair
- zdtm/static/fifo_ro

restore_pipe_data() now falls back to a plain write() when vmsplice()
reports EOPNOTSUPP, as suggested by @adrianreber in the issue.