### PR TITLE
util: Ignore chown errors on restore in unprivileged mode

### DIFF
--- a/criu/util.c
+++ b/criu/util.c
@@ -994,8 +994,14 @@ int cr_fchown(int fd, uid_t new_uid, gid_t new_gid)
 	}
 	pr_debug("fstat(%d): uid %u gid %u\n", fd, st.st_uid, st.st_gid);
 
-	if (new_uid != st.st_uid || new_gid != st.st_gid)
+	if (new_uid != st.st_uid || new_gid != st.st_gid) {
+		if (opts.unprivileged) {
+			pr_warn("Unable to change fd %d ownership (%d, %d) to (%d, %d): Operation not permitted (ignored in unprivileged mode)\n",
+				fd, st.st_uid, st.st_gid, new_uid, new_gid);
+			return 0;
+		}
 		goto out_eperm;
+	}
 
 	return 0;
 out_eperm:
@@ -1024,11 +1030,16 @@ int cr_fchpermat(int dirfd, const char *path, uid_t new_uid, gid_t new_gid, mode
 	}
 
 	if (new_uid != st.st_uid || new_gid != st.st_gid) {
-		errno = EPERM;
-		pr_perror("Unable to change [%d]/%s ownership (%d, %d) to (%d, %d)",
-			  dirfd, path, st.st_uid, st.st_gid, new_uid, new_gid);
-		errno = EPERM;
-		return -1;
+		if (opts.unprivileged) {
+			pr_warn("Unable to change [%d]/%s ownership (%d, %d) to (%d, %d): Operation not permitted (ignored in unprivileged mode)\n",
+				dirfd, path, st.st_uid, st.st_gid, new_uid, new_gid);
+		} else {
+			errno = EPERM;
+			pr_perror("Unable to change [%d]/%s ownership (%d, %d) to (%d, %d)",
+				  dirfd, path, st.st_uid, st.st_gid, new_uid, new_gid);
+			errno = EPERM;
+			return -1;
+		}
 	}
 
 	if (new_mode == st.st_mode)

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -471,6 +471,7 @@ TST_DIR		=				\
 		del_standalone_un_seqpacket	\
 		sk-unix-mntns			\
 		sk-unix01			\
+		sk_unix_owner			\
 		sk-unix01-seqpacket		\
 		sk-unix-dgram-ghost		\
 		unsupported_children_collision  \

--- a/test/zdtm/static/sk_unix_owner.c
+++ b/test/zdtm/static/sk_unix_owner.c
@@ -1,0 +1,171 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <linux/limits.h>
+#include <errno.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check UNIX socket ownership is preserved/handled after C/R";
+const char *test_author = "Apurve Karanwal <karanwalapurve@gmail.com>";
+
+char *dirname;
+TEST_OPTION(dirname, string, "directory name", 1);
+
+#define TEST_STRING "Hello UNIX socket owner"
+
+int main(int argc, char **argv)
+{
+	int listen_fd = -1, client_fd = -1, accept_fd = -1;
+	struct sockaddr_un addr;
+	char filename[PATH_MAX];
+	struct stat st_before, st_after;
+	uid_t expected_uid;
+	gid_t expected_gid;
+	char buf[sizeof(TEST_STRING)];
+	int ret;
+
+	test_init(argc, argv);
+
+	if (mkdir(dirname, 0755) < 0 && errno != EEXIST) {
+		pr_perror("Can't create %s", dirname);
+		return 1;
+	}
+
+	snprintf(filename, sizeof(filename), "%s/sk_unix_owner.sock", dirname);
+
+	if (unix_fill_sock_name(&addr, filename))
+		return 1;
+
+	listen_fd = socket(PF_UNIX, SOCK_STREAM, 0);
+	if (listen_fd < 0) {
+		pr_perror("socket() failed");
+		return 1;
+	}
+
+	unlink(addr.sun_path);
+
+	if (bind(listen_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		pr_perror("bind() failed");
+		close(listen_fd);
+		return 1;
+	}
+
+	if (listen(listen_fd, 5) < 0) {
+		pr_perror("listen() failed");
+		close(listen_fd);
+		return 1;
+	}
+
+	/*
+	 * If running as root, change socket file ownership to test that uid/gid
+	 * are properly saved and restored across C/R. Otherwise, just
+	 * verify the current ownership is preserved.
+	 */
+	if (getuid() == 0) {
+		expected_uid = 13333;
+		expected_gid = 44444;
+		if (chown(addr.sun_path, expected_uid, expected_gid)) {
+			pr_perror("chown() failed");
+			close(listen_fd);
+			return 1;
+		}
+	} else {
+		expected_uid = getuid();
+		expected_gid = getgid();
+	}
+
+	/* Record ownership before C/R */
+	if (stat(addr.sun_path, &st_before)) {
+		pr_perror("stat() failed before C/R");
+		close(listen_fd);
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	/* Verify ownership after C/R */
+	if (stat(addr.sun_path, &st_after)) {
+		pr_perror("stat() failed after C/R");
+		close(listen_fd);
+		return 1;
+	}
+
+	/*
+	 * If we run as root, we expect the ownership to be preserved.
+	 * In unprivileged mode, we might not have CAP_CHOWN to restore the
+	 * ownership to 13333:44444. So we only check for mismatch if getuid() == 0.
+	 */
+	if (getuid() == 0) {
+		if (st_after.st_uid != expected_uid || st_after.st_gid != expected_gid) {
+			fail("UID/GID mismatch (got %d/%d but %d/%d expected)",
+			     (int)st_after.st_uid, (int)st_after.st_gid,
+			     (int)expected_uid, (int)expected_gid);
+			close(listen_fd);
+			return 1;
+		}
+	}
+
+	/* Verify the socket still works by connecting and exchanging data */
+	client_fd = socket(PF_UNIX, SOCK_STREAM, 0);
+	if (client_fd < 0) {
+		pr_perror("client socket() failed");
+		close(listen_fd);
+		return 1;
+	}
+
+	if (connect(client_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		pr_perror("connect() failed");
+		close(client_fd);
+		close(listen_fd);
+		return 1;
+	}
+
+	accept_fd = accept(listen_fd, NULL, NULL);
+	if (accept_fd < 0) {
+		pr_perror("accept() failed");
+		close(client_fd);
+		close(listen_fd);
+		return 1;
+	}
+
+	ret = write(client_fd, TEST_STRING, sizeof(TEST_STRING));
+	if (ret != sizeof(TEST_STRING)) {
+		pr_perror("write() failed");
+		close(accept_fd);
+		close(client_fd);
+		close(listen_fd);
+		return 1;
+	}
+
+	ret = read(accept_fd, buf, sizeof(TEST_STRING));
+	if (ret != sizeof(TEST_STRING)) {
+		pr_perror("read() failed");
+		close(accept_fd);
+		close(client_fd);
+		close(listen_fd);
+		return 1;
+	}
+
+	if (strcmp(TEST_STRING, buf)) {
+		fail("data corruption");
+		close(accept_fd);
+		close(client_fd);
+		close(listen_fd);
+		return 1;
+	}
+
+	close(accept_fd);
+	close(client_fd);
+	close(listen_fd);
+	unlink(addr.sun_path);
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/sk_unix_owner.desc
+++ b/test/zdtm/static/sk_unix_owner.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h ns uns', 'flags': 'suid'}


### PR DESCRIPTION
# Description

### What does this PR do?
This PR resolves an issue where restoring UNIX domain sockets (and other files such as pipes or ghost files) fails with an `EPERM` error when running CRIU in unprivileged mode (e.g., inside a user namespace or a rootless container). 

### How does it do it?
In unprivileged mode, the restoring process does not possess `CAP_CHOWN`. Thus, any attempt to restore the socket's owner back to the original `uid`/`gid` via `fchown`/`fchownat` will fail. Since the restored process runs under the unprivileged user's UID anyway, it will still have access to the socket, making this ownership mismatch non-fatal.

This PR modifies `cr_fchown` and `cr_fchpermat` in `criu/util.c` to:
1. Log a warning using `pr_warn` when `fchown` or `fchownat` fails with `EPERM` due to insufficient privileges.
2. Gracefully bypass the ownership change failure and return `0` (success) when `opts.unprivileged` is set.
3. Added a new ZDTM static test case `sk_unix_owner` that validates UNIX domain socket ownership is correctly handled during checkpoint and restore under both root (`h` and `ns` flavors with SUID) and unprivileged/rootless (`uns` flavor) environments.

Fixes: #2762 

## Verification Results
### Automated ZDTM Tests
A new test `sk_unix_owner` was added to verify both SUID preservation (as root) and graceful fallback (under user namespaces):
- `sudo ./test/zdtm.py run -t zdtm/static/sk_unix_owner` (verifies `chown` ownership is preserved across C/R)
- `sudo ./test/zdtm.py run -t zdtm/static/sk_unix_owner -f uns` (verifies that ownership failure is ignored gracefully and socket communication remains fully functional)