### PR TITLE
python: remove redundant variable definitions flagged by CodeQL

### DIFF
--- a/soccr/test/run.py
+++ b/soccr/test/run.py
@@ -44,7 +44,6 @@ if str2 != eval(s):
     print("FAIL", repr(str2), repr(s))
     sys.exit(5)
 
-s = p1.stdout.read()
 m = hashlib.md5()
 m.update(str1)
 str1 = m.hexdigest()

--- a/test/inhfd/fifo.py
+++ b/test/inhfd/fifo.py
@@ -15,7 +15,6 @@ def create_fds():
     os.system("umount -l %s" % tdir)
     os.rmdir(tdir)
 
-    mnt_id = -1
     with open("/proc/self/fdinfo/%d" % fd1.fileno()) as f:
         for line in f:
             line = line.split()

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1178,7 +1178,7 @@ class criu:
 
     def fini(self):
         if self.__lazy_migrate:
-            ret = self.__dump_process.wait()
+            self.__dump_process.wait()
         if self.__lazy_pages_p:
             ret = self.__lazy_pages_p.wait()
             grep_errors(os.path.join(self.__ddir(), "lazy-pages.log"), err=ret)
@@ -1360,7 +1360,6 @@ class criu:
         if not os.access(self.__stats_file("dump"), os.R_OK):
             return
 
-        stats_written = -1
         with open(self.__stats_file("dump"), 'rb') as stfile:
             stats = crpc.images.load(stfile)
             stent = stats['entries'][0]['dump']
@@ -2223,8 +2222,6 @@ class Launcher:
             self.wait()
 
     def __wait_one(self, flags):
-        pid = -1
-        status = -1
         signal.alarm(10)
         while True:
             try:


### PR DESCRIPTION
  Remove "Variable defined multiple times" warnings reported by CodeQL.  Most are C-style sentinel initializations (e.g. `x = -1`) that are   unnecessary in Python because the variable is always assigned before  use or an exception is raised. Also removes a no-op  `p1.stdout.read()` call which was unused and overwritten.