### PR TITLE
Fix soccr tests and run them in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,7 @@ clean-cuda_plugin:
 
 clean-top:
 	$(Q) $(MAKE) -C Documentation clean
+	$(Q) $(MAKE) -C soccr/test clean
 	$(Q) $(MAKE) $(build)=test/compel clean
 	$(Q) $(RM) .gitid
 .PHONY: clean-top
@@ -469,7 +470,9 @@ ruff:
 		scripts/github-indent-warnings.py \
 		contrib/criu-service-client/test/*.py \
 		contrib/compression-benchmark/ \
-		test/others/compression/
+		test/others/compression/ \
+		soccr/test/run.py \
+		soccr/test/tcp-test.py
 
 shellcheck:
 	shellcheck --version

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -247,6 +247,7 @@ export SKIP_PREP=1
 chmod 0777 test/
 chmod 0777 test/zdtm/static
 chmod 0777 test/zdtm/transition
+chmod 0777 soccr/test/
 
 # We run streaming tests separately to improve test completion times,
 # hence the exit 0.
@@ -481,6 +482,9 @@ run_non_shardable_tests() {
 
 	# compel testing
 	make -C compel/test
+
+	# soccr testing
+	make -C soccr/test
 
 	# amdgpu and cuda plugin testing
 	make amdgpu_plugin

--- a/soccr/test/Makefile
+++ b/soccr/test/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -Wall -g -I../../
+CFLAGS += -Wall -g -I../../ -I../../include
 LDFLAGS += -L../ -lsoccr ../libsoccr.a -lnet
 
 RUN ?= tcp-constructor
@@ -10,7 +10,7 @@ tcp-constructor: tcp-constructor.c ../libsoccr.a
 	$(CC) $(CFLAGS) tcp-constructor.c -o tcp-constructor $(LDFLAGS)
 
 clean:
-	rm -f tcp-constructor
+	@rm -f tcp-constructor tcp-conn tcp-conn-v6
 
 tcp-conn: tcp-conn.c
 	$(CC) $(CFLAGS) tcp-conn.c -o tcp-conn $(LDFLAGS)
@@ -18,6 +18,8 @@ tcp-conn: tcp-conn.c
 tcp-conn-v6: tcp-conn-v6.c
 	$(CC) $(CFLAGS) -DTEST_IPV6 tcp-conn-v6.c -o tcp-conn-v6 $(LDFLAGS)
 
+# Do not call this target directly. Use "make run" instead, which
+# sets up the network namespace that tcp-constructor requires.
 test: tcp-constructor tcp-conn tcp-conn-v6
 	unshare -n sh -c "ip link set up dev lo; ./tcp-conn"
 	unshare -n sh -c "ip link set up dev lo; ./tcp-conn-v6"

--- a/soccr/test/run.py
+++ b/soccr/test/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
-import sys, os
+import ast
+import sys
+import os
 import hashlib
 from subprocess import Popen, PIPE
 
-str2 = "test_test" * (1 << 20)
-str1 = "Test_Test!"
+str2 = b"test_test" * (1 << 20)
+str1 = b"Test_Test!"
 
 src = os.getenv("TCP_SRC", "127.0.0.1")
 dst = os.getenv("TCP_DST", "127.0.0.1")
@@ -27,8 +29,8 @@ p2 = Popen(args + ["src"], stdout=PIPE, stdin=PIPE)
 
 p1.stdout.read(5)
 p2.stdout.read(5)
-p1.stdin.write("start")
-p2.stdin.write("start")
+p1.stdin.write(b"start")
+p2.stdin.write(b"start")
 
 p1.stdin.write(str1)
 p1.stdin.close()
@@ -40,7 +42,9 @@ m = hashlib.md5()
 m.update(str2)
 str2 = m.hexdigest()
 
-if str2 != eval(s):
+# tcp-test.py prints repr(hexdigest()), so we parse it back.
+# Use literal_eval instead of eval to avoid code injection.
+if str2 != ast.literal_eval(s.decode()):
     print("FAIL", repr(str2), repr(s))
     sys.exit(5)
 
@@ -49,7 +53,7 @@ m.update(str1)
 str1 = m.hexdigest()
 
 s = p2.stdout.read()
-if str1 != eval(s):
+if str1 != ast.literal_eval(s.decode()):
     print("FAIL", repr(str1), s)
     sys.exit(5)
 

--- a/soccr/test/tcp-conn.c
+++ b/soccr/test/tcp-conn.c
@@ -1,3 +1,7 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <sys/socket.h>
 #include <arpa/inet.h> /* for srvaddr_in and inet_ntoa() */
 #include <string.h>
@@ -7,13 +11,6 @@
 #include <stdarg.h>
 
 #define pr_perror(fmt, ...) printf(fmt ": %m\n", ##__VA_ARGS__)
-
-enum {
-	TCP_NO_QUEUE,
-	TCP_RECV_QUEUE,
-	TCP_SEND_QUEUE,
-	TCP_QUEUES_NR,
-};
 static void pr_printf(unsigned int level, const char *fmt, ...)
 {
 	va_list args;
@@ -145,7 +142,7 @@ int main(void)
 	}
 
 	libsoccr_resume(so_rst);
-	libsoccr_resume(so);
+	libsoccr_release(so);
 
 	if (read(rst, &buf, sizeof(buf)) != sizeof(buf)) {
 		pr_perror("read");

--- a/soccr/test/tcp-constructor.c
+++ b/soccr/test/tcp-constructor.c
@@ -1,13 +1,18 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
-#include <linux/socket.h>
-#include <netinet/tcp.h>
 #include <string.h>
 #include <getopt.h>
 #include <stdlib.h>
 
+/* soccr.h includes <netinet/tcp.h> and provides fallback
+ * definitions guarded by CONFIG_HAS_TCP_REPAIR. Including
+ * <netinet/tcp.h> separately can cause redefinition errors. */
 #include "soccr/soccr.h"
 
 #define pr_perror(fmt, ...)                                                                  \

--- a/soccr/test/tcp-test.py
+++ b/soccr/test/tcp-test.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
-import sys, socket
+import sys
+import socket
 import hashlib
 
 sk = socket.fromfd(3, socket.AF_INET, socket.SOCK_STREAM)
 
-s = sys.stdin.read()
+s = sys.stdin.buffer.read()
 ret = sk.send(s)
 print("%s: send() -> %d" % (sys.argv[1], ret), file=sys.stderr)
 sk.shutdown(socket.SHUT_WR)


### PR DESCRIPTION
The python code in `soccr/test` claimed to be Python 3 code according to the shebang but it was not. The C code also didn't compile any more. This fixes the C code, ports the Python code to 3, runs it through the linters and also runs the soccr tests now in CI.