### PR TITLE
ci: run flaky nftables test on 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
 
   nftables-test:
     needs: [alpine-test]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - uses: actions/checkout@v7
     - name: Remove iptables


### PR DESCRIPTION
The kernel for the github actions 26.04 images fixed the kernel to no longer have the bug that lead to the `socket-tcbuf*` failures.

Related to #3042