### PR TITLE
ci: skip ncurses installation for cross compile

### DIFF
--- a/contrib/dependencies/apt-cross-packages.sh
+++ b/contrib/dependencies/apt-cross-packages.sh
@@ -28,7 +28,6 @@ fi
 	libssl-dev:"${DEBIAN_ARCH}" \
 	libtraceevent-dev:"${DEBIAN_ARCH}" \
 	libtracefs-dev:"${DEBIAN_ARCH}" \
-	ncurses-dev:"${DEBIAN_ARCH}" \
 	uuid-dev:"${DEBIAN_ARCH}" \
 	build-essential \
 	pkg-config \


### PR DESCRIPTION
The cross compile test for riscv was always failing with repository inconsistencies around ncurses packages. The package is not actually needed for CRIU, so just drop it.