### PR TITLE
criu: force link-remap ON for nvproxy/vLLM container C/R

### DIFF
--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -506,6 +506,15 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 
 	if (req->has_link_remap)
 		opts.link_remap_ok = req->link_remap;
+	/*
+	 * Force link-remap ON. runc/crun invoke criu via the swrk RPC mode,
+	 * which neither passes --link-remap on the command line nor reads the
+	 * criu config file. Python/vLLM creates deleted POSIX semaphores in
+	 * /dev/shm (e.g. /dev/shm/sem.* (deleted)) that criu cannot dump without
+	 * link-remap. This is required for container checkpoint of vLLM under
+	 * nvproxy. Remove if a future runtime passes link-remap via RPC.
+	 */
+	opts.link_remap_ok = 1; /* force link-remap on for nvproxy/vLLM C/R */
 
 	if (req->has_auto_dedup)
 		opts.auto_dedup = req->auto_dedup;


### PR DESCRIPTION
runc/crun invoke criu via the swrk RPC mode, which neither passes --link-remap on the command line nor reads the criu config file. Python/vLLM creates deleted POSIX semaphores in /dev/shm (e.g. /dev/shm/sem.* (deleted)) that criu cannot dump without link-remap. Force opts.link_remap_ok = 1 so container checkpoint of vLLM under nvproxy succeeds.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
