### PR TITLE
tree-wide: Makefile: use -MP CFLAG to produce .d files

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -118,7 +118,7 @@ ifeq ($(PROTOUFIX),y)
 endif
 $(obj)/$(1).pb-c.d: $(obj)/$(1).pb-c.c $(addsuffix .pb-c.d,$(addprefix $(obj)/,$(2))) $(makefile-deps)
 	$$(E) "  DEP     " $$@
-	$$(Q) $$(CC) -M -MT $$@ -MT $$(patsubst %.d,%.o,$$@) $$(CFLAGS) $$< -o $$@
+	$$(Q) $$(CC) -M -MP -MT $$@ -MT $$(patsubst %.d,%.o,$$@) $$(CFLAGS) $$< -o $$@
 endef
 
 $(foreach file, $(proto-obj-y),                                                 \

--- a/scripts/nmk/scripts/build.mk
+++ b/scripts/nmk/scripts/build.mk
@@ -76,7 +76,7 @@ $(1).s: $(2).c $(__nmk-makefile-deps)
 	$$(Q) $$(CC) -S -fverbose-asm $$(strip $$(nmk-ccflags)) $$< -o $$@
 $(1).d: $(2).c $(__nmk-makefile-deps)
 	$$(call msg-dep, $$@)
-	$$(Q) $$(CC) -M -MT $$@ -MT $$(patsubst %.d,%.o,$$@) $$(strip $$(nmk-ccflags)) $$< -o $$@
+	$$(Q) $$(CC) -M -MP -MT $$@ -MT $$(patsubst %.d,%.o,$$@) $$(strip $$(nmk-ccflags)) $$< -o $$@
 $(1).o: $(2).S $(__nmk-makefile-deps)
 	$$(call msg-cc, $$@)
 	$$(Q) $$(CC) -c $$(strip $$(nmk-asflags)) $$< -o $$@
@@ -85,7 +85,7 @@ $(1).i: $(2).S $(__nmk-makefile-deps)
 	$$(Q) $$(CC) -E $$(strip $$(nmk-asflags)) $$< -o $$@
 $(1).d: $(2).S $(__nmk-makefile-deps)
 	$$(call msg-dep, $$@)
-	$$(Q) $$(CC) -M -MT $$@ -MT $$(patsubst %.d,%.o,$$@) $$(strip $$(nmk-asflags)) $$< -o $$@
+	$$(Q) $$(CC) -M -MP -MT $$@ -MT $$(patsubst %.d,%.o,$$@) $$(strip $$(nmk-asflags)) $$< -o $$@
 endef
 
 include $(src-makefile)
@@ -227,7 +227,7 @@ $(patsubst %.o,%.s,$(addprefix $(obj)/,$(1))): $(obj)/%.s: $(obj)/%.c $(__nmk-ma
 	$$(Q) $$(HOSTCC) -S -fverbose-asm $$(strip $$(nmk-host-ccflags)) $$< -o $$@
 $(patsubst %.o,%.d,$(addprefix $(obj)/,$(1))): $(obj)/%.d: $(obj)/%.c $(__nmk-makefile-deps)
 	$$(call msg-host-dep, $$@)
-	$$(Q) $$(HOSTCC) -M -MT $$@ -MT $$(patsubst %.d,%.o,$$@) $$(strip $$(nmk-host-ccflags)) $$< -o $$@
+	$$(Q) $$(HOSTCC) -M -MP -MT $$@ -MT $$(patsubst %.d,%.o,$$@) $$(strip $$(nmk-host-ccflags)) $$< -o $$@
 endef
 
 define gen-host-rules


### PR DESCRIPTION
Let's use -MP gcc flag when generating dependency (.d) files. According to the manual:
```
       -MP This option instructs CPP to add a phony target for each
           dependency other than the main file, causing each to depend on
           nothing.  These dummy rules work around errors make gives if
           you remove header files without updating the Makefile to
           match.
```
This fixes incremental rebuild failures like:
```
make[2]: 'compel/compel-host-bin' is up to date.
  DEP      criu/arch/x86/crtools.d
  CC       criu/arch/x86/crtools.o
  LINK     criu/arch/x86/crtools.built-in.o
make[3]: Nothing to be done for 'all'.
make[3]: *** No rule to make target 'criu/include/linux/rseq.h', needed by 'criu/pie/parasite.o'.  Stop.
make[2]: *** [criu/Makefile:59: pie] Error 2
```

Usually, after header files renames or source directory tree reorganization.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
