### PR TITLE
criu: add --rootless-container mode

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -185,10 +185,13 @@ In addition, *page-server* options may be specified.
     not passed the memory tracker get turned on implicitly.
 
 *--pre-dump-mode*='mode'::
-    There are two 'mode' to operate pre-dump algorithm. The 'splice' mode
-    is parasite based, whereas 'read' mode is based on process_vm_readv
-    syscall. The 'read' mode incurs reduced frozen time and reduced
-    memory pressure as compared to 'splice' mode. Default is 'splice' mode.
+*--memory-dump-mode*='mode'::
+    Alias for *--pre-dump-mode*. Applies to both dump and pre-dump
+    operations. There are two 'mode' to operate memory dumping algorithm.
+    The 'splice' mode is parasite based, whereas 'read' mode is based on
+    process_vm_readv syscall. The 'read' mode incurs reduced frozen
+    time and reduced memory pressure as compared to 'splice' mode.
+    Default is 'splice' mode.
 
 *dump*
 ~~~~~~

--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -184,14 +184,14 @@ In addition, *page-server* options may be specified.
     Turn on memory changes tracker in the kernel. If the option is
     not passed the memory tracker get turned on implicitly.
 
-*--pre-dump-mode*='mode'::
 *--memory-dump-mode*='mode'::
-    Alias for *--pre-dump-mode*. Applies to both dump and pre-dump
-    operations. There are two 'mode' to operate memory dumping algorithm.
-    The 'splice' mode is parasite based, whereas 'read' mode is based on
+*--pre-dump-mode*='mode'::
+    There are two modes to operate the memory dumping algorithm. The
+    'splice' mode is parasite based, whereas 'read' mode is based on
     process_vm_readv syscall. The 'read' mode incurs reduced frozen
     time and reduced memory pressure as compared to 'splice' mode.
-    Default is 'splice' mode.
+    Applies to both dump and pre-dump. *--pre-dump-mode* is an alias
+    for *--memory-dump-mode*. Default is 'splice' mode.
 
 *dump*
 ~~~~~~

--- a/compel/include/uapi/infect.h
+++ b/compel/include/uapi/infect.h
@@ -32,6 +32,7 @@ struct seize_task_status {
 	int vpid;
 	int ppid;
 	int seccomp_mode;
+	bool seccomp_suspend_failed;
 };
 
 extern int __must_check compel_wait_task(int pid, int ppid,

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -308,8 +308,12 @@ try_again:
 		return -1;
 	}
 
-	if (ss->seccomp_mode != SECCOMP_MODE_DISABLED && ptrace_suspend_seccomp(pid) < 0)
-		goto err;
+	if (ss->seccomp_mode != SECCOMP_MODE_DISABLED) {
+		if (ptrace_suspend_seccomp(pid) < 0) {
+			pr_warn("Unable to suspend seccomp for %d, memory will be read via process_vm_readv\n", pid);
+			ss->seccomp_suspend_failed = true;
+		}
+	}
 
 	/*
 	 * FIXME(issues/1429): parasite code contains instructions that trigger

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -310,7 +310,11 @@ try_again:
 
 	if (ss->seccomp_mode != SECCOMP_MODE_DISABLED) {
 		if (ptrace_suspend_seccomp(pid) < 0) {
-			pr_warn("Unable to suspend seccomp for %d, memory will be read via process_vm_readv\n", pid);
+			pr_warn("Unable to suspend seccomp for %d: %s. "
+				"Memory read via process_vm_readv; other parasite "
+				"syscalls may still be blocked. If the dump fails "
+				"with SIGSYS, relax the seccomp profile.\n",
+				pid, strerror(errno));
 			ss->seccomp_suspend_failed = true;
 		}
 	}

--- a/criu/config.c
+++ b/criu/config.c
@@ -751,6 +751,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		{ "tls-no-cn-verify", no_argument, &opts.tls_no_cn_verify, true },
 		{ "cgroup-yard", required_argument, 0, 1096 },
 		{ "pre-dump-mode", required_argument, 0, 1097 },
+		{ "memory-dump-mode", required_argument, 0, 1097 },
 		{ "file-validation", required_argument, 0, 1098 },
 		BOOL_OPT("skip-file-rwx-check", &opts.skip_file_rwx_check),
 		{ "lsm-mount-context", required_argument, 0, 1099 },
@@ -1132,7 +1133,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 			if (!strcmp("read", optarg)) {
 				opts.pre_dump_mode = PRE_DUMP_READ;
 			} else if (strcmp("splice", optarg)) {
-				pr_err("Unable to parse value of --pre-dump-mode\n");
+				pr_err("Unable to parse value of --pre-dump-mode/--memory-dump-mode\n");
 				return 1;
 			}
 			break;

--- a/criu/config.c
+++ b/criu/config.c
@@ -759,6 +759,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		{ "image-io-mode", required_argument, 0, 1101 },
 		BOOL_OPT("mntns-compat-mode", &opts.mntns_compat_mode),
 		BOOL_OPT("unprivileged", &opts.unprivileged),
+		BOOL_OPT("rootless-container", &opts.rootless_container),
 		BOOL_OPT("ghost-fiemap", &opts.ghost_fiemap),
 		BOOL_OPT(OPT_ALLOW_UPROBES, &opts.allow_uprobes),
 		{ "compress",                no_argument,       0, 'c'  },
@@ -1320,6 +1321,16 @@ int check_options(void)
 
 	if (check_namespace_opts()) {
 		pr_err("Error: namespace flags conflict\n");
+		return 1;
+	}
+
+	if (opts.rootless_container && opts.mode != CR_DUMP && opts.mode != CR_RESTORE) {
+		pr_err("--rootless-container is only valid for dump and restore\n");
+		return 1;
+	}
+
+	if (opts.rootless_container && opts.swrk_restore) {
+		pr_err("--rootless-container is incompatible with swrk restore\n");
 		return 1;
 	}
 

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -1738,7 +1738,7 @@ static int cr_pre_dump_finish(int status, const InventoryEntry *parent_ie)
 
 		mem_pp = dmpi(item)->mem_pp;
 
-		if (opts.pre_dump_mode == PRE_DUMP_READ) {
+		if (opts.pre_dump_mode == PRE_DUMP_READ || opts.seccomp_suspend_failed) {
 			timing_stop(TIME_MEMWRITE);
 			ret = page_xfer_predump_pages(item->pid->real, &xfer, mem_pp);
 		} else {

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -554,8 +554,9 @@ usage:
 	       "                        pages images of previous dump\n"
 	       "                        when used on restore, as soon as page is restored, it\n"
 	       "                        will be punched from the image\n"
-	       "  --pre-dump-mode       splice - parasite based pre-dumping (default)\n"
-	       "                        read   - process_vm_readv syscall based pre-dumping\n"
+	       "  --memory-dump-mode    splice - parasite based memory dumping (default)\n"
+	       "                        read   - process_vm_readv syscall based memory dumping\n"
+	       "                        (alias for --pre-dump-mode, applies to dump as well)\n"
 #ifdef CONFIG_LZ4
 	       "  -c|--compress         enable LZ4 per-page compression of memory pages\n"
 	       "  --compress-region size\n"

--- a/criu/crtools.c
+++ b/criu/crtools.c
@@ -556,7 +556,8 @@ usage:
 	       "                        will be punched from the image\n"
 	       "  --memory-dump-mode    splice - parasite based memory dumping (default)\n"
 	       "                        read   - process_vm_readv syscall based memory dumping\n"
-	       "                        (alias for --pre-dump-mode, applies to dump as well)\n"
+	       "                        (applies to dump as well)\n"
+	       "  --pre-dump-mode       (alias for --memory-dump-mode)\n"
 #ifdef CONFIG_LZ4
 	       "  -c|--compress         enable LZ4 per-page compression of memory pages\n"
 	       "  --compress-region size\n"

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -293,6 +293,12 @@ struct cr_options {
 	 * explicitly request it as it comes with many limitations.
 	 */
 	int unprivileged;
+	/*
+	 * Set when PTRACE_O_SUSPEND_SECCOMP failed during seize (e.g. rootless
+	 * containers). Page memory is dumped with process_vm_readv instead of
+	 * the parasite vmsplice path.
+	 */
+	bool seccomp_suspend_failed;
 };
 
 extern struct cr_options opts;

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -294,6 +294,13 @@ struct cr_options {
 	 */
 	int unprivileged;
 	/*
+	 * Set when the target lives inside a user namespace (rootless
+	 * containers). CRIU crosses the userns boundary with a helper
+	 * process for netns and mountns operations. Distinct from
+	 * --unprivileged (CRIU itself runs as non-root).
+	 */
+	int rootless_container;
+	/*
 	 * Set when PTRACE_O_SUSPEND_SECCOMP failed during seize (e.g. rootless
 	 * containers). Page memory is dumped with process_vm_readv instead of
 	 * the parasite vmsplice path.
@@ -303,6 +310,11 @@ struct cr_options {
 
 extern struct cr_options opts;
 extern char *rpc_cfg_file;
+
+static inline bool criu_is_unprivileged_or_rootless(void)
+{
+	return opts.unprivileged || opts.rootless_container;
+}
 
 extern int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, int state);
 extern int check_options(void);

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -356,6 +356,15 @@ prep_dump_pages_args(struct parasite_ctl *ctl, struct vm_area_list *vma_area_lis
 	return args;
 }
 
+static bool mem_read_externally(void)
+{
+	if (opts.seccomp_suspend_failed)
+		return true;
+	if (opts.pre_dump_mode == PRE_DUMP_READ)
+		return true;
+	return false;
+}
+
 static int drain_pages(struct page_pipe *pp, struct parasite_ctl *ctl, struct parasite_dump_pages_args *args)
 {
 	struct page_pipe_buf *ppb;
@@ -517,7 +526,7 @@ static int generate_vma_iovs(struct pstree_item *item, struct vma_area *vma, str
 	 */
 
 	if (!(vma->e->prot & PROT_READ)) {
-		if (opts.pre_dump_mode == PRE_DUMP_READ && pre_dump)
+		if (mem_read_externally())
 			return 0;
 		if ((parent_predump_mode == PRE_DUMP_READ && opts.pre_dump_mode == PRE_DUMP_SPLICE) || !pre_dump)
 			has_parent = false;
@@ -547,16 +556,12 @@ again:
 	if (ret == -EAGAIN) {
 		BUG_ON(!(pp->flags & PP_CHUNK_MODE));
 
-		/*
-		 * PP_CHUNK_MODE is only ever set for a full (non-pre) dump,
-		 * so this is never reached during pre-dump.
-		 */
-		if (opts.pre_dump_mode == PRE_DUMP_READ)
+		if (mem_read_externally())
 			ret = 0;
 		else
 			ret = drain_pages(pp, ctl, args);
 		if (!ret)
-			ret = xfer_pages(pp, xfer, item->pid->real, opts.pre_dump_mode == PRE_DUMP_READ);
+			ret = xfer_pages(pp, xfer, item->pid->real, mem_read_externally());
 		if (!ret) {
 			page_pipe_reinit(pp);
 			goto again;
@@ -583,6 +588,8 @@ static int __parasite_dump_pages_seized(struct pstree_item *item, struct parasit
 
 	pr_info("\n");
 	pr_info("Dumping pages (type: %d pid: %d)\n", CR_FD_PAGES, item->pid->real);
+	if (mem_read_externally())
+		pr_info("Using process_vm_readv for page memory (seccomp not suspended)\n");
 	pr_info("----------------------------------------\n");
 
 	timing_start(TIME_MEMDUMP);
@@ -665,13 +672,13 @@ static int __parasite_dump_pages_seized(struct pstree_item *item, struct parasit
 	 * defer to and no parasite vmsplice to drain either -- xfer_pages()
 	 * below reads the pages directly via process_vm_readv().
 	 */
-	if (opts.pre_dump_mode == PRE_DUMP_READ)
+	if (mem_read_externally())
 		ret = 0;
 	else
 		ret = drain_pages(pp, ctl, args);
 
 	if (!ret && !mdc->pre_dump)
-		ret = xfer_pages(pp, &xfer, item->pid->real, opts.pre_dump_mode == PRE_DUMP_READ);
+		ret = xfer_pages(pp, &xfer, item->pid->real, mem_read_externally());
 	if (ret)
 		goto out_xfer;
 
@@ -747,7 +754,12 @@ int parasite_dump_pages_seized(struct pstree_item *item, struct vm_area_list *vm
 	 *    data from M
 	 */
 
-	if (!mdc->pre_dump || opts.pre_dump_mode == PRE_DUMP_SPLICE) {
+	/*
+	 * READ pre-dump skips mprotect; seccomp-fallback full dump still needs
+	 * PROT_READ for process_vm_readv on non-readable mappings.
+	 */
+	if (!mem_read_externally() ||
+	    (opts.seccomp_suspend_failed && !mdc->pre_dump)) {
 		pargs->add_prot = PROT_READ;
 		ret = compel_rpc_call_sync(PARASITE_CMD_MPROTECT_VMAS, ctl);
 		if (ret) {
@@ -768,7 +780,8 @@ int parasite_dump_pages_seized(struct pstree_item *item, struct vm_area_list *vm
 		return ret;
 	}
 
-	if (!mdc->pre_dump || opts.pre_dump_mode == PRE_DUMP_SPLICE) {
+	if (!mem_read_externally() ||
+	    (opts.seccomp_suspend_failed && !mdc->pre_dump)) {
 		pargs->add_prot = 0;
 		if (compel_rpc_call_sync(PARASITE_CMD_MPROTECT_VMAS, ctl)) {
 			pr_err("Can't rollback unprotected vmas with parasite\n");

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -387,16 +387,23 @@ static int drain_pages(struct page_pipe *pp, struct parasite_ctl *ctl, struct pa
 	return 0;
 }
 
-static int xfer_pages(struct page_pipe *pp, struct page_xfer *xfer)
+static int xfer_pages(struct page_pipe *pp, struct page_xfer *xfer, int pid, bool external_read)
 {
 	int ret;
 
 	/*
 	 * Step 3 -- write pages into image (or delay writing for
 	 *           pre-dump action (see pre_dump_one_task)
+	 *
+	 * In READ mode no parasite vmsplice ever happened, so the pages
+	 * are pulled straight from the target's address space here via
+	 * process_vm_readv() instead of drained from the parasite pipe.
 	 */
 	timing_start(TIME_MEMWRITE);
-	ret = page_xfer_dump_pages(xfer, pp);
+	if (external_read)
+		ret = page_xfer_predump_pages(pid, xfer, pp);
+	else
+		ret = page_xfer_dump_pages(xfer, pp);
 	timing_stop(TIME_MEMWRITE);
 
 	return ret;
@@ -540,9 +547,16 @@ again:
 	if (ret == -EAGAIN) {
 		BUG_ON(!(pp->flags & PP_CHUNK_MODE));
 
-		ret = drain_pages(pp, ctl, args);
+		/*
+		 * PP_CHUNK_MODE is only ever set for a full (non-pre) dump,
+		 * so this is never reached during pre-dump.
+		 */
+		if (opts.pre_dump_mode == PRE_DUMP_READ)
+			ret = 0;
+		else
+			ret = drain_pages(pp, ctl, args);
 		if (!ret)
-			ret = xfer_pages(pp, xfer);
+			ret = xfer_pages(pp, xfer, item->pid->real, opts.pre_dump_mode == PRE_DUMP_READ);
 		if (!ret) {
 			page_pipe_reinit(pp);
 			goto again;
@@ -646,14 +660,18 @@ static int __parasite_dump_pages_seized(struct pstree_item *item, struct parasit
 	 * will happen after task unfreezing in cr_pre_dump_finish(). This is
 	 * actual optimization which reduces time for which process was frozen
 	 * during pre-dump.
+	 *
+	 * For a full (non-pre) dump in READ mode there's no later stage to
+	 * defer to and no parasite vmsplice to drain either -- xfer_pages()
+	 * below reads the pages directly via process_vm_readv().
 	 */
-	if (mdc->pre_dump && opts.pre_dump_mode == PRE_DUMP_READ)
+	if (opts.pre_dump_mode == PRE_DUMP_READ)
 		ret = 0;
 	else
 		ret = drain_pages(pp, ctl, args);
 
 	if (!ret && !mdc->pre_dump)
-		ret = xfer_pages(pp, &xfer);
+		ret = xfer_pages(pp, &xfer, item->pid->real, opts.pre_dump_mode == PRE_DUMP_READ);
 	if (ret)
 		goto out_xfer;
 

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -904,8 +904,21 @@ int collect_user_namespaces(bool for_dump)
 	if (!for_dump)
 		return 0;
 
-	if (!(root_ns_mask & CLONE_NEWUSER))
+	if (opts.rootless_container) {
+		/*
+		 * --rootless-container asserts the target lives inside a
+		 * user namespace. If CRIU and the target share the same
+		 * userns, the flag was misconfigured — abort immediately.
+		 */
+		if (!(root_ns_mask & CLONE_NEWUSER)) {
+			pr_err("--rootless-container requires the target to be in a different user namespace\n");
+			return -1;
+		}
+
+		pr_info("Rootless container mode: dumping userns maps from target\n");
+	} else if (!(root_ns_mask & CLONE_NEWUSER)) {
 		return 0;
+	}
 
 	return walk_namespaces(&user_ns_desc, collect_user_ns, NULL);
 }
@@ -1181,7 +1194,7 @@ int dump_namespaces(struct pstree_item *item, unsigned int ns_flags)
 	return 0;
 }
 
-static int write_id_map(pid_t pid, UidGidExtent **extents, int n, char *id_map)
+static int write_id_map(pid_t pid, UidGidExtent **extents, int n, const char *id_map)
 {
 	char buf[PAGE_SIZE];
 	int off = 0, i;

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -1406,7 +1406,7 @@ int page_xfer_predump_pages(int pid, struct page_xfer *xfer, struct page_pipe *p
 			if (xfer->write_pagemap(xfer, &iov, flags))
 				goto err;
 
-			if (xfer->write_pages(xfer, ppb->p[0], iov.iov_len))
+			if ((flags & PE_PRESENT) && xfer->write_pages(xfer, ppb->p[0], iov.iov_len))
 				goto err;
 		}
 

--- a/criu/parasite-syscall.c
+++ b/criu/parasite-syscall.c
@@ -160,8 +160,10 @@ int parasite_dump_thread_leader_seized(struct parasite_ctl *ctl, int pid, CoreEn
 	init_parasite_rseq_arg(&args->rseq);
 
 	ret = compel_rpc_call_sync(PARASITE_CMD_DUMP_THREAD, ctl);
-	if (ret < 0)
+	if (ret < 0) {
+		pr_err("Parasite failed to dump thread leader\n");
 		return ret;
+	}
 
 	ret = alloc_groups_copy_creds(tc->creds, pc);
 	if (ret) {
@@ -236,8 +238,10 @@ int parasite_dump_misc_seized(struct parasite_ctl *ctl, struct parasite_dump_mis
 
 	ma = compel_parasite_args(ctl, struct parasite_dump_misc);
 	ma->has_membarrier_get_registrations = kdat.has_membarrier_get_registrations;
-	if (compel_rpc_call_sync(PARASITE_CMD_DUMP_MISC, ctl) < 0)
+	if (compel_rpc_call_sync(PARASITE_CMD_DUMP_MISC, ctl) < 0) {
+		pr_err("Parasite failed to dump misc\n");
 		return -1;
+	}
 
 	*misc = *ma;
 	return 0;
@@ -251,8 +255,10 @@ struct parasite_tty_args *parasite_dump_tty(struct parasite_ctl *ctl, int fd, in
 	p->fd = fd;
 	p->type = type;
 
-	if (compel_rpc_call_sync(PARASITE_CMD_DUMP_TTY, ctl) < 0)
+	if (compel_rpc_call_sync(PARASITE_CMD_DUMP_TTY, ctl) < 0) {
+		pr_err("Parasite failed to dump tty\n");
 		return NULL;
+	}
 
 	return p;
 }

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -316,8 +316,33 @@ static int vma_stat(struct vma_area *vma, int fd)
 	return 0;
 }
 
+static int open_mapped_file(pid_t pid, const char *fname)
+{
+	int fd, root;
+	const char *rel = fname;
+
+	if (opts.unprivileged && fname[0] == '/') {
+		root = open_proc(pid, "root");
+		if (root >= 0) {
+			/*
+			 * openat() ignores dirfd when pathname is absolute; paths from
+			 * smaps are absolute container paths (e.g. /bin/busybox).
+			 */
+			if (*rel == '/')
+				rel++;
+
+			fd = openat(root, rel, O_RDONLY);
+			close(root);
+			if (fd >= 0)
+				return fd;
+		}
+	}
+
+	return open(fname, O_RDONLY);
+}
+
 static int vma_get_mapfile_user(const char *fname, struct vma_area *vma, struct vma_file_info *vfi, int *vm_file_fd,
-				const char *path)
+				const char *path, pid_t pid)
 {
 	int fd, hugetlb_flag = 0;
 	dev_t vfi_dev;
@@ -356,6 +381,11 @@ static int vma_get_mapfile_user(const char *fname, struct vma_area *vma, struct 
 		return 0;
 	}
 
+	if (!strncmp(fname, AIO_FNAME, sizeof(AIO_FNAME) - 1)) {
+		vma->e->status = VMA_AREA_AIORING;
+		return 0;
+	}
+
 	vfi_dev = makedev(vfi->dev_maj, vfi->dev_min);
 
 	if (is_hugetlb_dev(vfi_dev, &hugetlb_flag) || is_anon_shmem_map(vfi_dev)) {
@@ -380,7 +410,7 @@ static int vma_get_mapfile_user(const char *fname, struct vma_area *vma, struct 
 	}
 
 	pr_info("Failed to open map_files/%s, try to go via [%s] path\n", path, fname);
-	fd = open(fname, O_RDONLY);
+	fd = open_mapped_file(pid, fname);
 	if (fd < 0) {
 		pr_perror("Can't open mapped [%s]", fname);
 		return -1;
@@ -428,7 +458,7 @@ closefd:
 }
 
 static int vma_get_mapfile(const char *fname, struct vma_area *vma, DIR *mfd, struct vma_file_info *vfi,
-			   struct vma_file_info *prev_vfi, int *vm_file_fd)
+			   struct vma_file_info *prev_vfi, int *vm_file_fd, pid_t pid)
 {
 	char path[32];
 	int flags;
@@ -512,8 +542,8 @@ static int vma_get_mapfile(const char *fname, struct vma_area *vma, DIR *mfd, st
 			return -1;
 		}
 
-		if (errno == EPERM && !opts.aufs)
-			return vma_get_mapfile_user(fname, vma, vfi, vm_file_fd, path);
+		if ((errno == EPERM || errno == EACCES) && !opts.aufs)
+			return vma_get_mapfile_user(fname, vma, vfi, vm_file_fd, path, pid);
 
 		pr_perror("Can't open map_files");
 		return -1;
@@ -600,7 +630,7 @@ static inline int handle_vvar_vma(struct vma_area *vma)
 static int handle_vma(pid_t pid, struct vma_area *vma_area, const char *file_path, DIR *map_files_dir,
 		      struct vma_file_info *vfi, struct vma_file_info *prev_vfi, int *vm_file_fd)
 {
-	if (vma_get_mapfile(file_path, vma_area, map_files_dir, vfi, prev_vfi, vm_file_fd))
+	if (vma_get_mapfile(file_path, vma_area, map_files_dir, vfi, prev_vfi, vm_file_fd, pid))
 		goto err_bogus_mapfile;
 
 	if (vma_area->e->status != 0)
@@ -1116,6 +1146,7 @@ int parse_pid_status(pid_t pid, struct seize_task_status *ss, void *data)
 	cr->s.shdpnd = 0;
 	cr->s.sigblk = 0;
 	cr->s.seccomp_mode = SECCOMP_MODE_DISABLED;
+	cr->s.seccomp_suspend_failed = false;
 
 	if (bfdopenr(&f))
 		return -1;

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -755,6 +755,9 @@ static int collect_children(struct pstree_item *item)
 		if (ret < 0)
 			goto free;
 
+		if (creds.s.seccomp_suspend_failed)
+			opts.seccomp_suspend_failed = true;
+
 		/* Here is a recursive call (Depth-first search) */
 		ret = collect_task(c);
 		if (ret < 0)
@@ -943,6 +946,9 @@ static int collect_threads(struct pstree_item *item)
 		if (seccomp_collect_entry(pid, t_creds.s.seccomp_mode))
 			goto err;
 
+		if (t_creds.s.seccomp_suspend_failed)
+			opts.seccomp_suspend_failed = true;
+
 		if (ret == TASK_STOPPED) {
 			nr_stopped++;
 		}
@@ -1110,6 +1116,9 @@ int collect_pstree(void)
 	ret = seccomp_collect_entry(pid, creds.s.seccomp_mode);
 	if (ret < 0)
 		goto err;
+
+	if (creds.s.seccomp_suspend_failed)
+		opts.seccomp_suspend_failed = true;
 
 	ret = collect_task(root_item);
 	if (ret < 0)

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -162,6 +162,7 @@ TST_NOFILE	:=				\
 		maps09				\
 		maps10				\
 		maps11				\
+		mapfile_priv			\
 		mlock_setuid			\
 		xids00				\
 		groups				\

--- a/test/zdtm/static/mapfile_priv.c
+++ b/test/zdtm/static/mapfile_priv.c
@@ -1,0 +1,142 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <sys/mman.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <stdlib.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check mapped file survives C/R when path is only visible inside a mount namespace";
+const char *test_author = "Deepak Anand <deepakanand1300@gmail.com>";
+
+enum {
+	EXIT_SETUP = 1,
+	EXIT_MAGIC_MISMATCH = 2,
+};
+
+int main(int argc, char **argv)
+{
+	int sync_pipe[2], pid, status;
+
+	test_init(argc, argv);
+
+	if (pipe(sync_pipe)) {
+		pr_perror("pipe");
+		return 1;
+	}
+
+	pid = fork();
+	if (pid < 0) {
+		pr_perror("fork");
+		return 1;
+	}
+
+	if (pid == 0) {
+		char path[256];
+		uint32_t *addr;
+		int fd;
+
+		close(sync_pipe[0]);
+
+		if (unshare(CLONE_NEWNS)) {
+			pr_perror("unshare CLONE_NEWNS");
+			exit(EXIT_SETUP);
+		}
+
+		if (mount(NULL, "/", NULL, MS_PRIVATE | MS_REC, NULL)) {
+			pr_perror("mount --make-rprivate /");
+			exit(EXIT_SETUP);
+		}
+
+		if (mount("zdtm_mapfile_priv", "/tmp", "tmpfs", 0, NULL)) {
+			pr_perror("mount tmpfs on /tmp");
+			exit(EXIT_SETUP);
+		}
+
+		snprintf(path, sizeof(path), "/tmp/zdtm_mapfile_%d", getpid());
+		fd = open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
+		if (fd < 0) {
+			pr_perror("open %s", path);
+			exit(EXIT_SETUP);
+		}
+
+		if (ftruncate(fd, PAGE_SIZE)) {
+			pr_perror("ftruncate");
+			close(fd);
+			exit(EXIT_SETUP);
+		}
+
+		addr = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+		close(fd);
+		if (addr == MAP_FAILED) {
+			pr_perror("mmap file");
+			exit(EXIT_SETUP);
+		}
+
+		addr[0] = 0xDEADBEEF;
+
+		/* Tell parent we're set up */
+		if (write(sync_pipe[1], &(char){1}, 1) != 1) {
+			pr_perror("sync write");
+			exit(EXIT_SETUP);
+		}
+		close(sync_pipe[1]);
+
+		test_waitsig();
+
+		if (addr[0] != 0xDEADBEEF) {
+			test_msg("FAIL: mapped file content lost after C/R (got 0x%x, expected 0x%x)\n",
+				 addr[0], 0xDEADBEEF);
+			exit(EXIT_MAGIC_MISMATCH);
+		}
+
+		exit(0);
+	}
+
+	close(sync_pipe[1]);
+
+	/* Wait for child to finish setup before telling zdtm we're ready */
+	if (read(sync_pipe[0], &(char){0}, 1) != 1) {
+		pr_perror("sync read");
+		kill(pid, SIGTERM);
+		waitpid(pid, NULL, 0);
+		return 1;
+	}
+	close(sync_pipe[0]);
+
+	test_daemon();
+	test_waitsig();
+
+	if (kill(pid, SIGTERM)) {
+		pr_perror("kill child");
+		return 1;
+	}
+	if (waitpid(pid, &status, 0) != pid) {
+		pr_perror("waitpid");
+		return 1;
+	}
+
+	if (WIFSIGNALED(status)) {
+		fail("child killed by signal %d", WTERMSIG(status));
+		return 1;
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SETUP) {
+		fail("child setup failed");
+		return 1;
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) == EXIT_MAGIC_MISMATCH) {
+		fail("child reported data corruption after C/R");
+		return 1;
+	}
+	if (status) {
+		fail("child exited with unknown status 0x%x", status);
+		return 1;
+	}
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/mapfile_priv.desc
+++ b/test/zdtm/static/mapfile_priv.desc
@@ -1,0 +1,1 @@
+{'flavor': 'ns uns', 'flags': 'suid', 'opts': '--ext-mount-map auto --enable-external-masters'}


### PR DESCRIPTION
Follow-up to #3100, split out from #3057.

This PR adds the CRIU-side base flag for rootless container checkpoint/restore. The Podman/crun integration is being kept separate.

Main pieces:
- add --rootless-container
- add the initial user namespace preflight for rootless container targets
- use criu_is_unprivileged_or_rootless() for shared EPERM tolerance checks

--rootless-container means the target is a rootless container. It is separate from --unprivileged, which describes how CRIU itself is running.