### PR TITLE
vma: dump/restore content of MAP_SHARED tmpfs mappings

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -47,6 +47,8 @@
 #include "fs-magic.h"
 #include "namespaces.h"
 #include "proc_parse.h"
+#include "pagemap.h"
+#include "page.h"
 #include "pstree.h"
 #include "string.h"
 #include "fault-injection.h"
@@ -2464,6 +2466,81 @@ void filemap_ctx_fini(void)
 	}
 }
 
+/*
+ * A VMA_FILE_SHARED_TMPFS mapping is dumped like shared memory (see
+ * generate_vma_iovs() in mem.c), because its tmpfs-backed file can be
+ * mutated as a side effect of the dumped task dying (e.g. the kernel's
+ * exit_robust_list() rewriting a held PTHREAD_MUTEX_ROBUST futex word in
+ * place). Write the dumped content back into the just-reopened file so the
+ * live file matches the pre-dump snapshot before anyone -- including the
+ * restored task itself -- can observe it.
+ */
+static int restore_tmpfs_shared_vma_content(int pid, struct vma_area *vma, int fd)
+{
+	struct page_read pr;
+	unsigned long vstart = vma->e->start;
+	unsigned long vend = vma->e->end;
+	unsigned long va;
+	void *buf;
+	int ret;
+
+	ret = open_page_read(pid, &pr, PR_TASK);
+	if (ret <= 0)
+		return ret < 0 ? -1 : 0;
+
+	/*
+	 * seek_pagemap() leaves pr positioned exactly on the entry covering
+	 * @vstart (pr->cvaddr == vstart) -- unlike advance(), it must not be
+	 * followed by another advance() before the first read.
+	 */
+	ret = pr.seek_pagemap(&pr, vstart);
+	if (ret <= 0) {
+		ret = ret < 0 ? -1 : 0;
+		goto out_close;
+	}
+
+	buf = xmalloc(PAGE_SIZE);
+	if (!buf) {
+		ret = -1;
+		goto out_close;
+	}
+
+	va = vstart;
+	while (va < vend) {
+		unsigned long entry_end = (unsigned long)decode_pointer(pr.pe->vaddr) + pr.pe->nr_pages * PAGE_SIZE;
+		unsigned long chunk_end = entry_end < vend ? entry_end : vend;
+
+		while (va < chunk_end) {
+			off_t foff = vma->e->pgoff + (va - vstart);
+
+			ret = pr.read_pages(&pr, va, 1, buf, 0);
+			if (ret < 0)
+				goto out_free;
+
+			if (pwrite(fd, buf, PAGE_SIZE, foff) != PAGE_SIZE) {
+				pr_perror("Can't write back tmpfs shared content for %#lx", va);
+				ret = -1;
+				goto out_free;
+			}
+
+			va += PAGE_SIZE;
+		}
+
+		if (va >= vend)
+			break;
+
+		ret = pr.advance(&pr);
+		if (ret <= 0)
+			break;
+	}
+	ret = pr.sync(&pr);
+out_free:
+	xfree(buf);
+out_close:
+	pr.close(&pr);
+	return ret;
+}
+
 static int open_filemap(int pid, struct vma_area *vma)
 {
 	u32 flags;
@@ -2523,6 +2600,17 @@ static int open_filemap(int pid, struct vma_area *vma)
 
 	ctx.vma = vma;
 	vma->e->fd = ctx.fd;
+
+	if (vma_area_is(vma, VMA_FILE_SHARED_TMPFS)) {
+		if ((flags & O_ACCMODE) == O_RDONLY) {
+			pr_debug("Skipping tmpfs shared content restore for r/o vma %#016" PRIx64 "\n",
+				 vma->e->start);
+		} else if (restore_tmpfs_shared_vma_content(pid, vma, ctx.fd)) {
+			pr_err("Can't restore tmpfs shared content for vma %#016" PRIx64 "\n", vma->e->start);
+			return -1;
+		}
+	}
+
 	return 0;
 }
 
@@ -2533,7 +2621,15 @@ int collect_filemap(struct vma_area *vma)
 	if (!vma->e->has_fdflags) {
 		/* Make a wild guess for the fdflags */
 		vma->e->has_fdflags = true;
-		if ((vma->e->prot & PROT_WRITE) && vma_area_is(vma, VMA_FILE_SHARED))
+		/*
+		 * A VMA_FILE_SHARED_TMPFS mapping needs its content restored
+		 * via restore_tmpfs_shared_vma_content() regardless of this
+		 * particular mapping's own protection bits (a read-only
+		 * mapper must not skip content restore just because it isn't
+		 * PROT_WRITE), so always request O_RDWR for it.
+		 */
+		if (vma_area_is(vma, VMA_FILE_SHARED_TMPFS) ||
+		    ((vma->e->prot & PROT_WRITE) && vma_area_is(vma, VMA_FILE_SHARED)))
 			vma->e->fdflags = O_RDWR;
 		else
 			vma->e->fdflags = O_RDONLY;

--- a/criu/include/image.h
+++ b/criu/include/image.h
@@ -103,6 +103,15 @@
 #define VMA_AREA_UPROBES	(1 << 17)
 #define VMA_AREA_NOT_ACCOUNTABLE (1 << 18)
 
+/*
+ * A MAP_SHARED regular-file mapping whose backing file lives on a tmpfs
+ * mount. Its content is process-owned state (the file is used as shared
+ * memory, e.g. via shm_open()), not external ground truth, so it must be
+ * dumped/restored like VMA_ANON_SHARED instead of being left untouched
+ * like a plain VMA_FILE_SHARED mapping of a real on-disk file.
+ */
+#define VMA_FILE_SHARED_TMPFS (1 << 19)
+
 #define VMA_EXT_PLUGIN	  (1 << 27)
 #define VMA_CLOSE	  (1 << 28)
 #define VMA_NO_PROT_WRITE (1 << 29)

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -1307,8 +1307,27 @@ static int restore_priv_vma_content(struct pstree_item *t, struct page_read *pr)
 			if (va < vma->e->start)
 				goto err_addr;
 			else if (unlikely(!vma_area_is_private(vma, kdat.task_size))) {
-				pr_err("Trying to restore page for non-private VMA\n");
-				goto err_addr;
+				unsigned long len;
+
+				if (!vma_area_is(vma, VMA_FILE_SHARED_TMPFS)) {
+					pr_err("Trying to restore page for non-private VMA\n");
+					goto err_addr;
+				}
+
+				/*
+				 * VMA_FILE_SHARED_TMPFS content is written
+				 * straight into the backing tmpfs file before
+				 * it gets mmap()-ed (see open_filemap() ->
+				 * restore_tmpfs_shared_vma_content()), so these
+				 * pagemap entries carry no work here -- just
+				 * skip over them.
+				 */
+				len = min_t(unsigned long, (nr_pages - i) * PAGE_SIZE, vma->e->end - va);
+				pr->skip_pages(pr, len);
+				va += len;
+				len >>= PAGE_SHIFT;
+				i += len;
+				continue;
 			}
 
 			if (!vma_area_is(vma, VMA_PREMMAPED)) {

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -114,6 +114,15 @@ static bool should_dump_entire_vma(VmaEntry *vmae)
 		return true;
 	if (vma_entry_is(vmae, VMA_AREA_AIORING))
 		return true;
+	/*
+	 * A MAP_SHARED tmpfs mapping's pages are file-backed, so the
+	 * PAGEMAP_SCAN-based should_dump_page() path (which intentionally
+	 * excludes file-backed pages as a private-COW optimisation) would
+	 * otherwise skip them all. Force the full range through instead of
+	 * touching that shared, general-purpose query.
+	 */
+	if (vma_entry_is(vmae, VMA_FILE_SHARED_TMPFS))
+		return true;
 
 	return false;
 }
@@ -448,7 +457,8 @@ static int generate_vma_iovs(struct pstree_item *item, struct vma_area *vma, str
 	u64 vaddr;
 	int ret;
 
-	if (!vma_area_is_private(vma, kdat.task_size) && !vma_area_is(vma, VMA_ANON_SHARED))
+	if (!vma_area_is_private(vma, kdat.task_size) && !vma_area_is(vma, VMA_ANON_SHARED) &&
+	    !vma_area_is(vma, VMA_FILE_SHARED_TMPFS))
 		return 0;
 	/*
 	 * In turn VVAR area is special and referenced from

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -10,6 +10,7 @@
 #include <ctype.h>
 #include <linux/fs.h>
 #include <sys/sysmacros.h>
+#include <sys/vfs.h>
 
 #include "types.h"
 #include "common/list.h"
@@ -35,6 +36,7 @@
 #include "seccomp.h"
 #include "string.h"
 #include "namespaces.h"
+#include "fs-magic.h"
 #include "cgroup.h"
 #include "cgroup-props.h"
 #include "timerfd.h"
@@ -707,10 +709,32 @@ static int handle_vma(pid_t pid, struct vma_area *vma_area, const char *file_pat
 				return 0;
 			}
 
-			if (vma_area->e->flags & MAP_PRIVATE)
+			if (vma_area->e->flags & MAP_PRIVATE) {
 				vma_area->e->status |= VMA_FILE_PRIVATE;
-			else
+			} else {
+				struct statfs stfs;
+
 				vma_area->e->status |= VMA_FILE_SHARED;
+
+				/*
+				 * A shared mapping of a regular file that lives on
+				 * tmpfs (e.g. shm_open()'d /dev/shm/xxx) is really
+				 * shared memory wearing a file's clothes: its content
+				 * is process-owned state, not external ground truth,
+				 * so it needs the same dump/restore treatment as
+				 * VMA_ANON_SHARED.
+				 *
+				 * memfd/anon-shmem mappings (VMA_AREA_MEMFD) also sit
+				 * on this same internal tmpfs mount, but they already
+				 * have their own dedicated dump/restore path -- skip
+				 * them here, or they'd be force-dumped through the
+				 * generic page-pipe path without ever getting the
+				 * PROT_READ boost that path relies on.
+				 */
+				if (!(vma_area->e->status & VMA_AREA_MEMFD) && !fstatfs(*vm_file_fd, &stfs) &&
+				    stfs.f_type == TMPFS_MAGIC)
+					vma_area->e->status |= VMA_FILE_SHARED_TMPFS;
+			}
 		}
 
 		/*
@@ -778,9 +802,16 @@ static int vma_list_add(struct vma_area *vma_area, struct vm_area_list *vma_area
 
 	list_add_tail(&vma_area->list, &vma_area_list->h);
 	vma_area_list->nr++;
-	if (vma_area_is_private(vma_area, kdat.task_size)) {
+	if (vma_area_is_private(vma_area, kdat.task_size) || vma_area_is(vma_area, VMA_FILE_SHARED_TMPFS)) {
 		unsigned long pages;
 
+		/*
+		 * VMA_FILE_SHARED_TMPFS vmas are dumped through the same
+		 * page-pipe/pagemap-cache path as private vmas (generate_iovs()
+		 * via generate_vma_iovs()), so their pages must be counted here
+		 * too -- otherwise nr_priv_pages under-sizes create_page_pipe()
+		 * and nr_priv_pages_longest under-sizes the pagemap cache buffer.
+		 */
 		pages = vma_area_len(vma_area) / PAGE_SIZE;
 		vma_area_list->nr_priv_pages += pages;
 		vma_area_list->nr_priv_pages_longest = max(vma_area_list->nr_priv_pages_longest, pages);

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -220,7 +220,7 @@ class ns_flavor:
         "/bin", "/sbin", "/etc", "/lib", "/lib64", "/dev",
         "/tmp", "/usr", "/proc", "/run"
     ]
-    __dev_dirs = ["pts", "net"]
+    __dev_dirs = ["pts", "net", "shm"]
 
     def __init__(self, opts, name="ns", uns=False):
         self.name = name
@@ -300,6 +300,9 @@ class ns_flavor:
         for dir in self.__dev_dirs:
             os.mkdir(os.path.join(self.devpath, dir))
             os.chmod(os.path.join(self.devpath, dir), 0o755)
+        # /dev/shm needs the sticky bit, like on a real system, so
+        # POSIX shm_open() users can't unlink each other's segments.
+        os.chmod(os.path.join(self.devpath, "shm"), 0o1777)
         self.__mknod("tty", os.makedev(5, 0))
         self.__mknod("null", os.makedev(1, 3))
         self.__mknod("net/tun")

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -293,6 +293,8 @@ TST_NOFILE	:=				\
 		memfd06				\
 		shmemfd				\
 		shmemfd-priv			\
+		shmem_tmpfs_robust_mutex	\
+		shmem_tmpfs_robust_mutex_unlinked	\
 		time				\
 		timens_nested			\
 		timens_for_kids			\
@@ -624,6 +626,8 @@ futex:			CFLAGS += -pthread
 futex:			LDFLAGS += -pthread
 futex-rl:		CFLAGS += -pthread
 futex-rl:		LDFLAGS += -pthread
+shmem_tmpfs_robust_mutex:		LDLIBS += -lrt -pthread
+shmem_tmpfs_robust_mutex_unlinked:	LDLIBS += -lrt -pthread
 jobctl00:		LDLIBS += -lutil
 socket_listen:		LDLIBS += -lrt -pthread
 socket_aio:		LDLIBS += -lrt -pthread

--- a/test/zdtm/static/shmem_tmpfs_robust_mutex.c
+++ b/test/zdtm/static/shmem_tmpfs_robust_mutex.c
@@ -1,0 +1,116 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <pthread.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Test C/R of a robust process-shared mutex.\n";
+const char *test_author = "Radostin Stoyanov <rstoyanov@fedoraproject.org>";
+
+struct shm_state {
+	pthread_mutex_t mutex;
+	volatile int worker_started;
+	volatile int worker_done;
+	volatile int worker_lock_ret;
+};
+
+#define SHM_NAME_FMT "/zdtm_shmem_tmpfs_robust_mutex_%d"
+
+static void *worker_fn(void *arg)
+{
+	struct shm_state *st = arg;
+
+	st->worker_started = 1;
+	st->worker_lock_ret = pthread_mutex_lock(&st->mutex);
+	st->worker_done = 1;
+
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	char shm_name[64];
+	pthread_mutexattr_t attr;
+	pthread_t worker;
+	struct shm_state *st;
+	int fd;
+
+	test_init(argc, argv);
+
+	snprintf(shm_name, sizeof(shm_name), SHM_NAME_FMT, getpid());
+
+	fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, 0600);
+	if (fd < 0) {
+		pr_perror("shm_open");
+		return 1;
+	}
+
+	if (ftruncate(fd, sizeof(*st))) {
+		pr_perror("ftruncate");
+		return 1;
+	}
+
+	st = mmap(NULL, sizeof(*st), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (st == MAP_FAILED) {
+		pr_perror("mmap");
+		return 1;
+	}
+	close(fd);
+
+	if (pthread_mutexattr_init(&attr) || pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED) ||
+	    pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST) || pthread_mutex_init(&st->mutex, &attr)) {
+		pr_perror("Can't init robust process-shared mutex");
+		return 1;
+	}
+
+	if (pthread_mutex_lock(&st->mutex)) {
+		pr_perror("Can't take initial lock");
+		return 1;
+	}
+
+	st->worker_started = 0;
+	st->worker_done = 0;
+
+	if (pthread_create(&worker, NULL, worker_fn, st)) {
+		pr_perror("Can't create worker thread");
+		return 1;
+	}
+
+	while (!st->worker_started)
+		usleep(1000);
+	/* Give the worker a moment to actually enter the futex wait. */
+	usleep(100000);
+
+	test_daemon();
+	test_waitsig();
+
+	{
+		int ret = pthread_mutex_unlock(&st->mutex);
+
+		if (ret) {
+			fail("Can't unlock mutex after restore: %s", strerror(ret));
+			goto out;
+		}
+	}
+
+	while (!st->worker_done)
+		usleep(1000);
+
+	pthread_join(worker, NULL);
+
+	if (st->worker_lock_ret != 0) {
+		fail("worker woke with %s instead of success", strerror(st->worker_lock_ret));
+		goto out;
+	}
+
+	pass();
+out:
+	munmap(st, sizeof(*st));
+	shm_unlink(shm_name);
+	return 0;
+}

--- a/test/zdtm/static/shmem_tmpfs_robust_mutex_unlinked.c
+++ b/test/zdtm/static/shmem_tmpfs_robust_mutex_unlinked.c
@@ -1,0 +1,124 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <pthread.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Test robust mutex restore through CRIU ghost files.";
+const char *test_author = "Radostin Stoyanov <rstoyanov@fedoraproject.org>";
+
+struct shm_state {
+	pthread_mutex_t mutex;
+	volatile int worker_started;
+	volatile int worker_done;
+	volatile int worker_lock_ret;
+};
+
+#define SHM_NAME_FMT "/zdtm_shmem_tmpfs_robust_mutex_unlinked_%d"
+
+static void *worker_fn(void *arg)
+{
+	struct shm_state *st = arg;
+
+	st->worker_started = 1;
+	st->worker_lock_ret = pthread_mutex_lock(&st->mutex);
+	st->worker_done = 1;
+
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	char shm_name[64];
+	pthread_mutexattr_t attr;
+	pthread_t worker;
+	struct shm_state *st;
+	int fd;
+
+	test_init(argc, argv);
+
+	snprintf(shm_name, sizeof(shm_name), SHM_NAME_FMT, getpid());
+
+	fd = shm_open(shm_name, O_CREAT | O_EXCL | O_RDWR, 0600);
+	if (fd < 0) {
+		pr_perror("shm_open");
+		return 1;
+	}
+
+	if (ftruncate(fd, sizeof(*st))) {
+		pr_perror("ftruncate");
+		return 1;
+	}
+
+	st = mmap(NULL, sizeof(*st), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (st == MAP_FAILED) {
+		pr_perror("mmap");
+		return 1;
+	}
+	close(fd);
+
+	/* Unlink now: the mapping stays live, but the backing tmpfs file is
+	 * gone from the filesystem, forcing restore through CRIU's ghost-file
+	 * remap path instead of a plain path reopen.
+	 */
+	if (shm_unlink(shm_name)) {
+		pr_perror("shm_unlink");
+		return 1;
+	}
+
+	if (pthread_mutexattr_init(&attr) || pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED) ||
+	    pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST) || pthread_mutex_init(&st->mutex, &attr)) {
+		pr_perror("Can't init robust process-shared mutex");
+		return 1;
+	}
+
+	if (pthread_mutex_lock(&st->mutex)) {
+		pr_perror("Can't take initial lock");
+		return 1;
+	}
+
+	st->worker_started = 0;
+	st->worker_done = 0;
+
+	if (pthread_create(&worker, NULL, worker_fn, st)) {
+		pr_perror("Can't create worker thread");
+		return 1;
+	}
+
+	while (!st->worker_started)
+		usleep(1000);
+	/* Give the worker a moment to actually enter the futex wait. */
+	usleep(100000);
+
+	test_daemon();
+	test_waitsig();
+
+	{
+		int ret = pthread_mutex_unlock(&st->mutex);
+
+		if (ret) {
+			fail("Can't unlock mutex after restore: %s", strerror(ret));
+			goto out;
+		}
+	}
+
+	while (!st->worker_done)
+		usleep(1000);
+
+	pthread_join(worker, NULL);
+
+	if (st->worker_lock_ret != 0) {
+		fail("worker woke with %s instead of success", strerror(st->worker_lock_ret));
+		goto out;
+	}
+
+	pass();
+out:
+	munmap(st, sizeof(*st));
+	return 0;
+}


### PR DESCRIPTION
CRIU currently treats a MAP_SHARED mapping of a regular file as external state. It reopens the backing file on restore but never touches its content, assuming whatever wrote the file stays responsible for it. This assumption breaks for shared memory in `/dev/shm`,  where the file's bytes are process-owned state, not something external.

This pull request adds `VMA_FILE_SHARED_TMPFS` for `MAP_SHARED` mappings whose backing file lives on tmpfs. Using the same per-task page-pipe path used for private memory, the content of such files is saved (before the task is killed). On restore, the content written back to the file before it is `mmap()`'d. This approach covers both file reopen and the ghost-file remap path.

Fixes: #3095