### PR TITLE
criu: broker netns sockets through target userns

### DIFF
--- a/criu/Makefile.crtools
+++ b/criu/Makefile.crtools
@@ -48,6 +48,7 @@ obj-y			+= namespaces.o
 obj-y			+= asyncd.o
 obj-y			+= netfilter.o
 obj-y			+= net.o
+obj-y			+= netns-broker.o
 obj-y			+= userns-broker.o
 obj-y			+= pagemap-cache.o
 obj-y			+= page-pipe.o

--- a/criu/Makefile.crtools
+++ b/criu/Makefile.crtools
@@ -48,6 +48,7 @@ obj-y			+= namespaces.o
 obj-y			+= asyncd.o
 obj-y			+= netfilter.o
 obj-y			+= net.o
+obj-y			+= userns-broker.o
 obj-y			+= pagemap-cache.o
 obj-y			+= page-pipe.o
 obj-y			+= pagemap.o

--- a/criu/include/netns-broker.h
+++ b/criu/include/netns-broker.h
@@ -1,0 +1,27 @@
+#ifndef __CR_NETNS_BROKER_H__
+#define __CR_NETNS_BROKER_H__
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+/*
+ * One-shot helper per network namespace operation.  The parent forks,
+ * the child enters the target user namespace *first* followed by the
+ * target network namespace, creates the required sockets, and passes
+ * the file-descriptors back to the parent via SCM_RIGHTS.
+ *
+ * This is needed when the target network namespace is owned by a
+ * different user namespace than CRIU's current user namespace.
+ */
+
+struct ns_id;
+
+struct netns_broker_resp {
+	int nlsk;  /* SOCK_DIAG socket, or -1 */
+	int seqsk; /* parasite seqpacket socket */
+};
+
+extern int netns_broker_prep(const struct ns_id *ns, bool for_dump,
+			     struct netns_broker_resp *resp);
+
+#endif /* __CR_NETNS_BROKER_H__ */

--- a/criu/include/userns-broker.h
+++ b/criu/include/userns-broker.h
@@ -1,0 +1,13 @@
+#ifndef __CR_USERNS_BROKER_H__
+#define __CR_USERNS_BROKER_H__
+
+/*
+ * Enter the target process user namespace (userns-first broker step).
+ * EINVAL from setns(CLONE_NEWUSER) is treated as already inside the ns.
+ */
+
+extern int userns_broker_drop_groups(const char *broker_name, const char *op_name);
+extern int userns_broker_enter_creds(const char *broker_name, const char *op_name);
+extern int userns_broker_enter(int pid, const char *op_name);
+
+#endif /* __CR_USERNS_BROKER_H__ */

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -263,6 +263,7 @@ int mkdirpat(int fd, const char *path, int mode);
  * refer to different directories.
  */
 bool is_path_prefix(const char *path, const char *prefix);
+bool in_noninitial_userns(void);
 FILE *fopenat(int dirfd, char *path, char *cflags);
 void split(char *str, char token, char ***out, int *n);
 

--- a/criu/net.c
+++ b/criu/net.c
@@ -46,6 +46,7 @@
 #include "external.h"
 #include "fdstore.h"
 #include "netfilter.h"
+#include "netns-broker.h"
 
 #include "protobuf.h"
 #include "images/netdev.pb-c.h"
@@ -3632,12 +3633,107 @@ int macvlan_ext_add(struct external *ext)
  * needed other-ns sockets in advance.
  */
 
+static int open_netns_fd(struct ns_id *ns)
+{
+	if (ns->ext_key) {
+		int fd;
+
+		fd = inherit_fd_lookup_id(ns->ext_key);
+		if (fd >= 0)
+			return fd;
+
+		pr_debug("net: %s not in inherit fds, trying /proc\n", ns->ext_key);
+	}
+
+	return do_open_proc(ns->ns_pid, O_RDONLY, "ns/net");
+}
+
+static bool netns_fd_direct_roundtrip_works(int netns_fd)
+{
+	int old_netns_fd;
+	bool ret = false;
+
+	old_netns_fd = open_proc(PROC_SELF, "ns/net");
+	if (old_netns_fd < 0)
+		return false;
+
+	if (setns(netns_fd, CLONE_NEWNET))
+		goto out;
+
+	if (setns(old_netns_fd, CLONE_NEWNET))
+		goto out;
+
+	ret = true;
+out:
+	close(old_netns_fd);
+	return ret;
+}
+
+static bool netns_direct_roundtrip_works(struct ns_id *ns)
+{
+	int pid, status;
+
+	if (ns->type == NS_CRIU)
+		return true;
+
+	pid = fork();
+	if (pid < 0) {
+		pr_perror("net: can't fork netns roundtrip probe");
+		return false;
+	}
+
+	if (pid == 0) {
+		int netns_fd = -1;
+
+		netns_fd = open_netns_fd(ns);
+		if (netns_fd < 0)
+			_exit(1);
+
+		if (!netns_fd_direct_roundtrip_works(netns_fd))
+			_exit(1);
+
+		_exit(0);
+	}
+
+	if (waitpid(pid, &status, 0) < 0) {
+		pr_perror("net: can't wait netns roundtrip probe");
+		return false;
+	}
+
+	return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+static bool netns_needs_userns_broker(struct ns_id *ns)
+{
+	if (ns->type == NS_CRIU)
+		return false;
+
+	if (netns_direct_roundtrip_works(ns))
+		return false;
+
+	pr_info("Using netns broker because direct netns roundtrip is not permitted\n");
+	return true;
+}
+
 static int prep_ns_sockets(struct ns_id *ns, bool for_dump)
 {
 	int nsret = -1, ret;
 #ifdef CONFIG_HAS_SELINUX
 	char *ctx;
 #endif
+
+	if (netns_needs_userns_broker(ns)) {
+		struct netns_broker_resp resp;
+
+		pr_info("Using netns broker for %d's net (collecting sockets)\n", ns->ns_pid);
+
+		if (netns_broker_prep(ns, for_dump, &resp))
+			return -1;
+
+		ns->net.nlsk = resp.nlsk;
+		ns->net.seqsk = resp.seqsk;
+		return 0;
+	}
 
 	if (ns->type != NS_CRIU) {
 		pr_info("Switching to %d's net for collecting sockets\n", ns->ns_pid);

--- a/criu/netns-broker.c
+++ b/criu/netns-broker.c
@@ -1,0 +1,234 @@
+#include <sched.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <linux/netlink.h>
+#include <grp.h>
+
+#ifdef CONFIG_HAS_SELINUX
+#include <selinux/selinux.h>
+#include "images/inventory.pb-c.h"
+#endif
+
+#include "common/list.h"
+#include "common/scm.h"
+#include "external.h"
+#include "fdstore.h"
+#include "kerndat.h"
+#include "log.h"
+#include "lsm.h"
+#include "namespaces.h"
+#include "netns-broker.h"
+#include "userns-broker.h"
+#include "util.h"
+
+#undef LOG_PREFIX
+#define LOG_PREFIX "netns-bkr: "
+
+struct prep_msg {
+	int ret;
+};
+
+static int prep_sockets_in_child(bool for_dump, int root_pid, int *nlsk, int *seqsk)
+{
+	int ret;
+
+	*nlsk = -1;
+	*seqsk = -1;
+
+	if (for_dump) {
+		ret = socket(PF_NETLINK, SOCK_RAW, NETLINK_SOCK_DIAG);
+		if (ret < 0) {
+			pr_perror("Can't create sock diag socket");
+			return -1;
+		}
+		*nlsk = ret;
+	}
+
+#ifdef CONFIG_HAS_SELINUX
+	if (kdat.lsm == LSMTYPE__SELINUX) {
+		char *ctx;
+
+		ret = getpidcon_raw(root_pid, &ctx);
+		if (ret < 0) {
+			pr_perror("Getting SELinux context for PID %d failed", root_pid);
+			goto err;
+		}
+
+		ret = setsockcreatecon(ctx);
+		freecon(ctx);
+		if (ret < 0) {
+			pr_perror("Setting SELinux socket context for PID %d failed", root_pid);
+			goto err;
+		}
+	}
+#endif
+
+	ret = socket(PF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0);
+	if (ret < 0) {
+		pr_perror("Can't create seqsk for parasite");
+		goto err;
+	}
+	*seqsk = ret;
+
+#ifdef CONFIG_HAS_SELINUX
+	if (kdat.lsm == LSMTYPE__SELINUX) {
+		ret = setsockcreatecon_raw(NULL);
+		if (ret < 0) {
+			pr_perror("Resetting SELinux socket context failed");
+			goto err;
+		}
+	}
+#endif
+
+	return 0;
+
+err:
+	if (*seqsk >= 0) {
+		close(*seqsk);
+		*seqsk = -1;
+	}
+	if (*nlsk >= 0) {
+		close(*nlsk);
+		*nlsk = -1;
+	}
+	return -1;
+}
+
+int netns_broker_prep(const struct ns_id *ns, bool for_dump,
+		      struct netns_broker_resp *resp)
+{
+	int sk[2], netns_fd = -1, pid, status;
+	int fds[2] = { -1, -1 }, nr_fds;
+	struct prep_msg msg = {};
+	bool netns_owned = false;
+
+	resp->nlsk = -1;
+	resp->seqsk = -1;
+
+	if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sk) < 0) {
+		pr_perror("netns broker: socketpair");
+		return -1;
+	}
+
+	pid = fork();
+	if (pid < 0) {
+		pr_perror("netns broker: fork");
+		close(sk[0]);
+		close(sk[1]);
+		return -1;
+	}
+
+	if (pid == 0) {
+		int nlsk = -1, seqsk = -1, ret;
+
+		close(sk[0]);
+
+		if (userns_broker_enter(ns->ns_pid, "netns prep"))
+			goto child_err;
+
+		/* Step 2: enter the target network namespace. */
+		if (ns->ext_key) {
+			netns_fd = inherit_fd_lookup_id(ns->ext_key);
+			if (netns_fd < 0) {
+				/*
+				 * External netns FD isn't in the broker
+				 * child's FD table. Fall back to opening
+				 * via /proc — works in rootless setups
+				 * where the container's /proc is reachable.
+				 */
+				pr_debug("netns broker: %s not in inherit fds, trying /proc\n",
+					 ns->ext_key);
+				netns_fd = do_open_proc(ns->ns_pid, O_RDONLY, "ns/net");
+				if (netns_fd < 0) {
+					pr_perror("netns broker: open proc %d ns/net",
+						  ns->ns_pid);
+					goto child_err;
+				}
+				netns_owned = true;
+			}
+		} else {
+			netns_fd = do_open_proc(ns->ns_pid, O_RDONLY, "ns/net");
+			if (netns_fd < 0) {
+				pr_perror("netns broker: open proc %d ns/net",
+					  ns->ns_pid);
+				goto child_err;
+			}
+			netns_owned = true;
+		}
+
+		if (setns(netns_fd, CLONE_NEWNET)) {
+			pr_perror("netns broker: setns netns %d", ns->ns_pid);
+			goto child_err;
+		}
+
+		if (netns_owned) {
+			close(netns_fd);
+			netns_fd = -1;
+		}
+
+		/* Step 3: create sockets inside the target netns. */
+		ret = prep_sockets_in_child(for_dump, ns->ns_pid, &nlsk, &seqsk);
+		if (ret)
+			goto child_err;
+
+		nr_fds = 0;
+		if (for_dump)
+			fds[nr_fds++] = nlsk;
+		fds[nr_fds++] = seqsk;
+
+		msg.ret = 0;
+		if (send_fds(sk[1], NULL, 0, fds, nr_fds, &msg, sizeof(msg)))
+			goto child_err;
+
+		close(sk[1]);
+		_exit(0);
+
+child_err:
+		msg.ret = -1;
+		send_fds(sk[1], NULL, 0, NULL, 0, &msg, sizeof(msg));
+		close(sk[1]);
+		if (netns_owned && netns_fd >= 0)
+			close(netns_fd);
+		_exit(1);
+	}
+
+	close(sk[1]);
+
+	nr_fds = for_dump ? 2 : 1;
+	if (recv_fds(sk[0], fds, nr_fds, &msg, sizeof(msg)) < 0) {
+		pr_perror("netns broker: recv fds");
+		close(sk[0]);
+		waitpid(pid, &status, 0);
+		return -1;
+	}
+
+	close(sk[0]);
+
+	if (waitpid(pid, &status, 0) < 0) {
+		pr_perror("netns broker: waitpid");
+		return -1;
+	}
+
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0 || msg.ret) {
+		int i;
+
+		pr_err("netns broker: child failed (exit %d, ret %d)\n",
+		       WIFEXITED(status) ? WEXITSTATUS(status) : -1, msg.ret);
+		for (i = 0; i < nr_fds; i++)
+			if (fds[i] >= 0)
+				close(fds[i]);
+		return -1;
+	}
+
+	if (for_dump) {
+		resp->nlsk = fds[0];
+		resp->seqsk = fds[1];
+	} else {
+		resp->seqsk = fds[0];
+	}
+
+	pr_info("Prepared netns sockets via broker for pid %d\n", ns->ns_pid);
+	return 0;
+}

--- a/criu/userns-broker.c
+++ b/criu/userns-broker.c
@@ -1,0 +1,101 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <grp.h>
+
+#include "log.h"
+#include "namespaces.h"
+#include "userns-broker.h"
+#include "util.h"
+
+static void broker_pr_perror(const char *broker_name, const char *op_name, const char *msg)
+{
+	if (op_name)
+		pr_perror("%s %s: %s", broker_name, op_name, msg);
+	else
+		pr_perror("%s: %s", broker_name, msg);
+}
+
+int userns_broker_drop_groups(const char *broker_name, const char *op_name)
+{
+	if (setgroups(0, NULL)) {
+		if (errno == EPERM) {
+			gid_t *groups = NULL;
+			int i, nr_groups;
+
+			nr_groups = getgroups(0, NULL);
+			if (nr_groups > 0) {
+				groups = xmalloc(sizeof(*groups) * nr_groups);
+				if (!groups)
+					return -1;
+				nr_groups = getgroups(nr_groups, groups);
+			}
+
+			for (i = 0; i < nr_groups; i++) {
+				if (groups[i] != 0)
+					break;
+			}
+
+			xfree(groups);
+			if (nr_groups >= 0 && i == nr_groups) {
+				if (op_name)
+					pr_info("%s %s: setgroups denied, groups already safe\n", broker_name, op_name);
+				else
+					pr_info("%s: setgroups denied, groups already safe\n", broker_name);
+				return 0;
+			}
+
+			if (in_noninitial_userns()) {
+				if (op_name)
+					pr_info("%s %s: tolerate setgroups denial in user namespace\n", broker_name, op_name);
+				else
+					pr_info("%s: tolerate setgroups denial in user namespace\n", broker_name);
+				return 0;
+			}
+
+		}
+		broker_pr_perror(broker_name, op_name, "setgroups");
+		return -1;
+	}
+
+	return 0;
+}
+
+int userns_broker_enter_creds(const char *broker_name, const char *op_name)
+{
+	if ((geteuid() != 0 && setuid(0)) || (getegid() != 0 && setgid(0))) {
+		broker_pr_perror(broker_name, op_name, "set uid/gid 0 in target userns");
+		return -1;
+	}
+
+	return 0;
+}
+
+int userns_broker_enter(int pid, const char *op_name)
+{
+	int userns_fd;
+
+	if (userns_broker_drop_groups("userns broker", op_name))
+		return -1;
+
+	userns_fd = do_open_proc(pid, O_RDONLY, "ns/user");
+	if (userns_fd < 0) {
+		pr_perror("userns broker %s: open proc %d ns/user", op_name, pid);
+		return -1;
+	}
+
+	if (setns(userns_fd, CLONE_NEWUSER)) {
+		if (errno == EINVAL)
+			pr_info("userns broker %s: already in target userns\n", op_name);
+		else {
+			pr_perror("userns broker %s: setns userns %d", op_name, pid);
+			close(userns_fd);
+			return -1;
+		}
+	}
+	close(userns_fd);
+
+	return userns_broker_enter_creds("userns broker", op_name);
+}

--- a/criu/util.c
+++ b/criu/util.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -22,6 +23,7 @@
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <limits.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sched.h>
@@ -948,6 +950,38 @@ bool is_path_prefix(const char *path, const char *prefix)
 	}
 
 	return false;
+}
+
+bool in_noninitial_userns(void)
+{
+	unsigned long ns_id, parent_id, count;
+	char buf[128], *end;
+	int fd, len;
+
+	fd = open_proc(PROC_SELF, "uid_map");
+	if (fd < 0)
+		return false;
+
+	len = read(fd, buf, sizeof(buf) - 1);
+	close(fd);
+	if (len <= 0)
+		return false;
+	buf[len] = '\0';
+
+	errno = 0;
+	ns_id = strtoul(buf, &end, 10);
+	if (errno || end == buf)
+		return false;
+
+	parent_id = strtoul(end, &end, 10);
+	if (errno)
+		return false;
+
+	count = strtoul(end, &end, 10);
+	if (errno)
+		return false;
+
+	return !(ns_id == 0 && parent_id == 0 && count == UINT_MAX);
 }
 
 FILE *fopenat(int dirfd, char *path, char *cflags)


### PR DESCRIPTION
Follow-up to #3100.

This adds a userns broker helper and uses it when CRIU cannot directly enter and return from the target network namespace.

In that case, CRIU forks a helper that enters the target userns first, then the target netns, creates the netlink/parasite sockets there, and passes them back with SCM_RIGHTS.