### PR TITLE
seize, cr-restore: add sentinel notification for batched device plugins

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -2331,6 +2331,19 @@ skip_ns_bouncing:
 			pr_debug("restore late stage hook for external plugin failed\n");
 	}
 
+	/*
+	 * Sentinel: all RESUME_DEVICES_LATE per-PID hooks have completed;
+	 * let plugins run any batched/parallel finalization that must
+	 * happen once, after every device PID has been iterated.
+	 *
+	 * Handle errors as leniently as the per-PID loop above: -ENOTSUP is
+	 * ignored and any other error is logged but tolerated, so we do not
+	 * regress plugins whose hook may return a real error for pid = -1.
+	 */
+	ret = run_plugins(RESUME_DEVICES_LATE, -1);
+	if (ret < 0 && ret != -ENOTSUP)
+		pr_warn("restore late stage sentinel hook failed\n");
+
 	ret = run_scripts(ACT_PRE_RESUME);
 	if (ret)
 		pr_err("Pre-resume script ret code %d\n", ret);

--- a/criu/seize.c
+++ b/criu/seize.c
@@ -1143,6 +1143,14 @@ int checkpoint_devices(void)
 			goto err;
 	}
 
+	/*
+	 * Sentinel: every device PID has been iterated; let plugins run
+	 * any batched work that must happen once per checkpoint.
+	 */
+	ret = run_plugins(CHECKPOINT_DEVICES, -1);
+	if (ret < 0 && ret != -ENOTSUP)
+		goto err;
+
 	exit_code = 0;
 err:
 	return exit_code;


### PR DESCRIPTION
## Problem

The `CHECKPOINT_DEVICES` and `RESUME_DEVICES_LATE` plugin hooks are called once per task in a loop. Plugins that must act only after *all* device PIDs have been iterated — for example to run a batched/parallel checkpoint across several GPUs — have no reliable way to detect the end of iteration.

## Solution

Add a sentinel invocation with `pid = -1` after each per-PID loop:

- `seize.c` (`checkpoint_devices`): `run_plugins(CHECKPOINT_DEVICES, -1)`
- `cr-restore.c`: `run_plugins(RESUME_DEVICES_LATE, -1)`

Plugins that don't care return `-ENOTSUP`, which is already ignored, so existing plugins (e.g. amdgpu_plugin) are unaffected. No new hook point and no plugin API version bump.

## Backward compatibility

Behaviour only changes if a plugin explicitly handles `pid == -1`. With no device plugin loaded, both sentinel calls return `-ENOTSUP` and are ignored.

## Testing

- `make criu -j$(nproc)` builds cleanly with `-Werror`
- zdtm basic suite unaffected (sentinel is a no-op without a device plugin)

Design discussed in: https://github.com/checkpoint-restore/criu/discussions/3104