### PR TITLE
fifo: don't reopen a writer-less non-blocking reader as a closed pipe

### DIFF
--- a/criu/fifo.c
+++ b/criu/fifo.c
@@ -1,4 +1,5 @@
 #include <unistd.h>
+#include <poll.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -41,6 +42,30 @@ static struct pipe_data_dump pd_fifo = {
 	.img_type = CR_FD_FIFO_DATA,
 };
 
+/*
+ * fifo_open() latches pipe->w_counter into filp->f_version for a
+ * non-blocking read-only end opened with no writer around, and
+ * pipe_poll() suppresses POLLHUP while the two still match. An end
+ * that has not seen a writer and one whose writer is gone for good
+ * differ nowhere else, so ask poll().
+ */
+static int fifo_wait_writer(int lfd)
+{
+	struct pollfd pfd = {
+		.fd = lfd,
+		.events = POLLIN,
+	};
+	int ret;
+
+	ret = poll(&pfd, 1, 0);
+	if (ret < 0) {
+		pr_perror("Can't poll fifo");
+		return -1;
+	}
+
+	return !(ret > 0 && (pfd.revents & POLLHUP));
+}
+
 static int dump_one_fifo(int lfd, u32 id, const struct fd_parms *p)
 {
 	struct cr_img *img = img_from_set(glob_imgset, CR_FD_FILES);
@@ -65,6 +90,16 @@ static int dump_one_fifo(int lfd, u32 id, const struct fd_parms *p)
 	e.has_regf_id = true;
 	e.regf_id = rf_id;
 
+	if ((p->flags & O_ACCMODE) == O_RDONLY) {
+		int wait_writer = fifo_wait_writer(lfd);
+
+		if (wait_writer < 0)
+			return -1;
+
+		e.has_wait_writer = true;
+		e.wait_writer = wait_writer;
+	}
+
 	fe.type = FD_TYPES__FIFO;
 	fe.id = e.id;
 	fe.fifo = &e;
@@ -82,37 +117,78 @@ const struct fdtype_ops fifo_dump_ops = {
 
 static struct pipe_data_rst *pd_hash_fifo[PIPE_DATA_HASH_SIZE];
 
+static bool fifo_has_data(u32 id)
+{
+	struct pipe_data_rst *pd;
+
+	for (pd = pd_hash_fifo[id & PIPE_DATA_HASH_MASK]; pd != NULL; pd = pd->next)
+		if (pd->pde->pipe_id == id)
+			return pd->pde->bytes > 0;
+
+	return false;
+}
+
 static int do_open_fifo(int ns_root_fd, struct reg_file_info *rfi, void *arg)
 {
 	struct fifo_info *info = arg;
-	int new_fifo, fake_fifo = -1;
+	int new_fifo = -1, fake_fifo = -1;
+	int flags = rfi->rfe->flags;
+
+	bool read_only = (flags & O_ACCMODE) == O_RDONLY;
+	bool nonblocking = flags & O_NONBLOCK;
+	bool pipe_empty = !fifo_has_data(info->fe->pipe_id);
+	bool wait_writer = info->fe->has_wait_writer && info->fe->wait_writer;
 
 	/*
-	 * The fifos (except read-write fifos) do wait until
-	 * another pipe-end get connected, so to be able to
-	 * proceed the restoration procedure we open a fake
-	 * fifo here.
+	 * An end which had not seen a writer has to be opened with no
+	 * writer around too, or it comes back as a closed pipe and the
+	 * application polling it spins. Such an end never blocks on open,
+	 * so it needs no fake writer at all, and opening one would bump
+	 * w_counter and hang up the ends restored before it. A fifo with
+	 * buffered data is left alone, as the fake writer is the one
+	 * holding the data.
 	 */
-	fake_fifo = openat(ns_root_fd, rfi->path, O_RDWR);
-	if (fake_fifo < 0) {
-		pr_perror("Can't open fake fifo %#x [%s]", info->fe->id, rfi->path);
-		return -1;
+	bool skip_fake_writer = read_only && nonblocking && pipe_empty && wait_writer;
+
+	/*
+	 * FIFOs (except read-write FIFOs) block until the other end is
+	 * opened. Open a temporary read-write descriptor so the restore
+	 * process can proceed.
+	 */
+	if (!skip_fake_writer) {
+		fake_fifo = openat(ns_root_fd, rfi->path, O_RDWR);
+		if (fake_fifo < 0) {
+			pr_perror("Can't open fake fifo %#x [%s]", info->fe->id, rfi->path);
+			return -1;
+		}
+
+		if (info->restore_data) {
+			if (restore_pipe_data(CR_FD_FIFO_DATA, fake_fifo, info->fe->pipe_id, pd_hash_fifo))
+				goto out;
+		}
 	}
 
-	new_fifo = openat(ns_root_fd, rfi->path, rfi->rfe->flags);
+	new_fifo = openat(ns_root_fd, rfi->path, flags);
 	if (new_fifo < 0) {
 		pr_perror("Can't open fifo %#x [%s]", info->fe->id, rfi->path);
 		goto out;
 	}
 
-	if (info->restore_data)
-		if (restore_pipe_data(CR_FD_FIFO_DATA, fake_fifo, info->fe->pipe_id, pd_hash_fifo)) {
+	/*
+	 * With no fake writer around there is nothing else holding the pipe,
+	 * so its parameters are restored on the final descriptor instead.
+	 * The fifo carries no data in this case, so this only restores the
+	 * pipe size, which works on a read-only descriptor too.
+	 */
+	if (info->restore_data && skip_fake_writer) {
+		if (restore_pipe_data(CR_FD_FIFO_DATA, new_fifo, info->fe->pipe_id, pd_hash_fifo)) {
 			close(new_fifo);
 			new_fifo = -1;
 		}
+	}
 
 out:
-	close(fake_fifo);
+	close_safe(&fake_fifo);
 	return new_fifo;
 }
 

--- a/images/fifo.proto
+++ b/images/fifo.proto
@@ -6,4 +6,9 @@ message fifo_entry {
 	required uint32		id		= 1;
 	required uint32		pipe_id		= 2;
 	optional uint32		regf_id		= 3;
+	/*
+	 * Set for a read-only end which has not seen a writer yet, i.e.
+	 * the one poll() doesn't report POLLHUP for.
+	 */
+	optional bool		wait_writer	= 4;
 }

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -365,6 +365,7 @@ TST_FILE	=				\
 		fifo				\
 		fifo-ghost			\
 		fifo_ro				\
+		fifo_ro_nonblock		\
 		fifo_wronly			\
 		console				\
 		vt				\

--- a/test/zdtm/static/fifo_ro_nonblock.c
+++ b/test/zdtm/static/fifo_ro_nonblock.c
@@ -1,0 +1,191 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <poll.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check that O_RDONLY|O_NONBLOCK fifos keep their POLLHUP state after restore";
+const char *test_author = "Emir Buljubasic <emir.buljubasic@bicomsystems.com>";
+
+char *filename;
+TEST_OPTION(filename, string, "file name", 1);
+
+#define FIFO_SIZE (1 << 20)
+
+static int hup(int fd, int timeout)
+{
+	struct pollfd pfd = { .fd = fd, .events = POLLIN };
+	int ret;
+
+	ret = poll(&pfd, 1, timeout);
+	if (ret < 0) {
+		pr_perror("poll() failed");
+		return -1;
+	}
+
+	return (ret > 0 && (pfd.revents & (POLLHUP | POLLERR)));
+}
+
+static int open_fifo_ro(const char *path)
+{
+	int fd;
+
+	if (mknod(path, S_IFIFO | 0600, 0)) {
+		pr_perror("can't make fifo \"%s\"", path);
+		return -1;
+	}
+
+	fd = open(path, O_RDONLY | O_NONBLOCK);
+	if (fd < 0) {
+		pr_perror("can't open %s", path);
+		return -1;
+	}
+
+	return fd;
+}
+
+int main(int argc, char **argv)
+{
+	char hup_name[PATH_MAX];
+	int fd, fd2, fd_hup, fdw;
+	char buf[1];
+
+	test_init(argc, argv);
+
+	snprintf(hup_name, sizeof(hup_name), "%s.hup", filename);
+
+	/*
+	 * The read end is opened before any writer shows up -- this mirrors
+	 * how openrc-init holds its control fifo. The kernel suppresses
+	 * POLLHUP for such a reader, so poll() blocks instead of spinning.
+	 */
+	fd = open_fifo_ro(filename);
+	if (fd < 0)
+		return 1;
+
+	if (fcntl(fd, F_SETPIPE_SZ, FIFO_SIZE) < 0) {
+		pr_perror("can't set pipe size on %s", filename);
+		return 1;
+	}
+
+	/*
+	 * A second end waiting on the same fifo. Restoring one of them must
+	 * not hang up the other, as w_counter is per inode.
+	 */
+	fd2 = open(filename, O_RDONLY | O_NONBLOCK);
+	if (fd2 < 0) {
+		pr_perror("can't open %s", filename);
+		return 1;
+	}
+
+	/*
+	 * The second fifo has seen a writer come and go, so its read end is
+	 * a closed pipe and has to keep reporting POLLHUP.
+	 */
+	fd_hup = open_fifo_ro(hup_name);
+	if (fd_hup < 0)
+		return 1;
+
+	fdw = open(hup_name, O_WRONLY);
+	if (fdw < 0) {
+		pr_perror("can't open %s for writing", hup_name);
+		return 1;
+	}
+	close(fdw);
+
+	/* Sanity checks before C/R. */
+	switch (hup(fd, 0)) {
+	case -1:
+		pr_err("poll() failed before C/R\n");
+		return 1;
+	case 1:
+		pr_err("fifo reports POLLHUP before C/R\n");
+		return 1;
+	}
+
+	switch (hup(fd2, 0)) {
+	case -1:
+		pr_err("poll() failed before C/R\n");
+		return 1;
+	case 1:
+		pr_err("second fifo end reports POLLHUP before C/R\n");
+		return 1;
+	}
+
+	switch (hup(fd_hup, 0)) {
+	case -1:
+		pr_err("poll() failed before C/R\n");
+		return 1;
+	case 0:
+		pr_err("closed fifo doesn't report POLLHUP before C/R\n");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	/*
+	 * After restore poll() must still not report POLLHUP. If it does,
+	 * CRIU reopened the reader while a (fake) writer was present, and the
+	 * application would busy-loop at 100% CPU.
+	 */
+	switch (hup(fd, 100)) {
+	case -1:
+		fail("poll() failed after restore");
+		return 1;
+	case 1:
+		fail("fifo reports POLLHUP after restore -- would busy-loop");
+		return 1;
+	}
+
+	switch (hup(fd2, 100)) {
+	case -1:
+		fail("poll() failed after restore");
+		return 1;
+	case 1:
+		fail("second fifo end reports POLLHUP after restore");
+		return 1;
+	}
+
+	/*
+	 * The pipe size must survive the restore even though CRIU reopens
+	 * the reader against a writer-less (freshly created) pipe object.
+	 */
+	if (fcntl(fd, F_GETPIPE_SZ) != FIFO_SIZE) {
+		fail("fifo lost its pipe size after restore");
+		return 1;
+	}
+
+	/* A fifo whose writer is gone has to stay hung up. */
+	switch (hup(fd_hup, 100)) {
+	case -1:
+		fail("poll() failed after restore");
+		return 1;
+	case 0:
+		fail("closed fifo doesn't report POLLHUP after restore");
+		return 1;
+	}
+
+	if (read(fd_hup, buf, sizeof(buf)) != 0) {
+		fail("closed fifo hasn't been restored as closed");
+		return 1;
+	}
+
+	if (close(fd) < 0 || close(fd2) < 0 || close(fd_hup) < 0) {
+		fail("can't close fifos");
+		return 1;
+	}
+
+	if (unlink(filename) < 0 || unlink(hup_name) < 0) {
+		fail("can't unlink fifos");
+		return 1;
+	}
+
+	pass();
+	return 0;
+}


### PR DESCRIPTION
`do_open_fifo()` opens a temporary `O_RDWR` fake writer to unblock the restore, then opens the real descriptor while that writer is still present. For an `O_RDONLY|O_NONBLOCK` reader, like OpenRC's `/run/openrc/init.ctl`, this leaves every `poll()` returning `POLLHUP` instead of blocking, so an epoll loop spins at 100% CPU.

As far as I can tell, `fifo_open()` latches `pipe->w_counter` into `filp->f_version` only when such an end is opened with no writer around, and `pipe_poll()` suppresses `POLLHUP` while the two still match. So the fake writer has to be gone before the real descriptor is opened.

Doing that unconditionally is wrong, as @avagin pointed out: an end whose writer has already been opened and closed is a closed pipe and must keep reporting `POLLHUP`. The two states seem to differ nowhere but in `poll()`, so this tells them apart on dump by polling the descriptor drained from the dumpee (it is the dumpee's own `struct file`, so `f_version` is intact) and records the answer in a new `fifo_entry.wait_writer`. Images without the field keep the old behaviour.

Per @rst0git: closing the fake writer drops the last reference to the pipe and takes the just restored pipe size with it, so the pipe parameters are restored on the final descriptor in that case.

The test covers both states. It needs two fifos, since `w_counter` is per inode and a writer opened on one end hangs up every reader of that fifo. I checked that both assertions actually catch something: with the fake writer always kept the test fails on the waiting end, and with it always dropped it fails on @avagin's closed pipe reproducer. `fifo`, `fifo_ro`, `fifo_wronly` and `fifo-ghost` still pass.