### PR TITLE
criu: open mapped files through /proc/pid/root when unprivileged

### DIFF
--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -316,8 +316,33 @@ static int vma_stat(struct vma_area *vma, int fd)
 	return 0;
 }
 
+static int open_mapped_file(pid_t pid, const char *fname)
+{
+	int fd, root;
+	const char *rel = fname;
+
+	if (opts.unprivileged && fname[0] == '/') {
+		root = open_proc(pid, "root");
+		if (root >= 0) {
+			/*
+			 * openat() ignores dirfd when pathname is absolute; paths from
+			 * smaps are absolute container paths (e.g. /bin/busybox).
+			 */
+			if (*rel == '/')
+				rel++;
+
+			fd = openat(root, rel, O_RDONLY);
+			close(root);
+			if (fd >= 0)
+				return fd;
+		}
+	}
+
+	return open(fname, O_RDONLY);
+}
+
 static int vma_get_mapfile_user(const char *fname, struct vma_area *vma, struct vma_file_info *vfi, int *vm_file_fd,
-				const char *path)
+				const char *path, pid_t pid)
 {
 	int fd, hugetlb_flag = 0;
 	dev_t vfi_dev;
@@ -327,7 +352,8 @@ static int vma_get_mapfile_user(const char *fname, struct vma_area *vma, struct 
 	 * best we can do here is fill stat using the information
 	 * from smaps file and ... hope for the better :\
 	 *
-	 * Here we'll miss AIO-s and sockets :(
+	 * Without access to map_files, socket mappings still cannot be
+	 * identified through the link metadata.
 	 */
 
 	if (fname[0] == '\0') {
@@ -356,6 +382,11 @@ static int vma_get_mapfile_user(const char *fname, struct vma_area *vma, struct 
 		return 0;
 	}
 
+	if (!strncmp(fname, AIO_FNAME, sizeof(AIO_FNAME) - 1)) {
+		vma->e->status = VMA_AREA_AIORING;
+		return 0;
+	}
+
 	vfi_dev = makedev(vfi->dev_maj, vfi->dev_min);
 
 	if (is_hugetlb_dev(vfi_dev, &hugetlb_flag) || is_anon_shmem_map(vfi_dev)) {
@@ -380,7 +411,7 @@ static int vma_get_mapfile_user(const char *fname, struct vma_area *vma, struct 
 	}
 
 	pr_info("Failed to open map_files/%s, try to go via [%s] path\n", path, fname);
-	fd = open(fname, O_RDONLY);
+	fd = open_mapped_file(pid, fname);
 	if (fd < 0) {
 		pr_perror("Can't open mapped [%s]", fname);
 		return -1;
@@ -428,7 +459,7 @@ closefd:
 }
 
 static int vma_get_mapfile(const char *fname, struct vma_area *vma, DIR *mfd, struct vma_file_info *vfi,
-			   struct vma_file_info *prev_vfi, int *vm_file_fd)
+			   struct vma_file_info *prev_vfi, int *vm_file_fd, pid_t pid)
 {
 	char path[32];
 	int flags;
@@ -512,8 +543,8 @@ static int vma_get_mapfile(const char *fname, struct vma_area *vma, DIR *mfd, st
 			return -1;
 		}
 
-		if (errno == EPERM && !opts.aufs)
-			return vma_get_mapfile_user(fname, vma, vfi, vm_file_fd, path);
+		if ((errno == EPERM || errno == EACCES) && !opts.aufs)
+			return vma_get_mapfile_user(fname, vma, vfi, vm_file_fd, path, pid);
 
 		pr_perror("Can't open map_files");
 		return -1;
@@ -600,7 +631,7 @@ static inline int handle_vvar_vma(struct vma_area *vma)
 static int handle_vma(pid_t pid, struct vma_area *vma_area, const char *file_path, DIR *map_files_dir,
 		      struct vma_file_info *vfi, struct vma_file_info *prev_vfi, int *vm_file_fd)
 {
-	if (vma_get_mapfile(file_path, vma_area, map_files_dir, vfi, prev_vfi, vm_file_fd))
+	if (vma_get_mapfile(file_path, vma_area, map_files_dir, vfi, prev_vfi, vm_file_fd, pid))
 		goto err_bogus_mapfile;
 
 	if (vma_area->e->status != 0)

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -324,6 +324,8 @@ static int open_mapped_file(pid_t pid, const char *fname)
 	if (opts.unprivileged && fname[0] == '/') {
 		root = open_proc(pid, "root");
 		if (root >= 0) {
+			int root_errno;
+
 			/*
 			 * openat() ignores dirfd when pathname is absolute; paths from
 			 * smaps are absolute container paths (e.g. /bin/busybox).
@@ -332,9 +334,18 @@ static int open_mapped_file(pid_t pid, const char *fname)
 				rel++;
 
 			fd = openat(root, rel, O_RDONLY);
+			root_errno = errno;
 			close(root);
 			if (fd >= 0)
 				return fd;
+
+			pr_warn("Can't open mapped file [%s] through /proc/%d/root: %s; "
+				"falling back to host path\n",
+				fname, pid, strerror(root_errno));
+		} else {
+			pr_warn("Can't open /proc/%d/root for mapped file [%s]: %s; "
+				"falling back to host path\n",
+				pid, fname, strerror(errno));
 		}
 	}
 

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -162,6 +162,7 @@ TST_NOFILE	:=				\
 		maps09				\
 		maps10				\
 		maps11				\
+		mapfile_priv			\
 		mlock_setuid			\
 		xids00				\
 		groups				\

--- a/test/zdtm/static/mapfile_priv.c
+++ b/test/zdtm/static/mapfile_priv.c
@@ -1,0 +1,166 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <sys/mman.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <stdlib.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check mapped file survives C/R when path is only visible inside a mount namespace";
+const char *test_author = "Deepak Anand <deepakanand1300@gmail.com>";
+
+enum {
+	EXIT_SETUP = 1,
+	EXIT_MAGIC_MISMATCH = 2,
+	EXIT_BACKING_MISMATCH = 3,
+};
+
+int main(int argc, char **argv)
+{
+	int sync_pipe[2], pid, status;
+
+	test_init(argc, argv);
+
+	if (pipe(sync_pipe)) {
+		pr_perror("pipe");
+		return 1;
+	}
+
+	pid = fork();
+	if (pid < 0) {
+		pr_perror("fork");
+		return 1;
+	}
+
+	if (pid == 0) {
+		char path[256];
+		uint32_t file_value;
+		uint32_t *addr;
+		int fd;
+
+		close(sync_pipe[0]);
+
+		if (unshare(CLONE_NEWNS)) {
+			pr_perror("unshare CLONE_NEWNS");
+			exit(EXIT_SETUP);
+		}
+
+		if (mount(NULL, "/", NULL, MS_PRIVATE | MS_REC, NULL)) {
+			pr_perror("mount --make-rprivate /");
+			exit(EXIT_SETUP);
+		}
+
+		if (mount("zdtm_mapfile_priv", "/tmp", "tmpfs", 0, NULL)) {
+			pr_perror("mount tmpfs on /tmp");
+			exit(EXIT_SETUP);
+		}
+
+		snprintf(path, sizeof(path), "/tmp/zdtm_mapfile_%d", getpid());
+		fd = open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
+		if (fd < 0) {
+			pr_perror("open %s", path);
+			exit(EXIT_SETUP);
+		}
+
+		if (ftruncate(fd, PAGE_SIZE)) {
+			pr_perror("ftruncate");
+			close(fd);
+			exit(EXIT_SETUP);
+		}
+
+		addr = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+		close(fd);
+		if (addr == MAP_FAILED) {
+			pr_perror("mmap file");
+			exit(EXIT_SETUP);
+		}
+
+		addr[0] = 0xDEADBEEF;
+
+		/* Tell parent we're set up */
+		if (write(sync_pipe[1], &(char){1}, 1) != 1) {
+			pr_perror("sync write");
+			exit(EXIT_SETUP);
+		}
+		close(sync_pipe[1]);
+
+		test_waitsig();
+
+		if (addr[0] != 0xDEADBEEF) {
+			test_msg("FAIL: mapped file content lost after C/R (got 0x%x, expected 0x%x)\n",
+				 addr[0], 0xDEADBEEF);
+			exit(EXIT_MAGIC_MISMATCH);
+		}
+		addr[1] = 0xC0FFEE;
+
+		fd = open(path, O_RDONLY);
+		if (fd < 0) {
+			pr_perror("open %s after C/R", path);
+			exit(EXIT_BACKING_MISMATCH);
+		}
+		if (pread(fd, &file_value, sizeof(file_value), sizeof(addr[0])) != sizeof(file_value)) {
+			pr_perror("pread mapped file after C/R");
+			close(fd);
+			exit(EXIT_BACKING_MISMATCH);
+		}
+		close(fd);
+		if (file_value != 0xC0FFEE) {
+			test_msg("FAIL: mapped file is not backed by restored file (got 0x%x, expected 0x%x)\n",
+				 file_value, 0xC0FFEE);
+			exit(EXIT_BACKING_MISMATCH);
+		}
+
+		exit(0);
+	}
+
+	close(sync_pipe[1]);
+
+	/* Wait for child to finish setup before telling zdtm we're ready */
+	if (read(sync_pipe[0], &(char){0}, 1) != 1) {
+		pr_perror("sync read");
+		kill(pid, SIGTERM);
+		waitpid(pid, NULL, 0);
+		return 1;
+	}
+	close(sync_pipe[0]);
+
+	test_daemon();
+	test_waitsig();
+
+	if (kill(pid, SIGTERM)) {
+		pr_perror("kill child");
+		return 1;
+	}
+	if (waitpid(pid, &status, 0) != pid) {
+		pr_perror("waitpid");
+		return 1;
+	}
+
+	if (WIFSIGNALED(status)) {
+		fail("child killed by signal %d", WTERMSIG(status));
+		return 1;
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SETUP) {
+		fail("child setup failed");
+		return 1;
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) == EXIT_MAGIC_MISMATCH) {
+		fail("child reported data corruption after C/R");
+		return 1;
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) == EXIT_BACKING_MISMATCH) {
+		fail("child reported restored mapping is not backed by the file");
+		return 1;
+	}
+	if (status) {
+		fail("child exited with unknown status 0x%x", status);
+		return 1;
+	}
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/mapfile_priv.desc
+++ b/test/zdtm/static/mapfile_priv.desc
@@ -1,0 +1,1 @@
+{'flavor': 'ns uns', 'flags': 'suid', 'opts': '--ext-mount-map auto --enable-external-masters'}


### PR DESCRIPTION
When CRIU dumps a process from a non-initial user namespace, opening a mapped file by its host path can fail even though the file is still reachable from the target task's root. In that case, retry the open through `/proc/<pid>/root`.

Changes:

- retry mapped-file opens through `/proc/<pid>/root` when direct access is denied
- preserve AIO ring detection on the permission-denied `map_files` path
- warn before falling back to a host-side open
- add `zdtm/static/mapfile_priv` coverage for a mapped file whose path is only visible from the target mount namespace

When `mapfile_priv` is run with `--rootless`, it exercises the `/proc/<pid>/root` fallback because CRIU cannot read `/proc/<pid>/map_files`.