### PR TITLE
criu: restore into a caller-provided user namespace

### DIFF
--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1037,7 +1037,7 @@ static void maybe_clone_parent(struct pstree_item *item, struct cr_clone_arg *ca
 	 * off of 3.11, this condition can be simplified to just test the
 	 * options and not have the pdeath_sig test.
 	 */
-	if (opts.restore_sibling) {
+	if (opts.restore_sibling && !userns_join_ns_requested()) {
 		/*
 		 * This means we're called from lib's criu_restore_child().
 		 * In that case create the root task as the child one to+
@@ -1066,6 +1066,9 @@ static void maybe_clone_parent(struct pstree_item *item, struct cr_clone_arg *ca
 
 static bool needs_prep_creds(struct pstree_item *item)
 {
+	if (!item->parent && userns_join_ns_requested())
+		return false;
+
 	/*
 	 * Before the 4.13 kernel, it was impossible to set
 	 * an exe_file if uid or gid isn't zero.
@@ -1189,6 +1192,23 @@ static inline int fork_with_pid(struct pstree_item *item)
 	BUG_ON(ca.clone_flags & CLONE_VM);
 
 	pr_info("Forking task with %d pid (flags 0x%lx)\n", pid, ca.clone_flags);
+
+	if (!item->parent && userns_join_ns_requested()) {
+		if (join_user_namespace()) {
+			pr_perror("Join user namespace before root task clone failed");
+			return -1;
+		}
+		/*
+		 * Switching credentials while joining a user namespace clears
+		 * dumpability. Keep it enabled until the restorer puts the final
+		 * dumpable value back; otherwise the master can't inspect /proc or
+		 * ptrace the restored init during finalization.
+		 */
+		if (prctl(PR_SET_DUMPABLE, 1, 0)) {
+			pr_perror("Unable to set PR_SET_DUMPABLE after joining user namespace");
+			return -1;
+		}
+	}
 
 	if (!(ca.clone_flags & CLONE_NEWPID)) {
 		lock_last_pid();
@@ -2021,8 +2041,12 @@ static void restore_origin_ns_hook(void)
 		return;
 
 	/* not critical: it does not affect CT in any way */
-	if (prepare_loginuid(saved_loginuid) < 0)
-		pr_err("Restore original /proc/self/loginuid failed\n");
+	if (prepare_loginuid(saved_loginuid) < 0) {
+		if (userns_join_ns_requested())
+			pr_warn("Restore original /proc/self/loginuid failed in joined userns\n");
+		else
+			pr_err("Restore original /proc/self/loginuid failed\n");
+	}
 }
 
 static int write_restored_pid(void)
@@ -2150,7 +2174,7 @@ static int restore_root_task(struct pstree_item *init)
 	 * uid_map and gid_map must be filled from a parent user namespace.
 	 * prepare_userns_creds() must be called after filling mappings.
 	 */
-	if ((root_ns_mask & CLONE_NEWUSER) && prepare_userns(init))
+	if ((root_ns_mask & CLONE_NEWUSER) && !userns_join_ns_requested() && prepare_userns(init))
 		goto out_kill;
 
 	pr_info("Wait until namespaces are created\n");
@@ -2167,7 +2191,7 @@ static int restore_root_task(struct pstree_item *init)
 		goto out_kill;
 
 	if (root_ns_mask & CLONE_NEWNS) {
-		mnt_ns_fd = open_proc(init->pid->real, "ns/mnt");
+		mnt_ns_fd = open_proc(userns_join_ns_requested() ? PROC_SELF : init->pid->real, "ns/mnt");
 		if (mnt_ns_fd < 0)
 			goto out_kill;
 	}

--- a/criu/cr-restore.c
+++ b/criu/cr-restore.c
@@ -1025,6 +1025,7 @@ static int restore_one_task(int pid, CoreEntry *core)
 struct cr_clone_arg {
 	struct pstree_item *item;
 	unsigned long clone_flags;
+	int joined_userns_pipe_fd;
 
 	CoreEntry *core;
 };
@@ -1037,7 +1038,7 @@ static void maybe_clone_parent(struct pstree_item *item, struct cr_clone_arg *ca
 	 * off of 3.11, this condition can be simplified to just test the
 	 * options and not have the pdeath_sig test.
 	 */
-	if (opts.restore_sibling && !userns_join_ns_requested()) {
+	if (opts.restore_sibling) {
 		/*
 		 * This means we're called from lib's criu_restore_child().
 		 * In that case create the root task as the child one to+
@@ -1097,11 +1098,215 @@ static int set_next_pid(void *arg)
 	return 0;
 }
 
+struct joined_userns_clone_arg {
+	struct cr_clone_arg *ca;
+	unsigned long clone_flags;
+	pid_t requested_pid;
+	bool set_next_pid;
+	int pid_pipe_fd;
+	sigset_t child_sigmask;
+};
+
+static int write_pid_to_pipe(int fd, pid_t pid)
+{
+	const char *buf = (const char *)&pid;
+	size_t left = sizeof(pid);
+
+	while (left) {
+		ssize_t n = write(fd, buf, left);
+
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		if (!n) {
+			errno = EPIPE;
+			return -1;
+		}
+
+		buf += n;
+		left -= n;
+	}
+
+	return 0;
+}
+
+static int read_pid_from_pipe(int fd, pid_t *pid)
+{
+	char *buf = (char *)pid;
+	size_t left = sizeof(*pid);
+
+	while (left) {
+		ssize_t n = read(fd, buf, left);
+
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		if (!n) {
+			errno = EPIPE;
+			return -1;
+		}
+
+		buf += n;
+		left -= n;
+	}
+
+	return 0;
+}
+
+static int clone_root_in_joined_userns(void *arg)
+{
+	struct joined_userns_clone_arg *uca = arg;
+	unsigned long clone_flags = uca->clone_flags | CLONE_PARENT;
+	pid_t pid;
+
+	/*
+	 * The helper has already consumed a PID in the namespace selected for
+	 * children. Program the requested PID now, before joining the user
+	 * namespace can drop capabilities in the PID namespace's owner.
+	 */
+	if (uca->set_next_pid && set_next_pid(&uca->requested_pid)) {
+		pr_err("Setting PID in joined user namespace helper failed\n");
+		close(uca->pid_pipe_fd);
+		return 1;
+	}
+
+	if (join_user_namespace()) {
+		pr_err("Unable to join the target user namespace\n");
+		close(uca->pid_pipe_fd);
+		return 1;
+	}
+
+	/* The restored root must not inherit the helper's temporary signal mask. */
+	if (sigprocmask(SIG_SETMASK, &uca->child_sigmask, NULL)) {
+		pr_perror("Unable to restore signal mask in userns helper");
+		close_join_user_namespace();
+		close(uca->pid_pipe_fd);
+		return 1;
+	}
+	uca->ca->joined_userns_pipe_fd = uca->pid_pipe_fd;
+
+	/*
+	 * CLONE_PARENT makes the restored root a child of the CRIU coordinator,
+	 * while this short-lived helper is the process that owns the namespace
+	 * context used by clone().
+	 */
+	if (kdat.has_clone3_set_tid)
+		pid = clone3_with_pid_noasan(restore_task_with_children, uca->ca, clone_flags, SIGCHLD,
+					     uca->requested_pid);
+	else {
+		close_pid_proc();
+		pid = clone_noasan(restore_task_with_children, clone_flags | SIGCHLD, uca->ca);
+	}
+
+	if (pid < 0) {
+		pr_perror("Unable to clone the root task from the target user namespace");
+		close_join_user_namespace();
+		close(uca->pid_pipe_fd);
+		return 1;
+	}
+
+	/* The helper has a private address space, so report the PID over the pipe. */
+	if (write_pid_to_pipe(uca->pid_pipe_fd, pid)) {
+		pr_perror("Unable to report the restored root PID");
+		close_join_user_namespace();
+		close(uca->pid_pipe_fd);
+		return 1;
+	}
+	/* The restored root inherited the descriptor and closes it on entry. */
+	close(uca->pid_pipe_fd);
+	close_join_user_namespace();
+	return 0;
+}
+
+static int fork_root_in_joined_userns(struct cr_clone_arg *ca, unsigned long clone_flags, pid_t pid)
+{
+	struct joined_userns_clone_arg uca = {
+		.ca = ca,
+		.clone_flags = clone_flags,
+		.requested_pid = pid,
+		.set_next_pid = !kdat.has_clone3_set_tid && !(clone_flags & CLONE_NEWPID),
+		.pid_pipe_fd = -1,
+	};
+	int pid_pipe[2] = {-1, -1};
+	pid_t child_pid;
+	sigset_t blockmask;
+	unsigned long helper_flags = CLONE_VFORK | SIGCHLD;
+	int status = 0, ret = -1;
+	pid_t helper = -1;
+
+	sigemptyset(&blockmask);
+	sigaddset(&blockmask, SIGCHLD);
+	if (sigprocmask(SIG_BLOCK, &blockmask, &uca.child_sigmask)) {
+		pr_perror("Unable to block SIGCHLD for userns helper");
+		return -1;
+	}
+	if (pipe(pid_pipe)) {
+		pr_perror("Unable to create userns restore PID pipe");
+		goto out;
+	}
+	uca.pid_pipe_fd = pid_pipe[1];
+
+	/*
+	 * CLONE_VFORK keeps the coordinator stopped until the helper has created
+	 * and reported the restored root. The helper has a private address space;
+	 * this preserves the libc rseq registration inherited by the restored root.
+	 */
+	helper = clone_noasan(clone_root_in_joined_userns, helper_flags, &uca);
+	if (helper < 0) {
+		pr_perror("Unable to create userns restore helper");
+		goto out;
+	}
+	close(pid_pipe[1]);
+	pid_pipe[1] = -1;
+
+	if (read_pid_from_pipe(pid_pipe[0], &child_pid)) {
+		pr_perror("Userns restore helper did not report the root task PID");
+		goto out;
+	}
+	close(pid_pipe[0]);
+	pid_pipe[0] = -1;
+	if (child_pid <= 0) {
+		pr_err("Userns restore helper reported invalid root task PID %d\n", child_pid);
+		errno = EINVAL;
+		goto out;
+	}
+
+	if (waitpid(helper, &status, 0) != helper) {
+		pr_perror("Unable to reap userns restore helper");
+		goto out;
+	}
+	helper = -1;
+	if (!WIFEXITED(status) || WEXITSTATUS(status)) {
+		pr_err("Userns restore helper failed (status=%d)\n", status);
+		goto out;
+	}
+
+	ret = child_pid;
+out:
+	if (helper > 0)
+		waitpid(helper, &status, 0);
+	if (pid_pipe[0] >= 0)
+		close(pid_pipe[0]);
+	if (pid_pipe[1] >= 0)
+		close(pid_pipe[1]);
+	if (sigprocmask(SIG_SETMASK, &uca.child_sigmask, NULL)) {
+		pr_perror("Unable to restore SIGCHLD mask after userns helper");
+		ret = -1;
+	}
+	return ret;
+}
+
 static inline int fork_with_pid(struct pstree_item *item)
 {
 	struct cr_clone_arg ca;
 	struct ns_id *pid_ns = NULL;
+	unsigned long clone_flags;
 	bool external_pidns = false;
+	bool joined_userns_root;
 	int ret = -1;
 	pid_t pid = vpid(item);
 
@@ -1188,32 +1393,21 @@ static inline int fork_with_pid(struct pstree_item *item)
 
 	ca.item = item;
 	ca.clone_flags = rsti(item)->clone_flags;
+	ca.joined_userns_pipe_fd = -1;
 
 	BUG_ON(ca.clone_flags & CLONE_VM);
 
 	pr_info("Forking task with %d pid (flags 0x%lx)\n", pid, ca.clone_flags);
-
-	if (!item->parent && userns_join_ns_requested()) {
-		if (join_user_namespace()) {
-			pr_perror("Join user namespace before root task clone failed");
-			return -1;
-		}
-		/*
-		 * Switching credentials while joining a user namespace clears
-		 * dumpability. Keep it enabled until the restorer puts the final
-		 * dumpable value back; otherwise the master can't inspect /proc or
-		 * ptrace the restored init during finalization.
-		 */
-		if (prctl(PR_SET_DUMPABLE, 1, 0)) {
-			pr_perror("Unable to set PR_SET_DUMPABLE after joining user namespace");
-			return -1;
-		}
+	joined_userns_root = !item->parent && userns_join_ns_requested();
+	if (joined_userns_root && external_pidns) {
+		pr_err("Joining a user namespace with an external PID namespace is not supported\n");
+		return -1;
 	}
 
 	if (!(ca.clone_flags & CLONE_NEWPID)) {
 		lock_last_pid();
 
-		if (!kdat.has_clone3_set_tid) {
+		if (!kdat.has_clone3_set_tid && !joined_userns_root) {
 			if (external_pidns) {
 				/*
 				 * Restoring into another namespace requires a helper
@@ -1239,10 +1433,12 @@ static inline int fork_with_pid(struct pstree_item *item)
 		}
 	}
 
-	if (kdat.has_clone3_set_tid) {
+	clone_flags = ca.clone_flags & ~(CLONE_NEWNET | CLONE_NEWCGROUP | CLONE_NEWTIME);
+	if (joined_userns_root) {
+		ret = fork_root_in_joined_userns(&ca, clone_flags, pid);
+	} else if (kdat.has_clone3_set_tid) {
 		ret = clone3_with_pid_noasan(restore_task_with_children, &ca,
-					     (ca.clone_flags & ~(CLONE_NEWNET | CLONE_NEWCGROUP | CLONE_NEWTIME)),
-					     SIGCHLD, pid);
+					     clone_flags, SIGCHLD, pid);
 	} else {
 		/*
 		 * Some kernel modules, such as network packet generator
@@ -1257,8 +1453,7 @@ static inline int fork_with_pid(struct pstree_item *item)
 		 * move_in_cgroup(), so drop this flag here as well.
 		 */
 		close_pid_proc();
-		ret = clone_noasan(restore_task_with_children,
-				   (ca.clone_flags & ~(CLONE_NEWNET | CLONE_NEWCGROUP | CLONE_NEWTIME)) | SIGCHLD, &ca);
+		ret = clone_noasan(restore_task_with_children, clone_flags | SIGCHLD, &ca);
 	}
 
 	if (ret < 0) {
@@ -1547,6 +1742,11 @@ static int __restore_task_with_children(void *_arg)
 	pid_t pid;
 	int ret;
 
+	if (ca->joined_userns_pipe_fd >= 0) {
+		close(ca->joined_userns_pipe_fd);
+		ca->joined_userns_pipe_fd = -1;
+	}
+
 	current = ca->item;
 
 	if (current != root_item) {
@@ -1637,6 +1837,10 @@ static int __restore_task_with_children(void *_arg)
 	if (current->parent == NULL) {
 		if (join_namespaces()) {
 			pr_perror("Join namespaces failed");
+			goto err;
+		}
+		if (userns_join_ns_requested() && prctl(PR_SET_DUMPABLE, 1, 0)) {
+			pr_perror("Unable to set PR_SET_DUMPABLE after joining user namespace");
 			goto err;
 		}
 
@@ -2041,12 +2245,8 @@ static void restore_origin_ns_hook(void)
 		return;
 
 	/* not critical: it does not affect CT in any way */
-	if (prepare_loginuid(saved_loginuid) < 0) {
-		if (userns_join_ns_requested())
-			pr_warn("Restore original /proc/self/loginuid failed in joined userns\n");
-		else
-			pr_err("Restore original /proc/self/loginuid failed\n");
-	}
+	if (prepare_loginuid(saved_loginuid) < 0)
+		pr_err("Restore original /proc/self/loginuid failed\n");
 }
 
 static int write_restored_pid(void)
@@ -2191,7 +2391,7 @@ static int restore_root_task(struct pstree_item *init)
 		goto out_kill;
 
 	if (root_ns_mask & CLONE_NEWNS) {
-		mnt_ns_fd = open_proc(userns_join_ns_requested() ? PROC_SELF : init->pid->real, "ns/mnt");
+		mnt_ns_fd = open_proc(init->pid->real, "ns/mnt");
 		if (mnt_ns_fd < 0)
 			goto out_kill;
 	}

--- a/criu/image.c
+++ b/criu/image.c
@@ -696,7 +696,6 @@ static int img_write_magic(struct cr_img *img, int oflags, int type)
 struct openat_args {
 	char path[PATH_MAX];
 	int flags;
-	int err;
 	int mode;
 };
 
@@ -706,10 +705,8 @@ static int userns_openat(void *arg, int dfd, int pid)
 	int ret;
 
 	ret = openat(dfd, pa->path, pa->flags, pa->mode);
-	if (ret < 0) {
-		pa->err = errno;
+	if (ret < 0)
 		return -errno;
-	}
 
 	return ret;
 }
@@ -733,13 +730,12 @@ static int do_open_image(struct cr_img *img, int dfd, int type, unsigned long of
 		 */
 		struct openat_args pa = {
 			.flags = flags,
-			.err = 0,
 			.mode = CR_FD_PERM,
 		};
 		snprintf(pa.path, PATH_MAX, "%s", path);
 		ret = userns_call(userns_openat, UNS_FDOUT, &pa, sizeof(struct openat_args), dfd);
 		if (ret < 0)
-			errno = pa.err ? pa.err : -ret;
+			errno = -ret;
 	} else
 		ret = openat(dfd, path, flags, CR_FD_PERM);
 	if (ret < 0) {
@@ -890,25 +886,30 @@ int open_parent(int dfd, int *pfd)
 	struct stat st;
 
 	*pfd = -1;
-	/* Check if the parent symlink exists */
-	if (fstatat(dfd, CR_PARENT_LINK, &st, AT_SYMLINK_NOFOLLOW) && errno == ENOENT) {
-		pr_debug("No parent images directory provided\n");
-		return 0;
-	}
 
 	if ((root_ns_mask & CLONE_NEWUSER) && opts.mode == CR_RESTORE && userns_join_ns_requested()) {
 		struct openat_args pa = {
 			.flags = O_RDONLY,
-			.err = 0,
 			.mode = 0,
 		};
 
 		snprintf(pa.path, PATH_MAX, "%s", CR_PARENT_LINK);
 		*pfd = userns_call(userns_openat, UNS_FDOUT, &pa, sizeof(struct openat_args), dfd);
-		if (*pfd < 0)
-			errno = pa.err ? pa.err : -*pfd;
-	} else
+		if (*pfd < 0) {
+			errno = -*pfd;
+			if (errno == ENOENT) {
+				pr_debug("No parent images directory provided\n");
+				return 0;
+			}
+		}
+	} else {
+		/* Check if the parent symlink exists. */
+		if (fstatat(dfd, CR_PARENT_LINK, &st, AT_SYMLINK_NOFOLLOW) && errno == ENOENT) {
+			pr_debug("No parent images directory provided\n");
+			return 0;
+		}
 		*pfd = openat(dfd, CR_PARENT_LINK, O_RDONLY);
+	}
 	if (*pfd < 0) {
 		pr_perror("Can't open parent path");
 		return -1;

--- a/criu/image.c
+++ b/criu/image.c
@@ -706,8 +706,10 @@ static int userns_openat(void *arg, int dfd, int pid)
 	int ret;
 
 	ret = openat(dfd, pa->path, pa->flags, pa->mode);
-	if (ret < 0)
+	if (ret < 0) {
 		pa->err = errno;
+		return -errno;
+	}
 
 	return ret;
 }
@@ -721,11 +723,13 @@ static int do_open_image(struct cr_img *img, int dfd, int type, unsigned long of
 	if (opts.stream && !(oflags & O_FORCE_LOCAL)) {
 		ret = img_streamer_open(path, flags);
 		errno = EIO; /* errno value is meaningless, only the ret value is meaningful */
-	} else if (root_ns_mask & CLONE_NEWUSER && type == CR_FD_PAGES && oflags & O_RDWR) {
+	} else if ((root_ns_mask & CLONE_NEWUSER) &&
+		   ((type == CR_FD_PAGES && (flags & O_ACCMODE) == O_RDWR) ||
+		    (userns_join_ns_requested() && opts.mode == CR_RESTORE && (flags & O_ACCMODE) == O_RDONLY))) {
 		/*
-		 * For pages images dedup we need to open images read-write on
-		 * restore, that may require proper capabilities, so we ask
-		 * usernsd to do it for us
+		 * For page-image dedup and external-userns restore, keep image
+		 * access in usernsd, which retains the caller's filesystem
+		 * credentials.
 		 */
 		struct openat_args pa = {
 			.flags = flags,
@@ -735,7 +739,7 @@ static int do_open_image(struct cr_img *img, int dfd, int type, unsigned long of
 		snprintf(pa.path, PATH_MAX, "%s", path);
 		ret = userns_call(userns_openat, UNS_FDOUT, &pa, sizeof(struct openat_args), dfd);
 		if (ret < 0)
-			errno = pa.err;
+			errno = pa.err ? pa.err : -ret;
 	} else
 		ret = openat(dfd, path, flags, CR_FD_PERM);
 	if (ret < 0) {
@@ -892,7 +896,19 @@ int open_parent(int dfd, int *pfd)
 		return 0;
 	}
 
-	*pfd = openat(dfd, CR_PARENT_LINK, O_RDONLY);
+	if ((root_ns_mask & CLONE_NEWUSER) && opts.mode == CR_RESTORE && userns_join_ns_requested()) {
+		struct openat_args pa = {
+			.flags = O_RDONLY,
+			.err = 0,
+			.mode = 0,
+		};
+
+		snprintf(pa.path, PATH_MAX, "%s", CR_PARENT_LINK);
+		*pfd = userns_call(userns_openat, UNS_FDOUT, &pa, sizeof(struct openat_args), dfd);
+		if (*pfd < 0)
+			errno = pa.err ? pa.err : -*pfd;
+	} else
+		*pfd = openat(dfd, CR_PARENT_LINK, O_RDONLY);
 	if (*pfd < 0) {
 		pr_perror("Can't open parent path");
 		return -1;

--- a/criu/include/namespaces.h
+++ b/criu/include/namespaces.h
@@ -194,7 +194,9 @@ extern int dump_user_ns(pid_t pid, int ns_id);
 extern void free_userns_data(void);
 extern int join_ns_add(const char *type, char *ns_file, char *extra_opts);
 extern int check_namespace_opts(void);
+extern int join_user_namespace(void);
 extern int join_namespaces(void);
+extern int userns_join_ns_requested(void);
 
 typedef int (*uns_call_t)(void *arg, int fd, pid_t pid);
 /*

--- a/criu/include/namespaces.h
+++ b/criu/include/namespaces.h
@@ -195,6 +195,7 @@ extern void free_userns_data(void);
 extern int join_ns_add(const char *type, char *ns_file, char *extra_opts);
 extern int check_namespace_opts(void);
 extern int join_user_namespace(void);
+extern void close_join_user_namespace(void);
 extern int join_namespaces(void);
 extern int userns_join_ns_requested(void);
 

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -53,6 +53,10 @@ int check_namespace_opts(void)
 		pr_err("Conflicting flags: --join-ns and --empty-ns\n");
 		return -1;
 	}
+	if ((join_ns_flags & CLONE_NEWUSER) && opts.restore_sibling) {
+		pr_err("--join-ns user is not supported with --restore-sibling\n");
+		return -1;
+	}
 	if (join_ns_flags & CLONE_NEWUSER)
 		pr_warn("join-ns with user-namespace is not fully tested and dangerous\n");
 
@@ -148,6 +152,7 @@ int join_ns_add(const char *type, char *ns_file, char *extra_opts)
 	jn = xmalloc(sizeof(*jn));
 	if (!jn)
 		return -1;
+	jn->ns_fd = -1;
 
 	jn->ns_file = xstrdup(ns_file);
 	if (!jn->ns_file) {
@@ -1378,7 +1383,8 @@ static int usernsd(int sk)
 		else
 			fd = -1;
 
-		unsc_msg_init(&um, &call, &ret, NULL, 0, fd, NULL);
+		/* SO_PASSCRED supplies credentials in the receiver's PID namespace. */
+		unsc_msg_init_nocreds(&um, &call, &ret, NULL, 0, fd);
 		if (sendmsg(sk, &um.h, 0) <= 0) {
 			pr_perror("uns: send resp error");
 			return -1;
@@ -1429,7 +1435,8 @@ int __userns_call(const char *func_name, uns_call_t call, int flags, void *arg, 
 
 	/* Send the request */
 
-	unsc_msg_init(&um, &call, &flags, arg, arg_size, fd, NULL);
+	/* SO_PASSCRED avoids attaching a PID from a different PID namespace. */
+	unsc_msg_init_nocreds(&um, &call, &flags, arg, arg_size, fd);
 	ret = sendmsg(sk, &um.h, 0);
 	if (ret <= 0) {
 		pr_perror("uns: send req error");
@@ -1790,8 +1797,15 @@ static int switch_join_ns(struct join_ns *jn)
 
 static int switch_user_join_ns(struct join_ns *jn)
 {
+	struct __user_cap_data_struct cap_data[_LINUX_CAPABILITY_U32S_3];
+	struct __user_cap_header_struct cap_header = {
+		.version = _LINUX_CAPABILITY_VERSION_3,
+		.pid = 0,
+	};
+	bool keep_caps = false;
 	uid_t uid;
 	gid_t gid;
+	int i;
 
 	if (jn == NULL)
 		return 0;
@@ -1809,26 +1823,85 @@ static int switch_user_join_ns(struct join_ns *jn)
 	else
 		gid = atoi(jn->extra_opts.user_extra.gid);
 
-	/* FIXME:
-	 * if err occurs in setuid/setgid, should we just alert or
-	 * return an error
-	 */
+	if (uid != geteuid()) {
+		if (prctl(PR_SET_KEEPCAPS, 1)) {
+			pr_perror("Unable to retain capabilities while joining userns");
+			return -1;
+		}
+		keep_caps = true;
+	}
+
 	if (setgid(gid)) {
 		pr_perror("setgid failed while joining userns");
-		return -1;
+		goto err;
 	}
 	if (setuid(uid)) {
 		pr_perror("setuid failed while joining userns");
-		return -1;
+		goto err;
+	}
+
+	if (keep_caps) {
+		if (capget(&cap_header, cap_data)) {
+			pr_perror("Unable to read capabilities after joining userns");
+			goto err;
+		}
+		for (i = 0; i < _LINUX_CAPABILITY_U32S_3; i++)
+			cap_data[i].effective = cap_data[i].permitted;
+		if (capset(&cap_header, cap_data)) {
+			pr_perror("Unable to restore capabilities after joining userns");
+			goto err;
+		}
+		if (prctl(PR_SET_KEEPCAPS, 0)) {
+			pr_perror("Unable to clear PR_SET_KEEPCAPS after joining userns");
+			return -1;
+		}
 	}
 
 	return 0;
+err:
+	if (keep_caps)
+		prctl(PR_SET_KEEPCAPS, 0);
+	return -1;
+}
+
+static int drop_join_userns_groups(void)
+{
+	gid_t *groups = NULL;
+	int i, nr_groups;
+
+	if (!setgroups(0, NULL))
+		return 0;
+	if (errno != EPERM)
+		goto err;
+
+	nr_groups = getgroups(0, NULL);
+	if (nr_groups < 0)
+		goto err;
+	if (!nr_groups)
+		return 0;
+
+	groups = xmalloc(sizeof(*groups) * nr_groups);
+	if (!groups)
+		return -1;
+	nr_groups = getgroups(nr_groups, groups);
+	if (nr_groups < 0)
+		goto err;
+
+	for (i = 0; i < nr_groups; i++)
+		if (groups[i] != 0)
+			goto err;
+
+	xfree(groups);
+	return 0;
+err:
+	xfree(groups);
+	pr_perror("Unable to drop supplementary groups before joining userns");
+	return -1;
 }
 
 int join_user_namespace(void)
 {
 	struct join_ns *jn;
-	int ret;
 
 	list_for_each_entry(jn, &opts.join_ns, list) {
 		if (jn->nd != &user_ns_desc)
@@ -1837,12 +1910,25 @@ int join_user_namespace(void)
 		if (get_join_ns_fd(jn))
 			return -1;
 
-		ret = switch_user_join_ns(jn);
-		close_safe(&jn->ns_fd);
-		return ret;
+		if (drop_join_userns_groups() || switch_join_ns(jn)) {
+			close_safe(&jn->ns_fd);
+			return -1;
+		}
+
+		/* Keep this descriptor open so the restored root inherits it. */
+		return 0;
 	}
 
 	return 0;
+}
+
+void close_join_user_namespace(void)
+{
+	struct join_ns *jn;
+
+	list_for_each_entry(jn, &opts.join_ns, list)
+		if (jn->nd == &user_ns_desc)
+			close_safe(&jn->ns_fd);
 }
 
 int join_namespaces(void)
@@ -1851,7 +1937,7 @@ int join_namespaces(void)
 	int ret = -1;
 
 	list_for_each_entry(jn, &opts.join_ns, list)
-		if (get_join_ns_fd(jn))
+		if (jn->ns_fd < 0 && get_join_ns_fd(jn))
 			goto err_out;
 
 	list_for_each_entry(jn, &opts.join_ns, list)

--- a/criu/namespaces.c
+++ b/criu/namespaces.c
@@ -1454,9 +1454,11 @@ int __userns_call(const char *func_name, uns_call_t call, int flags, void *arg, 
 
 	/* Decode the result and return */
 
-	if (flags & UNS_FDOUT)
+	if (flags & UNS_FDOUT) {
 		unsc_msg_pid_fd(&um, NULL, &ret);
-	else
+		if (ret < 0 && res < 0)
+			ret = res;
+	} else
 		ret = res;
 out:
 	if (!async)
@@ -1811,13 +1813,33 @@ static int switch_user_join_ns(struct join_ns *jn)
 	 * if err occurs in setuid/setgid, should we just alert or
 	 * return an error
 	 */
+	if (setgid(gid)) {
+		pr_perror("setgid failed while joining userns");
+		return -1;
+	}
 	if (setuid(uid)) {
 		pr_perror("setuid failed while joining userns");
 		return -1;
 	}
-	if (setgid(gid)) {
-		pr_perror("setgid failed while joining userns");
-		return -1;
+
+	return 0;
+}
+
+int join_user_namespace(void)
+{
+	struct join_ns *jn;
+	int ret;
+
+	list_for_each_entry(jn, &opts.join_ns, list) {
+		if (jn->nd != &user_ns_desc)
+			continue;
+
+		if (get_join_ns_fd(jn))
+			return -1;
+
+		ret = switch_user_join_ns(jn);
+		close_safe(&jn->ns_fd);
+		return ret;
 	}
 
 	return 0;
@@ -1848,6 +1870,11 @@ err_out:
 	list_for_each_entry(jn, &opts.join_ns, list)
 		close_safe(&jn->ns_fd);
 	return ret;
+}
+
+int userns_join_ns_requested(void)
+{
+	return !!(join_ns_flags & CLONE_NEWUSER);
 }
 
 int prepare_namespace(struct pstree_item *item, unsigned long clone_flags)

--- a/criu/pstree.c
+++ b/criu/pstree.c
@@ -954,6 +954,9 @@ static int prepare_pstree_kobj_ids(void)
 		if (vpid(item) != INIT_PID)
 			rsti(item)->clone_flags &= ~CLONE_NEWPID;
 
+		if (userns_join_ns_requested())
+			rsti(item)->clone_flags &= ~CLONE_NEWUSER;
+
 		cflags &= CLONE_ALLNS;
 
 		if (item == root_item) {

--- a/test/others/libcriu/.gitignore
+++ b/test/others/libcriu/.gitignore
@@ -9,3 +9,4 @@ test_feature_check
 output/
 libcriu.so.*
 test_rpc_config
+test_rpc_join_ns_errors

--- a/test/others/libcriu/Makefile
+++ b/test/others/libcriu/Makefile
@@ -4,6 +4,7 @@ TESTS += test_sub
 TESTS += test_self
 TESTS += test_notify
 TESTS += test_rpc_config
+TESTS += test_rpc_join_ns_errors
 TESTS += test_iters
 TESTS += test_errno
 TESTS += test_join_ns

--- a/test/others/libcriu/run.sh
+++ b/test/others/libcriu/run.sh
@@ -58,6 +58,7 @@ run_test test_sub
 run_test test_self
 run_test test_notify
 run_test test_rpc_config
+run_test test_rpc_join_ns_errors
 if [ "$(uname -m)" = "x86_64" ]; then
 	# Skip this on aarch64 as aarch64 has no dirty page tracking
 	run_test test_iters

--- a/test/others/libcriu/test_rpc_join_ns_errors.c
+++ b/test/others/libcriu/test_rpc_join_ns_errors.c
@@ -1,0 +1,148 @@
+#include "criu.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "lib.h"
+
+static int dir_fd;
+static char *criu_bin;
+static char *image_dir;
+
+static void init_criu(const char *log_file)
+{
+	criu_init_opts();
+	criu_set_service_binary(criu_bin);
+	criu_set_images_dir_fd(dir_fd);
+	criu_set_log_level(CRIU_LOG_DEBUG);
+	criu_set_log_file(log_file);
+}
+
+static pid_t start_child(void)
+{
+	int ready[2];
+	pid_t pid;
+	char c;
+
+	if (pipe(ready)) {
+		perror("pipe");
+		return -1;
+	}
+
+	pid = fork();
+	if (pid < 0) {
+		perror("fork");
+		return -1;
+	}
+
+	if (pid == 0) {
+		close(ready[0]);
+		if (setsid() < 0)
+			_exit(1);
+		if (write(ready[1], "R", 1) != 1)
+			_exit(1);
+		while (1)
+			pause();
+	}
+
+	close(ready[1]);
+	if (read(ready[0], &c, 1) != 1) {
+		perror("read ready");
+		kill(pid, SIGKILL);
+		return -1;
+	}
+	close(ready[0]);
+
+	return pid;
+}
+
+int main(int argc, char **argv)
+{
+	pid_t pid;
+	int ret;
+
+	if (argc < 3) {
+		fprintf(stderr, "Usage: %s CRIU-BIN IMAGE-DIR\n", argv[0]);
+		return 1;
+	}
+
+	criu_bin = argv[1];
+	image_dir = argv[2];
+	dir_fd = open(argv[2], O_DIRECTORY);
+	if (dir_fd < 0) {
+		perror("Can't open images dir");
+		return 1;
+	}
+
+	pid = start_child();
+	if (pid < 0)
+		return 1;
+
+	init_criu("dump.log");
+	criu_set_pid(pid);
+	ret = criu_dump();
+	if (ret) {
+		what_err_ret_mean(ret);
+		kill(pid, SIGKILL);
+		return 1;
+	}
+	{
+		char inventory[PATH_MAX];
+
+		snprintf(inventory, sizeof(inventory), "%s/inventory.img", image_dir);
+		if (access(inventory, F_OK)) {
+			perror("dump did not create inventory.img");
+			kill(pid, SIGKILL);
+			return 1;
+		}
+	}
+
+	kill(pid, SIGKILL);
+	waitpid(pid, NULL, 0);
+
+	init_criu("restore.log");
+	if (criu_join_ns_add("user", "/proc/self/ns/user", "not-a-uid,0")) {
+		fprintf(stderr, "libcriu rejected join-ns before RPC\n");
+		return 1;
+	}
+
+	ret = criu_restore_child();
+	if (ret > 0) {
+		fprintf(stderr, "restore unexpectedly accepted invalid userns join options\n");
+		kill(ret, SIGKILL);
+		waitpid(ret, NULL, 0);
+		return 1;
+	}
+
+	if (ret != -EBADE) {
+		fprintf(stderr, "restore failed with %d, expected %d\n", ret, -EBADE);
+		return 1;
+	}
+
+	init_criu("restore-sibling.log");
+	if (criu_join_ns_add("user", "/proc/self/ns/user", NULL)) {
+		fprintf(stderr, "libcriu rejected valid userns join options before RPC\n");
+		return 1;
+	}
+
+	ret = criu_restore_child();
+	if (ret > 0) {
+		fprintf(stderr, "restore-sibling unexpectedly accepted joined userns\n");
+		kill(ret, SIGKILL);
+		waitpid(ret, NULL, 0);
+		return 1;
+	}
+
+	if (ret != -EBADE) {
+		fprintf(stderr, "restore-sibling failed with %d, expected %d\n", ret, -EBADE);
+		return 1;
+	}
+
+	return 0;
+}

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -271,6 +271,7 @@ TST_NOFILE	:=				\
 		net_lock_socket_iptables6		\
 		net_lock_socket_nftables		\
 		net_lock_socket_nftables6		\
+		rootless_runtime_userns		\
 		netns_sub			\
 		netns_sub_veth			\
 		netns_sub_sysctl	\

--- a/test/zdtm/static/rootless_runtime_userns.c
+++ b/test/zdtm/static/rootless_runtime_userns.c
@@ -1,0 +1,86 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc = "Check rootless restore into a runtime-provided user namespace";
+const char *test_author = "Deepak Anand <deepakanand1300@gmail.com>";
+
+static int noninitial_userns(void)
+{
+	unsigned long ns_id, parent_id, count;
+	FILE *map;
+	int ret;
+
+	map = fopen("/proc/self/uid_map", "r");
+	if (!map) {
+		fail("Can't open uid_map");
+		return -1;
+	}
+
+	ret = fscanf(map, "%lu %lu %lu", &ns_id, &parent_id, &count);
+	fclose(map);
+	if (ret != 3) {
+		fail("Can't parse uid_map");
+		return -1;
+	}
+
+	return !(ns_id == 0 && parent_id == 0 && count == 4294967295UL);
+}
+
+int main(int argc, char **argv)
+{
+	uid_t ruid, euid, suid, ruid_after, euid_after, suid_after;
+	gid_t rgid, egid, sgid, rgid_after, egid_after, sgid_after;
+
+	test_init(argc, argv);
+
+	if (noninitial_userns() <= 0)
+		return 1;
+
+	if (getresuid(&ruid, &euid, &suid)) {
+		fail("Can't get uid set");
+		return 1;
+	}
+
+	if (getresgid(&rgid, &egid, &sgid)) {
+		fail("Can't get gid set");
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	if (noninitial_userns() <= 0)
+		return 1;
+
+	if (getresuid(&ruid_after, &euid_after, &suid_after)) {
+		fail("Can't get restored uid set");
+		return 1;
+	}
+
+	if (getresgid(&rgid_after, &egid_after, &sgid_after)) {
+		fail("Can't get restored gid set");
+		return 1;
+	}
+
+	if (ruid != ruid_after || euid != euid_after || suid != suid_after) {
+		fail("UIDs changed across restore: %u/%u/%u -> %u/%u/%u",
+		     (unsigned int)ruid, (unsigned int)euid, (unsigned int)suid,
+		     (unsigned int)ruid_after, (unsigned int)euid_after,
+		     (unsigned int)suid_after);
+		return 1;
+	}
+
+	if (rgid != rgid_after || egid != egid_after || sgid != sgid_after) {
+		fail("GIDs changed across restore: %u/%u/%u -> %u/%u/%u",
+		     (unsigned int)rgid, (unsigned int)egid, (unsigned int)sgid,
+		     (unsigned int)rgid_after, (unsigned int)egid_after,
+		     (unsigned int)sgid_after);
+		return 1;
+	}
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/rootless_runtime_userns.checkskip
+++ b/test/zdtm/static/rootless_runtime_userns.checkskip
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+command -v setpriv >/dev/null
+unshare --user --map-root-user true

--- a/test/zdtm/static/rootless_runtime_userns.checkskip
+++ b/test/zdtm/static/rootless_runtime_userns.checkskip
@@ -1,4 +1,9 @@
 #!/bin/bash
 
-command -v setpriv >/dev/null
-unshare --user --map-root-user true
+if [ "$(id -u)" = 0 ] && [ -n "${SUDO_UID:-}" ] && [ -n "${SUDO_GID:-}" ]; then
+	command -v setpriv >/dev/null
+	setpriv --reuid "${SUDO_UID}" --regid "${SUDO_GID}" --clear-groups \
+		unshare --user --map-root-user true
+else
+	unshare --user --map-root-user true
+fi

--- a/test/zdtm/static/rootless_runtime_userns.desc
+++ b/test/zdtm/static/rootless_runtime_userns.desc
@@ -1,0 +1,1 @@
+{'flavor': 'uns', 'flags': 'suid excl', 'dopts': '--network-lock skip', 'ropts': '--join-ns user:/tmp/criu-rootless-runtime-userns/userns,0,0 --skip-file-rwx-check'}

--- a/test/zdtm/static/rootless_runtime_userns.hook
+++ b/test/zdtm/static/rootless_runtime_userns.hook
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+test_dir=/tmp/criu-rootless-runtime-userns
+pidfile=${test_dir}/pid
+nsfile=${test_dir}/userns
+test_pidfile=zdtm/static/rootless_runtime_userns.pid
+
+cleanup()
+{
+	if mountpoint -q "${nsfile}" 2>/dev/null; then
+		umount -l "${nsfile}" || true
+	fi
+
+	if [ -s "${pidfile}" ]; then
+		kill "$(cat "${pidfile}")" 2>/dev/null || true
+	fi
+
+	rm -rf "${test_dir}"
+}
+
+case "$1" in
+--pre-restore)
+	cleanup
+	chmod 0666 zdtm/static/rootless_runtime_userns.out* 2>/dev/null || true
+
+	mkdir -p "${test_dir}"
+	chmod 0777 "${test_dir}"
+	touch "${nsfile}"
+	chmod 0666 "${nsfile}"
+
+	if [ "$(id -u)" = 0 ] && [ -n "${SUDO_UID:-}" ] && [ -n "${SUDO_GID:-}" ]; then
+		PIDFILE="${pidfile}" setpriv --reuid "${SUDO_UID}" --regid "${SUDO_GID}" --clear-groups \
+			unshare --user --map-root-user --mount --propagation private \
+			sh -c 'echo $$ > "${PIDFILE}" && exec sleep infinity' &
+	else
+		PIDFILE="${pidfile}" unshare --user --map-root-user --mount --propagation private \
+			sh -c 'echo $$ > "${PIDFILE}" && exec sleep infinity' &
+	fi
+
+	for _ in $(seq 1 50); do
+		if [ -s "${pidfile}" ]; then
+			break
+		fi
+		sleep 0.1
+	done
+
+	test -s "${pidfile}"
+	mount --bind "/proc/$(cat "${pidfile}")/ns/user" "${nsfile}"
+	;;
+--post-restore)
+	test -s "${test_pidfile}"
+	test "$(stat -Lc '%d:%i' "/proc/$(cat "${test_pidfile}")/ns/user")" = "$(stat -Lc '%d:%i' "${nsfile}")"
+	;;
+--clean)
+	cleanup
+	;;
+esac

--- a/test/zdtm/static/rootless_runtime_userns.hook
+++ b/test/zdtm/static/rootless_runtime_userns.hook
@@ -5,6 +5,7 @@ set -e
 test_dir=/tmp/criu-rootless-runtime-userns
 pidfile=${test_dir}/pid
 nsfile=${test_dir}/userns
+coordinator_nsfile=${test_dir}/coordinator-userns
 test_pidfile=zdtm/static/rootless_runtime_userns.pid
 
 cleanup()
@@ -27,6 +28,7 @@ case "$1" in
 
 	mkdir -p "${test_dir}"
 	chmod 0777 "${test_dir}"
+	stat -Lc '%d:%i' /proc/self/ns/user > "${coordinator_nsfile}"
 	touch "${nsfile}"
 	chmod 0666 "${nsfile}"
 
@@ -51,6 +53,7 @@ case "$1" in
 	;;
 --post-restore)
 	test -s "${test_pidfile}"
+	test "$(stat -Lc '%d:%i' /proc/self/ns/user)" = "$(cat "${coordinator_nsfile}")"
 	test "$(stat -Lc '%d:%i' "/proc/$(cat "${test_pidfile}")/ns/user")" = "$(stat -Lc '%d:%i' "${nsfile}")"
 	;;
 --clean)


### PR DESCRIPTION
This adds restore support for joining a caller-provided user namespace.

The restore path can now use `--join-ns user:<path>` when the user namespace is created and owned by the caller. This lets CRIU restore tasks into an existing user namespace instead of always creating the namespace itself.

Changes:
- support joining a user namespace during restore without moving the main CRIU process into it
- use a short-lived helper to clone the restored root inside the supplied user namespace
- skip user namespace map setup when restoring into a joined user namespace
- route image opens through usernsd where needed
- add diagnostics for joined-userns paths
- add `zdtm/static/rootless_runtime_userns` coverage
- add libcriu coverage for invalid userns join options