### PR TITLE
page-xfer: send compressed page-server data over TLS

### DIFF
--- a/Documentation/criu.txt
+++ b/Documentation/criu.txt
@@ -386,7 +386,7 @@ mount -t cgroup -o devices,freezer none devices,freezer
     are stored raw to avoid decompression overhead on *restore*. The
     compression config is recorded in the inventory image and applied
     automatically on *restore*. This functionality is compatible with
-    *--page-server* when *--tls* is not used, *--stream*, *--lazy-pages*,
+    *--page-server*, *--stream*, *--lazy-pages*,
     iterative checkpointing, *--auto-dedup*, and the *dedup* command.
 
 *--compress-block* 'size'::
@@ -398,10 +398,10 @@ mount -t cgroup -o devices,freezer none devices,freezer
     suffixes (e.g. *256K*, *1M*); it must be a multiple of the system
     page size and at most 4M. When both this option and *--compress* are
     specified, the last option takes precedence.
-    Currently supports only the local image path (no
-    *--page-server* / *--stream*). Hole-punching deduplication is
-    skipped for compressed images since compressed pages are
-    variably-sized.
+    Page-sized blocks are compatible with *--page-server* and *--stream*;
+    multi-page blocks currently support only the local image path.
+    Hole-punching deduplication is skipped for compressed images since
+    compressed blocks are variably-sized.
 
 *--compress-acceleration* 'N'::
     Set the LZ4 acceleration level for page compression (1 to 65537).

--- a/criu/config.c
+++ b/criu/config.c
@@ -1244,16 +1244,6 @@ int check_options(void)
 		}
 	}
 
-	/*
-	 * The compressed page-server sender writes its records straight to
-	 * the socket and does not route them through the TLS helpers, so a
-	 * TLS page-server would receive plaintext into the encrypted stream.
-	 * Reject the combination until compressed sends learn to use TLS.
-	 */
-	if (opts.compress_mode && opts.tls && (opts.use_page_server || opts.addr)) {
-		pr_err("Memory page compression is not supported with a TLS page-server\n");
-		return 1;
-	}
 	if (opts.tcp_established_ok)
 		pr_info("Will dump/restore TCP connections\n");
 	if (opts.tcp_skip_in_flight)

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -148,7 +148,36 @@ static inline int __recv(int sk, void *buf, size_t sz, int fl)
 	return opts.tls ? tls_recv(buf, sz, fl) : recv(sk, buf, sz, fl);
 }
 
-static int recv_full(int sk, void *buf, size_t size, const char *what)
+static int send_full_flags(int sk, const void *buf, size_t size, int flags,
+			   const char *what)
+{
+	size_t done = 0;
+
+	while (done < size) {
+		ssize_t ret = __send(sk, (const char *)buf + done, size - done, flags);
+
+		if (ret < 0) {
+			if (errno == EINTR)
+				continue;
+			pr_perror("Can't send %s", what);
+			return -1;
+		}
+		if (ret == 0) {
+			pr_err("Unexpected EOF sending %s\n", what);
+			return -1;
+		}
+		done += ret;
+	}
+	return 0;
+}
+
+static int send_full(int sk, const void *buf, size_t size, const char *what)
+{
+	return send_full_flags(sk, buf, size, 0, what);
+}
+
+/* Return 0 for EOF before the frame, the number of bytes read, or -1 on error. */
+static ssize_t recv_full_or_eof(int sk, void *buf, size_t size, const char *what)
 {
 	size_t done = 0;
 
@@ -162,21 +191,30 @@ static int recv_full(int sk, void *buf, size_t size, const char *what)
 			return -1;
 		}
 		if (ret == 0) {
+			if (done == 0)
+				return 0;
 			pr_err("Unexpected EOF reading %s\n", what);
 			return -1;
 		}
 		done += ret;
 	}
-	return 0;
+	return done;
+}
+
+static int recv_full(int sk, void *buf, size_t size, const char *what)
+{
+	ssize_t ret = recv_full_or_eof(sk, buf, size, what);
+
+	if (ret == 0) {
+		pr_err("Unexpected EOF reading %s\n", what);
+		return -1;
+	}
+	return ret < 0 ? -1 : 0;
 }
 
 static inline int send_psi_flags(int sk, struct page_server_iov *pi, int flags)
 {
-	if (__send(sk, pi, sizeof(*pi), flags) != sizeof(*pi)) {
-		pr_perror("Can't send PSI %d to server", pi->cmd);
-		return -1;
-	}
-	return 0;
+	return send_full_flags(sk, pi, sizeof(*pi), flags, "page-server command");
 }
 
 static inline int send_psi(int sk, struct page_server_iov *pi)
@@ -274,7 +312,7 @@ static int write_pages_to_server_compressed(struct page_xfer *xfer, int p, unsig
 		}
 
 		/* Send compressed size */
-		if (write_fd_full(xfer->sk, &compressed_size, sizeof(compressed_size)))
+		if (send_full(xfer->sk, &compressed_size, sizeof(compressed_size), "compressed size"))
 			return -1;
 
 		/* Send page data (compressed, raw, or nothing for zero) */
@@ -282,11 +320,11 @@ static int write_pages_to_server_compressed(struct page_xfer *xfer, int p, unsig
 			/* Zero page, nothing to send */
 		} else if (compressed_size == PAGE_SIZE) {
 			/* Raw page: incompressible, send the original PAGE_SIZE bytes */
-			if (write_fd_full(xfer->sk, buf, PAGE_SIZE))
+			if (send_full(xfer->sk, buf, PAGE_SIZE, "raw page"))
 				return -1;
 		} else {
 			/* Compressed page: send the compressed_size-byte LZ4 block */
-			if (write_fd_full(xfer->sk, compressed_buf, compressed_size))
+			if (send_full(xfer->sk, compressed_buf, compressed_size, "compressed page"))
 				return -1;
 		}
 	}
@@ -334,8 +372,7 @@ static int open_page_server_xfer(struct page_xfer *xfer, int fd_type, unsigned l
 	/* Push the command NOW */
 	tcp_nodelay(xfer->sk, true);
 
-	if (__recv(xfer->sk, &has_parent, 1, 0) != 1) {
-		pr_perror("The page server doesn't answer");
+	if (recv_full(xfer->sk, &has_parent, sizeof(has_parent), "page-server open response")) {
 		return -1;
 	}
 
@@ -1454,8 +1491,7 @@ static int page_server_check_parent(int sk, struct page_server_iov *pi)
 	if (ret < 0)
 		return -1;
 
-	if (__send(sk, &ret, sizeof(ret), 0) != sizeof(ret)) {
-		pr_perror("Unable to send response");
+	if (send_full(sk, &ret, sizeof(ret), "page-server parent response")) {
 		return -1;
 	}
 
@@ -1475,8 +1511,7 @@ static int check_parent_server_xfer(int fd_type, unsigned long img_id)
 
 	tcp_nodelay(page_server_sk, true);
 
-	if (__recv(page_server_sk, &has_parent, sizeof(int), 0) != sizeof(int)) {
-		pr_perror("The page server doesn't answer");
+	if (recv_full(page_server_sk, &has_parent, sizeof(has_parent), "page-server parent response")) {
 		return -1;
 	}
 
@@ -1548,8 +1583,7 @@ static int page_server_open(int sk, struct page_server_iov *pi)
 
 	if (sk >= 0) {
 		char has_parent = !!cxfer.loc_xfer.parent;
-		if (__send(sk, &has_parent, 1, 0) != 1) {
-			pr_perror("Unable to send response");
+		if (send_full(sk, &has_parent, sizeof(has_parent), "page-server open response")) {
 			page_server_close();
 			return -1;
 		}
@@ -1876,15 +1910,9 @@ static int page_server_serve(int sk)
 		struct page_server_iov pi;
 		u32 cmd;
 
-		ret = __recv(sk, &pi, sizeof(pi), MSG_WAITALL);
-		if (!ret)
+		ret = recv_full_or_eof(sk, &pi, sizeof(pi), "page-server command");
+		if (ret <= 0)
 			break;
-
-		if (ret != sizeof(pi)) {
-			pr_perror("Can't read pagemap from socket");
-			ret = -1;
-			break;
-		}
 
 		flushed = false;
 		cmd = decode_ps_cmd(pi.cmd);
@@ -1930,8 +1958,7 @@ static int page_server_serve(int sk)
 			 * An answer must be sent back to inform another side,
 			 * that all data were received
 			 */
-			if (__send(sk, &status, sizeof(status), 0) != sizeof(status)) {
-				pr_perror("Can't send the final package");
+			if (send_full(sk, &status, sizeof(status), "page-server final status")) {
 				ret = -1;
 			}
 
@@ -2279,7 +2306,7 @@ no_server:
 		return ret > 0 ? 0 : -1;
 
 	if (tls_x509_init(ask, true)) {
-		close_safe(&sk);
+		close_safe(&ask);
 		return -1;
 	}
 
@@ -2300,18 +2327,16 @@ static int connect_to_page_server(void)
 	if (opts.ps_socket != -1) {
 		page_server_sk = opts.ps_socket;
 		pr_info("Reusing ps socket %d\n", page_server_sk);
-		goto out;
+	} else {
+		page_server_sk = setup_tcp_client(opts.addr);
+		if (page_server_sk == -1)
+			return -1;
 	}
-
-	page_server_sk = setup_tcp_client(opts.addr);
-	if (page_server_sk == -1)
-		return -1;
 
 	if (tls_x509_init(page_server_sk, false)) {
-		close(page_server_sk);
+		close_safe(&page_server_sk);
 		return -1;
 	}
-out:
 	/*
 	 * CORK the socket at the very beginning. As per ANK
 	 * the corked by default socket with sporadic NODELAY-s
@@ -2353,8 +2378,7 @@ int disconnect_from_page_server(void)
 	if (send_psi(page_server_sk, &pi))
 		goto out;
 
-	if (__recv(page_server_sk, &status, sizeof(status), 0) != sizeof(status)) {
-		pr_perror("The page server doesn't answer");
+	if (recv_full(page_server_sk, &status, sizeof(status), "page-server final status")) {
 		goto out;
 	}
 
@@ -2507,7 +2531,7 @@ int request_remote_pages(unsigned long img_id, unsigned long addr, unsigned long
 		.dst_id = img_id,
 	};
 
-	/* XXX: why MSG_DONTWAIT here? */
+	/* Do not block the event loop while issuing an asynchronous request. */
 	if (send_psi_flags(page_server_sk, &pi, MSG_DONTWAIT))
 		return -1;
 

--- a/scripts/ci/run-ci-tests.sh
+++ b/scripts/ci/run-ci-tests.sh
@@ -276,6 +276,9 @@ run_non_shardable_tests() {
 	if criu/criu check --feature compress; then
 		./test/zdtm.py run -t zdtm/static/maps00 --lazy-pages --compress
 		./test/zdtm.py run -t zdtm/static/compress_pages00 --remote-lazy-pages --compress
+		./test/zdtm.py run -t zdtm/static/compress_pages00 --page-server --tls --compress
+		./test/zdtm.py run -t zdtm/static/compress_pages00 --page-server-socket --tls --compress
+		./test/zdtm.py run -t zdtm/static/compress_pages00 --page-server-socket --rpc --compress
 	else
 		echo "Skipping lazy-pages compression tests"
 	fi

--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -1030,6 +1030,8 @@ class criu_rpc:
                 criu.opts.ps.port = int(args.pop(0))
             elif "--address" == arg:
                 criu.opts.ps.address = args.pop(0)
+            elif "--ps-socket" == arg:
+                criu.opts.ps.fd = int(args.pop(0))
             elif "--page-server" == arg:
                 continue
             elif "--prev-images-dir" == arg:
@@ -1170,7 +1172,9 @@ class criu:
         self.__dump_path = None
         self.__iter = 0
         self.__prev_dump_iter = None
-        self.__page_server = bool(opts['page_server'])
+        self.__page_server_socket = bool(opts['page_server_socket'])
+        self.__page_server = (bool(opts['page_server']) or
+                              self.__page_server_socket)
         self.__remote_lazy_pages = bool(opts['remote_lazy_pages'])
         self.__lazy_pages = (self.__remote_lazy_pages or
                              bool(opts['lazy_pages']))
@@ -1604,6 +1608,9 @@ class criu:
         return ret
 
     def dump(self, action, opts=[]):
+        page_server_server = None
+        page_server_client = None
+
         self.__iter += 1
         os.mkdir(self.__ddir())
         os.chmod(self.__ddir(), 0o777)
@@ -1619,7 +1626,14 @@ class criu:
         if self.__page_server:
             print("Adding page server")
 
-            ps_opts = ["--port", "12345"] + self.__tls
+            if self.__page_server_socket:
+                page_server_server, page_server_client = socket.socketpair()
+                page_server_server.set_inheritable(True)
+                ps_opts = [
+                    "--ps-socket", str(page_server_server.fileno())
+                ] + self.__tls
+            else:
+                ps_opts = ["--port", "12345"] + self.__tls
             if self.__dedup:
                 ps_opts += ["--auto-dedup"]
 
@@ -1627,12 +1641,29 @@ class criu:
             # compressed. Keep the server deliberately unconfigured so
             # page-server tests also exercise asymmetric client/server options.
 
-            self.__page_server_p = self.__criu_act("page-server",
-                                                   opts=ps_opts,
-                                                   nowait=True)
-            a_opts += [
-                "--page-server", "--address", "127.0.0.1", "--port", "12345"
-            ] + self.__tls
+            try:
+                self.__page_server_p = self.__criu_act("page-server",
+                                                       opts=ps_opts,
+                                                       nowait=True)
+            except BaseException:
+                if page_server_client is not None:
+                    page_server_client.close()
+                raise
+            finally:
+                if page_server_server is not None:
+                    page_server_server.close()
+
+            if self.__page_server_socket:
+                page_server_client.set_inheritable(True)
+                a_opts += [
+                    "--page-server", "--ps-socket",
+                    str(page_server_client.fileno()),
+                ] + self.__tls
+            else:
+                a_opts += [
+                    "--page-server", "--address", "127.0.0.1",
+                    "--port", "12345",
+                ] + self.__tls
 
         a_opts += self.__test.getdopts()
 
@@ -1670,9 +1701,13 @@ class criu:
         if self.__lazy_migrate and action == "dump":
             a_opts += ["--lazy-pages", "--port", "12345"] + self.__tls
             nowait = True
-        self.__dump_process = self.__criu_act(action,
-                                              opts=a_opts + opts,
-                                              nowait=nowait)
+        try:
+            self.__dump_process = self.__criu_act(action,
+                                                  opts=a_opts + opts,
+                                                  nowait=nowait)
+        finally:
+            if page_server_client is not None:
+                page_server_client.close()
         if self.__stream:
             ret = self.wait_for_criu_image_streamer()
             if ret:
@@ -2348,7 +2383,8 @@ class Launcher:
         self.__nr += 1
         self.__show_progress(name)
 
-        nd = ('nocr', 'norst', 'pre', 'iters', 'page_server', 'sibling',
+        nd = ('nocr', 'norst', 'pre', 'iters', 'page_server',
+              'page_server_socket', 'sibling',
               'stop', 'empty_ns', 'fault', 'keep_img', 'report', 'snaps',
               'sat', 'script', 'rpc', 'criu_config', 'lazy_pages', 'join_ns',
               'dedup', 'sbs', 'freezecg', 'user', 'dry_run', 'noauto_dedup',
@@ -3006,6 +3042,9 @@ def get_cli_args():
                     action='store_true')
     rp.add_argument("--page-server",
                     help="Use page server dump",
+                    action='store_true')
+    rp.add_argument("--page-server-socket",
+                    help="Use an inherited socket for the page server dump",
                     action='store_true')
     rp.add_argument("--stream",
                     help="Use criu-image-streamer",


### PR DESCRIPTION
When compression is used with the page-server, the sizes and payloads would bypass the TLS-aware transport and write directly to the socket. As a result, when TLS is used this mixes plaintext into the encrypted stream, so CRIU has to reject the combination.

To fix this, we add helpers that send and receive complete buffers through the TLS wrapper. These helpers are used for page-server commands, sizes, payloads, responses, and final status. Initialize client TLS for both newly connected and inherited page-server sockets.