### PR TITLE
criu: always dump socket uid

### DIFF
--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -528,11 +528,8 @@ static int do_dump_one_inet_fd(int lfd, u32 id, const struct fd_parms *p, int fa
 	ie.dst_port = sk->dst_port;
 	ie.backlog = sk->wqlen;
 	ie.flags = p->flags;
-
-	if (sk->uid != 0) {
-		ie.uid = userns_uid(sk->uid);
-		ie.has_uid = true;
-	}
+	ie.uid = userns_uid(sk->uid);
+	ie.has_uid = true;
 
 	ie.fown = (FownEntry *)&p->fown;
 	ie.opts = &skopts;


### PR DESCRIPTION
simply always dump the socket uid as sk->uid could be 0 in a criu namespace.