### PR TITLE
github: remove "changes requested" label on PR synchronize

### DIFF
--- a/.github/workflows/remove-changes-label.yml
+++ b/.github/workflows/remove-changes-label.yml
@@ -1,0 +1,19 @@
+name: Remove changes requested label
+
+on:
+  pull_request:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove "changes requested" label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" --remove-label "changes requested" || true


### PR DESCRIPTION
Add a GitHub Actions workflow that triggers when new commits are pushed to an open pull request (`pull_request` synchronize event).

The workflow uses GitHub CLI (`gh`) to remove the "changes requested" label from the pull request and cleanly ignores cases where the label is not present.
