### PR TITLE
kerndat: remove redundant ret check in root_only_init()

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -2003,7 +2003,7 @@ static int root_only_init(void)
 	if (opts.unprivileged)
 		return 0;
 
-	if (!ret && kerndat_loginuid()) {
+	if (kerndat_loginuid()) {
 		pr_err("kerndat_loginuid failed when initializing kerndat.\n");
 		ret = -1;
 	}


### PR DESCRIPTION
## What problem does this solve?

Codacy static analysis (pattern 2237, "condition is always true/false") flags a redundant condition in `root_only_init()` in `criu/kerndat.c`, tracked in #2120.

## What changed

The first check in `root_only_init()` was:

    if (!ret && kerndat_loginuid()) {

Since `ret` is freshly initialized to `0` immediately before this check, and no code path between the initialization and this check can change it, `!ret` is always true here — making the check dead/redundant.

Changed to:

    if (kerndat_loginuid()) {

All subsequent `!ret && kerndat_*()` checks later in the same function are intentionally left untouched, since they correctly guard against proceeding after an earlier failure (short-circuit "stop on first error" pattern).

## How to test

1. Build CRIU: `make` — compiles cleanly with `-Werror`, no warnings.
2. Run `criu check` — behaves identically before/after this change (verified in a Docker-based Ubuntu 22.04 environment).
3. This is a pure control-flow simplification with no behavioral change, so no test suite specifically covers this function. `root_only_init()` is exercised indirectly any time CRIU runs kerndat initialization as root.

## Related issue

Relates to #2120 (Codacy pattern 2237). This is one of several redundant conditions flagged by that issue; a previous attempt to fix several of them (#2141) went stale and was closed unmerged due to messy/unrebased commit history. This PR addresses just the kerndat.c instance cleanly, as a first, minimal, reviewable step.