### PR TITLE
netfilter: fix silent truncation of the nftables table name

### DIFF
--- a/criu/include/netfilter.h
+++ b/criu/include/netfilter.h
@@ -1,6 +1,16 @@
 #ifndef __CR_NETFILTER_H__
 #define __CR_NETFILTER_H__
 
+#include "compel/infect-util.h"
+
+/*
+ * The nftables table name is "inet CRIU-" followed by the CRIU run id,
+ * which is a UUID string. RUN_ID_HASH_LENGTH already accounts for the
+ * terminating NUL.
+ */
+#define NFTABLES_TABLE_PREFIX	"inet CRIU-"
+#define NFTABLES_TABLE_NAME_LEN (sizeof(NFTABLES_TABLE_PREFIX) - 1 + RUN_ID_HASH_LENGTH)
+
 struct inet_sk_desc;
 extern int iptables_lock_connection(struct inet_sk_desc *);
 extern int iptables_unlock_connection(struct inet_sk_desc *);

--- a/criu/net.c
+++ b/criu/net.c
@@ -3362,7 +3362,7 @@ static inline int nftables_lock_network_internal(bool restore)
 	cleanup_file FILE *fp = NULL;
 	struct nft_ctx *nft;
 	int ret = 0, exit_code = -1;
-	char table[32];
+	char table[NFTABLES_TABLE_NAME_LEN];
 	char buf[128];
 
 	if (nftables_get_table(table, sizeof(table)))
@@ -3469,7 +3469,7 @@ static inline int nftables_network_unlock(void)
 	int ret = 0;
 	cleanup_file FILE *fp = NULL;
 	struct nft_ctx *nft;
-	char table[32];
+	char table[NFTABLES_TABLE_NAME_LEN];
 	char buf[128];
 
 	if (nftables_get_table(table, sizeof(table)))

--- a/criu/netfilter.c
+++ b/criu/netfilter.c
@@ -158,7 +158,7 @@ int nftables_init_connection_lock(void)
 #if defined(CONFIG_HAS_NFTABLES_LIB_API_0) || defined(CONFIG_HAS_NFTABLES_LIB_API_1)
 	struct nft_ctx *nft;
 	int ret = 0;
-	char table[32];
+	char table[NFTABLES_TABLE_NAME_LEN];
 
 	if (nftables_get_table(table, sizeof(table)))
 		return -1;
@@ -241,7 +241,7 @@ static int nftables_lock_connection_raw(int family, u32 *src_addr, u16 src_port,
 	struct nft_ctx *nft;
 	int ret = 0;
 	char sip[INET_ADDR_LEN], dip[INET_ADDR_LEN];
-	char table[32];
+	char table[NFTABLES_TABLE_NAME_LEN];
 
 	if (nftables_get_table(table, sizeof(table)))
 		return -1;
@@ -304,20 +304,20 @@ int nftables_get_table(char *table, int n)
 	switch(dump_criu_run_id[0]) {
 	case 0:
 		/* This is not a restore.*/
-		ret = snprintf(table, n, "inet CRIU-%s", criu_run_id);
+		ret = snprintf(table, n, NFTABLES_TABLE_PREFIX "%s", criu_run_id);
 		break;
 	case NO_DUMP_CRIU_RUN_ID:
 		/**
 		 * This is a restore from an older image with no
 		 * dump_criu_run_id available. Let's use the old ID.
 		 */
-		ret = snprintf(table, n, "inet CRIU-%d", root_item->pid->real);
+		ret = snprintf(table, n, NFTABLES_TABLE_PREFIX "%d", root_item->pid->real);
 		break;
 	default:
-		ret = snprintf(table, n, "inet CRIU-%s", dump_criu_run_id);
+		ret = snprintf(table, n, NFTABLES_TABLE_PREFIX "%s", dump_criu_run_id);
 	}
 
-	if (ret < 0) {
+	if (ret < 0 || ret >= n) {
 		pr_err("Cannot generate CRIU's nftables table name\n");
 		return -1;
 	}


### PR DESCRIPTION
Fixes #3131

`nftables_get_table()` builds the table name as `"inet CRIU-" + criu_run_id`. Since commit 54795f174 ("criu: use libuuid for criu_run_id generation") the run id is a 36 character UUID string, so the name needs 47 bytes, but all four call sites pass a 32 byte buffer:

```
wanted:  inet CRIU-059cf9cb-3ff4-4591-a9dd-67402190e10b
written: inet CRIU-059cf9cb-3ff4-4591-a9
```

`snprintf()` returns the length it would have written, so the existing `ret < 0` check cannot detect the truncation and the function reports success.

This adds `NFTABLES_TABLE_NAME_LEN`, derived from `RUN_ID_HASH_LENGTH` so it stays correct if the run id format changes again, uses it for the four `table` buffers, and makes `nftables_get_table()` treat truncation as an error.

### Testing

- `make -j8` builds clean with no new warnings, with `libnftables` present so the `CONFIG_HAS_NFTABLES_LIB_API_*` paths are compiled.
- Verified against the real header that `NFTABLES_TABLE_NAME_LEN` evaluates to 47 and that the full 46 character name is preserved.

I was not able to exercise the nftables locking paths end to end locally: the test kernel here is a WSL2 6.6 build without `CONFIG_INET_DIAG_DESTROY`, so the TCP established tests that drive network locking cannot run. Happy to add a test or rework the approach if you would prefer a different fix.
