### PR TITLE
pipes: close pipe descriptors on open_pipe() error paths

### DIFF
--- a/criu/pipes.c
+++ b/criu/pipes.c
@@ -308,20 +308,20 @@ int open_pipe(struct file_desc *d, int *new_fd)
 	if (pi->pe->has_uid && pi->pe->has_gid) {
 		if (cr_fchown(pfd[0], pi->pe->uid, pi->pe->gid) < 0) {
 			pr_perror("Can't change pipe ownership");
-			return -1;
+			goto err_close;
 		}
 	}
 
 	ret = restore_pipe_data(CR_FD_PIPES_DATA, pfd[1], pi->pe->pipe_id, pd_hash_pipes);
 	if (ret)
-		return -1;
+		goto err_close;
 
 	list_for_each_entry(p, &pi->pipe_list, pipe_list) {
 		int fd = pfd[p->pe->flags & O_WRONLY];
 
 		if (send_desc_to_peer(fd, &p->d)) {
 			pr_perror("Can't send file descriptor");
-			return -1;
+			goto err_close;
 		}
 	}
 
@@ -332,13 +332,21 @@ reopen:
 	if (pi->reopen)
 		tmp = reopen_pipe(tmp, pi->pe->flags);
 
-	if (tmp >= 0)
-		if (rst_file_params(tmp, pi->pe->fown, pi->pe->flags))
-			return -1;
 	if (tmp < 0)
 		return -1;
+
+	if (rst_file_params(tmp, pi->pe->fown, pi->pe->flags)) {
+		close(tmp);
+		return -1;
+	}
+
 	*new_fd = tmp;
 	return 0;
+
+err_close:
+	close(pfd[0]);
+	close(pfd[1]);
+	return -1;
 }
 
 static struct file_desc_ops pipe_desc_ops = {


### PR DESCRIPTION
Fixes #3133

`open_pipe()` creates a pipe pair and returns `-1` from four places without closing the descriptors: when `cr_fchown()` fails, when `restore_pipe_data()` fails, when `send_desc_to_peer()` fails, and when `rst_file_params()` fails after one end has already been closed.

This adds a common `err_close` label that closes both ends, and closes `tmp` when `rst_file_params()` fails.

Closing `tmp` is safe because `reopen_pipe()` always closes the descriptor it is given and returns a new one, and the inherited-fd path sets `pi->reopen` before jumping to the `reopen` label, so every path reaching `rst_file_params()` owns `tmp`.

The `tmp < 0` test is moved ahead of `rst_file_params()`, which makes the trailing `tmp >= 0` guard redundant. Behaviour is otherwise unchanged.

### Testing

- `make -j8` builds clean with no new warnings.
- Found with `gcc -fanalyzer`. Note that the analyzer still reports a leak at the function exit after this change: it cannot resolve the computed index in `pfd[!(pi->pe->flags & O_WRONLY)]` and so cannot tell that the success path transfers the descriptor to the caller. That report is a false positive and is present both before and after this patch, so the analyzer does not confirm the fix; the error paths above were verified by inspection.

I was not able to exercise the failing paths end to end locally, as they need a restore to fail at exactly these points. Happy to add a test or take a different approach if you prefer.
