### PR TITLE
fix(netfilter): handle existing nftables tables gracefully during res…

### DIFF
--- a/criu/net.c
+++ b/criu/net.c
@@ -3376,7 +3376,7 @@ static inline int nftables_lock_network_internal(bool restore)
 	if (!fp)
 		goto err2;
 
-	snprintf(buf, sizeof(buf), "create table %s", table);
+	snprintf(buf, sizeof(buf), "add table %s", table);
 	ret = NFT_RUN_CMD(nft, buf);
 	if (ret) {
 		/* The network has been locked on dump. */


### PR DESCRIPTION
**What this PR does:**
When restoring a container into an already existing, persistent network namespace, CRIU fails during the netfilter restoration phase with an `nftables` "File exists" error because it blindly attempts to recreate tables that are already present in the namespace.

**How it does it:**
This patch modifies the netfilter restore logic to make `nftables` table creation idempotent. If a table already exists during the restoration phase, the error is handled gracefully and the process continues, rather than throwing a fatal error and aborting the restore.

**Testing:**
Validated on OpenSUSE Tumbleweed using a `runc` reproducer. Checkpointed a running container and successfully restored it into an existing, persistent network namespace (`ip netns add repro-netns`) without triggering the `File exists` table conflict in `restore.log`.

Fixes: #3135

Signed-off-by: Yash Ashok Maurya <iyashmauryagdsc@example.com>