### PR TITLE
cgroup: restore cgroup namespace in the ignore mode

### DIFF
--- a/criu/cgroup.c
+++ b/criu/cgroup.c
@@ -1305,12 +1305,45 @@ static int move_in_cgroup(CgSetEntry *se)
 	return 0;
 }
 
+static bool has_cgns_prefix(CgSetEntry *se)
+{
+	int i;
+
+	for (i = 0; i < se->n_ctls; i++)
+		if (se->ctls[i]->has_cgns_prefix)
+			return true;
+
+	return false;
+}
+
+/*
+ * In the CG_MODE_IGNORE mode we do not deal with cgroups at all, relying
+ * on the caller (e.g. a container runtime) to have placed us into the
+ * proper cgroup, which the restored tasks inherit.
+ *
+ * A cgroup namespace, though, can not be set up by the caller: unshare()
+ * pins the namespace root to the cgroup of the calling task, so it has to
+ * be done by the very process the restored tasks are forked from, i.e.
+ * here. As the caller has already put us into the right cgroup, no moving
+ * around is needed -- a plain unshare() is sufficient.
+ */
+static int prepare_cgns_ignore(CgSetEntry *se)
+{
+	if (!has_cgns_prefix(se))
+		return 0;
+
+	pr_info("Creating cgns rooted at the current cgroup\n");
+	if (unshare(CLONE_NEWCGROUP) < 0) {
+		pr_perror("couldn't unshare cgns");
+		return -1;
+	}
+
+	return 0;
+}
+
 int prepare_cgroup_namespace(struct pstree_item *root_task)
 {
 	CgSetEntry *se;
-
-	if (opts.manage_cgroups == CG_MODE_IGNORE)
-		return 0;
 
 	if (root_task->parent) {
 		pr_err("Expecting root_task to restore cgroup namespace\n");
@@ -1333,6 +1366,9 @@ int prepare_cgroup_namespace(struct pstree_item *root_task)
 		pr_err("No set %d found\n", rsti(root_task)->cg_set);
 		return -1;
 	}
+
+	if (opts.manage_cgroups == CG_MODE_IGNORE)
+		return prepare_cgns_ignore(se);
 
 	if (prepare_cgns(se) < 0) {
 		pr_err("failed preparing cgns\n");

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -255,6 +255,7 @@ TST_NOFILE	:=				\
 		oom_score_adj			\
 		loginuid			\
 		cgroupns			\
+		cgroupns_ignore			\
 		helper_zombie_child		\
 		clone_fs			\
 		macvlan			\

--- a/test/zdtm/static/cgroupns.c
+++ b/test/zdtm/static/cgroupns.c
@@ -68,8 +68,9 @@ int mount_and_add(const char *controller, const char *path)
 
 	return 0;
 err_rs:
-	umount(dirname);
+	umount(subdir);
 err_rd:
+	rmdir(subdir);
 	rmdir(dirname);
 	return -1;
 }

--- a/test/zdtm/static/cgroupns_ignore.c
+++ b/test/zdtm/static/cgroupns_ignore.c
@@ -1,0 +1,138 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sched.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/mount.h>
+#include <sys/types.h>
+#include <limits.h>
+#include "zdtmtst.h"
+
+#ifndef CLONE_NEWCGROUP
+#define CLONE_NEWCGROUP 0x02000000
+#endif
+
+const char *test_doc = "Check that cgroup NS is restored in --manage-cgroups=ignore mode.";
+const char *test_author = "Kir Kolyshkin <kolyshkin@gmail.com>";
+
+/* we need dirname before test_init() here */
+char *dirname = "cgroupns_ignore.test";
+static const char *cgname = "zdtmtst_ignore";
+
+static int mount_and_add(const char *controller, const char *path)
+{
+	char aux[1024], paux[1024], subdir[1024];
+	int cgfd, l;
+
+	if (mkdir(dirname, 0700) < 0 && errno != EEXIST) {
+		pr_perror("Can't make dir");
+		return -1;
+	}
+
+	ssprintf(subdir, "%s/%s", dirname, controller);
+	if (mkdir(subdir, 0700) < 0) {
+		pr_perror("Can't make dir");
+		return -1;
+	}
+
+	ssprintf(aux, "none,name=%s", controller);
+	if (mount("none", subdir, "cgroup", 0, aux)) {
+		pr_perror("Can't mount cgroups");
+		goto err_rd;
+	}
+
+	ssprintf(paux, "%s/%s", subdir, path);
+	mkdir(paux, 0600);
+
+	l = ssprintf(aux, "%d", getpid());
+	ssprintf(paux, "%s/%s/tasks", subdir, path);
+
+	cgfd = open(paux, O_WRONLY);
+	if (cgfd < 0) {
+		pr_perror("Can't open tasks");
+		goto err_rs;
+	}
+
+	l = write(cgfd, aux, l);
+	close(cgfd);
+
+	if (l < 0) {
+		pr_perror("Can't move self to subcg");
+		goto err_rs;
+	}
+
+	return 0;
+err_rs:
+	umount(subdir);
+err_rd:
+	rmdir(subdir);
+	rmdir(dirname);
+	return -1;
+}
+
+static int get_cgns_id(pid_t pid, ino_t *id)
+{
+	char path[PATH_MAX];
+	struct stat st;
+
+	ssprintf(path, "/proc/%d/ns/cgroup", pid);
+	if (stat(path, &st) < 0) {
+		pr_perror("Can't stat %s", path);
+		return -1;
+	}
+
+	*id = st.st_ino;
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	ino_t init_cgns, self_cgns;
+	char path[PATH_MAX];
+	int ret = -1;
+
+	/*
+	 * The cgroup namespace has to be unshared while being in a
+	 * non-root cgroup, otherwise there is no cgns prefix to dump.
+	 */
+	if (mount_and_add(cgname, "test") < 0)
+		return -1;
+
+	if (unshare(CLONE_NEWCGROUP) < 0) {
+		pr_perror("Can't unshare cgns");
+		goto out;
+	}
+
+	test_init(argc, argv);
+
+	test_daemon();
+	test_waitsig();
+
+	/*
+	 * In the ignore mode CRIU does not move the restored tasks into
+	 * any cgroup, so the only thing to check is that the tasks still
+	 * live in a cgroup namespace of their own rather than in the one
+	 * inherited from CRIU.
+	 */
+	if (get_cgns_id(1, &init_cgns) < 0 || get_cgns_id(getpid(), &self_cgns) < 0)
+		goto out;
+
+	if (init_cgns == self_cgns) {
+		fail("cgroup namespace is not restored");
+		goto out;
+	}
+
+	ret = 0;
+	pass();
+
+out:
+	ssprintf(path, "%s/%s/test", dirname, cgname);
+	rmdir(path);
+	ssprintf(path, "%s/%s", dirname, cgname);
+	umount(path);
+	rmdir(path);
+	rmdir(dirname);
+	return ret;
+}

--- a/test/zdtm/static/cgroupns_ignore.desc
+++ b/test/zdtm/static/cgroupns_ignore.desc
@@ -1,0 +1,5 @@
+{   'feature': 'cgroupns',
+    'flags': 'suid excl',
+    'flavor': 'h',
+    'dopts': '--manage-cgroups=ignore',
+    'ropts': '--manage-cgroups=ignore'}

--- a/test/zdtm/static/cgroupns_ignore.hook
+++ b/test/zdtm/static/cgroupns_ignore.hook
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+[ "$1" == "--clean" ] || exit 0
+
+# On a failure the test may not get to its own cleanup. A leftover cgroup keeps
+# the named hierarchy alive, so remove it here, once the test is gone.
+
+tname=$(mktemp -d cgclean.XXXXXX)
+trap 'rmdir "${tname}"' EXIT
+
+mount -t cgroup none $tname -o "none,name=zdtmtst_ignore"
+trap 'umount "${tname}"; rmdir "${tname}"' EXIT
+
+echo "Cleaning $tname"
+
+rmdir "$tname/test" || true
+
+echo "Left there is:"
+ls "$tname"


### PR DESCRIPTION
## Problem

With `--manage-cgroups-mode=ignore`, a private cgroup namespace is not restored:
the restored tasks end up in the cgroup namespace inherited from CRIU (i.e. the
caller's one) and therefore see the caller's cgroup paths rather than their own
cgroup root.

As an example, a container that is checkpointed and then restored into a
different cgroup by runc (see opencontainers/runc#5417) sees this:

```
                     before C/R          after restore
host:                0::/cgroupns-a      0::/cgroupns-b
inside container:    0::/                0::/cgroupns-b   <-- should be 0::/
```

The reason is that `prepare_cgroup_namespace()` bails out early in this mode:

```c
	if (opts.manage_cgroups == CG_MODE_IGNORE)
		return 0;
```

## Fix

Unlike the cgroup placement, a cgroup namespace can not be prepared by the
caller: `unshare(CLONE_NEWCGROUP)` pins the namespace root to the cgroup of the
calling task (`copy_cgroup_ns()` uses `task_css_set(current)`), so it has to be
done by the very process the restored tasks are forked from, i.e. by CRIU
itself. This is true for `CLONE_NEWCGROUP` passed to `clone(2)` as well -- the
namespace is rooted at the *parent's* cgroup, so `CLONE_INTO_CGROUP` does not
help either.

Since in this mode the caller has already placed us into the right cgroup, no
moving around is needed (and the cgroup yard, which is not prepared in this
mode, is not needed either) -- a plain `unshare()` is sufficient. Do it, but
only if the tasks did have a cgroup namespace of their own on dump.

## Compatibility

The change only affects restores of images in which the dumped tasks had a
private cgroup namespace, i.e. exactly the case that is broken today. There is
no image format change: `dump_sets()` writes `cgns_prefix` regardless of the
cgroups mode (on dump, `!opts.manage_cgroups` only skips walking the cgroup
directories and their properties), so both old images with new CRIU and new
images with old CRIU keep working.

Two things worth pointing out:

- The namespace is rooted at the cgroup CRIU is in at restore time. This extends
  the existing `ignore` mode contract ("the caller is responsible for the cgroup
  placement") to the cgroup namespace. A caller that moves the restored tasks
  into their cgroup only *after* the restore now gets a namespace rooted at
  wherever CRIU happened to be, instead of no namespace at all.
- `unshare(CLONE_NEWCGROUP)` requires `CAP_SYS_ADMIN` in the current user
  namespace, so a restore that used to (incorrectly) succeed can now fail. The
  `--unprivileged` case is covered by the pre-existing `!rsti(root_task)->cg_set`
  check above. Failing loudly still looks better than silently restoring the
  tasks into the wrong cgroup namespace.

I went for an unconditional fix rather than a new option, as an opt-in would
leave the bug in place for every caller that does not know about it. Happy to
put it behind an option if you prefer.

## Testing

New zdtm test `cgroupns_ignore` (passing) checks that after a C/R cycle done with
`--manage-cgroups=ignore` the task is in a cgroup namespace of its own rather
than in the one inherited from CRIU. Since in this mode CRIU does not move the
restored tasks into any cgroup, this is the only thing that can be checked; the
namespace is unshared while being in a non-root cgroup, as otherwise there is no
cgns prefix to dump.

Verified on the original runc scenario as well (runc built from main, cgroup v2,
`linux.cgroupsPath` changed between checkpoint and restore, `ignore` mode on both
sides):

```
                                     without the fix   with the fix
inside container after restore:      0::/cgroupns-b    0::/
on the host after restore:           0::/cgroupns-b    0::/cgroupns-b
```

With this fix runc needs no changes of its own: it already moves the CRIU
process into the container's cgroup before sending the restore request.
