### PR TITLE
files-reg: restore ghost device files through usernsd in user namespaces

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -427,6 +427,22 @@ static int ghost_apply_metadata(const char *path, GhostFileEntry *gfe)
 	return 0;
 }
 
+struct ghost_mknod_args {
+	char path[PATH_MAX];
+	mode_t mode;
+	dev_t rdev;
+};
+
+static int userns_mknod(void *arg, int fd, pid_t pid)
+{
+	struct ghost_mknod_args *a = arg;
+
+	(void)fd;
+	(void)pid;
+
+	return mknod(a->path, a->mode, a->rdev);
+}
+
 static int create_ghost_dentry(char *path, GhostFileEntry *gfe, struct cr_img *img)
 {
 	int ret = -1;
@@ -437,11 +453,18 @@ again:
 		if ((ret = mknod(path, gfe->mode, 0)) < 0)
 			msg = "Can't create node for ghost file";
 	} else if (S_ISCHR(gfe->mode) || S_ISBLK(gfe->mode)) {
+		struct ghost_mknod_args args;
+
 		if (!gfe->has_rdev) {
 			pr_err("No rdev for ghost device\n");
 			goto err;
 		}
-		if ((ret = mknod(path, gfe->mode, gfe->rdev)) < 0)
+
+		__strlcpy(args.path, path, sizeof(args.path));
+		args.mode = gfe->mode;
+		args.rdev = gfe->rdev;
+
+		if ((ret = userns_call(userns_mknod, 0, &args, sizeof(args), -1)) < 0)
 			msg = "Can't create node for ghost dev";
 	} else if (S_ISDIR(gfe->mode)) {
 		if ((ret = mkdirpat(AT_FDCWD, path, gfe->mode)) < 0)


### PR DESCRIPTION
## Summary

Ghost device files are currently restored with a direct `mknod()` call. During restores inside a user namespace, that call executes in the restoring process and can fail because creating character and block device nodes requires capabilities that are not available there.

This change routes ghost device node creation through `userns_call()`, allowing the existing `usernsd` helper to perform `mknod()` from the appropriate privilege context. The restore path for regular files, directories, FIFOs, and symlinks is unchanged.

## Changes

* Add a `userns_mknod()` callback that follows the existing `userns_call()` callback pattern.
* Add `ghost_mknod_args` to pass the path, mode, and device number to the helper.
* Replace the direct `mknod()` call for ghost character and block devices with `userns_call(userns_mknod, ...)`.
* Leave the restore path unchanged for regular files, directories, FIFOs, and symlinks.

## Why this approach

CRIU already uses `userns_call()` for operations that must execute outside a restricted user namespace, including `open_by_handle()`, `mount_root()`, `apply_sb_flags()`, and cgroup related operations. Reusing the same mechanism keeps the implementation consistent with the existing restore architecture.

## Verification

* `make -j$(nproc)` completed successfully.
* `git diff --check` reported no formatting issues.
* The change is limited to `criu/files-reg.c`.
* Full ZDTM restore tests could not be run in GitHub Codespaces because the cgroup mount setup fails with `permission denied`.

Fixes: #92

Signed-off-by: Rohan Pattanayak rohanpxquantum@gmail.com
