### PR TITLE
zdtm: don't leave cgroups in the named zdtmtst hierarchies

### DIFF
--- a/test/zdtm.py
+++ b/test/zdtm.py
@@ -3199,9 +3199,14 @@ if __name__ == '__main__':
         for tst in test_classes.values():
             tst.available()
 
-    orig_hugepages = set_nr_hugepages(20)
-    opts['action'](opts)
-    set_nr_hugepages(orig_hugepages)
-
-    for tst in test_classes.values():
-        tst.cleanup()
+    # A failed run ends with sys.exit(), and the cleanup still has to be
+    # done, otherwise e.g. the cgroup holders are left behind.
+    try:
+        orig_hugepages = set_nr_hugepages(20)
+        try:
+            opts['action'](opts)
+        finally:
+            set_nr_hugepages(orig_hugepages)
+    finally:
+        for tst in test_classes.values():
+            tst.cleanup()

--- a/test/zdtm/static/cgroup_stray.c
+++ b/test/zdtm/static/cgroup_stray.c
@@ -222,7 +222,7 @@ out_kill:
 out_umount:
 	sprintf(path, "%s/%s/foo", dirname, cgname);
 	rmdir(path);
-	sprintf(path, "%s/%s/test", dirname, cgname);
+	sprintf(path, "%s/%s/bar", dirname, cgname);
 	rmdir(path);
 	sprintf(path, "%s/%s", dirname, cgname);
 	umount(path);

--- a/test/zdtm/static/cgroup_stray.hook
+++ b/test/zdtm/static/cgroup_stray.hook
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+[ "$1" == "--clean" ] || exit 0
+
+# The test can not remove the cgroup it is in itself, and on a failure it may
+# not get to the cleanup at all. A leftover cgroup keeps the named hierarchy
+# alive, so remove it here, once the test is gone.
+
+# On a failure, only the test's main process is waited for, and its children
+# may still be exiting, so retry for a while on EBUSY.
+remove_cg() {
+	[ -d "$1" ] || return 0
+	for _ in $(seq 50); do
+		rmdir "$1" 2>/dev/null && return 0
+		sleep 0.1
+	done
+	rmdir "$1"
+}
+
+tname=$(mktemp -d cgclean.XXXXXX)
+trap 'rmdir "${tname}"' EXIT
+
+mount -t cgroup none $tname -o "none,name=zdtmtst"
+trap 'umount "${tname}"; rmdir "${tname}"' EXIT
+
+echo "Cleaning $tname"
+
+remove_cg "$tname/foo" || true
+remove_cg "$tname/bar" || true
+
+echo "Left there is:"
+ls "$tname"

--- a/test/zdtm/static/cgroupns.hook
+++ b/test/zdtm/static/cgroupns.hook
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+[ "$1" == "--clean" ] || exit 0
+
+# The test can not remove the cgroup it is in itself, and on a failure it may
+# not get to the cleanup at all. A leftover cgroup keeps the named hierarchy
+# alive, so remove it here, once the test is gone.
+
+# On a failure, only the test's main process is waited for, and its children
+# may still be exiting, so retry for a while on EBUSY.
+remove_cg() {
+	[ -d "$1" ] || return 0
+	for _ in $(seq 50); do
+		rmdir "$1" 2>/dev/null && return 0
+		sleep 0.1
+	done
+	rmdir "$1"
+}
+
+tname=$(mktemp -d cgclean.XXXXXX)
+trap 'rmdir "${tname}"' EXIT
+
+mount -t cgroup none $tname -o "none,name=zdtmtst"
+trap 'umount "${tname}"; rmdir "${tname}"' EXIT
+
+echo "Cleaning $tname"
+
+remove_cg "$tname/test" || true
+
+echo "Left there is:"
+ls "$tname"


### PR DESCRIPTION
Some zdtm runs leave cgroups behind in the named cgroup v1 hierarchies used by the tests (`name=zdtmtst`, `name=zdtmtst.defaultroot`). A leftover cgroup keeps such a hierarchy alive forever, even after it is unmounted everywhere.

On its own this is a few stray cgroups, but anything that later checkpoints and restores tasks on the same host picks the hierarchy up. For example, crun on cgroup v2 used to have CRIU relocate all hierarchies on restore (containers/crun#2256), so every checkpoint/restore cycle doubled the leftover hierarchy. On my machine this eventually reached ~4.6M cgroups, ~60 GB of kernel memory, and a global OOM.

Found leaks, one commit each:

* **zdtm.py**: a failed run ends with `sys.exit(1)` from `Launcher.finish()`, and the cleanup at the end of main is skipped, so the `holder.<uuid>` cgroups created by `zdtm_mount_cgroups` are never removed. Do the cleanup in a `finally` clause.
* **cgroup_stray**: the cleanup removes a `test` cgroup instead of `bar`, and could not remove `bar` anyway as the test is in it. `bar` is left on every run, including a passing one. Fix the name and add a `--clean` hook.
* **cgroupns**: after restore the test is in its `test` cgroup, so its own `rmdir` fails with `EBUSY`, and `test` is left on every run, including a passing one. Add a `--clean` hook.

Tested as root on a cgroup v2 host, keeping the named hierarchies mounted and listing their contents after each test:

* before: `cgroupns` leaves `zdtmtst/test`, `cgroup_stray` leaves `zdtmtst/bar`; after: nothing is left by `cgroupns`, `cgroupns_ignore`, `cgroup00`, `cgroup01`, `cgroup02`, `cgroup03`, `cgroup_stray`, `cgroup_threads`, `cgroup_yard`;
* a run made to fail at dump leaves `zdtmtst/holder.<uuid>` and `zdtmtst.defaultroot/holder.<uuid>` with the old `zdtm.py`, and no holders with the fixed one.
